### PR TITLE
Add auto-update infrastructure

### DIFF
--- a/eng/.gitignore
+++ b/eng/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/eng/_util/README.md
+++ b/eng/_util/README.md
@@ -1,0 +1,12 @@
+## `github.com/microsoft/go/_util`
+
+This module is a set of utilities Microsoft uses to maintain this repository.
+Run `eng/run.ps1` to list the available commands and see instructions on how to
+use them.
+
+The `_` prefix is not required for this repository, but in the microsoft/go
+repository, it is required in `_util` so `cmd/internal/moddeps/moddeps_test.go`
+ignores it. See
+[eng/_util/README.md](https://github.com/microsoft/go/eng/_util/) for more
+information. We use a `_` in microsoft/go-docker as well so the `eng/run.ps1`
+script (which assumes a `_` prefix) can be reused without any modification.

--- a/eng/_util/buildmodel/buildmodel.go
+++ b/eng/_util/buildmodel/buildmodel.go
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package buildmodel
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// GenerateManifest takes a 'versions.json' model and generates a 'manifest.json' model that would
+// build and tag all versions specified. Slices in the generated model are sorted for diff
+// stability. Map stability is handled by the Go JSON library when the model is serialized.
+func GenerateManifest(versions VersionsJSON) Manifest {
+	sortedMajorMinorKeys := make([]string, 0, len(versions))
+	for key := range versions {
+		sortedMajorMinorKeys = append(sortedMajorMinorKeys, key)
+	}
+	sort.Strings(sortedMajorMinorKeys)
+
+	var images []*Image
+
+	for _, majorMinor := range sortedMajorMinorKeys {
+		v := versions[majorMinor]
+
+		// The key is always a major.minor version. Split out the major part.
+		major, _, _, _ := parseVersion(majorMinor)
+
+		for _, variant := range v.Variants {
+			os := "linux"
+			osVersion := variant
+			if strings.HasPrefix(variant, "windows/") {
+				os = "windows"
+				osVersion = strings.TrimPrefix(variant, "windows/")
+			}
+
+			// If the versions.json doesn't specify a revision, default to "1". (1 is the
+			// default/initial revision for Deb/RPM packages, and we may as well follow that.)
+			if v.Revision == "" {
+				v.Revision = "1"
+			}
+
+			// The main tag that is shared by all architectures.
+			mainSharedTag := v.Version + "-" + v.Revision + "-" + osVersion
+
+			sharedTags := map[string]Tag{
+				mainSharedTag: {},
+				// Revisionless tag.
+				v.Version + "-" + osVersion: {},
+				// We only maintain one patch version, so it's always preferred. Add major.minor tag.
+				majorMinor + "-" + osVersion: {},
+			}
+
+			// If this is a preferred major.minor version, create major-only tag.
+			if v.PreferredMinor {
+				sharedTags[major+"-"+osVersion] = Tag{}
+			}
+			// If this is the preferred major version, create versionless tag.
+			if v.PreferredMajor {
+				sharedTags[osVersion] = Tag{}
+			}
+
+			// If this is the preferred variant, create tags without the variant (OS) part.
+			if v.PreferredVariant == variant {
+				sharedTags[v.Version+"-"+v.Revision] = Tag{}
+				sharedTags[v.Version] = Tag{}
+				sharedTags[majorMinor] = Tag{}
+
+				if v.PreferredMinor {
+					sharedTags[major] = Tag{}
+				}
+				if v.PreferredMajor {
+					sharedTags["latest"] = Tag{}
+				}
+			}
+
+			var buildArgs map[string]string
+			// The nanoserver Dockerfile requires some args so it can be connected properly to its
+			// dependency, windowsservercore.
+			if strings.Contains(osVersion, "nanoserver") {
+				buildArgs = map[string]string{
+					// nanoserver doesn't have good download capability, so it copies the Go install
+					// from the windowsservercore image.
+					"DOWNLOADER_TAG": v.Version + "-" + v.Revision + "-windowsservercore-1809-amd64",
+					// The nanoserver Dockerfile needs to know what repository we're building for so
+					// it can figure out the windowsservercore tag's full name.
+					"REPO": "$(Repo:golang)",
+				}
+			}
+
+			images = append(images, &Image{
+				ProductVersion: majorMinor,
+				SharedTags:     sharedTags,
+				Platforms: []*Platform{
+					{
+						Dockerfile: "src/microsoft/" + majorMinor + "/" + variant,
+						OS:         os,
+						OSVersion:  osVersion,
+
+						BuildArgs: buildArgs,
+
+						Tags: map[string]Tag{
+							// We only build amd64 at the moment. The way to implement other
+							// architectures in the future is to add more Platform entries.
+							mainSharedTag + "-amd64": {},
+						},
+					},
+				},
+			})
+		}
+	}
+
+	return Manifest{
+		Readme:    "README.md",
+		Registry:  "mcr.microsoft.com",
+		Variables: map[string]interface{}{},
+		Includes:  []string{},
+		Repos: []*Repo{
+			{
+				ID:     "golang",
+				Name:   "oss/go/golang/alpha",
+				Images: images,
+			},
+		},
+	}
+}
+
+// NoMajorMinorUpgradeMatchError indicates that while running UpdateVersions, the input assets file
+// didn't match any major.minor versions and no update could be performed.
+var NoMajorMinorUpgradeMatchError = errors.New("no match found in existing versions.json file")
+
+// UpdateVersions takes a build asset file containing a list of build outputs and updates a
+// versions.json model to consume the new build.
+func UpdateVersions(assets *BuildAssets, versions VersionsJSON) error {
+	major, minor, patch, revision := parseVersion(assets.Version)
+
+	key := major + "." + minor
+	if v, ok := versions[key]; ok {
+		v.Version = major + "." + minor + "." + patch
+		v.Revision = revision
+		// Look through the asset arches, find an arch in the versions file that matches each asset,
+		// and update its info.
+		for _, arch := range assets.Arches {
+			// The versions file has a map of "GOOS-GOARCH" keys, but the key omits "linux-" if
+			// included. This is upstream behavior we are conforming to.
+			archKey := arch.Env.GOOS + "-"
+			if archKey == "linux-" {
+				archKey = ""
+			}
+			archKey += arch.Env.GOARCH
+
+			if match, ok := v.Arches[archKey]; ok {
+				// Copy over the previous value of keys that aren't specific to an asset, but
+				// actually indicate the state of the Dockerfile. All other values come from the new
+				// asset's data.
+				arch.Supported = match.Supported
+			}
+			// Copy the asset data into the versions file whether it's a new arch or not.
+			v.Arches[archKey] = arch
+		}
+	} else {
+		return fmt.Errorf("%v: %w", key, NoMajorMinorUpgradeMatchError)
+	}
+	return nil
+}
+
+// parseVersion parses a "major.minor.patch-revision" version string into each part. If a part
+// doesn't exist, it defaults to "0".
+func parseVersion(v string) (string, string, string, string) {
+	dashParts := strings.Split(v, "-")
+	majorMinorPatch := dashParts[0]
+	revision := "0"
+	if len(dashParts) > 1 {
+		revision = dashParts[1]
+	}
+
+	dotParts := strings.Split(majorMinorPatch, ".")
+	major := dotParts[0]
+	minor := "0"
+	if len(dotParts) > 1 {
+		minor = dotParts[1]
+	}
+	patch := "0"
+	if len(dotParts) > 2 {
+		patch = dotParts[2]
+	}
+
+	return major, minor, patch, revision
+}

--- a/eng/_util/buildmodel/buildmodel_test.go
+++ b/eng/_util/buildmodel/buildmodel_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package buildmodel
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestBuildAssets_UpdateVersions(t *testing.T) {
+	newArch := &Arch{
+		Env: ArchEnv{
+			GOARCH: "amd64",
+			GOOS:   "linux",
+		},
+		SHA256: "abcdef123",
+		URL:    "example.org",
+	}
+	a := &BuildAssets{
+		Version: "1.42",
+		Arches:  []*Arch{newArch},
+	}
+
+	t.Run("Update existing", func(t *testing.T) {
+		v := VersionsJSON{
+			"1.42": {
+				Version:  "1.42",
+				Revision: "",
+				Arches: map[string]*Arch{
+					"amd64": {
+						Env:       ArchEnv{},
+						SHA256:    "old-sha",
+						URL:       "old-url",
+						Supported: true,
+					},
+				},
+			},
+		}
+		if err := UpdateVersions(a, v); err != nil {
+			t.Fatal(err)
+		}
+
+		gotArch := v["1.42"].Arches["amd64"]
+		if gotArch.URL != newArch.URL || gotArch.SHA256 != newArch.SHA256 {
+			t.Errorf("Old arch was not replaced by new arch.")
+		}
+		if gotArch.Supported != true {
+			t.Errorf("Supported flag not correctly copied from old arch to new arch.")
+		}
+	})
+
+	t.Run("Reject mismatched major.minor", func(t *testing.T) {
+		v := VersionsJSON{
+			// This is not 1.42, so update should fail to find a match.
+			"1.48": {
+				Version:  "1.48.15",
+				Revision: "5",
+				Arches:   nil,
+			},
+		}
+		err := UpdateVersions(a, v)
+		if !errors.Is(err, NoMajorMinorUpgradeMatchError) {
+			t.Fatalf("Failed to reject the update with expected error result.")
+		}
+	})
+}
+
+func TestBuildAssets_parseVersion(t *testing.T) {
+	tests := []struct {
+		name                          string
+		version                       string
+		major, minor, patch, revision string
+	}{
+		{
+			"Full version",
+			"1.2.3-4",
+			"1", "2", "3", "4",
+		},
+		{
+			"Major only",
+			"1",
+			"1", "0", "0", "0",
+		},
+		{
+			"Major.minor",
+			"1.42",
+			"1", "42", "0", "0",
+		},
+		{
+			"Major.minor-revision",
+			"1.42-6",
+			"1", "42", "0", "6",
+		},
+		{
+			"Too many dotted parts",
+			"1.2.3.4.5.6",
+			"1", "2", "3", "0",
+		},
+		{
+			"Too many dashed parts",
+			"1-2-3-4",
+			"1", "0", "0", "2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMajor, gotMinor, gotPatch, gotRevision := parseVersion(tt.version)
+			if gotMajor != tt.major {
+				t.Errorf("parseVersion() gotMajor = %v, major %v", gotMajor, tt.major)
+			}
+			if gotMinor != tt.minor {
+				t.Errorf("parseVersion() gotMinor = %v, minor %v", gotMinor, tt.minor)
+			}
+			if gotPatch != tt.patch {
+				t.Errorf("parseVersion() gotPatch = %v, patch %v", gotPatch, tt.patch)
+			}
+			if gotRevision != tt.revision {
+				t.Errorf("parseVersion() gotRevision = %v, revision %v", gotRevision, tt.revision)
+			}
+		})
+	}
+}

