### PR TITLE
Patch fixup for updating submodule to latest `master` in `microsoft/main` with patch fixup

### DIFF
--- a/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
+++ b/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
@@ -17,7 +17,7 @@ in JSON format, and the ordinary logs are still important.
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index cd3c26ab3a..8ce6c3a0be 100644
+index a540a2abda..b21c99adb6 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -29,6 +29,7 @@ func cmdtest() {
@@ -51,9 +51,9 @@ index cd3c26ab3a..8ce6c3a0be 100644
  }
  
  func (t *tester) tags() string {
-@@ -399,6 +405,9 @@ func (t *tester) registerStdTest(pkg string) {
- 				t.timeout(timeoutSec),
- 				"-gcflags=all=" + gcflags,
+@@ -401,6 +407,9 @@ func (t *tester) registerStdTest(pkg string) {
+ 			if gcflags != "" {
+ 				args = append(args, "-gcflags=all="+gcflags)
  			}
 +			if t.jsonMode {
 +				args = append(args, "-json")


### PR DESCRIPTION
This PR takes the failing `master` -> `microsoft/main` PR https://github.com/microsoft/go/pull/489 and applies a patch fixup to get auto-sync on track again.

Patch fixup was a simple `git am -3` call--nothing needed manual resolution, so I'll turn on auto-merge with one approval.

Initially I pushed a patch fixup to https://github.com/microsoft/go/pull/489 directly, but it hit test flakiness on Windows so it didn't auto-merge. Then, the auto-update infra force-pushed a new commit that got rid of my fixup.

Related:
* https://github.com/microsoft/go/issues/68
* https://github.com/microsoft/go/pull/475