### PR TITLE
Fix go upstream url in eng/README.md

### DIFF
--- a/eng/README.md
+++ b/eng/README.md
@@ -73,7 +73,7 @@ first make sure you have the upstream Git refs locally. One way to do this is to
 set up a remote:
 
 ```sh
-git remote add golang https://github.com/golang/go
+git remote add golang https://go.googlesource.com/go
 git fetch golang
 ```
 


### PR DESCRIPTION
The upstream url points to this same repo, but it should point to `github.com/golang/go` in order to get a complete list of files that are modified vs. the upstream Git repository.