--- a/eng/_util/buildmodel/commands.go
+++ b/eng/_util/buildmodel/commands.go
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package buildmodel
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/microsoft/go-docker/eng/_util/gitpr"
+)
+
+// ParseBoundFlags parses all flags that have been registered with the flag package. This function
+// handles '-help' and validates no unhandled args were passed, so may exit rather than returning.
+func ParseBoundFlags(name, description string) {
+	var help = flag.Bool("h", false, "Print this help message.")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "\nUsage of '%s' utility:\n", name)
+		flag.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n\n", description)
+	}
+
+	flag.Parse()
+
+	if len(flag.Args()) > 0 {
+		fmt.Printf("Non-flag argument(s) provided but not accepted: %v\n", flag.Args())
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if *help {
+		flag.Usage()
+		// We're exiting early, successfully. All we were asked to do is print usage info.
+		os.Exit(0)
+	}
+}
+
+// UpdateFlags is a list of flags used for an update command.
+type UpdateFlags struct {
+	manifest        *string
+	skipDockerfiles *bool
+}
+
+// CreateBoundUpdateFlags creates UpdateFlags with the 'flag' package, registering them for
+// ParseBoundFlags.
+func CreateBoundUpdateFlags() *UpdateFlags {
+	return &UpdateFlags{
+		manifest: flag.String("manifest", "", "The build asset manifest describing the Go build to update to."),
+
+		skipDockerfiles: flag.Bool("skip-dockerfiles", false, "If set, don't touch Dockerfiles.\nUpdating Dockerfiles requires bash/awk/jq, so when developing on Windows, skipping may be useful."),
+	}
+}
+
+// RunUpdateHere executes RunUpdate, passing the current working directory as the Go Docker
+// repository root. This allows devs to easily test out auto-update code locally.
+func RunUpdateHere(f *UpdateFlags) error {
+	return RunUpdate(getwd(), f)
+}
+
+// RunUpdate runs an auto-update process in the given Go Docker repository using the given update
+// options. It finds the 'versions.json' and 'manifest.json' files, updates them appropriately, and
+// optionally regenerates the Dockerfiles.
+func RunUpdate(repoRoot string, f *UpdateFlags) error {
+	var versionsJsonPath = filepath.Join(repoRoot, "src", "microsoft", "versions.json")
+	var manifestJsonPath = filepath.Join(repoRoot, "manifest.json")
+
+	var dockerfileUpdateScript = filepath.Join(repoRoot, "eng", "update-dockerfiles.sh")
+
+	if !*f.skipDockerfiles {
+		missingTools := false
+		for _, requiredCmd := range []string{"bash", "jq", "awk"} {
+			if _, err := exec.LookPath(requiredCmd); err != nil {
+				fmt.Printf("Unable to find '%s' in PATH. It is required to run 'eng/update-dockerfiles.sh'.\n", requiredCmd)
+				fmt.Printf("Error: %s\n", err)
+				missingTools = true
+			}
+		}
+		if missingTools {
+			return fmt.Errorf("missing required tools to generate Dockerfiles. Make sure the tools are in PATH and try again, or pass '-skip-dockerfiles' to the command")
+		}
+	}
+
+	versions := VersionsJSON{}
+	if err := ReadJSONFile(versionsJsonPath, &versions); err != nil {
+		return err
+	}
+
+	if *f.manifest != "" {
+		assets := &BuildAssets{}
+		if err := ReadJSONFile(*f.manifest, &assets); err != nil {
+			return err
+		}
+		if err := UpdateVersions(assets, versions); err != nil {
+			return err
+		}
+		if err := WriteJSONFile(versionsJsonPath, &versions); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Generating '%v' based on '%v'...\n", manifestJsonPath, versionsJsonPath)
+
+	manifest := GenerateManifest(versions)
+	if err := WriteJSONFile(manifestJsonPath, &manifest); err != nil {
+		return err
+	}
+
+	if !*f.skipDockerfiles {
+		fmt.Println("Generating Dockerfiles...")
+		if err := run(exec.Command("bash", dockerfileUpdateScript)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PRFlags is a list of flags used to submit a PR. It should normally be set up at the same time as
+// UpdateFlags, to update the repo and then submit a PR.
+type PRFlags struct {
+	dryRun     *bool
+	tempGitDir *string
+	branch     *string
+
+	origin *string
+	to     *string
+
+	githubPAT         *string
+	githubPATReviewer *string
+}
+
+// CreateBoundPRFlags creates PRFlags with the 'flag' package, registering them for ParseBoundFlags.
+func CreateBoundPRFlags() *PRFlags {
+	var artifactsDir = filepath.Join(getwd(), "eng", "artifacts")
+	return &PRFlags{
+		dryRun:     flag.Bool("n", false, "Enable dry run: do not push, do not submit PR."),
+		tempGitDir: flag.String("temp-git-dir", filepath.Join(artifactsDir, "sync-upstream-temp-repo"), "Location to create the temporary Git repo. Must not exist."),
+		branch:     flag.String("branch", "", "Branch to submit PR into. Required, if origin is provided."),
+
+		origin: flag.String("origin", "", "Submit PR to this repo. \n[Need fetch Git permission.]"),
+		to:     flag.String("to", "", "Push PR branch to this Git repository. Defaults to the same repo as 'origin' if not set.\n[Need push Git permission.]"),
+
+		githubPAT:         flag.String("github-pat", "", "Submit the PR with this GitHub PAT, if specified."),
+		githubPATReviewer: flag.String("github-pat-reviewer", "", "Approve the PR and turn on auto-merge with this PAT, if specified. Required, if github-pat specified."),
+	}
+}
+
+// SubmitUpdatePR runs an auto-update in a temp Git repo. If GitHub credentials are provided,
+// submits the resulting commit as a GitHub PR, approves with a second account, and enables the
+// GitHub auto-merge feature.
+func SubmitUpdatePR(uf *UpdateFlags, pf *PRFlags) error {
+	if _, err := os.Stat(*pf.tempGitDir); !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("temporary Git dir already exists: %v", *pf.tempGitDir)
+	}
+
+	if *pf.origin == "" {
+		fmt.Println("Origin not specified. Continuing to update files in temporary Git dir, but will not submit PR.")
+	} else {
+		if *pf.branch == "" {
+			return fmt.Errorf("origin is specified, but no base branch is specified")
+		}
+	}
+
+	if *pf.to == "" {
+		pf.to = pf.origin
+	}
+
+	b := gitpr.PRBranch{
+		Name:    *pf.branch,
+		Purpose: "auto-update",
+	}
+	// Clone from the local repo into the fresh clone to initialize it with all the Git data we
+	// already have. This avoids downloading everything from scratch when we fetch origin. Most of
+	// the time, we're running in infrastructure, and the local clone is fresh, so this is
+	// worthwhile. (Git is also smart enough to use symlinks for a local->local clone, when
+	// possible.)
+	runOrPanic(exec.Command("git", "clone", getwd(), *pf.tempGitDir))
+
+	// runGitOrPanic runs "git {args}" in the temp git dir, and panics on failure.
+	runGitOrPanic := func(args ...string) {
+		c := exec.Command("git", args...)
+		c.Dir = *pf.tempGitDir
+		runOrPanic(c)
+	}
+
+	// If the caller gave an origin, fetch the base branch. Otherwise, keep what the "git clone"
+	// gave us (the last commit of the current checked-out branch) and make an update on top.
+	if *pf.origin != "" {
+		// Fetch the base branch into the PR branch ref and check out the ref.
+		runGitOrPanic("fetch", "--no-tags", *pf.origin, b.BaseBranchFetchRefspec())
+		runGitOrPanic("checkout", b.PRBranch())
+	}
+
+	// Make changes to the files ins the temp repo.
+	if err := RunUpdate(*pf.tempGitDir, uf); err != nil {
+		return err
+	}
+
+	runGitOrPanic("commit", "-a", "-m", "Update dependencies in "+b.Name)
+
+	if *pf.origin != "" {
+		// Force push the update commit, to make sure the update branch is fresh. The branch might
+		// hold an old update with bad changes that was rejected or caused PR validation to fail.
+		// This isn't necessarily ideal, and may change. https://github.com/microsoft/go/issues/68
+		args := []string{"push", "--force", *pf.origin, b.PRPushRefspec()}
+		if *pf.dryRun {
+			// Show what would be pushed, but don't actually push it.
+			args = append(args, "-n")
+		}
+		runGitOrPanic(args...)
+	}
+
+	// Find reasons to skip all the PR submission code. The caller might intentionally be in one of
+	// these cases, so it's not necessarily an error. For example, they can take the commit we
+	// generated and submit their own PR later.
+	skipReason := ""
+	switch {
+	case *pf.dryRun:
+		skipReason = "Dry run"
+	case *pf.origin == "":
+		skipReason = "No origin specified"
+	case *pf.githubPAT == "":
+		skipReason = "github-pat not provided"
+	case *pf.githubPATReviewer == "":
+		skipReason = "github-pat-reviewer not provided"
+	}
+	if skipReason != "" {
+		fmt.Printf("---- %s: skipping submitting PR for %v\n", skipReason, b.Name)
+		return nil
+	}
+
+	githubUser := gitpr.GetUsername(*pf.githubPAT)
+	fmt.Printf("---- User for github-pat is: %v\n", githubUser)
+
+	parsedOrigin, err := gitpr.ParseRemoteURL(*pf.origin)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("---- PR for %v: Submitting...\n", b.Name)
+
+	// POST the PR. The call returns success if the PR is created or if we receive a specific error
+	// message back from GitHub saying the PR is already created.
+	p, err := gitpr.PostGitHub(parsedOrigin.GetOwnerSlashRepo(), b.CreateGitHubPR(githubUser), *pf.githubPAT)
+	fmt.Printf("%+v\n", p)
+
+	if err != nil {
+		return err
+	}
+
+	if p.AlreadyExists {
+		fmt.Println("---- A PR already exists. Attempting to find it...")
+		p.NodeID, err = gitpr.FindExistingPR(&b, githubUser, parsedOrigin.GetOwner(), *pf.githubPAT)
+		if err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("---- Submitted brand new PR: %v\n", p.HTMLURL)
+
+		fmt.Printf("---- Approving with reviewer account...\n")
+		err = gitpr.MutateGraphQL(
+			*pf.githubPATReviewer,
+			`mutation {
+						addPullRequestReview(input: {pullRequestId: "`+p.NodeID+`", event: APPROVE, body: "Thanks! Auto-approving."}) {
+							clientMutationId
+						}
+					}`)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("---- Enabling auto-merge with reviewer account...\n")
+	err = gitpr.MutateGraphQL(
+		*pf.githubPATReviewer,
+		`mutation {
+					enablePullRequestAutoMerge(input: {pullRequestId: "`+p.NodeID+`", mergeMethod: MERGE}) {
+						clientMutationId
+					}
+				}`)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("---- PR for %v: Done.\n", b.Name)
+
+	return nil
+}
+
+// getwd gets the current working dir or panics, for easy use in expressions.
+func getwd() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	return wd
+}
+
+// runOrPanic uses 'run', then panics on error (such as nonzero exit code).
+func runOrPanic(c *exec.Cmd) {
+	if err := run(c); err != nil {
+		panic(err)
+	}
+}
+
+// run sets up the command so it logs directly to our stdout/stderr streams, then runs it.
+func run(c *exec.Cmd) error {
+	fmt.Printf("---- Running command: %v %v\n", c.Path, c.Args)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}

--- a/eng/_util/buildmodel/json.go
+++ b/eng/_util/buildmodel/json.go
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package buildmodel
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// This file contains JSON read/write utils and JSON models used for Go Docker build/auto-update.
+
+// ReadJSONFile reads one JSON value from the specified file.
+func ReadJSONFile(path string, i interface{}) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	d := json.NewDecoder(f)
+	if err := d.Decode(i); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteJSONFile writes the specified value to a file as indented JSON with a trailing newline.
+func WriteJSONFile(path string, i interface{}) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	d := json.NewEncoder(f)
+	d.SetIndent("", "  ")
+	if err := d.Encode(i); err != nil {
+		return err
+	}
+	return nil
+}
+
+// --- src/microsoft/versions.json
+
+// VersionsJSON is the root of a 'versions.json' file. It maps a 'major.minor' key to the details of
+// that version.
+//
+// Note: this type is an alias of a map, so it's essentially a pointer. Use VersionsJSON, not
+// *VersionsJSON. The 'versions.json' file is also used by upstream infrastructure, so this model is
+// designed to be compatible with it.
+type VersionsJSON map[string]*MajorMinorVersion
+
+// MajorMinorVersion contains information about a major.minor version.
+type MajorMinorVersion struct {
+	// Arches is the list of architectures that should be built.
+	Arches map[string]*Arch `json:"arches"`
+	// Variants lists OS variants that should be built. It must be provided in dependency order.
+	Variants []string `json:"variants"`
+	// Version is the current major.minor.patch version of this major.minor version.
+	Version string `json:"version"`
+
+	// Revision extends the upstream model by adding the Microsoft revision of the Go version. The
+	// Microsoft build might get new versions that aren't associated with an upstream version bump.
+	Revision string `json:"revision"`
+
+	// PreferredMajor extends the upstream model by marking this major version as "preferred" over
+	// other major versions. This is used when generating the manifest to create the "latest" tags.
+	PreferredMajor bool `json:"preferredMajor,omitempty"`
+	// PreferredMinor extends the upstream model by marking this minor version as "preferred" over
+	// other minor versions. For example, if "1.42" is preferred, this would generate a "1" tag in
+	// the manifest that people can use to pull "1.42" rather than "1.41".
+	PreferredMinor bool `json:"preferredMinor,omitempty"`
+	// PreferredVariant extends the upstream model and specifies the variant that should be
+	// "preferred" in the tagging structure. For example, if buster is preferred over stretch, the
+	// generated "1.16.6" tag will point at a buster image.
+	PreferredVariant string `json:"preferredVariant,omitempty"`
+}
+
+// Arch points at the publicly accessible artifacts for a specific OS/arch.
+type Arch struct {
+	Env       ArchEnv `json:"env"`
+	SHA256    string  `json:"sha256"`
+	Supported bool    `json:"supported,omitempty"`
+	URL       string  `json:"url"`
+}
+
+type ArchEnv struct {
+	GOARCH string
+	GOOS   string
+}
+
+// --- manifest.json
+
+// Manifest is the root of a 'manifest.json' file. This implementation in Go only contains the
+// subset of syntax that we actually use in the Go Docker repository.
+//
+// For more details about this model, see the dotnet/docker-tools C# implementation:
+// https://github.com/dotnet/docker-tools/blob/main/src/Microsoft.DotNet.ImageBuilder/src/Models/Manifest/Manifest.cs
+type Manifest struct {
+	Readme    string                 `json:"readme"`
+	Registry  string                 `json:"registry"`
+	Variables map[string]interface{} `json:"variables"`
+	Includes  []string               `json:"includes"`
+	Repos     []*Repo                `json:"repos"`
+}
+
+// Repo is a Docker repository: the 'oss/go/microsoft/golang' part of a tag name.
+type Repo struct {
+	ID     string   `json:"id"`
+	Name   string   `json:"name"`
+	Images []*Image `json:"images"`
+}
+
+// Image represents the build for a given version of Go. It contains the set of tags for this
+// version, which may include multiple images for various OS/architectures.
+type Image struct {
+	ProductVersion string         `json:"productVersion"`
+	SharedTags     map[string]Tag `json:"sharedTags"`
+	Platforms      []*Platform    `json:"platforms"`
+}
+
+// Platform is one OS+arch combination, and it maps to a specific Dockerfile in the Git repo.
+type Platform struct {
+	BuildArgs map[string]string `json:"buildArgs,omitempty"`
+
+	Dockerfile string `json:"dockerfile"`
+	OS         string `json:"os"`
+	OSVersion  string `json:"osVersion"`
+	// Tags is a map of tag names to Tag metadata.
+	Tags map[string]Tag `json:"tags"`
+}
+
+// Tag is the metadata about a tag. Intentionally empty: we don't use any metadata yet.
+type Tag struct{}
+
+// --- assets.json
+
+// BuildAssets is the root of a file that describes the output of a Go build. We use this file to
+// update to that build. This file's structure is controlled by our team, so we can choose to reuse
+// parts of other files' schema to keep it simple.
+type BuildAssets struct {
+	// Branch that produced this build. This is not used for auto-update.
+	Branch string `json:"branch"`
+	// BuildID is a link to the build that produced these assets. It is not used for auto-update.
+	BuildID string `json:"buildId"`
+
+	// Version of the build, as 'major.minor.patch-revision'.
+	Version string `json:"version"`
+	// Arches is the list of artifacts that was produced for this version, typically one per target
+	// os/architecture. The name "Arches" is shared with the versions.json format.
+	Arches []*Arch `json:"arches"`
+}

--- a/eng/_util/cmd/build/build.go
+++ b/eng/_util/cmd/build/build.go
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	// The caller may have run 'eng/run.ps1 build' by mistake. They might not realize the
+	// microsoft/go and microsoft/go-docker infrastructure works differently. Print a message to
+	// make it obvious what they need to do next to get a build going.
+	fmt.Println("----------")
+	fmt.Println("'eng/run.ps1' is for utilities, not for building the Docker images: the build process isn't implemented in Go.")
+	fmt.Println("Use 'eng/build.ps1' instead.")
+}

--- a/eng/_util/cmd/update/update.go
+++ b/eng/_util/cmd/update/update.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/microsoft/go-docker/eng/_util/buildmodel"
+)
+
+const description = `
+Example: Update the files in the repo based on a build output manifest:
+
+  pwsh eng/run.ps1 update -manifest /home/me/downloads/assets.json
+
+This command updates the checked-in files in this repository to make the repo
+build Docker images that contain a new build of Go.
+
+The 'src/microsoft/versions.json' file is the single source of truth for the
+version of Go included in the Go Docker images. This command will optionally
+update the versions.json file, then it regenerates other files like
+'manifest.json' and the Dockerfiles to conform.`
+
+func main() {
+	f := buildmodel.CreateBoundUpdateFlags()
+
+	buildmodel.ParseBoundFlags("update", description)
+
+	if err := buildmodel.RunUpdateHere(f); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("\nSuccess.")
+}

