### PR TITLE
Remove MicroBuild from NuGet.Config to avoid false positive

### DIFF
--- a/eng/pipeline/jobs/sign-job.yml
+++ b/eng/pipeline/jobs/sign-job.yml
@@ -28,10 +28,16 @@ jobs:
       steps:
         - template: ../steps/checkout-windows-task.yml
 
-        - task: MicroBuildSigningPlugin@2
-          displayName: 'Install MicroBuild Signing Plugin'
+        # Add MicroBuild, based on Arcade: https://github.com/dotnet/arcade/blob/927f8d4d5036f68a5fc6d042f336bc9458027208/eng/common/templates/job/job.yml#L106-L115
+        - task: MicroBuildSigningPlugin@3
+          displayName: Install MicroBuild plugin
           inputs:
-            feedSource: 'https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json'
+            signType: $(SigningType)
+            zipSources: false
+            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          env:
+            TeamName: $(TeamName)
+          condition: and(succeeded(), in(variables['SigningType'], 'real', 'test'))
 
         - ${{ each builder in parameters.builders }}:
           - download: current

--- a/eng/signing/NuGet.Config
+++ b/eng/signing/NuGet.Config
@@ -5,7 +5,6 @@
     <clear />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="MicroBuildToolset" value="https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/signing/README.md
+++ b/eng/signing/README.md
@@ -16,6 +16,8 @@ This infrastructure runs on Windows only.
    ```
    dotnet restore
    ```
+   * You may need to add the MicroBuild feed into a NuGet.Config file:  
+     `https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json`
 1. Run a "test sign" job to exercise the tooling:
    ```
    dotnet msbuild /t:SignGoFiles /p:SignFilesDir=tosign /p:SigningType=test /bl


### PR DESCRIPTION
* For #207 

See https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1631550925889?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1631550925889&teamName=.NET%20Core%20Eng%20Services%20Partners&channelName=First%20Responders&createdTime=1631550925889

Test build with this change: https://dev.azure.com/dnceng/internal/_build/results?buildId=1500367&view=results