### PR TITLE
Use build.sh directly for "buildandpack" job

### DIFF
--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -92,10 +92,6 @@ func main() {
 
 	// After the build completes, run builder-specific commands.
 	switch config {
-	case "buildandpack":
-		// "buildandpack" runs the pack script to produce a Go tarball, not tests.
-		runOrPanic("eng/pack.sh")
-
 	case "devscript":
 		// "devscript" is specific to the Microsoft infrastructure. It means the builder should
 		// validate the dev-friendly "eng/build.sh" script works to build and test Go. It runs

--- a/eng/pipeline/jobs/run-linux-job.yml
+++ b/eng/pipeline/jobs/run-linux-job.yml
@@ -27,15 +27,31 @@ jobs:
       - script: eng/init-stage0.sh
         displayName: Init stage 0 Go toolset
 
-      - script: |
-          set -ex
+      # Use build script directly for "buildandpack". If we used run-builder, we would need to
+      # download its external module dependencies.
+      - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
+        - script: |
+            set -ex
 
-          eng/run-util.sh run-builder \
-            -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' \
-            -junitfile '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml'
-        displayName: Run ${{ parameters.builder.config }}
+            eng/build.sh --pack
+          displayName: Build and Pack
 
+        - publish: eng/artifacts/bin
+          artifact: Binaries ${{ parameters.builder.os }}_${{ parameters.builder.arch }}_${{ parameters.builder.config }}
+          displayName: Pipeline publish
+          condition: succeededOrFailed()
+
+      # Use run-builder for any configuration that includes tests. run-builder uses the "gotestsum"
+      # module to convert test results to a JUnit file that Azure DevOps can understand.
       - ${{ if ne(parameters.builder.config, 'buildandpack') }}:
+        - script: |
+            set -ex
+
+            eng/run-util.sh run-builder \
+              -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' \
+              -junitfile '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml'
+          displayName: Run ${{ parameters.builder.config }}
+
         - task: PublishTestResults@2
           displayName: Publish test results
           condition: succeededOrFailed()
@@ -46,9 +62,3 @@ jobs:
             buildPlatform: ${{ parameters.builder.arch }}
             buildConfiguration: ${{ parameters.builder.config }}
             publishRunAttachments: true
-
-      - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
-        - publish: eng/artifacts/bin
-          artifact: Binaries ${{ parameters.builder.os }}_${{ parameters.builder.arch }}_${{ parameters.builder.config }}
-          displayName: Pipeline publish
-          condition: succeededOrFailed()


### PR DESCRIPTION
Avoid an unnecessary dependency in the official build job by calling `microsoft/build.sh --pack` directly rather than passing the `buildandpack` builder configuration to `run-builder`.

Remove `buildandpack` handling from `run-builder` because the official build job was the only usage. Locally, there's no reason to type `microsoft/run-util.sh run-builder --builder linux-amd64-buildandpack` rather than `microsoft/build.sh --pack`.

Originally, `run-builder` ran `microsoft/build.sh` then `microsoft/pack.sh`. `microsoft/build.sh --pack` does the same sequence.