--- a/eng/_util/cmd/updatepr/updatepr.go
+++ b/eng/_util/cmd/updatepr/updatepr.go
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/microsoft/go-docker/eng/_util/buildmodel"
+)
+
+const description = `
+Example: Create a temporary repo and create a commit that updates the repo to use the build listed
+in the asset manifest:
+
+  pwsh eng/run.ps1 updatepr -manifest /home/me/downloads/assets.json
+
+This command runs the 'update' command, then submits a PR on GitHub to the target repository.
+
+It may be useful to specify Git addresses like 'git@github.com:microsoft/go' to
+use SSH authentication.
+
+This script creates a temporary copy of the repository in 'eng/artifacts/' by
+default. This avoids trampling changes in the user's clone.`
+
+func main() {
+	uf := buildmodel.CreateBoundUpdateFlags()
+	pf := buildmodel.CreateBoundPRFlags()
+
+	buildmodel.ParseBoundFlags("updatepr", description)
+
+	if err := buildmodel.SubmitUpdatePR(uf, pf); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("\nSuccess.")
+}

--- a/eng/_util/gitpr/gitpr.go
+++ b/eng/_util/gitpr/gitpr.go
@@ -1,0 +1,346 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gitpr
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var client = http.Client{
+	Timeout: time.Second * 30,
+}
+
+// PRBranch contains information about the specific branch to update. During the sync process,
+// more info can be added to this struct to be used later. This struct has methods that help
+// calculate derived information such as Git ref names.
+type PRBranch struct {
+	// Name of the branch to update, without "refs/heads/".
+	Name string
+	// Purpose of the PR. This is used to generate the PR branch name, "dev/{Purpose}/{Name}".
+	Purpose string
+}
+
+func (b PRBranch) PRBranch() string {
+	return "dev/" + b.Purpose + "/" + b.Name
+}
+
+func (b PRBranch) BaseBranchFetchRefspec() string {
+	return "refs/heads/" + b.Name + ":refs/heads/" + b.PRBranch()
+}
+
+func (b PRBranch) PRBranchFetchRefspec() string {
+	return "refs/heads/" + b.PRBranch() + ":refs/heads/" + b.PRBranch()
+}
+
+func (b PRBranch) PRPushRefspec() string {
+	return b.PRBranch() + ":refs/heads/" + b.PRBranch()
+}
+
+// CreateGitHubPR creates the data model that can be sent to GitHub to create a PR for this branch.
+func (b PRBranch) CreateGitHubPR(githubUser string) GitHubRequest {
+	return GitHubRequest{
+		Head: githubUser + ":" + b.PRBranch(),
+		Base: b.Name,
+
+		Title: fmt.Sprintf("Update dependencies in `%v`", b.Name),
+		Body: fmt.Sprintf(
+			"🔃 This is an automatically generated PR updating the version of Go in `%v`.\n\n"+
+				"This PR should auto-merge itself when PR validation passes.\n\n",
+			b.Name,
+		),
+
+		MaintainerCanModify: true,
+		Draft:               false,
+	}
+}
+
+// Remote is a parsed version of a Git Remote. It helps determine how to send a GitHub PR.
+type Remote struct {
+	url      string
+	urlParts []string
+}
+
+// ParseRemoteURL takes the URL ("https://github.com/microsoft/go", "git@github.com:microsoft/go")
+// and grabs the owner ("microsoft") and repository name ("go"). This assumes the URL follows one of
+// these two patterns, or something that's compatible. Returns an initialized 'Remote'.
+func ParseRemoteURL(url string) (*Remote, error) {
+	r := &Remote{
+		url,
+		strings.FieldsFunc(url, func(r rune) bool { return r == '/' || r == ':' }),
+	}
+	if len(r.urlParts) < 3 {
+		return r, fmt.Errorf(
+			"failed to find 3 parts of Remote url '%v'. Found '%v'. Expected a string separated with '/' or ':', like https://github.com/microsoft/go or git@github.com:microsoft/go",
+			r.url,
+			r.urlParts,
+		)
+	}
+	fmt.Printf("From repo URL %v, detected %v for the PR target.\n", url, r.urlParts)
+	return r, nil
+}
+
+func (r Remote) GetOwnerRepo() []string {
+	return r.urlParts[len(r.urlParts)-2:]
+}
+
+func (r Remote) GetOwner() string {
+	return r.GetOwnerRepo()[0]
+}
+
+func (r Remote) GetOwnerSlashRepo() string {
+	return strings.Join(r.GetOwnerRepo(), "/")
+}
+
+// GetUsername queries GitHub for the username associated with a PAT.
+func GetUsername(pat string) string {
+	request, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	if err != nil {
+		panic(err)
+	}
+	request.SetBasicAuth("", pat)
+
+	response := &struct {
+		Login string `json:"login"`
+	}{}
+
+	if err := sendJSONRequestSuccessful(request, response); err != nil {
+		panic(err)
+	}
+
+	return response.Login
+}
+
+// sendJSONRequest sends a request for JSON information. The JSON response is unmarshalled (parsed)
+// into the 'response' parameter, based on the structure of 'response'.
+func sendJSONRequest(request *http.Request, response interface{}) (status int, err error) {
+	request.Header.Add("Accept", "application/vnd.github.v3+json")
+	fmt.Printf("Sending request: %v %v\n", request.Method, request.URL)
+
+	httpResponse, err := client.Do(request)
+	if err != nil {
+		return
+	}
+	defer httpResponse.Body.Close()
+	status = httpResponse.StatusCode
+
+	for key, value := range httpResponse.Header {
+		if strings.HasPrefix(key, "X-Ratelimit-") {
+			fmt.Printf("%v : %v\n", key, value)
+		}
+	}
+
+	jsonBytes, err := ioutil.ReadAll(httpResponse.Body)
+	if err != nil {
+		return
+	}
+
+	fmt.Printf("---- Full response:\n%v\n", string(jsonBytes))
+	fmt.Printf("----\n")
+
+	err = json.Unmarshal(jsonBytes, response)
+	return
+}
+
+// sendJSONRequestSuccessful sends a request for JSON information via sendJsonRequest and verifies
+// the status code is success.
+func sendJSONRequestSuccessful(request *http.Request, response interface{}) error {
+	status, err := sendJSONRequest(request, response)
+	if err != nil {
+		return err
+	}
+	if status < 200 || status > 299 {
+		return fmt.Errorf("request unsuccessful, http status %v, %v", status, http.StatusText(status))
+	}
+	return nil
+}
+
+// GitHubRequest is the payload for a GitHub PR creation API call, marshallable as JSON.
+type GitHubRequest struct {
+	Head                string `json:"head"`
+	Base                string `json:"base"`
+	Title               string `json:"title"`
+	Body                string `json:"body"`
+	MaintainerCanModify bool   `json:"maintainer_can_modify"`
+	Draft               bool   `json:"draft"`
+}
+
+// GitHubResponse is a PR creation response from GitHub. It may represent success or failure.
+type GitHubResponse struct {
+	// GitHub success response:
+	HTMLURL string `json:"html_url"`
+	NodeID  string `json:"node_id"`
+
+	// GitHub failure response:
+	Message string               `json:"message"`
+	Errors  []GitHubRequestError `json:"errors"`
+
+	// AlreadyExists is set to true if the error message says the PR exists. Otherwise, false. For
+	// our purposes, a GitHub failure response that indicates a PR already exists is not an error.
+	AlreadyExists bool
+}
+
+type GitHubRequestError struct {
+	Message string `json:"message"`
+}
+
+func PostGitHub(ownerRepo string, request GitHubRequest, pat string) (response *GitHubResponse, err error) {
+	prSubmitContent, err := json.MarshalIndent(request, "", "")
+	fmt.Printf("Submitting payload: %s\n", prSubmitContent)
+
+	httpRequest, err := http.NewRequest("POST", "https://api.github.com/repos/"+ownerRepo+"/pulls", bytes.NewReader(prSubmitContent))
+	if err != nil {
+		return
+	}
+	httpRequest.SetBasicAuth("", pat)
+
+	response = &GitHubResponse{}
+	statusCode, err := sendJSONRequest(httpRequest, response)
+	if err != nil {
+		return
+	}
+
+	switch statusCode {
+	case http.StatusCreated:
+		// 201 Created is the expected code if the PR is created. Do nothing.
+
+	case http.StatusUnprocessableEntity:
+		// 422 Unprocessable Entity may indicate the PR already exists. GitHub also gives us a response
+		// that looks like this:
+		/*
+			{
+				"message": "Validation Failed",
+				"errors": [
+					{
+						"resource": "GitHubRequest",
+						"code": "custom",
+						"message": "A pull request already exists for microsoft-golang-bot:auto-merge/microsoft/main."
+					}
+				],
+				"documentation_url": "https://docs.github.com/rest/reference/pulls#create-a-pull-request"
+			}
+		*/
+		for _, e := range response.Errors {
+			if strings.HasPrefix(e.Message, "A pull request already exists for ") {
+				response.AlreadyExists = true
+			}
+		}
+		if !response.AlreadyExists {
+			err = fmt.Errorf(
+				"response code %v may indicate PR already exists, but the error message is not recognized: %v",
+				statusCode,
+				response.Errors,
+			)
+		}
+
+	default:
+		err = fmt.Errorf("unexpected http status code: %v", statusCode)
+	}
+	return
+}
+
+func QueryGraphQL(pat string, query string, result interface{}) error {
+	queryBytes, err := json.Marshal(&struct {
+		Query string `json:"query"`
+	}{query})
+	if err != nil {
+		return err
+	}
+
+	httpRequest, err := http.NewRequest("POST", "https://api.github.com/graphql", bytes.NewReader(queryBytes))
+	if err != nil {
+		return err
+	}
+	httpRequest.SetBasicAuth("", pat)
+
+	return sendJSONRequestSuccessful(httpRequest, result)
+}
+
+func MutateGraphQL(pat string, query string) error {
+	// Queries and mutations use the same API. But with a mutation, the results aren't useful to us.
+	return QueryGraphQL(pat, query, &struct{}{})
+}
+
+func FindExistingPR(b *PRBranch, githubUser string, originOwner string, githubPAT string) (string, error) {
+	prQuery := `{
+		user(login: "` + githubUser + `") {
+			pullRequests(states: OPEN, baseRefName: "` + b.Name + `", first: 5) {
+				nodes {
+					title
+					id
+					headRepositoryOwner {
+						login
+					}
+					baseRepository {
+						owner {
+							login
+						}
+					}
+				}
+			}
+		}
+	}`
+	// Output structure from the query. We pull out some data to make sure our search result is what
+	// we expect and avoid relying solely on the search engine query. This may be expanded in the
+	// future to search for a specific PR among the search results, if necessary. (Needed if we want
+	// to submit multiple, similar PRs from this bot.)
+	//
+	// Declared adjacent to the query because the query determines the structure.
+	result := &struct {
+		// Note: Go encoding/json only detects exported properties (capitalized), but it does handle
+		// matching it to the lowercase JSON for us.
+		Data struct {
+			User struct {
+				PullRequests struct {
+					Nodes []struct {
+						Title               string
+						ID                  string
+						HeadRepositoryOwner struct {
+							Login string
+						}
+						BaseRepository struct {
+							Owner struct {
+								Login string
+							}
+						}
+					}
+					PageInfo struct {
+						HasNextPage bool
+					}
+				}
+			}
+		}
+	}{}
+
+	if err := QueryGraphQL(githubPAT, prQuery, result); err != nil {
+		return "", err
+	}
+	fmt.Printf("%+v\n", result)
+
+	// Basic search result validation. We could be more flexible in some cases, but the goal here is
+	// to detect an unknown state early so we don't end up doing something strange.
+
+	if prNodes := len(result.Data.User.PullRequests.Nodes); prNodes != 1 {
+		return "", fmt.Errorf("expected 1 PR search result, found %v", prNodes)
+	}
+	if result.Data.User.PullRequests.PageInfo.HasNextPage {
+		return "", fmt.Errorf("expected 1 PR search result, but the results say there's another page")
+	}
+
+	n := result.Data.User.PullRequests.Nodes[0]
+	if headOwner := n.HeadRepositoryOwner.Login; headOwner != githubUser {
+		return "", fmt.Errorf("pull request head owner is %v, expected %v", headOwner, githubUser)
+	}
+	if baseOwner := n.BaseRepository.Owner.Login; baseOwner != originOwner {
+		return "", fmt.Errorf("pull request base owner is %v, expected %v", baseOwner, originOwner)
+	}
+
+	return n.ID, nil
+}

