### PR TITLE
Sync 1.15 and 1.16 release branches from upstream

### DIFF
--- a/eng/sync/sync-pipeline.yml
+++ b/eng/sync/sync-pipeline.yml
@@ -41,5 +41,8 @@ jobs:
             -to https://microsoft-golang-bot:$(BotAccount-microsoft-golang-bot-PAT)@github.com/microsoft-golang-bot/go `
             -github-pat $(BotAccount-microsoft-golang-bot-PAT) `
             -github-pat-reviewer $(BotAccount-microsoft-golang-review-bot-PAT) `
+            -b release-branch.go1.15 `
+            -b release-branch.go1.16 `
+            -b release-branch.go1.17 `
             -b master
         displayName: Sync


### PR DESCRIPTION
Enable sync for 1.15 and 1.16 release branches, now that we have infra in the associated `microsoft/` branch:
* https://github.com/microsoft/go/pull/135
* https://github.com/microsoft/go/pull/131

Also sync 1.17: fixes https://github.com/microsoft/go/issues/178. I seeded the 1.17 branch with the ["if `microsoft/main` is ahead"](https://github.com/microsoft/go/tree/microsoft/main/eng/doc/branches#if-microsoftmain-is-ahead) technique.

A dev build produced:
* https://github.com/microsoft/go/pull/185
* #184
* #183
* #182