### PR TITLE
Use SAS token to publish to public `dotnetbuildoutput`, not private `golangartifacts`

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -28,7 +28,9 @@ stages:
           # This is a utility job that doesn't use Go: use generic recent LTS for publishing.
           vmImage: ubuntu-20.04
         variables:
-          blobDestinationUrl: 'https://golangartifacts.blob.core.windows.net/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
+          - name: blobDestinationUrl
+            value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
+          - group: go-storage
         steps:
           - checkout: none
 
@@ -68,7 +70,7 @@ stages:
               # Send literal '*' to az: it handles the wildcard itself. Az copy only accepts one
               # "from" argument, so we can't use the shell's wildcard expansion.
               inlineScript: |
-                az storage copy -s '*' -d '$(blobDestinationUrl)'
+                az storage copy -s '*' -d '$(blobDestinationUrl)' --sas-token '$(dotnetbuildoutput-golang-write-sas-query)'
               workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
 
           - script: |


### PR DESCRIPTION
`golangartifacts` is a private storage account, but there's no good reason to keep the tar.gz/zip artifacts private: the Docker images end up published to MCR publicly. The authentication also makes Dockerfiles more complicated, and Docker builds more difficult to run.

Instead, use the existing `dotnetbuildoutput` account to simply make the artifacts public. Share this infrastructure with .NET.

This change uses an SAS token scoped to the `golang` container to be sure existing containers won't be touched.

I ran a test internal build here, which published: https://dev.azure.com/dnceng/internal/_build/results?buildId=1297005&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=137ae243-aea2-5f4b-07dd-c1ffa47f753f&l=12