--- a/eng/_util/go.mod
+++ b/eng/_util/go.mod
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+module github.com/microsoft/go-docker/eng/_util
+
+go 1.16

--- a/eng/run.ps1
+++ b/eng/run.ps1
@@ -1,0 +1,123 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+<#
+.DESCRIPTION
+This script builds and runs a tool defined in a module in 'eng'.
+
+To run a tool:
+  run.ps1 <tool> [arguments...]
+
+For example, to build the repository:
+  run.ps1 build
+
+To list all possible tools:
+  run.ps1
+
+Builds 'eng/<module>/cmd/<tool>/<tool>.go' and runs it using the list of
+arguments. If necessary, this command automatically installs Go and downloads
+the dependencies of the module.
+
+Every tool accepts a '-h' argument to show tool usage help.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+# Take the first arg as the tool name, and "shift" the rest so we can pass "@args" to the tool.
+#
+# "param($tool)" would make PowerShell eagerly bind partial matches ("-too", "-to", "-t"). These
+# matches overlap with tool args and cause unexpected behavior. ("sync" uses "-to", for example.)
+$tool = $args[0]
+$args = $args[1..$args.Count]
+
+# Import utilities. May throw if our version of PowerShell is too old.
+. (Join-Path $PSScriptRoot "utilities.ps1")
+if ($LASTEXITCODE) {
+  throw "Dot-sourcing utilities.ps1 failed with non-null/non-zero exit code. ($LASTEXITCODE)"
+}
+
+function Write-ToolList() {
+  Write-Host "Possible tools:"
+  foreach ($module in Get-ChildItem (Join-Path $PSScriptRoot "_*")) {
+    Write-Host "  Module $($module.Name):"
+    foreach ($tool in Get-ChildItem (Join-Path $module "cmd" "*")) {
+      Write-Host "    $($tool.Name)"
+    }
+  }
+  Write-Host ""
+}
+
+if (-not $tool) {
+  Write-Host "No tool specified. Showing help and listing available tools:"
+  (Get-Help $PSCommandPath).DESCRIPTION | Out-String | Write-Host
+  Write-ToolList
+  exit 0
+}
+
+# Find tool script file based on the name given.
+$tool_search = Join-Path $PSScriptRoot "_*" "cmd" "$tool" "$tool.go"
+# Find matches, and force the result to be an array.
+$tool_matches = @(Get-Item $tool_search)
+
+if ($tool_matches.Count -gt 1) {
+  Write-Host "Error: Multiple tools match '$tool_search'. Found:"
+  $tool_matches | Write-Host
+  Write-Host "This is a most likely a repository infrastructure issue. Every name should be unique."
+  exit 1
+} elseif ($tool_matches.Count -lt 1) {
+  Write-Host "Error: No tools found matching '$tool_search'."
+  Write-ToolList
+  exit 1
+}
+
+$tool_source = $tool_matches[0]
+if (-not ($tool_source -is [System.IO.FileInfo])) {
+  Write-Host "Found tool source code, but it is not a file: $tool_source"
+  exit 1
+}
+
+# Now that we have a single result, navigate upwards to see which module it's in.
+$tool_module = $tool_source.Directory.Parent.Parent.FullName
+
+# Get (downloading if necessary) the GOROOT directory of a stage 0 Go.
+$stage0_goroot = Get-Stage0GoRoot
+
+# The tool may need to know where our copy of Go is located. Save it in env to give it access. Don't
+# pass it to the tool as an arg, becuase that would complicate arg handling in each tool.
+$env:STAGE_0_GOROOT = $stage0_goroot
+
+# Decide where to place the compiled tool.
+$tool_output = Join-Path $PSScriptRoot "artifacts" "toolbin" $tool
+if ($IsWindows) {
+  $tool_output += ".exe"
+}
+
+try {
+  # Move into module so "go build" detects it and fetches dependencies.
+  Push-Location $tool_module
+  # Use a module-local path so Go resolves imports correctly.
+  $module_local_script_path = Join-Path "." "cmd" "$tool"
+
+  Write-Host "In '$tool_module', building '$module_local_script_path' -> $tool_output"
+  & (Join-Path $stage0_goroot "bin" "go") build -o $tool_output $module_local_script_path
+  if ($LASTEXITCODE) {
+    Write-Host "Failed to build tool."
+    exit 1
+  }
+  Write-Host "Building done."
+} finally {
+  Pop-Location
+}
+
+try {
+  # Run tool from the root of the repo.
+  Push-Location (Join-Path $PSScriptRoot "..")
+  & "$tool_output" @args
+  if ($LASTEXITCODE) {
+    Write-Host "Failed to run tool."
+    exit 1
+  }
+} finally {
+  Pop-Location
+}

