### PR TITLE
Recreate all dirs, not only "s", for component governance

### DIFF
--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -45,7 +45,7 @@ jobs:
             set -x
             echo 'Cleaning old build dirs with sudo in case of root ownership.'
             sudo rm -v -rf a b s
-            mkdir s
+            mkdir a b s
           workingDirectory: $(Agent.BuildDirectory)
           displayName: Cleanup
 


### PR DESCRIPTION
A component governance task complains that the `a` directory doesn't exist:
https://dev.azure.com/dnceng/internal/_build/results?buildId=1670932&view=results

So, change the job to recreate all directories we clean up.

I ran a test job, but it looks like the CG task isn't injected during manual builds, so this only makes sure that creating these directories didn't crash the rest of the build:
https://dev.azure.com/dnceng/internal/_build/results?buildId=1674758&view=results
(This is also why we didn't see it when it was initially added: it wouldn't have shown up in an internal test build.)

Adding the cleanup step was part of adding linux-arm64, so this is a small fixup for that work.
* #474 