### PR TITLE
Reenable elliptic curve P224

### DIFF
--- a/src/crypto/ecdsa/ecdsa_test.go
+++ b/src/crypto/ecdsa/ecdsa_test.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"compress/bzip2"
 	"crypto/elliptic"
-	"crypto/internal/boring"
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -36,9 +35,6 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
 		tests = tests[:1]
 	}
 	for _, test := range tests {
-		if boring.Enabled() && test.name == "P224" {
-			t.Skip("p224 not supported in FIPS mode")
-		}
 		curve := test.curve
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -227,9 +223,6 @@ func TestVectors(t *testing.T) {
 
 			switch parts[0] {
 			case "P-224":
-				if boring.Enabled() { // P-224 not supported in RHEL OpenSSL.
-					continue
-				}
 				pub.Curve = elliptic.P224()
 			case "P-256":
 				pub.Curve = elliptic.P256()

--- a/src/crypto/ecdsa/equal_test.go
+++ b/src/crypto/ecdsa/equal_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/internal/boring"
 	"crypto/rand"
 	"crypto/x509"
 	"testing"
@@ -66,10 +65,8 @@ func testEqual(t *testing.T, c elliptic.Curve) {
 }
 
 func TestEqual(t *testing.T) {
-	if !boring.Enabled() {
-		t.Run("P224", func(t *testing.T) { testEqual(t, elliptic.P224()) })
-	}
-	if !boring.Enabled() && testing.Short() {
+	t.Run("P224", func(t *testing.T) { testEqual(t, elliptic.P224()) })
+	if testing.Short() {
 		return
 	}
 	t.Run("P256", func(t *testing.T) { testEqual(t, elliptic.P256()) })

--- a/src/crypto/internal/boring/ecdsa.go
+++ b/src/crypto/internal/boring/ecdsa.go
@@ -43,7 +43,7 @@ var errUnsupportedCurve = errors.New("boringcrypto: unsupported elliptic curve")
 func curveNID(curve string) (C.int, error) {
 	switch curve {
 	case "P-224":
-		return 0, errUnsupportedCurve
+		return C.GO_NID_secp224r1, nil
 	case "P-256":
 		return C.GO_NID_X9_62_prime256v1, nil
 	case "P-384":

--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -58,6 +58,7 @@ _goboringcrypto_OPENSSL_setup(void)
 
 enum
 {
+	GO_NID_secp224r1 = NID_secp224r1,
 	GO_NID_X9_62_prime256v1 = NID_X9_62_prime256v1,
 	GO_NID_secp384r1 = NID_secp384r1,
 	GO_NID_secp521r1 = NID_secp521r1,


### PR DESCRIPTION
EC P224 is disabled in Fedora's fork because RHEL OpenSSL does not support it. On the other hand, it is supported by official openssl, boringcrypto and even [Fedora](https://src.fedoraproject.org/rpms/openssl/blob/rawhide/f/0011-Remove-EC-curves.patch).

I can't find the source code for RHEL OpenSSL to see if they really patched openssl to removed EC P224 support, but I've found this issue from 2015 where someone is asking RedHat to enable it without much luck: https://bugzilla.redhat.com/show_bug.cgi?id=1067697.

In this PR I'm reverting the changes RedHat did to disable EC P224 so we don't break existing Go code that uses EC P224.