### PR TITLE
Include bot as code owner for sync PR automerge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
-# Automatically request review from golang-compiler team for changes in the Microsoft-specific files.
-/microsoft/ @microsoft/golang-compiler
-
 # Require review from golang-compiler team for changes in any file. This keeps us in the loop on
-# auto-merge PRs. We may remove this rule once auto-merges are routine.
-* @microsoft/golang-compiler
+# auto-merge PRs. The review bot is also an owner so that it can still trigger auto-merge for sync
+# PRs on its own. We may remove this rule once auto-merges are routine.
+* @microsoft/golang-compiler @microsoft-golang-review-bot
+
+# Automatically request review from golang-compiler team for changes in the Microsoft-specific
+# files. This takes precedence over earlier rules in the file.
+/microsoft/ @microsoft/golang-compiler


### PR DESCRIPTION
`* @microsoft/golang-compiler @microsoft-golang-review-bot` should ping us whenever a new PR comes along (in case we want to check up on it), but also let the review bot enable auto-merge so we don't have to approve it ourselves.

Now that the list of approvers isn't the same for every file in the repo, precedence matters. Fixed it up based on https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners.