### PR TITLE
Change auto-merge title: "Merge" as first word

### DIFF
--- a/eng/_util/cmd/sync/sync.go
+++ b/eng/_util/cmd/sync/sync.go
@@ -421,7 +421,7 @@ func (b branch) createPRRequest(githubUser string) prRequest {
 		Head: githubUser + ":auto-merge/" + b.mergeTarget,
 		Base: b.mergeTarget,
 
-		Title: fmt.Sprintf("[`%v`] Merge upstream `%v`", b.mergeTarget, b.name),
+		Title: fmt.Sprintf("Merge upstream `%v` into `%v`", b.name, b.mergeTarget),
 		Body: fmt.Sprintf(
 			"🔃 This is an automatically generated PR merging upstream `%v` into `%v`.\n\n"+
 				"This PR should auto-merge itself when PR validation passes. If CI fails and you need to make fixups, be sure to use a merge commit, not a squash or rebase!\n\n"+


### PR DESCRIPTION
This allows a simple substring-based email subject filter on "[microsoft/go] Merge".

Fixes https://github.com/microsoft/go/issues/121

I'm not able to give it an easy end-to-end test right now because upstream `master` hasn't had any new commits since the last sync. It's a pretty trivial change, though.