### PR TITLE
Update go-infra to latest

### DIFF
--- a/eng/_util/go.mod
+++ b/eng/_util/go.mod
@@ -7,6 +7,6 @@ module github.com/microsoft/go/_util
 go 1.16
 
 require (
-	github.com/microsoft/go-infra v0.0.0-20210927221531-36ab28c98734
+	github.com/microsoft/go-infra v0.0.0-20211206195537-520f2621bcf4
 	gotest.tools/gotestsum v1.6.5-0.20210515201937-ecb7c6956f6d
 )

--- a/eng/_util/go.sum
+++ b/eng/_util/go.sum
@@ -15,8 +15,8 @@ github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/microsoft/go-infra v0.0.0-20210927221531-36ab28c98734 h1:Nh4Xo8VRiv1SQ1Q0lCJxCi7pHWYyI2xVdyawB8F9w6w=
-github.com/microsoft/go-infra v0.0.0-20210927221531-36ab28c98734/go.mod h1:3IVGTm7qFJldQHximiWLg2kYfmugjZMGNHnvUo5Mo5M=
+github.com/microsoft/go-infra v0.0.0-20211206195537-520f2621bcf4 h1:goYnnCGbN9HBwd0CtdiokVAlq5rTQkqq66K43kvGnhc=
+github.com/microsoft/go-infra v0.0.0-20211206195537-520f2621bcf4/go.mod h1:3IVGTm7qFJldQHximiWLg2kYfmugjZMGNHnvUo5Mo5M=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
This update gives us some fixes to build asset json generation: https://github.com/microsoft/go-infra/compare/36ab28c98734...520f2621bcf4.

This would fix the issue with newlines appearing in the FIPS branch's build asset JSON files, but that might be preempted by https://github.com/microsoft/go/pull/316 removing the source of the newlines anyway.