### PR TITLE
Add aka.ms link generation to internal rolling build publish stage

### DIFF
--- a/eng/.gitignore
+++ b/eng/.gitignore
@@ -1,1 +1,11 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Ignore build artifacts and intermediate files.
 artifacts/
+
+# Ignore Arcade C# project artifacts and intermediate output.
+*.binlog
+obj/
+bin/

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,5 +9,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f7136626d0109856df867481219eb7366951985d</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Deployment.Tasks.Links" Version="7.0.0-beta.22124.4">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>f7136626d0109856df867481219eb7366951985d</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,5 +2,6 @@
 <Project>
   <PropertyGroup>
     <MicrosoftDotNetSignToolVersion>7.0.0-beta.22124.4</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetDeploymentTasksLinksVersion>7.0.0-beta.22124.4</MicrosoftDotNetDeploymentTasksLinksVersion>
   </PropertyGroup>
 </Project>

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -30,15 +30,23 @@ stages:
           # This is a utility job: use generic recent LTS for publishing.
           vmImage: ubuntu-20.04
         variables:
+          - name: buildNumber
+            value: $(Build.BuildNumber)
           - name: blobDestinationUrl
-            value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/$(PublishBranchAlias)/$(Build.BuildNumber)'
+            value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/$(PublishBranchAlias)/$(buildNumber)'
           - group: go-storage
+          - group: go-akams-auth
         workspace:
           clean: all
         steps:
           - template: steps/checkout-unix-task.yml
           - template: steps/init-pwsh-task.yml
           - template: steps/init-submodule-task.yml
+
+          - task: UseDotNet@2
+            displayName: 'Use .NET SDK'
+            inputs:
+              version: 6.x
 
           - pwsh: |
               function TrimStart($s, $prefix) {
@@ -100,3 +108,19 @@ stages:
               done
             displayName: Show uploaded URLs
             workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
+
+          - script: |
+              dotnet build '$(Build.SourcesDirectory)/eng/publishing/UpdateAkaMSLinks/UpdateAkaMSLinks.csproj' \
+                /p:AkaMSClientId=$(akams-client-id) \
+                /p:AkaMSClientSecret=$(akams-client-secret) \
+                /p:UploadedDir="$(Pipeline.Workspace)/Binaries Signed/" \
+                /p:PublishBranchAlias="$(PublishBranchAlias)" \
+                /p:BlobDestinationUrl="$(blobDestinationUrl)" \
+                /p:BuildNumber="$(buildNumber)" \
+                /bl:UpdateAkaMSLinks.binlog
+            displayName: Update aka.ms links
+
+          - publish: 'UpdateAkaMSLinks.binlog'
+            artifact: UpdateAkaMSLinksBinlog
+            displayName: Publish UpdateAkaMSLinksBinlog
+            condition: always()

--- a/eng/publishing/UpdateAkaMSLinks/UpdateAkaMSLinks.csproj
+++ b/eng/publishing/UpdateAkaMSLinks/UpdateAkaMSLinks.csproj
@@ -1,0 +1,72 @@
+<!-- Copyright (c) Microsoft Corporation. Use of this source code is governed by a BSD-style license that can be found in the LICENSE file. -->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    This is a 'csproj' even though it has no C# code. It is simply a csproj to take advantage of the
+    .NET SDK's default csproj handling, which lets us easily download the Links package and use its
+    task. Our target hooks into "Build", so "dotnet build" should be used to run this project in a
+    way that automatically restores the Links package and runs our target.
+  -->
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Versions.props))" />
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Deployment.Tasks.Links" Version="$(MicrosoftDotNetDeploymentTasksLinksVersion)" />
+  </ItemGroup>
+
+  <!-- Fix Links package issue: wrong task name. https://github.com/dotnet/arcade/issues/8573 -->
+  <UsingTask
+    TaskName="CreateAkaMSLinks"
+    AssemblyFile="$(MicrosoftDotNetDeploymentTasksLinksTaskAssembly)"
+    Condition="'$(MicrosoftDotNetDeploymentTasksLinksTaskAssembly)' != ''" />
+
+  <Target Name="UpdateAkaMSLinks" BeforeTargets="Build">
+    <PropertyGroup>
+      <BranchPrefix>golang/daily/$(PublishBranchAlias)/</BranchPrefix>
+      <TargetPrefix>$(BlobDestinationUrl)/</TargetPrefix>
+    </PropertyGroup>
+
+    <Message Text="Updating aka.ms links for branch: $(PublishBranchAlias)" Importance="high" />
+    <Message Text="Pointing from 'https://aka.ms/$(BranchPrefix)' to $(TargetPrefix)" Importance="high" />
+
+    <ItemGroup>
+      <!--
+        Generate an aka.ms link for each file that was uploaded. Remove version number so we end up
+        generating a stable link that points at the latest build.
+      -->
+      <UploadedFile Include="$([MSBuild]::NormalizeDirectory('$(UploadedDir)'))*" />
+      <UploadedFileNameExtension
+        Include="%(UploadedFile.Filename)%(UploadedFile.Extension)"
+        WithoutVersion="$([System.String]::new('%(UploadedFile.Filename)%(UploadedFile.Extension)').Replace('$(BuildNumber)', 'latest'))" />
+      <AkaMSLink
+        Include="@(UploadedFileNameExtension -> '$(BranchPrefix)%(WithoutVersion)')"
+        TargetUrl="$(TargetPrefix)%(Identity)" />
+    </ItemGroup>
+
+    <Message Text="%0A@(AkaMSLink -> 'https://aka.ms/%(Identity) -> %(TargetUrl)', '%0A')%0A" Importance="high" />
+
+    <PropertyGroup>
+      <!-- https://github.com/dotnet/arcade/blob/8b368b64f181855148d55aa76fd8932c46cf8387/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj#L96-L99 -->
+      <AkaMSTenant Condition="'$(AkaMSTenant)' == ''">ncd</AkaMSTenant>
+      <AkaMSOwners Condition="'$(AkaMSOwners)' == ''">jamshedd;leecow;rbhanda;v-susles</AkaMSOwners>
+      <AkaMSCreatedBy Condition="'$(AkaMSCreatedBy)' == ''">dn-bot</AkaMSCreatedBy>
+      <AkaMSGroupOwner Condition="'$(AkaMSGroupOwner)' == ''">ddfwlink</AkaMSGroupOwner>
+    </PropertyGroup>
+
+    <Message Text="Now running CreateAkaMSLinks..." Importance="high" />
+    <CreateAkaMSLinks
+      Links="@(AkaMSLink)"
+      ClientId="$(AkaMSClientId)"
+      ClientSecret="$(AkaMSClientSecret)"
+      Tenant="$(AkaMSTenant)"
+      Owners="$(AkaMSOwners)"
+      CreatedBy="$(AkaMSCreatedBy)"
+      GroupOwner="$(AkaMSGroupOwner)"
+      />
+  </Target>
+
+</Project>

