### PR TITLE
Fall back to std hmac when openssl does not recognize it

### DIFF
--- a/src/crypto/hmac/hmac.go
+++ b/src/crypto/hmac/hmac.go
@@ -133,8 +133,7 @@ func New(h func() hash.Hash, key []byte) hash.Hash {
 		if hm != nil {
 			return hm
 		}
-		// BoringCrypto did not recognize h.
-		boring.UnreachableExceptTests()
+		// BoringCrypto did not recognize h, so fall through to standard Go code.
 	}
 	hm := new(hmac)
 	hm.outer = h()

--- a/src/crypto/hmac/hmac_test.go
+++ b/src/crypto/hmac/hmac_test.go
@@ -7,6 +7,7 @@ package hmac
 import (
 	"bytes"
 	"crypto/internal/boring"
+	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -77,6 +78,16 @@ var hmacTests = []hmacTest{
 		"bcf41eab8bb2d802f3d05caf7cb092ecf8d1a3aa",
 		sha1.Size,
 		sha1.BlockSize,
+	},
+
+	// Test from Plan 9.
+	{
+		md5.New,
+		[]byte("Jefe"),
+		[]byte("what do ya want for nothing?"),
+		"750c783e6ab0b503eaa86e310a5db738",
+		md5.Size,
+		md5.BlockSize,
 	},
 
 	// Tests from RFC 4231


### PR DESCRIPTION
Fedora's fork changed boringcrypto branch behavior to panic when calling `hmac.New` and openssl does not recognize the hash function. This is disruptive for our downstream users, who may want to use this function in a non-FIPS compliant way.

This PR instruct `hmac.New` to fall back to standard library hmac in this situation.