### PR TITLE
Use Mariner for CI, keep a single Ubuntu job for coverage

### DIFF
--- a/eng/pipeline/jobs/builders-to-jobs.yml
+++ b/eng/pipeline/jobs/builders-to-jobs.yml
@@ -5,7 +5,7 @@
 # This template expands a list of builders into a list of jobs.
 
 parameters:
-  # [] of { os, arch, config }
+  # [] of { id, os, arch, config, distro? }
   builders: []
   # If true, include a signing job that depends on all 'buildandpack' builder jobs finishing. This
   # lets us start the lengthy tasks of signing and testing in parallel.

--- a/eng/pipeline/jobs/go-builder-matrix-jobs.yml
+++ b/eng/pipeline/jobs/go-builder-matrix-jobs.yml
@@ -11,14 +11,17 @@ parameters:
   sign: false
 
 jobs:
-  - template: builders-to-jobs.yml
+  - template: shorthand-builders-to-builders.yml
     parameters:
-      sign: ${{ parameters.sign }}
-      builders:
+      jobsTemplate: builders-to-jobs.yml
+      jobsParameters:
+        sign: ${{ parameters.sign }}
+      shorthandBuilders:
         - ${{ if eq(parameters.innerloop, true) }}:
           - { os: linux, arch: amd64, config: buildandpack }
           - { os: linux, arch: amd64, config: devscript }
           - { os: linux, arch: amd64, config: test }
+          - { os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: windows, arch: amd64, config: buildandpack }
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }

--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -5,11 +5,11 @@
 # This job runs a builder for any OS.
 
 parameters:
-  # { os, arch, config }
+  # { id, os, arch, config, distro? }
   builder: {}
 
 jobs:
-  - job: ${{ parameters.builder.os }}_${{ parameters.builder.arch }}_${{ parameters.builder.config }}
+  - job: ${{ parameters.builder.id }}
     workspace:
       clean: all
 
@@ -24,7 +24,10 @@ jobs:
         vmImage: ubuntu-18.04
       # The image used for the container this job runs in. The tests run in this container, so it
       # should match what we support as closely as possible.
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+      ${{ if not(parameters.builder.distro) }}:
+        container: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
+      ${{ if eq(parameters.builder.distro, 'ubuntu') }}:
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
 
     steps:
       - ${{ if eq(parameters.builder.os, 'linux') }}:
@@ -49,7 +52,7 @@ jobs:
           displayName: Build and Pack
 
         - publish: eng/artifacts/bin
-          artifact: Binaries ${{ parameters.builder.os }}_${{ parameters.builder.arch }}_${{ parameters.builder.config }}
+          artifact: Binaries ${{ parameters.builder.id }}
           displayName: Pipeline publish
           condition: succeededOrFailed()
 
@@ -76,7 +79,7 @@ jobs:
           inputs:
             testResultsFormat: JUnit
             testResultsFiles: $(Build.SourcesDirectory)/eng/artifacts/TestResults.xml
-            testRunTitle: ${{ parameters.builder.os }}_${{ parameters.builder.arch }}_${{ parameters.builder.config }}
+            testRunTitle: ${{ parameters.builder.id }}
             buildPlatform: ${{ parameters.builder.arch }}
             buildConfiguration: ${{ parameters.builder.config }}
             publishRunAttachments: true

--- a/eng/pipeline/jobs/shorthand-builders-to-builders.yml
+++ b/eng/pipeline/jobs/shorthand-builders-to-builders.yml
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This template expands each "shorthand" builder in a list of builders into a builder object that
+# includes its job ID. The list of builders is then passed into a given jobs template. This way, we
+# don't need to repeat the ID evaluation template expression everywhere the value is needed.
+#
+# If any other builder-specific calculated value is needed based on shorthand properties, it can be
+# added to this file. Passing data through a template like this one is the only way to share values
+# to be used by template expressions, as of writing.
+
+parameters:
+  # [] of { os, arch, config, distro? }
+  shorthandBuilders: []
+  # The inner jobs template to pass the filed-out builders into.
+  #
+  # It should accept parameter "builders", [] of { id, os, arch, config, distro? }
+  jobsTemplate: ""
+  jobsParameters: {}
+
+jobs:
+  - template: ${{ parameters.jobsTemplate }}
+    parameters:
+      ${{ insert }}: ${{ parameters.jobsParameters }}
+      builders:
+        - ${{ each builder in parameters.shorthandBuilders }}:
+          - ${{ insert }}: ${{ builder }}
+            ${{ if builder.distro }}:
+              id: ${{ builder.os }}_${{ builder.distro }}_${{ builder.arch }}_${{ builder.config }}
+            ${{ if not(builder.distro) }}:
+              id: ${{ builder.os }}_${{ builder.arch }}_${{ builder.config }}
+
+

--- a/eng/pipeline/jobs/sign-job.yml
+++ b/eng/pipeline/jobs/sign-job.yml
@@ -6,7 +6,7 @@
 # publishes the signed files and signatures into a consolidated pipeline artifact.
 
 parameters:
-  # [] of { os, arch, config }
+  # [] of { id, os, arch, config, distro? }
   builders: []
 
 jobs:
@@ -15,7 +15,7 @@ jobs:
       # Depend on all build jobs that produced artifacts that need signing.
       dependsOn:
         - ${{ each builder in parameters.builders }}:
-          - ${{ builder.os }}_${{ builder.arch }}_${{ builder.config }}
+          - ${{ builder.id }}
       pool:
         # This is a utility job that doesn't use Go: use a pool that supports signing.
         name: NetCore1ESPool-Internal
@@ -35,22 +35,22 @@ jobs:
 
         - ${{ each builder in parameters.builders }}:
           - download: current
-            artifact: Binaries ${{ builder.os }}_${{ builder.arch }}_${{ builder.config }}
-            displayName: 'Download: Binaries ${{ builder.os }}_${{ builder.arch }}_${{ builder.config }}'
+            artifact: Binaries ${{ builder.id }}
+            displayName: 'Download: Binaries ${{ builder.id }}'
 
           - powershell: |
               $flatDir = "$(Build.StagingDirectory)/ToSign"
               New-Item $flatDir -ItemType Directory -ErrorAction Ignore
 
               Get-ChildItem -Recurse -File -Path @(
-                'Binaries ${{ builder.os }}_${{ builder.arch }}_${{ builder.config }}'
+                'Binaries ${{ builder.id }}'
               ) | %{
                 if (Test-Path "$flatDir\$($_.Name)") {
                   throw "Duplicate filename, unable to flatten: $($_.FullName)"
                 }
                 Copy-Item $_.FullName $flatDir
               }
-            displayName: 'Copy to flat dir: ${{ builder.os }}_${{ builder.arch }}_${{ builder.config }}'
+            displayName: 'Copy to flat dir: ${{ builder.id }}'
             workingDirectory: '$(Pipeline.Workspace)'
 
         - task: DotNetCoreCLI@2


### PR DESCRIPTION
Switch from Ubuntu to Mariner for all existing jobs. Add one Ubuntu `test` job to make sure builds and short tests still work 
there.

Use Mariner image from https://github.com/microsoft/go-infra-images/pull/1, but keep using the existing Ubuntu image for now.