--- a/eng/signing/.gitignore
+++ b/eng/signing/.gitignore
@@ -3,8 +3,6 @@
 # license that can be found in the LICENSE file.
 
 # Ignore results of reproducing a signing job locally.
-*.binlog
-obj/
 signing-log/
 signing-temp/
 tosign/


### PR DESCRIPTION
Generate/update aka.ms links that point at the latest artifacts from a given branch. Replaces the build number with "latest" in the aka.ms URL so you can keep using one link to always pull the latest build number.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1652663&view=results

That generated these links (see logs of the `Update aka.ms links` step):

```
https://aka.ms/golang/daily/dev/dagood/akams-main/assets.json -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/akams-main/20220308.9/assets.json
https://aka.ms/golang/daily/dev/dagood/akams-main/go.latest.linux-amd64.tar.gz -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/akams-main/20220308.9/go.20220308.9.linux-amd64.tar.gz
https://aka.ms/golang/daily/dev/dagood/akams-main/go.latest.linux-amd64.tar.gz.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/akams-main/20220308.9/go.20220308.9.linux-amd64.tar.gz.sha256
https://aka.ms/golang/daily/dev/dagood/akams-main/go.latest.linux-amd64.tar.gz.sig -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/akams-main/20220308.9/go.20220308.9.linux-amd64.tar.gz.sig
https://aka.ms/golang/daily/dev/dagood/akams-main/go.latest.src.tar.gz -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/akams-main/20220308.9/go.20220308.9.src.tar.gz
https://aka.ms/golang/daily/dev/dagood/akams-main/go.latest.src.tar.gz.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/akams-main/20220308.9/go.20220308.9.src.tar.gz.sha256
https://aka.ms/golang/daily/dev/dagood/akams-main/go.latest.src.tar.gz.sig -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/akams-main/20220308.9/go.20220308.9.src.tar.gz.sig
https://aka.ms/golang/daily/dev/dagood/akams-main/go.latest.windows-amd64.zip -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/akams-main/20220308.9/go.20220308.9.windows-amd64.zip
https://aka.ms/golang/daily/dev/dagood/akams-main/go.latest.windows-amd64.zip.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev/dagood/akams-main/20220308.9/go.20220308.9.windows-amd64.zip.sha256
```

These "daily" links should only be used for testing/evaluation purposes. They're probably the most useful when you're trying out `main`, or a dev branch with a particular change in it.

* For https://github.com/microsoft/go/issues/453, but I wouldn't consider the issue complete because this won't generate "last *stable release*" links yet. (We only decide if a build is fit to be called "stable" after the fact.)
* For stable links, we need a release-day pipeline. https://github.com/microsoft/go/issues/423. This PR is an incremental step towards that. (Although it will likely need to be moved into an AzDO template or refactored more broadly.)