### PR TITLE
Update links to CI build definitions

### DIFF
--- a/eng/pipeline/README.md
+++ b/eng/pipeline/README.md
@@ -5,18 +5,18 @@ This directory contains Azure DevOps (AzDO) YAML pipelines for CI.
 Pipeline definitions currently using each YAML file are:
 
 * [`pr-pipeline.yml`](pr-pipeline.yml) - Required PR check.
-  * [microsoft-go-private-github](https://dev.azure.com/dnceng/internal/_build?definitionId=969)
+  * (Public) [microsoft-go](https://dev.azure.com/dnceng/public/_build?definitionId=1099)
 * [`pr-outerloop-pipeline.yml`](pr-outerloop-pipeline.yml) - Optional PR check.
   Runs outerloop.
-  * [microsoft-go-pr-outerloop](https://dev.azure.com/dnceng/internal/_build?definitionId=989)
-    * Comment `/azp run microsoft-go-pr-outerloop` on a PR to run.
+  * (Public) [microsoft-go-outerloop](https://dev.azure.com/dnceng/public/_build/index?definitionId=1100)
+    * Comment `/azp run microsoft-go-outerloop` on a PR to run.
 * [`rolling-pipeline.yml`](rolling-pipeline.yml) - Triggers on merge, runs
   innerloop + outerloop.
-  * [microsoft-go-rolling](https://dev.azure.com/dnceng/internal/_build?definitionId=987)
+  * (Internal) [microsoft-go-rolling](https://dev.azure.com/dnceng/internal/_build?definitionId=987)
 * [`rolling-internal-pipeline.yml`](rolling-internal-pipeline.yml) - Triggers on
   merge. Builds, signs, and publishes. Runs innerloop, and won't publish if
   innerloop fails.
-  * [microsoft-go](https://dev.azure.com/dnceng/internal/_build?definitionId=958)
+  * (Internal) [microsoft-go](https://dev.azure.com/dnceng/internal/_build?definitionId=958)
 
 The pipeline filenames are (mostly) based on the trigger scenario, not what they
 do. This means we can change their content later without worrying about


### PR DESCRIPTION
Now that the repo is public, move the CI to the public AzDO instance.

This PR is also a test that the triggers work.