### PR TITLE
set GOTMPDIR to Agent.TempDirectory in build pipeline

### DIFF
--- a/eng/pipeline/jobs/go-builder-matrix-jobs.yml
+++ b/eng/pipeline/jobs/go-builder-matrix-jobs.yml
@@ -21,11 +21,21 @@ jobs:
           - { os: windows, arch: amd64, config: buildandpack, gotmp: true, name: 3 }
           - { os: windows, arch: amd64, config: buildandpack, gotmp: true, name: 4 }
           - { os: windows, arch: amd64, config: buildandpack, gotmp: true, name: 5 }
-          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 6 }
-          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 7 }
-          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 8 }
-          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 9 }
-          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 10 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: true, name: 6 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: true, name: 7 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: true, name: 8 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: true, name: 9 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: true, name: 10 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 11 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 12 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 13 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 14 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 15 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 16 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 17 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 18 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 19 }
+          - { os: windows, arch: amd64, config: buildandpack, gotmp: false, name: 20 }
         - ${{ if eq(parameters.outerloop, true) }}:
           # Upstream builders.
           - { os: linux, arch: amd64, config: clang }

--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -52,7 +52,7 @@ jobs:
               GOTMPDIR: $(Agent.TempDirectory)
 
         - publish: eng/artifacts/bin
-          artifact: Binaries ${{ parameters.builder.os }}_${{ parameters.builder.arch }}_${{ parameters.builder.config }}
+          artifact: Binaries ${{ parameters.builder.os }}_${{ parameters.builder.arch }}_${{ parameters.builder.config }}_${{ parameters.builder.gotmp }}_${{ parameters.builder.name }}
           displayName: Pipeline publish
           condition: succeededOrFailed()
 


### PR DESCRIPTION
The CI build pipeline sometimes fail when moving binaries from a temporary folder located in the `C:\` drive to the tools folder in the `D:\` drive. This failure is caused by an antivirus agent, and it could be that it doesn't like how Go moves binaries between drives.

This PR sets the `GOTMPDIR` to `$(Agent.TempDirectory)` so Go uses the temporary directory provided by azure, which is in the `D:\` drives, instead of the default Windows temporary directory.

For #241