### PR TITLE
[1.17] Share public storage: use "dotnetbuildoutput"

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -28,7 +28,9 @@ stages:
           # This is a utility job that doesn't use Go: use generic recent LTS for publishing.
           vmImage: ubuntu-20.04
         variables:
-          blobDestinationUrl: 'https://golangartifacts.blob.core.windows.net/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
+          - name: blobDestinationUrl
+            value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
+          - group: go-storage
         steps:
           - checkout: none
 
@@ -68,7 +70,7 @@ stages:
               # Send literal '*' to az: it handles the wildcard itself. Az copy only accepts one
               # "from" argument, so we can't use the shell's wildcard expansion.
               inlineScript: |
-                az storage copy -s '*' -d '$(blobDestinationUrl)'
+                az storage copy -s '*' -d '$(blobDestinationUrl)' --sas-token '$(dotnetbuildoutput-golang-write-sas-query)'
               workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
 
           - script: |


### PR DESCRIPTION
(cherry picked from commit a22d254e42bd12756b728d5b056c940da911ca3f)  (#175)

The upstream 1.17 release branch was created before this commit was on `microsoft/main`, so we need to cherry-pick it. (I used the command listed in ["if `microsoft/main` is ahead"](https://github.com/microsoft/go/tree/microsoft/main/eng/doc/branches#if-microsoftmain-is-ahead) to find this commit, and to confirm that it's the only one we need to cherry-pick.)

Without this commit, we wouldn't be able to create a Docker image for 1.17 because the artifacts wouldn't be publicly accessible.