### PR TITLE
[1.15] Publish artifacts using proper branch name into the `dotnetbuildoutput` account

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -28,7 +28,9 @@ stages:
           # This is a utility job that doesn't use Go: use generic recent LTS for publishing.
           vmImage: ubuntu-20.04
         variables:
-          blobDestinationUrl: 'https://golangartifacts.blob.core.windows.net/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
+          - name: blobDestinationUrl
+            value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
+          - group: go-storage
         steps:
           - checkout: none
 
@@ -68,7 +70,7 @@ stages:
               # Send literal '*' to az: it handles the wildcard itself. Az copy only accepts one
               # "from" argument, so we can't use the shell's wildcard expansion.
               inlineScript: |
-                az storage copy -s '*' -d '$(blobDestinationUrl)'
+                az storage copy -s '*' -d '$(blobDestinationUrl)' --sas-token '$(dotnetbuildoutput-golang-write-sas-query)'
               workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
 
           - script: |


### PR DESCRIPTION
Clean cherry-picks from `microsoft/main`. The `dotnetbuildoutput` change depends on the branch naming fix, so I cherry-picked both.

I ran an internal build on this branch here: https://dev.azure.com/dnceng/internal/_build/results?buildId=1298597&view=results (Different commit hash, but same changes.)