### PR TITLE
[1.17] Merge from 1.16

### DIFF
--- a/eng/_core/cmd/pack-source/pack-source.go
+++ b/eng/_core/cmd/pack-source/pack-source.go
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/microsoft/go/_core/archive"
+)
+
+const description = `
+This command creates a source archive of the Go submodule at HEAD.
+`
+
+func main() {
+	output := flag.String("o", "", "The path of the archive file to create, including extension. Default: a tar.gz file including build number in 'eng/artifacts/bin'.")
+	help := flag.Bool("h", false, "Print this help message.")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n", description)
+	}
+
+	flag.Parse()
+	if *help {
+		flag.Usage()
+		return
+	}
+
+	repoRootDir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	goRootDir := filepath.Join(repoRootDir, "go")
+
+	if err := archive.CreateFromSource(goRootDir, *output); err != nil {
+		panic(err)
+	}
+}

--- a/eng/_core/cmd/submodule-refresh/submodule-refresh.go
+++ b/eng/_core/cmd/submodule-refresh/submodule-refresh.go
@@ -19,6 +19,7 @@ applies patches to the stage by default, or optionally as commits.
 `
 
 var commits = flag.Bool("commits", false, "Apply the patches as commits.")
+var skipPatch = flag.Bool("skip-patch", false, "Skip applying patches.")
 var origin = flag.String("origin", "", "Use this origin instead of the default defined in '.gitmodules' to fetch the repository.")
 var shallow = flag.Bool("shallow", false, "Clone the submodule with depth 1.")
 var fetchBearerToken = flag.String("fetch-bearer-token", "", "Use this bearer token to fetch the submodule repository.")
@@ -55,6 +56,10 @@ func refresh(rootDir string) error {
 
 	if err := submodule.Reset(rootDir); err != nil {
 		return err
+	}
+
+	if *skipPatch {
+		return nil
 	}
 
 	mode := patch.ApplyModeIndex

--- a/eng/_util/go.mod
+++ b/eng/_util/go.mod
@@ -7,6 +7,6 @@ module github.com/microsoft/go/_util
 go 1.16
 
 require (
-	github.com/microsoft/go-infra v0.0.0-20211206195537-520f2621bcf4
+	github.com/microsoft/go-infra v0.0.0-20220208232830-51df6c5b8843
 	gotest.tools/gotestsum v1.6.5-0.20210515201937-ecb7c6956f6d
 )

--- a/eng/_util/go.sum
+++ b/eng/_util/go.sum
@@ -15,8 +15,8 @@ github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/microsoft/go-infra v0.0.0-20211206195537-520f2621bcf4 h1:goYnnCGbN9HBwd0CtdiokVAlq5rTQkqq66K43kvGnhc=
-github.com/microsoft/go-infra v0.0.0-20211206195537-520f2621bcf4/go.mod h1:3IVGTm7qFJldQHximiWLg2kYfmugjZMGNHnvUo5Mo5M=
+github.com/microsoft/go-infra v0.0.0-20220208232830-51df6c5b8843 h1:IAk1GrsBP2l3sdWnaARrLALS9m6fVkGNgefpWRS0x2c=
+github.com/microsoft/go-infra v0.0.0-20220208232830-51df6c5b8843/go.mod h1:3IVGTm7qFJldQHximiWLg2kYfmugjZMGNHnvUo5Mo5M=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/eng/pipeline/jobs/builders-to-jobs.yml
+++ b/eng/pipeline/jobs/builders-to-jobs.yml
@@ -10,12 +10,15 @@ parameters:
   # If true, include a signing job that depends on all 'buildandpack' builder jobs finishing. This
   # lets us start the lengthy tasks of signing and testing in parallel.
   sign: false
+  # If true, generate source archive tarballs, and sign them if signing is enabled.
+  createSourceArchive: false
 
 jobs:
   - ${{ each builder in parameters.builders }}:
     - template: run-job.yml
       parameters:
         builder: ${{ builder }}
+        createSourceArchive: ${{ parameters.createSourceArchive }}
 
   - ${{ if eq(parameters.sign, true) }}:
     - template: sign-job.yml

--- a/eng/pipeline/jobs/go-builder-matrix-jobs.yml
+++ b/eng/pipeline/jobs/go-builder-matrix-jobs.yml
@@ -9,6 +9,7 @@ parameters:
   innerloop: false
   outerloop: false
   sign: false
+  createSourceArchive: false
 
 jobs:
   - template: shorthand-builders-to-builders.yml
@@ -16,6 +17,7 @@ jobs:
       jobsTemplate: builders-to-jobs.yml
       jobsParameters:
         sign: ${{ parameters.sign }}
+        createSourceArchive: ${{ parameters.createSourceArchive }}
       shorthandBuilders:
         - ${{ if eq(parameters.innerloop, true) }}:
           - { os: linux, arch: amd64, config: buildandpack }

--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -7,6 +7,7 @@
 parameters:
   # { id, os, arch, config, distro? }
   builder: {}
+  createSourceArchive: false
 
 jobs:
   - job: ${{ parameters.builder.id }}
@@ -41,7 +42,6 @@ jobs:
             Write-Host "##vso[task.setvariable variable=GO_MAKE_MAX_RETRY_ATTEMPTS]5"
           displayName: Increase 'make' retry attempts
 
-
       # Initialize stage 0 toolset ahead of time so we can track timing data separately from the
       # build operations. When we call this script again later, it won't download Go again.
       - pwsh: |
@@ -50,6 +50,22 @@ jobs:
         displayName: Init stage 0 Go toolset
 
       - template: ../steps/init-submodule-task.yml
+
+      # Create the source archive on one job only. The os choice is arbitrary.
+      - ${{ if and(eq(parameters.createSourceArchive, true), eq(parameters.builder.config, 'buildandpack'), eq(parameters.builder.os, 'linux')) }}:
+        - pwsh: |
+            git config --global user.name "microsoft-golang-bot"
+            git config --global user.email "microsoft-golang-bot@users.noreply.github.com"
+
+            # Turn the patches into commits, so HEAD includes the changes.
+            eng/run.ps1 submodule-refresh -commits
+            eng/run.ps1 pack-source
+          displayName: Archive submodule source
+
+      - pwsh: |
+          # Apply the patches as staged changes, so the HEAD commit is the same as upstream.
+          eng/run.ps1 submodule-refresh
+        displayName: Apply patches
 
       # Use build script directly for "buildandpack". If we used run-builder, we would need to
       # download its external module dependencies.

--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -49,26 +49,7 @@ jobs:
           Get-Stage0GoRoot
         displayName: Init stage 0 Go toolset
 
-      - pwsh: |
-          function fetch_submodule() {
-            eng/run.ps1 submodule-refresh -shallow @args
-          }
-
-          if ("$env:FETCH_BEARER_TOKEN") {
-            fetch_submodule `
-              -origin 'https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror' `
-              -fetch-bearer-token $env:FETCH_BEARER_TOKEN
-          } else {
-            fetch_submodule
-          }
-        # If non-public, use access token to fetch from repo. If public, don't use the access token,
-        # because anonymous auth is fine.
-        ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          env:
-            FETCH_BEARER_TOKEN: $(System.AccessToken)
-          displayName: Set up submodule from internal mirror
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          displayName: Set up submodule
+      - template: ../steps/init-submodule-task.yml
 
       # Use build script directly for "buildandpack". If we used run-builder, we would need to
       # download its external module dependencies.

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -20,6 +20,7 @@ stages:
         parameters:
           innerloop: true
           sign: true
+          createSourceArchive: true
 
   - stage: Publish
     dependsOn: Build

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -37,6 +37,7 @@ stages:
         steps:
           - template: steps/checkout-unix-task.yml
           - template: steps/init-pwsh-task.yml
+          - template: steps/init-submodule-task.yml
 
           - pwsh: |
               function TrimStart($s, $prefix) {
@@ -68,7 +69,7 @@ stages:
           - pwsh: |
               eng/run.ps1 createbuildassetjson `
                 -artifacts-dir '$(Pipeline.Workspace)/Binaries Signed/' `
-                -source-dir '$(Build.SourcesDirectory)' `
+                -source-dir '$(Build.SourcesDirectory)/go' `
                 -destination-url '$(blobDestinationUrl)' `
                 -branch '$(PublishBranchAlias)' `
                 -o '$(Pipeline.Workspace)/Binaries Signed/assets.json'

--- a/eng/pipeline/steps/init-submodule-task.yml
+++ b/eng/pipeline/steps/init-submodule-task.yml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Shallow checkout sources on Windows
+steps:
+  - pwsh: |
+      function fetch_submodule() {
+        eng/run.ps1 submodule-refresh -shallow @args
+      }
+
+      if ("$env:FETCH_BEARER_TOKEN") {
+        fetch_submodule `
+          -origin 'https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror' `
+          -fetch-bearer-token $env:FETCH_BEARER_TOKEN
+      } else {
+        fetch_submodule
+      }
+    # If non-public, use access token to fetch from repo. If public, don't use the access token,
+    # because anonymous auth is fine.
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      env:
+        FETCH_BEARER_TOKEN: $(System.AccessToken)
+      displayName: Set up submodule from internal mirror
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      displayName: Set up submodule

--- a/eng/pipeline/steps/init-submodule-task.yml
+++ b/eng/pipeline/steps/init-submodule-task.yml
@@ -6,7 +6,7 @@
 steps:
   - pwsh: |
       function fetch_submodule() {
-        eng/run.ps1 submodule-refresh -shallow @args
+        eng/run.ps1 submodule-refresh -shallow -skip-patch @args
       }
 
       if ("$env:FETCH_BEARER_TOKEN") {

--- a/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
+++ b/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
@@ -17,7 +17,7 @@ in JSON format, and the ordinary logs are still important.
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 4f081c9f88..c4f1157751 100644
+index f40fa926df..f76ecbe28c 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -29,6 +29,7 @@ func cmdtest() {
@@ -28,7 +28,7 @@ index 4f081c9f88..c4f1157751 100644
  	flag.BoolVar(&t.rebuild, "rebuild", false, "rebuild everything first")
  	flag.BoolVar(&noRebuild, "no-rebuild", false, "overrides -rebuild (historical dreg)")
  	flag.BoolVar(&t.keepGoing, "k", false, "keep going even when error occurred")
-@@ -49,6 +50,7 @@ func cmdtest() {
+@@ -50,6 +51,7 @@ func cmdtest() {
  type tester struct {
  	race        bool
  	listMode    bool
@@ -36,7 +36,7 @@ index 4f081c9f88..c4f1157751 100644
  	rebuild     bool
  	failed      bool
  	keepGoing   bool
-@@ -270,9 +272,13 @@ func short() string {
+@@ -286,9 +288,13 @@ func short() string {
  // Callers should use goTest and then pass flags overriding these
  // defaults as later arguments in the command line.
  func (t *tester) goTest() []string {
@@ -51,9 +51,9 @@ index 4f081c9f88..c4f1157751 100644
  }
  
  func (t *tester) tags() string {
-@@ -345,6 +351,9 @@ func (t *tester) registerStdTest(pkg string) {
+@@ -371,6 +377,9 @@ func (t *tester) registerStdTest(pkg string, useG3 bool) {
  				t.timeout(timeoutSec),
- 				"-gcflags=all=" + gogcflags,
+ 				"-gcflags=all=" + gcflags,
  			}
 +			if t.jsonMode {
 +				args = append(args, "-json")

--- a/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
+++ b/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
@@ -1,4 +1,4 @@
-From be418f20052ddea746451bafe21fdbf2bb1c915d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Davis Goodin <dagood@microsoft.com>
 Date: Tue, 4 Jan 2022 11:23:27 -0600
 Subject: [PATCH] cmd/dist: add JSON output support for some tests
@@ -17,7 +17,7 @@ in JSON format, and the ordinary logs are still important.
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 50a2e5936c..0436c63063 100644
+index 4f081c9f88..c4f1157751 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -29,6 +29,7 @@ func cmdtest() {
@@ -28,7 +28,7 @@ index 50a2e5936c..0436c63063 100644
  	flag.BoolVar(&t.rebuild, "rebuild", false, "rebuild everything first")
  	flag.BoolVar(&noRebuild, "no-rebuild", false, "overrides -rebuild (historical dreg)")
  	flag.BoolVar(&t.keepGoing, "k", false, "keep going even when error occurred")
-@@ -50,6 +51,7 @@ func cmdtest() {
+@@ -49,6 +50,7 @@ func cmdtest() {
  type tester struct {
  	race        bool
  	listMode    bool
@@ -36,7 +36,7 @@ index 50a2e5936c..0436c63063 100644
  	rebuild     bool
  	failed      bool
  	keepGoing   bool
-@@ -294,9 +296,13 @@ func short() string {
+@@ -270,9 +272,13 @@ func short() string {
  // Callers should use goTest and then pass flags overriding these
  // defaults as later arguments in the command line.
  func (t *tester) goTest() []string {
@@ -51,9 +51,9 @@ index 50a2e5936c..0436c63063 100644
  }
  
  func (t *tester) tags() string {
-@@ -379,6 +385,9 @@ func (t *tester) registerStdTest(pkg string, useG3 bool) {
+@@ -345,6 +351,9 @@ func (t *tester) registerStdTest(pkg string) {
  				t.timeout(timeoutSec),
- 				"-gcflags=all=" + gcflags,
+ 				"-gcflags=all=" + gogcflags,
  			}
 +			if t.jsonMode {
 +				args = append(args, "-json")


### PR DESCRIPTION
Making this PR went like this:

* `git merge` from 1.16 in a dev branch.
  * One conflict: the submodule. Resolve using `git reset -- go`, `git merge --continue`.
* Try to build locally. Patches fail to apply because the merge brought in a 1.16-specific tweak.
* Run `git go-patch apply` to start the patch fixup process.
* Inside the submodule, run `git am -3` to start a three-way merge.
* See that the three-way merge was able to take care of the problem and the `am` completed without any more input.
* Run `git go-patch extract` to rewrite the patch file with the fixup.
  * This failed on my first attempt, because of an issue with `git-go-patch`. Pushed a fix (with explanation in comment): https://github.com/microsoft/go-infra/pull/21/commits/e19d885e8e6a68045a7991074e5107e32ed19dbf. Then re-ran the process from `git go-patch apply`.
* Commit and push dev branch.