### PR TITLE
Add ACR cleanup pipeline

### DIFF
--- a/eng/pipeline/cleanup-acr-images.yml
+++ b/eng/pipeline/cleanup-acr-images.yml
@@ -1,0 +1,52 @@
+# This pipeline deletes old images from our ACR to free up space. This doesn't affect images that
+# have already been published to MCR.
+#
+# This pipeline is based on .NET Docker's cleanup pipeline:
+# https://github.com/dotnet/docker-tools/blob/main/eng/pipelines/cleanup-acr-images.yml
+
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 6 * * *"
+  displayName: Nightly build
+  branches:
+    include:
+    - main
+  always: true
+
+variables:
+- template: variables/common.yml
+
+jobs:
+- job: Build
+  pool:
+    vmImage: $(defaultLinuxAmd64PoolImage)
+  steps:
+  - template: ../common/templates/steps/init-docker-linux.yml
+  - template: steps/clean-acr-images.yml
+    parameters:
+      repo: "build-staging/*"
+      action: delete
+      # There is a reason to keep these around in some cases: you can trigger a build, wait, then
+      # trigger the publish an arbitrary amount of time later. This is useful to test a set of
+      # images before release day. Cleaning up the images would prevent the publish. This number
+      # needs to hit the right balance.
+      age: 9
+  - template: steps/clean-acr-images.yml
+    parameters:
+      repo: "public/oss/go/golang/nightly/*"
+      action: pruneDangling
+      age: 30
+  - template: steps/clean-acr-images.yml
+    parameters:
+      repo: "public/oss/go/golang/alpha/*"
+      action: pruneDangling
+      age: 30
+  # Disabled due to https://github.com/dotnet/docker-tools/issues/797
+  # - template: steps/clean-acr-images.yml
+  #   parameters:
+  #     repo: "mirror/*"
+  #     action: pruneDangling
+  #     age: 0
+  - template: ../common/templates/steps/cleanup-docker-linux.yml

--- a/eng/pipeline/steps/clean-acr-images.yml
+++ b/eng/pipeline/steps/clean-acr-images.yml
@@ -1,0 +1,21 @@
+# Copied from https://github.com/dotnet/docker-tools/blob/1ff076fcba565b85b6105eaa366d3684652e82a6/eng/pipelines/templates/steps/clean-acr-images.yml
+# Filed https://github.com/dotnet/docker-tools/issues/849 to track moving it to eng/common to share.
+parameters:
+  repo: null
+  action: null
+  age: null
+  customArgs: ""
+steps:
+  - script: >
+      $(runImageBuilderCmd) cleanAcrImages
+      ${{ parameters.repo }}
+      $(acr.servicePrincipalName)
+      $(app-dotnetdockerbuild-client-secret)
+      $(acr.servicePrincipalTenant)
+      $(acr.subscription)
+      $(acr.resourceGroup)
+      $(acr.server)
+      --action ${{ parameters.action }}
+      --age ${{ parameters.age }}
+      ${{ parameters.customArgs }}
+    displayName: Clean ACR Images - ${{ parameters.repo }}


### PR DESCRIPTION
Fixes #156 

Our ACR was up to 50% full, then I ran this cleanup (https://dev.azure.com/dnceng/internal/_build/results?buildId=1305464&view=results) and we're down to 37%.

Cleanup is age-based, so we'll also need approx build frequency to figure out how much cleanup we actually need to stay within capacity. We'll have to tweak this, and may end up needing a more expensive ACR anyway to have practical lifetimes.

This also gets a little more complicated because we also mirror our base images onto the MCR, and don't have a way to clean those up yet. (https://github.com/dotnet/docker-tools/issues/797)