### PR TITLE
Implement aes-gcm-192 using openssl

### DIFF
--- a/src/crypto/internal/boring/aes.go
+++ b/src/crypto/internal/boring/aes.go
@@ -315,11 +315,12 @@ func (c *aesCipher) newGCM(tls bool) (cipher.AEAD, error) {
 	switch len(c.key) * 8 {
 	case 128:
 		g.cipher = C._goboringcrypto_EVP_aes_128_gcm()
+	case 192:
+		g.cipher = C._goboringcrypto_EVP_aes_192_gcm()
 	case 256:
 		g.cipher = C._goboringcrypto_EVP_aes_256_gcm()
 	default:
-		// Fall back to standard library for GCM with non-standard key size.
-		return cipher.NewGCMWithNonceSize(&noGCM{c}, gcmStandardNonceSize)
+		panic("crypto/boring: unsupported key length")
 	}
 
 	return g, nil

--- a/src/crypto/internal/boring/openssl_funcs.h
+++ b/src/crypto/internal/boring/openssl_funcs.h
@@ -176,6 +176,7 @@ DEFINEFUNC(const EVP_CIPHER*, EVP_aes_128_gcm, (void), ()) \
 DEFINEFUNC(const EVP_CIPHER*, EVP_aes_128_cbc, (void), ()) \
 DEFINEFUNC(const EVP_CIPHER*, EVP_aes_128_ctr, (void), ()) \
 DEFINEFUNC(const EVP_CIPHER*, EVP_aes_128_ecb, (void), ()) \
+DEFINEFUNC(const EVP_CIPHER*, EVP_aes_192_gcm, (void), ()) \
 DEFINEFUNC(const EVP_CIPHER*, EVP_aes_192_cbc, (void), ()) \
 DEFINEFUNC(const EVP_CIPHER*, EVP_aes_192_ctr, (void), ()) \
 DEFINEFUNC(const EVP_CIPHER*, EVP_aes_192_ecb, (void), ()) \


### PR DESCRIPTION
[EVP_aes_192_gcm](https://www.openssl.org/docs/man3.0/man3/EVP_aes_192_gcm.html) is implemented for all our supported OpenSSL versions, so there is no reason to implement it using Go, which is not FIPS compliant.