### PR TITLE
Trigger CI on dev/* PRs and dev/official/* commits

### DIFF
--- a/eng/pipeline/pr-outerloop-pipeline.yml
+++ b/eng/pipeline/pr-outerloop-pipeline.yml
@@ -14,6 +14,7 @@ pr:
   # AzDO UI to require a comment before running the build. There is unfortunately no way to
   # configure this from YAML.
   - microsoft/*
+  - dev/*
 
 jobs:
   - template: jobs/go-builder-matrix-jobs.yml

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -7,6 +7,7 @@
 trigger: none
 pr:
   - microsoft/*
+  - dev/*
 
 jobs:
   - template: jobs/go-builder-matrix-jobs.yml

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -10,6 +10,7 @@ trigger:
   branches:
     include:
       - microsoft/*
+      - dev/official/*
 pr: none
 
 stages:

--- a/eng/pipeline/rolling-pipeline.yml
+++ b/eng/pipeline/rolling-pipeline.yml
@@ -14,6 +14,7 @@ trigger:
   branches:
     include:
       - microsoft/*
+      - dev/official/*
 pr: none
 
 jobs:


### PR DESCRIPTION
This trigger *might* need to exist on both the default branch (`microsoft/main`) *and* on the target branch for it to work, but I might be wrong about that. The docs don't seem to get into any detail about trigger behavior, as far as I can find.

In any case, it's good to have it in `microsoft/main` for future branches.

For PRs, the trigger is `dev/*` because it seem unlikely there's a reason to create a PR unless you want review.

For internal rolling builds (official builds), `dev/official/*` so we don't waste resources on dev branches that don't need official builds.