### PR TITLE
Update branch in eng/doc/fips link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This fork exists to produce a version of Go that can be used to build FIPS 140-2
 compliant applications. Our goal is to share this implementation with others in
 the Go community who have the same requirement, and to merge this capability
 into upstream Go as soon as possible. See
-[eng/doc/fips@dev/official/go1.17-openssl-fips](https://github.com/microsoft/go/tree/dev/official/go1.17-openssl-fips/eng/doc/fips)
+[eng/doc/fips@microsoft/dev.boringcrypto.go1.17](https://github.com/microsoft/go/tree/microsoft/dev.boringcrypto.go1.17/eng/doc/fips)
 for more information about this feature and the history of FIPS 140-2 compliance
 in Go.
 


### PR DESCRIPTION
Update from `dev/official/go1.17-openssl-fips` to `microsoft/dev.boringcrypto.go1.17` (most recent FIPS branch) when linking to `eng/doc/fips` in the readme.

I think we should do this so if anyone writes a link to the page somewhere after we open the repo, at least they'll be on an actual release branch rather than a temp dev branch. (We could add a pointer to a newer doc when we move it to `microsoft/dev.boringcrypto` or `microsoft/main`.)