### PR TITLE
Generate and log links to uploaded artifacts

### DIFF
--- a/microsoft/azure-pipelines.yml
+++ b/microsoft/azure-pipelines.yml
@@ -121,6 +121,8 @@ jobs:
     - Sign
     pool:
       vmImage: ubuntu-20.04
+    variables:
+      blobDestinationUrl: 'https://golangartifacts.blob.core.windows.net/microsoft/$(Build.SourceBranchName)/$(Build.BuildNumber)'
     steps:
     - checkout: none
 
@@ -135,4 +137,13 @@ jobs:
         scriptType: bash
         scriptLocation: inlineScript
         inlineScript: |
-          az storage copy -s "$(Pipeline.Workspace)/Binaries Signed/*" -d "https://golangartifacts.blob.core.windows.net/microsoft/$(Build.SourceBranchName)/$(Build.BuildNumber)"
+          az storage copy -s "$(Pipeline.Workspace)/Binaries Signed/*" -d '$(blobDestinationUrl)'
+
+    - script: |
+        echo 'Generated links to artifacts in blob storage:'
+        echo ''
+        cd "$(Pipeline.Workspace)/Binaries Signed/"
+        for f in *; do
+          echo "$(blobDestinationUrl)/$f"
+        done
+      displayName: Show uploaded URLs


### PR DESCRIPTION
Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1074925&view=logs&j=0ccccc7a-9630-5914-467b-15a9c61f0287&t=99382d24-8d15-5806-7987-cdd17442596e&l=14

This makes it easier to tell where our internal builds ended up uploading. (Note: The storage account is not public at the moment, but the URLs are right.)

Fixes https://github.com/microsoft/go/issues/49.