### PR TITLE
Update go-infra: detect `VERSION` or `go/VERSION`

### DIFF
--- a/eng/_util/go.mod
+++ b/eng/_util/go.mod
@@ -7,6 +7,6 @@ module github.com/microsoft/go/_util
 go 1.16
 
 require (
-	github.com/microsoft/go-infra v0.0.0-20220208232830-51df6c5b8843
+	github.com/microsoft/go-infra v0.0.0-20220209233812-d528ea99adb8
 	gotest.tools/gotestsum v1.6.5-0.20210515201937-ecb7c6956f6d
 )

--- a/eng/_util/go.sum
+++ b/eng/_util/go.sum
@@ -15,8 +15,8 @@ github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/microsoft/go-infra v0.0.0-20220208232830-51df6c5b8843 h1:IAk1GrsBP2l3sdWnaARrLALS9m6fVkGNgefpWRS0x2c=
-github.com/microsoft/go-infra v0.0.0-20220208232830-51df6c5b8843/go.mod h1:3IVGTm7qFJldQHximiWLg2kYfmugjZMGNHnvUo5Mo5M=
+github.com/microsoft/go-infra v0.0.0-20220209233812-d528ea99adb8 h1:2aNRJlGG6hOhHsQV3/5+udsetpNT24/5eeJBMWOmjDY=
+github.com/microsoft/go-infra v0.0.0-20220209233812-d528ea99adb8/go.mod h1:3IVGTm7qFJldQHximiWLg2kYfmugjZMGNHnvUo5Mo5M=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -70,7 +70,7 @@ stages:
           - pwsh: |
               eng/run.ps1 createbuildassetjson `
                 -artifacts-dir '$(Pipeline.Workspace)/Binaries Signed/' `
-                -source-dir '$(Build.SourcesDirectory)/go' `
+                -source-dir '$(Build.SourcesDirectory)' `
                 -destination-url '$(blobDestinationUrl)' `
                 -branch '$(PublishBranchAlias)' `
                 -o '$(Pipeline.Workspace)/Binaries Signed/assets.json'


### PR DESCRIPTION
* Update go-infra to get this change: https://github.com/microsoft/go-infra/pull/22
* Now that it's handled in go-infra, undo https://github.com/microsoft/go/pull/390

When we changed to submodules, I changed `eng/pipeline/rolling-internal-pipeline.yml` to point at `go/VERSION` rather than `VERSION`. Updating the file detection in microsoft/go rather than microsoft/go-infra was a quick fix.

However, the boring branches don't have `VERSION` files. This means in the build asset JSON files, boring builds have the default `main-1` value in them, because there's no version info. So, auto-update into microsoft/go-images isn't working.

To fix this, I changed go-infra to first check `VERSION` (in our repo) then `go/VERSION` (the submodule). (https://github.com/microsoft/go-infra/pull/22) This means we can undo the `eng/pipeline/rolling-internal-pipeline.yml` change. In the boring branches, we can check in our own `VERSION` file to make auto-update work.

We probably also need a `VERSION` file to exist in the boring branches for some future work:
* #140
* #262 

