### PR TITLE
Fork dev.boringcrypto from main

### DIFF
--- a/eng/_core/cmd/build/build.go
+++ b/eng/_core/cmd/build/build.go
@@ -165,6 +165,11 @@ func build(o *options) error {
 			}
 		}
 
+		// Extend the test timeout to allow slower build agents.
+		if err := os.Setenv("GO_TEST_TIMEOUT_SCALE", "10"); err != nil {
+			return err
+		}
+
 		// "-json": Get test results as lines of JSON.
 		if o.JSON {
 			testCommandLine = append(testCommandLine, "-json")

--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -88,6 +88,9 @@ func main() {
 		env("GOEXPERIMENT", "staticlockranking")
 	}
 
+	// Extend the test timeout to allow slower build agents.
+	env("GO_TEST_TIMEOUT_SCALE", "10")
+
 	runOrPanic("pwsh", "eng/run.ps1", "build")
 
 	// After the build completes, run builder-specific commands.

--- a/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
+++ b/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
@@ -1,4 +1,4 @@
-From be418f20052ddea746451bafe21fdbf2bb1c915d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Davis Goodin <dagood@microsoft.com>
 Date: Tue, 4 Jan 2022 11:23:27 -0600
 Subject: [PATCH] cmd/dist: add JSON output support for some tests
@@ -17,7 +17,7 @@ in JSON format, and the ordinary logs are still important.
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 50a2e5936c..0436c63063 100644
+index 98e30a158f..518b35c53a 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -29,6 +29,7 @@ func cmdtest() {

--- a/patches/0002-cmd-dist-add-explicit-default-timeout-for-cgo.patch
+++ b/patches/0002-cmd-dist-add-explicit-default-timeout-for-cgo.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Mon, 31 Jan 2022 15:48:37 -0600
+Subject: [PATCH] cmd/dist: add explicit default timeout for cgo
+
+Add "t.timeout" call to cgo test command with the default value, 600.
+This makes GO_TEST_TIMEOUT_SCALE have an effect on cgo test timeout.
+---
+ src/cmd/dist/test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
+index 518b35c53a..b63bf1fcdc 100644
+--- a/src/cmd/dist/test.go
++++ b/src/cmd/dist/test.go
+@@ -1136,7 +1136,7 @@ func (t *tester) runHostTest(dir, pkg string) error {
+ }
+ 
+ func (t *tester) cgoTest(dt *distTest) error {
+-	cmd := t.addCmd(dt, "misc/cgo/test", t.goTest())
++	cmd := t.addCmd(dt, "misc/cgo/test", t.goTest(), t.timeout(600))
+ 	setEnv(cmd, "GOFLAGS", "-ldflags=-linkmode=auto")
+ 
+ 	// Skip internal linking cases on linux/arm64 to support GCC-9.4 and above.


### PR DESCRIPTION
Recreating https://github.com/microsoft/go/pull/346 with the submodule+patches method, as a fork from `microsoft/main`.

A submodule-based `microsoft/dev.boringcrypto` branch doesn't exist yet, so I'm testing the PR against `microsoft/main`. Once this PR works and gets approval, I'll push this branch as `microsoft/dev.boringcrypto`, to kick it off. This branch had CI issues as of https://github.com/microsoft/go/pull/346.