### PR TITLE
Remove private repo pipeline's checkout workaround

### DIFF
--- a/eng/pipeline/steps/checkout-unix-task.yml
+++ b/eng/pipeline/steps/checkout-unix-task.yml
@@ -4,15 +4,7 @@
 
 # Shallow checkout sources on Unix
 steps:
-  # If this is a PR to a private GitHub repo, AzDO needs to know so it can generate a token with
-  # GitHub access. This workaround can be removed once our GitHub repo is public.
-  - ${{ if in(variables['Build.DefinitionName'], 'microsoft-go-private-github', 'microsoft-go-pr-outerloop') }}:
-    - checkout: self
-      fetchDepth: 1
-
-  - ${{ if not(in(variables['Build.DefinitionName'], 'microsoft-go-private-github', 'microsoft-go-pr-outerloop')) }}:
-    - checkout: none
-
+  - checkout: none
   - script: |
       set -x
 

--- a/eng/pipeline/steps/checkout-windows-task.yml
+++ b/eng/pipeline/steps/checkout-windows-task.yml
@@ -4,15 +4,7 @@
 
 # Shallow checkout sources on Windows
 steps:
-  # If this is a PR to a private GitHub repo, AzDO needs to know so it can generate a token with
-  # GitHub access. This workaround can be removed once our GitHub repo is public.
-  - ${{ if in(variables['Build.DefinitionName'], 'microsoft-go-private-github', 'microsoft-go-pr-outerloop') }}:
-    - checkout: self
-      fetchDepth: 1
-
-  - ${{ if not(in(variables['Build.DefinitionName'], 'microsoft-go-private-github', 'microsoft-go-pr-outerloop')) }}:
-    - checkout: none
-
+  - checkout: none
   - powershell: |
       git init
       git remote add ci-origin "$(Build.Repository.Uri)"


### PR DESCRIPTION
Remove an auth-related workaround now that this repository is public. It isn't harmful, but it will no longer be used.