### PR TITLE
Add scheduled sync trigger

### DIFF
--- a/microsoft/sync/sync-pipeline.yml
+++ b/microsoft/sync/sync-pipeline.yml
@@ -4,6 +4,13 @@
 
 trigger: none
 pr: none
+schedules:
+  - cron: '0 16 * * Mon,Wed,Fri'
+    displayName: Sync from upstream three times a week
+    branches:
+      include:
+        - microsoft/main
+    always: true
 
 variables:
   - group: Microsoft-GoLang-bot


### PR DESCRIPTION
Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers

I tried pushing this to a dev branch and setting the pipeline to point at it, but the schedule didn't show up in the UI anywhere that I could find. I think we should just merge this and I'll keep an eye on it.

The crontab expression itself is `0 16 * * Mon,Wed,Fri`: minute 0 of UTC hour 16 (9am PDT), any day, any month, if it's Mon/Wed/Fri. I don't have good reasons in mind for this schedule in particular--just something to start with that we can change later. (It's basically one of the examples from the doc.)