--- a/eng/utilities.ps1
+++ b/eng/utilities.ps1
@@ -1,0 +1,121 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+$ErrorActionPreference = 'Stop'
+
+# Require PowerShell 6+, otherwise throw. Throw rather than "exit 1" so the error is reliably seen
+# without $LASTEXITCODE handling on the caller. For example, the error will be easy to see even if
+# this script is being dot-sourced in a user terminal.
+#
+# PowerShell 5 support could feasibly be added later. The scripts don't support it now because 5:
+# * Only supports two "Join-Path" args.
+# * Doesn't set OS detection automatic variables like "$IsWindows".
+if ($host.Version.Major -lt 6) {
+  Write-Host "Error: This script requires PowerShell 6 or higher; detected $($host.Version.Major)."
+  Write-Host "See https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell"
+  Write-Host "Or add 'pwsh' to the beginning of your command and try again."
+
+  throw "Missing prerequisites; see logs above for details."
+}
+
+function Get-Stage0GoRoot() {
+  # We need Go installed in order to build Go, but our common build environment doesn't have it
+  # pre-installed. This CI script installs a consistent, official version of Go to a directory in
+  # $HOME to handle this. This also makes it easier to locally repro issues in CI that involve a
+  # specific version of Go. The downloaded copy of Go is called the "stage 0" version.
+  $stage0_go_version = '1.16.5'
+
+  if ($IsWindows) {
+    $stage0_go_sha256 = '0a3fa279ae5b91bc8c88017198c8f1ba5d9925eb6e5d7571316e567c73add39d'
+    $stage0_go_suffix = 'windows-amd64.zip'
+  } elseif ($IsLinux) {
+    $stage0_go_sha256 = 'b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061'
+    $stage0_go_suffix = 'linux-amd64.tar.gz'
+  } else {
+    throw "Current OS/Platform is not supported by the Microsoft scripts to build Go."
+  }
+  $stage0_url = "https://golang.org/dl/go${stage0_go_version}.${stage0_go_suffix}"
+
+  # Ideally we could set up stage 0 inside the repository, rather than
+  # userprofile. Tracked by: https://github.com/microsoft/go/issues/12
+  $stage0_dir = Join-Path $HOME ".go-stage-0" $stage0_go_version
+
+  # A file that indicates that this version of the stage 0 Go toolset has already been installed.
+  $download_complete_indicator = Join-Path $stage0_dir ".downloaded-$stage0_go_sha256"
+
+  if (-not (Test-Path $download_complete_indicator -PathType Leaf)) {
+    Write-Host "Downloading stage 0 Go compiler and extracting to '$stage0_dir' ..."
+
+    # Clear existing stage0 dir in case it's in a broken state.
+    Remove-Item -Recurse -Force $stage0_dir -ErrorAction Ignore 
+    New-Item -ItemType Directory $stage0_dir | Out-Null
+
+    $go_tarball = Join-Path $stage0_dir "go.$stage0_go_suffix"
+
+    Write-Host "Downloading from '$stage0_url' to '$go_tarball'..."
+    Invoke-WithRetry -MaxAttempts 5 {
+      (New-Object System.Net.WebClient).DownloadFile($stage0_url, $go_tarball)
+    }
+
+    Write-Host "Comparing checksum..."
+    $actual_hash = (Get-FileHash $go_tarball -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual_hash -ne $stage0_go_sha256) {
+      Write-Host ""
+      Write-Host "Error: hash of downloaded file '$go_tarball' doesn't match expected value:"
+      Write-Host "Actual:   $actual_hash"
+      Write-Host "Expected: $stage0_go_sha256"
+      Write-Host "Visit https://golang.org/dl/ to see the list of expected hashes."
+
+      throw "Checksum mismatch. See logs above for details."
+    }
+
+    Write-Host "Extracting '$go_tarball' to '$stage0_dir'..."
+    if ($go_tarball.EndsWith(".zip")) {
+      Extract-Zip $go_tarball $stage0_dir
+    } elseif ($go_tarball.EndsWith(".tar.gz")) {
+      Extract-TarGz $go_tarball $stage0_dir
+    }
+    Remove-Item "$go_tarball"
+
+    New-Item -ItemType File "$download_complete_indicator" | Out-Null
+
+    Write-Host "Done extracting stage 0 Go compiler to '$stage0_dir'"
+  }
+
+  # Return GOROOT: contains "bin/go".
+  return Join-Path $stage0_dir "go"
+}
+
+# Copied from https://github.com/dotnet/install-scripts/blob/49d5da7f7d313aa65d24fe95cc29767faef553fd/src/dotnet-install.ps1#L180-L197
+function Invoke-WithRetry([ScriptBlock]$ScriptBlock, [int]$MaxAttempts = 3, [int]$SecondsBetweenAttempts = 1) {
+  $Attempts = 0
+
+  while ($true) {
+    try {
+      return & $ScriptBlock
+    }
+    catch {
+      $Attempts++
+      if ($Attempts -lt $MaxAttempts) {
+        Start-Sleep $SecondsBetweenAttempts
+      }
+      else {
+        throw
+      }
+    }
+  }
+}
+
+# Utility method to unzip a file to a specific path.
+function Extract-Zip([string] $file, [string] $destination) {
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($file, $destination)
+}
+
+function Extract-TarGz([string] $file, [string] $destination) {
+  & tar -C $destination -xzf $file
+  if ($LASTEXITCODE) {
+    throw "Error: 'tar' exit code $($LASTEXITCODE): failed to extract '$file' to '$destination'"
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -11,10 +11,12 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-buster": {},
+            "1.15": {},
             "1.15-buster": {},
             "1.15.14": {},
-            "1.15": {}
+            "1.15.14-1": {},
+            "1.15.14-1-buster": {},
+            "1.15.14-buster": {}
           },
           "platforms": [
             {
@@ -22,7 +24,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.15.14-buster-amd64": {}
+                "1.15.14-1-buster-amd64": {}
               }
             }
           ]
