### PR TITLE
Add missing boring import replacement

### DIFF
--- a/patches/0003-Integrate-OpenSSL-crypto-module.patch
+++ b/patches/0003-Integrate-OpenSSL-crypto-module.patch
@@ -4,6 +4,8 @@ Date: Thu, 27 Jan 2022 11:45:14 -0600
 Subject: [PATCH] Integrate OpenSSL crypto module
 
 replace boring import
+
+crypto/tls: boringEnabled is not const
 ---
  src/cmd/link/internal/ld/lib.go              |   2 +-
  src/crypto/aes/cipher.go                     |   2 +-
@@ -30,11 +32,11 @@ replace boring import
  src/crypto/sha256/sha256_test.go             |   2 +-
  src/crypto/sha512/sha512.go                  |   2 +-
  src/crypto/sha512/sha512_test.go             |   2 +-
- src/crypto/tls/boring.go                     |   2 +-
+ src/crypto/tls/boring.go                     |   4 +-
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/go/build/deps_test.go                    |  13 +-
  src/runtime/runtime_boring.go                |   5 +
- 29 files changed, 336 insertions(+), 26 deletions(-)
+ 29 files changed, 337 insertions(+), 27 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/dummy.s
  create mode 100644 src/crypto/internal/backend/nobackend.go
@@ -639,10 +641,10 @@ index 6964bef8f7..255c51f3a7 100644
  type sha512Test struct {
  	out       string
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index d61deb5b81..c0d281255a 100644
+index d61deb5b81..d4b67bb692 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
-@@ -6,7 +6,7 @@ package tls
+@@ -6,14 +6,14 @@ package tls
  
  import (
  	"crypto/ecdsa"
@@ -651,6 +653,14 @@ index d61deb5b81..c0d281255a 100644
  	"crypto/internal/boring/fipstls"
  	"crypto/rsa"
  	"crypto/x509"
+ )
+ 
+ // boringEnabled is an alias of boring.Enabled to avoid a new import in common.go.
+-const boringEnabled = boring.Enabled
++var boringEnabled = boring.Enabled
+ 
+ // needFIPS returns fipstls.Required(); it avoids a new import in common.go.
+ func needFIPS() bool {
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
 index 6596562fb1..9e8960671e 100644
 --- a/src/crypto/tls/cipher_suites.go


### PR DESCRIPTION
go 1.16 and older versions contains a `crypto/internal/boring` import which was removed in go1.17, therefore the go1.17 patches do not replace it with `crypto/internal/backend`.

This has been detected in the CI because there is a test that verifies no one is importing `crypto/internal/boring`.

The corresponding patch has been updated using `git go-patch rebase` squashing the commit that replaces the import.