### PR TITLE
[1.17] Share public storage: use "dotnetbuildoutput" (#175)

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -28,7 +28,9 @@ stages:
           # This is a utility job that doesn't use Go: use generic recent LTS for publishing.
           vmImage: ubuntu-20.04
         variables:
-          blobDestinationUrl: 'https://golangartifacts.blob.core.windows.net/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
+          - name: blobDestinationUrl
+            value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
+          - group: go-storage
         steps:
           - checkout: none
 
@@ -68,7 +70,7 @@ stages:
               # Send literal '*' to az: it handles the wildcard itself. Az copy only accepts one
               # "from" argument, so we can't use the shell's wildcard expansion.
               inlineScript: |
-                az storage copy -s '*' -d '$(blobDestinationUrl)'
+                az storage copy -s '*' -d '$(blobDestinationUrl)' --sas-token '$(dotnetbuildoutput-golang-write-sas-query)'
               workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
 
           - script: |


### PR DESCRIPTION
(cherry picked from commit a22d254e42bd12756b728d5b056c940da911ca3f)  (#175)

I submitted this PR before, but to the wrong base branch (main): https://github.com/microsoft/go/pull/186. Resubmitting to the right branch to get 1.17 builds on public storage.