### PR TITLE
Fix init-stage0.sh: exit on error

### DIFF
--- a/microsoft/init-stage0.sh
+++ b/microsoft/init-stage0.sh
@@ -28,10 +28,10 @@ if [ ! -f "$download_complete_indicator" ]; then
 
   go_tarball="$stage0_dir/go.tar.gz"
 
-  curl -SL --output "$go_tarball" https://golang.org/dl/go${stage0_go_version}.linux-amd64.tar.gz \
-    && echo "$stage0_go_sha256  $go_tarball" | sha256sum -c - \
-    && tar -C "$stage0_dir" -xzf "$go_tarball" \
-    && rm "$go_tarball"
+  curl -SL --output "$go_tarball" https://golang.org/dl/go${stage0_go_version}.linux-amd64.tar.gz
+  echo "$stage0_go_sha256  $go_tarball" | sha256sum -c -
+  tar -C "$stage0_dir" -xzf "$go_tarball"
+  rm "$go_tarball"
 
   touch "$download_complete_indicator"
 

--- a/microsoft/workaround-install-mercurial.sh
+++ b/microsoft/workaround-install-mercurial.sh
@@ -17,8 +17,8 @@ fetch() {
   out=$1
   url=$2
   sum=$3
-  curl -SL --output "$out" "$url" \
-    && echo "$sum  $out" | sha256sum -c -
+  curl -SL --output "$out" "$url"
+  echo "$sum  $out" | sha256sum -c -
 }
 
 # Install mercurial to test Go integration.


### PR DESCRIPTION
I noticed a rolling build where `curl` failed while setting up stage 0, but the step succeeded anyway:

https://dev.azure.com/dnceng/internal/_build/results?buildId=1182013&view=logs&j=0dc5894a-280c-5daf-7974-626bf869c742&t=a448ff55-576e-5019-d913-0f00cfd70f20&l=25

```
...
 97  123M   97  120M    0     0  36.5M      0  0:00:03  0:00:03 --:--:-- 44.1M
curl: (18) transfer closed with 2912825 bytes remaining to read
Done extracting stage 0 Go compiler to '/home/vsts_azpcontainer/.go-stage-0/1.16'
Finishing: Init stage 0 Go toolset
```

(Filed https://github.com/microsoft/go/issues/97 to track the apparent network flakiness, which I'm not fixing here.)

This resulted in the build step failing. The "stage0 installed" indicator file was created even though the download failed, so the build script couldn't run `go`. Making the download URL invalid reproduces the issue locally. This also affects the checksum.

This is because the script uses `&&`:

```sh
curl -SL --output "$go_tarball" https://golang.org/dl/go${stage0_go_version}.linux-amd64.tar.gz \
  && echo "$stage0_go_sha256  $go_tarball" | sha256sum -c - \
  && tar -C "$stage0_dir" -xzf "$go_tarball" \
  && rm "$go_tarball"
```

* `set -e` doesn't apply because when `&&` is involved in a command, any failure is considered "caught". The exit code of the command *is* non-zero, but it's allowed.
* `set -o pipefail` doesn't apply because `|` makes a pipeline, not `&&`.

The reason this uses `&&` in the first place is that I took the download implementation from a Dockerfile. `&&` works in Dockerfiles because Docker just runs one command and checks its exit code. Dockerfiles don't have a way to write full scripts inline, so `&&` is a common idiom to string together multiple commands in that context.

To fix this, instead of `&&`, run each command in sequence. If any command fails, `set -e` terminates the script and returns the exit code.

---

I also removed the bad `&&` pattern from `microsoft/workaround-install-mercurial.sh`. It isn't causing a problem in this script, but it could become a problem if the pattern is copied somewhere else or if the script is slightly modified. The reason it doesn't show up there currently is that the command with `&&` is the last command in a function, so it sets the function's exit code, and `set -e` *does* terminate the script when the *function's* exit code is nonzero.