### PR TITLE
Add 'createbuildassetjson' tool, use in publish

### DIFF
--- a/eng/_util/cmd/createbuildassetjson/createbuildassetjson.go
+++ b/eng/_util/cmd/createbuildassetjson/createbuildassetjson.go
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/microsoft/go-infra/buildmodel"
+)
+
+const description = `
+This command creates a build asset JSON file for a given Go build, where all assets are in a flat
+directory on disk. Downstream repos (in particular Go Docker) can use this summary file to point at
+new builds of Go automatically.
+`
+
+func main() {
+	f := buildmodel.BindBuildAssetJSONFlags()
+
+	buildmodel.ParseBoundFlags(description)
+
+	if err := buildmodel.GenerateBuildAssetJSON(f); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("\nSuccess.")
+}

--- a/eng/_util/go.mod
+++ b/eng/_util/go.mod
@@ -6,4 +6,7 @@ module github.com/microsoft/go/_util
 
 go 1.16
 
-require gotest.tools/gotestsum v1.6.5-0.20210515201937-ecb7c6956f6d
+require (
+	github.com/microsoft/go-infra v0.0.0-20210927221531-36ab28c98734
+	gotest.tools/gotestsum v1.6.5-0.20210515201937-ecb7c6956f6d
+)

--- a/eng/_util/go.sum
+++ b/eng/_util/go.sum
@@ -15,6 +15,8 @@ github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/microsoft/go-infra v0.0.0-20210927221531-36ab28c98734 h1:Nh4Xo8VRiv1SQ1Q0lCJxCi7pHWYyI2xVdyawB8F9w6w=
+github.com/microsoft/go-infra v0.0.0-20210927221531-36ab28c98734/go.mod h1:3IVGTm7qFJldQHximiWLg2kYfmugjZMGNHnvUo5Mo5M=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -25,14 +25,17 @@ stages:
     jobs:
       - job: Publish
         pool:
-          # This is a utility job that doesn't use Go: use generic recent LTS for publishing.
+          # This is a utility job: use generic recent LTS for publishing.
           vmImage: ubuntu-20.04
         variables:
           - name: blobDestinationUrl
             value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
           - group: go-storage
+        workspace:
+          clean: all
         steps:
-          - checkout: none
+          - template: steps/checkout-unix-task.yml
+          - template: steps/init-pwsh-task.yml
 
           - pwsh: |
               function TrimStart($s, $prefix) {
@@ -60,6 +63,19 @@ stages:
           - download: current
             artifact: Binaries Signed
             displayName: 'Download: Binaries Signed'
+
+          - pwsh: |
+              eng/run.ps1 createbuildassetjson `
+                -artifacts-dir '$(Pipeline.Workspace)/Binaries Signed/' `
+                -source-dir '$(Build.SourcesDirectory)' `
+                -destination-url '$(blobDestinationUrl)' `
+                -branch '$(PublishBranchAlias)' `
+                -o '$(Pipeline.Workspace)/Binaries Signed/assets.json'
+            displayName: 'Create build asset JSON'
+
+          - publish: $(Pipeline.Workspace)/Binaries Signed/assets.json
+            artifact: BuildAssets
+            displayName: Publish build asset JSON
 
           - task: AzureCLI@2
             displayName: Upload to blob storage


### PR DESCRIPTION
Depend on https://github.com/microsoft/go-infra/pull/3, use it to add a `createbuildassetjson` `_util` tool, and use the tool in the publish step to generate a build asset JSON file based on finalized/signed bits.

Once this gets merged, the official build will produce the file as a pipeline artifact and automatically trigger https://github.com/microsoft/go-infra/blob/main/eng/pipelines/go-update.yml to take that file and apply it as an update on the go-docker repo. (Although go-docker isn't currently configured to receive updates for `microsoft/main` (https://github.com/microsoft/go/issues/168), so this flow will only happen end-to-end once we port this code to the release branches.)

* Part of https://github.com/microsoft/go/issues/162
* Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1389131&view=results, produced:
  ```json
  {
    "branch": "dev/dagood/manifest",
    "buildId": "1389131",
    "version": "main-1",
    "arches": [
      {
        "env": {
          "GOARCH": "amd64",
          "GOOS": "linux"
        },
        "sha256": "ef9c576651650523ed7aba6a23a1718c9089a86233cdcc37e17fddac007f443c",
        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/manifest/20210927.3/go.20210927.3.linux-amd64.tar.gz"
      },
      {
        "env": {
          "GOARCH": "amd64",
          "GOOS": "windows"
        },
        "sha256": "f7cf08ab4c39c2ac8a02333b27e6998593f31702f4be2b0680b39b3a4507447a",
        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/manifest/20210927.3/go.20210927.3.windows-amd64.zip"
      }
    ]
  }
  ```