@@ -30,8 +32,9 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-stretch": {},
-            "1.15-stretch": {}
+            "1.15-stretch": {},
+            "1.15.14-1-stretch": {},
+            "1.15.14-stretch": {}
           },
           "platforms": [
             {
@@ -39,7 +42,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.15.14-stretch-amd64": {}
+                "1.15.14-1-stretch-amd64": {}
               }
             }
           ]
@@ -47,8 +50,9 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-windowsservercore-1809": {},
-            "1.15-windowsservercore-1809": {}
+            "1.15-windowsservercore-1809": {},
+            "1.15.14-1-windowsservercore-1809": {},
+            "1.15.14-windowsservercore-1809": {}
           },
           "platforms": [
             {
@@ -56,7 +60,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.15.14-windowsservercore-1809-amd64": {}
+                "1.15.14-1-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -64,21 +68,21 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-nanoserver-1809": {},
-            "1.15-nanoserver-1809": {}
+            "1.15-nanoserver-1809": {},
+            "1.15.14-1-nanoserver-1809": {},
+            "1.15.14-nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:golang)",
-                // Specify the complete platform tag of the server core image so ImageBuilder can detect this dependency.
-                "DOWNLOADER_TAG": "1.15.14-windowsservercore-1809-amd64"
+                "DOWNLOADER_TAG": "1.15.14-1-windowsservercore-1809-amd64",
+                "REPO": "$(Repo:golang)"
               },
               "dockerfile": "src/microsoft/1.15/windows/nanoserver-1809",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.15.14-nanoserver-1809-amd64": {}
+                "1.15.14-1-nanoserver-1809-amd64": {}
               }
             }
           ]
