### PR TITLE
Port "make" retry on Windows to main branch

### DIFF
--- a/eng/_core/cmd/build/build.go
+++ b/eng/_core/cmd/build/build.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"github.com/microsoft/go/_core/archive"
 	"github.com/microsoft/go/_core/patch"
@@ -126,10 +127,33 @@ func build(o *options) error {
 			}
 		}
 
+		// Set GOBUILDEXIT so 'make.bat' exits with exit code upon failure. The ordinary behavior of
+		// 'make.bat' is to always end with 0 exit code even if an error occurred, so 'all.bat' can
+		// handle the error. See https://github.com/golang/go/issues/7806.
+		if err := os.Setenv("GOBUILDEXIT", "1"); err != nil {
+			return err
+		}
+
+		maxAttempts, err := getMaxMakeRetryAttempts()
+		if err != nil {
+			return err
+		}
+
 		buildCommandLine := append(shellPrefix, "make"+scriptExtension)
 
-		if err := runCommandLine(buildCommandLine...); err != nil {
-			return err
+		for i := 0; i < maxAttempts; i++ {
+			if maxAttempts > 1 {
+				fmt.Printf("---- Running 'make' attempt %v of %v...\n", i+1, maxAttempts)
+			}
+			err := runCommandLine(buildCommandLine...)
+			if err != nil {
+				if i+1 < maxAttempts {
+					fmt.Printf("---- Build command failed with error: %v\n", err)
+					continue
+				}
+				return err
+			}
+			break
 		}
 
 		if os.Getenv("CGO_ENABLED") != "0" {
@@ -215,4 +239,17 @@ func runCommandLine(commandLine ...string) error {
 func runCmd(cmd *exec.Cmd) error {
 	fmt.Printf("---- Running command: %v\n", cmd.Args)
 	return cmd.Run()
+}
+
+func getMaxMakeRetryAttempts() (int, error) {
+	const retryEnvVarName = "GO_MAKE_MAX_RETRY_ATTEMPTS"
+	a := os.Getenv(retryEnvVarName)
+	if a == "" {
+		return 1, nil
+	}
+	i, err := strconv.Atoi(a)
+	if err != nil {
+		return 0, fmt.Errorf("env var '%v' is not an int: %w", retryEnvVarName, err)
+	}
+	return i, nil
 }

--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -36,6 +36,11 @@ jobs:
 
       - ${{ if eq(parameters.builder.os, 'windows') }}:
         - template: ../steps/checkout-windows-task.yml
+        - pwsh: |
+            Write-Host "Increasing max build retries to mitigate 'Access denied' flakiness during EXE copying on Windows."
+            Write-Host "##vso[task.setvariable variable=GO_MAKE_MAX_RETRY_ATTEMPTS]5"
+          displayName: Increase 'make' retry attempts
+
 
       # Initialize stage 0 toolset ahead of time so we can track timing data separately from the
       # build operations. When we call this script again later, it won't download Go again.


### PR DESCRIPTION
Port https://github.com/microsoft/go/commit/a0895e34f0e9752dd23fae90c48af5197d168483 (https://github.com/microsoft/go/pull/299) to `microsoft/main` to mitigate:

* https://github.com/microsoft/go/issues/241

---

At the time of the original PR, Windows flakiness was only showing up in the 1.17 branch, so this feature was implemented there. But, I saw it in `microsoft/main` while working on the migration to submodules: 

```
go install cmd/link: copying
  C:\Users\VSSADM~1\AppData\Local\Temp\go-build2884892749\b164\exe\a.out.exe:
  open D:\a\1\s\go\pkg\tool\windows_amd64\link.exe: Access is denied.
```

https://dev.azure.com/dnceng/internal/_build/results?buildId=1574835&view=logs&j=b5927786-9a30-525e-205c-cd8ea15c1825&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=f7c1727d-5b14-5ff4-8b2e-08087f80ab99&l=86

(Technically `link.exe` rather than `compile.exe`, but it seems likely to be the same root cause.)