### PR TITLE
Improve libcrypto.so dynamic loading logic

### DIFF
--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -60,6 +60,7 @@ _goboringcrypto_DLOPEN_OPENSSL(void)
 #elif OPENSSL_VERSION_NUMBER < 0x10100000L
 	handle = dlopen("libcrypto.so.10", RTLD_NOW | RTLD_GLOBAL);
 	if (handle == NULL) {
+		// The libcrypto shared library naming convention differs among linux distros
 		handle = dlopen("libcrypto.so.1.0.0", RTLD_NOW | RTLD_GLOBAL);
 	}
 #else


### PR DESCRIPTION
#261 CI is failing because `libcrypto` shared library is being loaded as `libcrypto.so.10`, but our base image name it `libcrypto.so.1.0.0` so `dlopen` fails.

This PR contains two improvements:

- If `OPENSSL_VERSION_NUMBER` is not defined just load `libcrypto.so`, which will normally be a symbolic link to the default system `libcrypto` (in our case `libcrypto.so.1.0.0`
- If `OPENSSL_VERSION_NUMBER` is set to `< 0x10100000L`, first try to load `libcrypto.so.10` and if it fails try loading `libcrypto.so.1.0.0`. This is necessary because there is no general agreement on how to name libcrypto shared libraries among Linux distros.

I'm open to other solutions.

@dagood I've submitted a merge instead of a patch file because I'm not sure if the pipeline is ready to apply patch files. If that's the case then I'll resubmit as a patch file. 

  