### PR TITLE
Switch to 1ES servicing pools on microsoft/release-branch.go1.15

### DIFF
--- a/eng/pipeline/jobs/sign-job.yml
+++ b/eng/pipeline/jobs/sign-job.yml
@@ -18,8 +18,8 @@ jobs:
           - ${{ builder.os }}_${{ builder.arch }}_${{ builder.config }}
       pool:
         # This is a utility job that doesn't use Go: use a pool that supports signing.
-        name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2019
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019
       variables:
         - name: TeamName
           value: golang


### PR DESCRIPTION
Same as https://github.com/microsoft/go/pull/231 but for microsoft/release-branch.go1.15.