### PR TITLE
Add /microsoft/ code owner: golang-compiler team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Automatically request review from golang-compiler team for changes in the Microsoft-specific files.
+
+/microsoft/ @microsoft/golang-compiler


### PR DESCRIPTION
Thanks for the suggestion, @jcouv!