### PR TITLE
Runtime detection of systems FIPS settings

### DIFF
--- a/src/crypto/internal/boring/boring.go
+++ b/src/crypto/internal/boring/boring.go
@@ -73,6 +73,13 @@ func needFIPS() bool {
 	// Check if Linux kernel is booted in FIPS mode.
 	buf, err := os.ReadFile("/proc/sys/crypto/fips_enabled")
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false
+		}
+		// If there is an error reading we could either panic or assume FIPS is not enabled.
+		// Panicking would be too disruptive for apps that don't require FIPS.
+		// If an app wants to be 100% sure that is running in FIPS mode
+		// it should use boring.Enabled() or GOLANG_FIPS=1.
 		return false
 	}
 	return strings.TrimSpace(string(buf)) == "1"


### PR DESCRIPTION
This PR modifies how users can opt-in and opt-out to FIPS mode.

We will panic if FIPS mode is needed but we cannot load nor configure openssl in FIPS mode in order to avoid applications unintentionally running without FIPS.

If FIPS mode is not required we will always use standard Go crypto primitives.

These are the new rules to decide if FIPS is required:
- If `GOLANG_FIPS=1` then FIPS mode is required, whatever is the system-wide FIPS mode.
- If `GOLANG_FIPS=0` then FIPS mode is not required, whatever is the system-wide FIPS mode.
- If Linux kernel is booted with system-wide FIPS enabled then FIPS mode is required.
- In all other situations, FIPS mode is not required.