@@ -86,8 +90,9 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-windowsservercore-ltsc2016": {},
-            "1.15-windowsservercore-ltsc2016": {}
+            "1.15-windowsservercore-ltsc2016": {},
+            "1.15.14-1-windowsservercore-ltsc2016": {},
+            "1.15.14-windowsservercore-ltsc2016": {}
           },
           "platforms": [
             {
@@ -95,22 +100,23 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "1.15.14-windowsservercore-ltsc2016-amd64": {}
+                "1.15.14-1-windowsservercore-ltsc2016-amd64": {}
               }
             }
           ]
         },
-
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-buster": {},
-            "1.16-buster": {},
-            "1-buster": {},
-            "buster": {},
-            "1.16.6": {},
-            "1.16": {},
             "1": {},
+            "1-buster": {},
+            "1.16": {},
+            "1.16-buster": {},
+            "1.16.6": {},
+            "1.16.6-1": {},
+            "1.16.6-1-buster": {},
+            "1.16.6-buster": {},
+            "buster": {},
             "latest": {}
           },
           "platforms": [
@@ -119,7 +125,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.16.6-buster-amd64": {}
+                "1.16.6-1-buster-amd64": {}
               }
             }
           ]
@@ -127,9 +133,10 @@
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-stretch": {},
-            "1.16-stretch": {},
             "1-stretch": {},
