### PR TITLE
[dev/official/go1.17-openssl-fips] Trigger CI on dev/* PRs and dev/official/* commits

### DIFF
--- a/eng/pipeline/pr-outerloop-pipeline.yml
+++ b/eng/pipeline/pr-outerloop-pipeline.yml
@@ -14,6 +14,7 @@ pr:
   # AzDO UI to require a comment before running the build. There is unfortunately no way to
   # configure this from YAML.
   - microsoft/*
+  - dev/*
 
 jobs:
   - template: jobs/go-builder-matrix-jobs.yml

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -7,6 +7,7 @@
 trigger: none
 pr:
   - microsoft/*
+  - dev/*
 
 jobs:
   - template: jobs/go-builder-matrix-jobs.yml

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -10,6 +10,7 @@ trigger:
   branches:
     include:
       - microsoft/*
+      - dev/official/*
 pr: none
 
 stages:

--- a/eng/pipeline/rolling-pipeline.yml
+++ b/eng/pipeline/rolling-pipeline.yml
@@ -14,6 +14,7 @@ trigger:
   branches:
     include:
       - microsoft/*
+      - dev/official/*
 pr: none
 
 jobs:


### PR DESCRIPTION
Cherry-pick https://github.com/microsoft/go/pull/271 to `dev/official/go1.17-openssl-fips` to enable CI (PR validation and official builds).