### PR TITLE
Fix ssacheck builder: compile-only

### DIFF
--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -138,6 +138,11 @@ func main() {
 			)
 		}
 
+		// The ssacheck builder compiles the tests but doesn't run them.
+		if config == "ssacheck" {
+			cmdline = append(cmdline, "--compile-only")
+		}
+
 		runTest(cmdline, *jUnitFile)
 	}
 }


### PR DESCRIPTION
I ran into this test error while working on the 1.15 branch:

```
##### ../test
# go run run.go -- fixedbugs/issue30908.go
exit status 1
cmd/link: while reading object for 'a': duplicate symbol 'go.builtin.error.Error', previous def at 'os', with mismatched payload: same length but different contents

WARN invalid TestEvent: FAIL	fixedbugs/issue30908.go	0.738s
bad output from test2json: FAIL	fixedbugs/issue30908.go	0.738s
2021/07/15 19:08:40 Failed: exit status 1
```
https://dev.azure.com/dnceng/internal/_build/results?buildId=1240549&view=logs&j=6bf5b5b7-76a1-5507-dae2-ae2ac1851b51&t=86267f30-ffe0-59bb-dce9-8f41ff5229cf&l=583

Searching around, I found and issue that happened on the same file on Plan 9 that seems pretty similar, but I don't quite understand the fix enough to know how to apply it (and it that would break something else):
* https://github.com/golang/go/issues/31503

But, I didn't look into that too long--I noticed that our `ssacheck` builder is missing `--compile-only` vs. the upstream definition of the `ssacheck` builder. The builder is not even intended to run this test!
https://github.com/golang/build/blob/fa5c6e87e680b621066712172cd92426fb206416/dashboard/builders.go#L1713

Adding `--compile-only` into our builder fixes the build break on 1.15.

---

I haven't seen this problem (or anything that seems related) on `microsoft/main`, but the builder difference should be fixed everywhere. The difference is not intentional and I think it's possible it could cause a problem later.