+            "1.16-stretch": {},
+            "1.16.6-1-stretch": {},
+            "1.16.6-stretch": {},
             "stretch": {}
           },
           "platforms": [
@@ -138,7 +145,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.16.6-stretch-amd64": {}
+                "1.16.6-1-stretch-amd64": {}
               }
             }
           ]
@@ -146,9 +153,10 @@
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-windowsservercore-1809": {},
-            "1.16-windowsservercore-1809": {},
             "1-windowsservercore-1809": {},
+            "1.16-windowsservercore-1809": {},
+            "1.16.6-1-windowsservercore-1809": {},
+            "1.16.6-windowsservercore-1809": {},
             "windowsservercore-1809": {}
           },
           "platforms": [
@@ -157,7 +165,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.16.6-windowsservercore-1809-amd64": {}
+                "1.16.6-1-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -165,23 +173,23 @@
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-nanoserver-1809": {},
-            "1.16-nanoserver-1809": {},
             "1-nanoserver-1809": {},
+            "1.16-nanoserver-1809": {},
+            "1.16.6-1-nanoserver-1809": {},
+            "1.16.6-nanoserver-1809": {},
             "nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:golang)",
-                // Specify the complete platform tag of the server core image so ImageBuilder can detect this dependency.
-                "DOWNLOADER_TAG": "1.16.6-windowsservercore-1809-amd64"
+                "DOWNLOADER_TAG": "1.16.6-1-windowsservercore-1809-amd64",
+                "REPO": "$(Repo:golang)"
               },
               "dockerfile": "src/microsoft/1.16/windows/nanoserver-1809",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.16.6-nanoserver-1809-amd64": {}
+                "1.16.6-1-nanoserver-1809-amd64": {}
               }
             }
           ]
@@ -189,9 +197,10 @@
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-windowsservercore-ltsc2016": {},
-            "1.16-windowsservercore-ltsc2016": {},
             "1-windowsservercore-ltsc2016": {},
+            "1.16-windowsservercore-ltsc2016": {},
+            "1.16.6-1-windowsservercore-ltsc2016": {},
+            "1.16.6-windowsservercore-ltsc2016": {},
             "windowsservercore-ltsc2016": {}
           },
           "platforms": [
@@ -200,7 +209,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "1.16.6-windowsservercore-ltsc2016-amd64": {}
+                "1.16.6-1-windowsservercore-ltsc2016-amd64": {}
               }
             }
           ]

--- a/src/microsoft/1.15/buster/Dockerfile
+++ b/src/microsoft/1.15/buster/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 RUN set -eux; \
 	\

--- a/src/microsoft/1.15/stretch/Dockerfile
+++ b/src/microsoft/1.15/stretch/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 RUN set -eux; \
 	\

--- a/src/microsoft/1.15/windows/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.15/windows/nanoserver-1809/Dockerfile
@@ -14,7 +14,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.15.5-windowsservercore-1809
+ARG DOWNLOADER_TAG=1.15.14-windowsservercore-1809
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 # END NO MICROSOFT_UPSTREAM
 
@@ -35,7 +35,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 # NO MICROSOFT_UPSTREAM: Use "downloader" stage defined earlier.

--- a/src/microsoft/1.15/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.15/windows/windowsservercore-1809/Dockerfile
@@ -53,7 +53,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.15/20210817.4/go.20210817.4.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \

--- a/src/microsoft/1.15/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.15/windows/windowsservercore-ltsc2016/Dockerfile
@@ -53,7 +53,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.15/20210817.4/go.20210817.4.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -24,10 +24,11 @@
       "buster",
       "stretch",
       "windows/windowsservercore-1809",
-      "windows/windowsservercore-ltsc2016",
-      "windows/nanoserver-1809"
+      "windows/nanoserver-1809",
+      "windows/windowsservercore-ltsc2016"
     ],
-    "version": "1.15.5"
+    "version": "1.15.14",
+    "preferredVariant": "buster"
   },
   "1.16": {
     "arches": {
@@ -54,9 +55,12 @@
       "buster",
       "stretch",
       "windows/windowsservercore-1809",
-      "windows/windowsservercore-ltsc2016",
-      "windows/nanoserver-1809"
+      "windows/nanoserver-1809",
+      "windows/windowsservercore-ltsc2016"
     ],
-    "version": "1.16.6"
+    "version": "1.16.6",
+    "preferredMajor": true,
+    "preferredMinor": true,
+    "preferredVariant": "buster"
   }
 }


### PR DESCRIPTION
Add new update and PR commands to "_util" module based on microsoft/go's module and eng/run.ps1 script.

Update manifest, versions.json, and Dockerfiles to match how they are generated by the tools.

The list of (e.g.) shared `1.16.6-1-buster-amd64` tags has some new entries now, because I also added a Revision part (`-1`) based on an email discussion about MCR tagging:

```
"latest": {},
"buster": {},
"1": {},
"1-buster": {},
"1.16": {},
"1.16-buster": {},
"1.16.6": {},
"1.16.6-buster": {},
"1.16.6-1": {},
"1.16.6-1-buster": {},
```

(I sorted the list in a human order here--Go sorts map keys as ordinary strings when marshalling to JSON.)

Example auto-update PR (BuildAssets JSON file in PR comment): https://github.com/dagood/go/pull/4

---

Next steps:
* Have the Go build produce a `BuildAssets` file as an artifact.
* Create a Go Docker build definition that runs `updatepr` with auth, based on the BuildAssets file from a specified Go build.
* Make the Go build kick off an auto-update build.

I plan to move most of this into https://github.com/microsoft/go-infra, but I think it's worth getting the core flow working first. I also need to move the `microsoft/docker-images` branch into https://github.com/microsoft/go-docker.

A significant chunk of `eng/_util/gitpr/gitpr.go` is copied from https://github.com/microsoft/go/blob/microsoft/main/eng/_util/cmd/sync/sync.go, but I did modify it to work with the Docker flow. (Simplified.) When we unify the code in https://github.com/microsoft/go-infra, it might be best to bring in a proper GitHub API library so we can reasonably improve the PR workflow. (This infra still does blind force pushes, which could potentially overwrite work. #68)