### PR TITLE
Find submodule VERSION file for build asset json

### DIFF
--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -44,26 +44,7 @@ jobs:
           Get-Stage0GoRoot
         displayName: Init stage 0 Go toolset
 
-      - pwsh: |
-          function fetch_submodule() {
-            eng/run.ps1 submodule-refresh -shallow @args
-          }
-
-          if ("$env:FETCH_BEARER_TOKEN") {
-            fetch_submodule `
-              -origin 'https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror' `
-              -fetch-bearer-token $env:FETCH_BEARER_TOKEN
-          } else {
-            fetch_submodule
-          }
-        # If non-public, use access token to fetch from repo. If public, don't use the access token,
-        # because anonymous auth is fine.
-        ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          env:
-            FETCH_BEARER_TOKEN: $(System.AccessToken)
-          displayName: Set up submodule from internal mirror
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          displayName: Set up submodule
+      - template: ../steps/init-submodule-task.yml
 
       # Use build script directly for "buildandpack". If we used run-builder, we would need to
       # download its external module dependencies.

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -37,6 +37,7 @@ stages:
         steps:
           - template: steps/checkout-unix-task.yml
           - template: steps/init-pwsh-task.yml
+          - template: steps/init-submodule-task.yml
 
           - pwsh: |
               function TrimStart($s, $prefix) {
@@ -68,7 +69,7 @@ stages:
           - pwsh: |
               eng/run.ps1 createbuildassetjson `
                 -artifacts-dir '$(Pipeline.Workspace)/Binaries Signed/' `
-                -source-dir '$(Build.SourcesDirectory)' `
+                -source-dir '$(Build.SourcesDirectory)/go' `
                 -destination-url '$(blobDestinationUrl)' `
                 -branch '$(PublishBranchAlias)' `
                 -o '$(Pipeline.Workspace)/Binaries Signed/assets.json'

--- a/eng/pipeline/steps/init-submodule-task.yml
+++ b/eng/pipeline/steps/init-submodule-task.yml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Shallow checkout sources on Windows
+steps:
+  - pwsh: |
+      function fetch_submodule() {
+        eng/run.ps1 submodule-refresh -shallow @args
+      }
+
+      if ("$env:FETCH_BEARER_TOKEN") {
+        fetch_submodule `
+          -origin 'https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror' `
+          -fetch-bearer-token $env:FETCH_BEARER_TOKEN
+      } else {
+        fetch_submodule
+      }
+    # If non-public, use access token to fetch from repo. If public, don't use the access token,
+    # because anonymous auth is fine.
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      env:
+        FETCH_BEARER_TOKEN: $(System.AccessToken)
+      displayName: Set up submodule from internal mirror
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      displayName: Set up submodule


### PR DESCRIPTION
* https://github.com/microsoft/go/issues/386

The build asset JSON file is generated in the publish job. To get the `VERSION` file, the job has to initialize the submodule, so I turned that into a template so it can be shared by publish and build jobs. Then I tweaked the source dir to point at the submodule instead of our own source dir.

This doesn't change anything in `microsoft/main` because there is no `VERSION` file in the submodule, but this will be used when future releases fork from `microsoft/main`. (I'm also cherry-picking this backwards.)