### PR TITLE
Update infra file license header to match upstream

### DIFF
--- a/microsoft/azure-pipelines.yml
+++ b/microsoft/azure-pipelines.yml
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
 
 trigger:
 - microsoft/*

--- a/microsoft/build.sh
+++ b/microsoft/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
 
 set -euo pipefail
 

--- a/microsoft/mirror-upstream-refs.sh
+++ b/microsoft/mirror-upstream-refs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
 
 set -euo pipefail
 

--- a/microsoft/pack.sh
+++ b/microsoft/pack.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
 
 set -euo pipefail
 

--- a/microsoft/pipeline/checkout-unix-task.yml
+++ b/microsoft/pipeline/checkout-unix-task.yml
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
 
 # Shallow checkout sources on Unix
 steps:


### PR DESCRIPTION
Update the license headers in our files to more closely match upstream's license headers.

https://github.com/microsoft/go/blob/6583cb8152da6638ed317ef3afcbaf1430b46e98/src/make.bash#L2-L4

What I have in this PR so far:

```
# Copyright (c) Microsoft Corporation.
# Use of this source code is governed by a BSD-style
# license that can be found in the LICENSE file.
```