### PR TITLE
[microsoft/release-branch.go1.4] Update 1.4 branch submodule, add branch-specific readme note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,63 +15,12 @@ of Go](https://go.dev/dl/).
 Unless otherwise noted, the Go source files are distributed under the
 BSD-style license found in the LICENSE file.
 
-## Why does this fork exist?
+## The microsoft/release-branch.go1.4 branch
 
-The `microsoft/dev.boringcrypto*` branches produce a modified version of Go that
-can be used to build FIPS 140-2 compliant applications. Our goal is to share
-this implementation with others in the Go community who have the same
-requirement, and to merge this capability into upstream Go as soon as possible.
-See [eng/doc/fips](eng/doc/fips) for more information about this feature and the
-history of FIPS 140-2 compliance in Go.
-
-The `microsoft/release-branch.go*` branches rebuild released versions of Go with
-no significant changes, for use within Microsoft.
-
-We call this repository a fork even though it isn't a traditional Git fork. Its
-branches do not share Git ancestry with the Go repository. However, the
-repository serves the same purpose as a Git fork: maintaining a modified version
-of the Go source code over time.
-
-## Download and install
-
-This repository's infrastructure currently supports these OS/Arch combinations:
-
-* `linux_amd64`
-* `windows_amd64`
-
-See [eng/README.md](eng/README.md) for more details about the infrastructure.
-
-### Build from source
-
-Prerequisites:
-
-* [PowerShell 6+](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell)
-* [Go install from source prerequisites](https://go.dev/doc/install/source)
-  * Exception: this repository's build script automatically downloads a
-    bootstrap version of Go.
-
-After cloning the repository, use the following build command. You can pass the
-`-help` flag to show more options:
-
-```
-pwsh eng/run.ps1 build -refresh
-```
-
-The resulting Go binary is at `go/bin/go`.
-
-> If you download a source archive from a GitHub release, use the official Go
-> install from source instructions. These source archives only include the `go`
-> directory, not the microsoft/go build infrastructure.
-
-### Binary distribution
-
-[microsoft/go-images](https://github.com/microsoft/go-images) distributes the
-binaries of this Go fork by producing Docker images. The Dockerfiles contain
-URLs that point at the tar.gz or zip binary distribution file used for a
-particular image.
-
-More options are planned in the future.
-[![](https://img.shields.io/github/labels/microsoft/go/Area-Release)](https://github.com/microsoft/go/labels/Area-Release)
+This branch isn't directly used to build Go. It is a place to put a 1.4 Git tag,
+which lets us create a GitHub release that serves a mirror of the official 1.4
+Go C bootstrap source archive. The mirrored source code can then be used by
+other teams in Microsoft to build Go from source.
 
 ## Contributing
 

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -10,6 +10,6 @@ pr:
   - dev/*
 
 jobs:
-  - template: jobs/go-builder-matrix-jobs.yml
-    parameters:
-      innerloop: true
+  - job: noop
+    displayName: 'No-op: branch not used to build'
+    pool: server


### PR DESCRIPTION
This PR updates the readme ([rendered](https://github.com/dagood/go/blob/dev/dagood/1.4/README.md)) and updates the submodule to https://github.com/golang/go/tree/go1.4.

I initially also deleted all the infrastructure, but I decided to leave it alone and just update the readme for now. If we actually end up wanting to build this branch (to produce our own source archives?), we could fit that into the infra.

The idea is that I'll merge this PR, tag it as `v1.4.0-1`, add a GitHub release on that tag, and reupload the source from https://go.dev/doc/install/source#bootstrapFromSource as a GitHub release attachment. (GitHub releases is how Mariner wants to get Go source.)

If we need to update the bootstrap sources, we have options. We could add a `v1.4.0-2` tag on the same commit and make a new release to store the new version. Or, I believe we can always go back and add new files to the existing release. For context about updates: the archive filename mentions 2017-10-03, vs. 1.4's release date of Dec 2014.

* For https://github.com/microsoft/go/issues/486