### PR TITLE
[microsoft/dev.boringcrypto.go1.16] gate openssl backend behind cgo build constraint

### DIFF
--- a/patches/0003-Integrate-OpenSSL-crypto-module.patch
+++ b/patches/0003-Integrate-OpenSSL-crypto-module.patch
@@ -330,7 +330,7 @@ index 0000000000..4de8d404f8
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 0000000000..c1656d6576
+index 0000000000..9fa156894a
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,145 @@
@@ -338,8 +338,8 @@ index 0000000000..c1656d6576
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build linux && !android && !gocrypt && !cmd_go_bootstrap && !msan
-+// +build linux,!android,!gocrypt,!cmd_go_bootstrap,!msan
++//go:build linux && cgo && !android && !gocrypt && !cmd_go_bootstrap && !msan
++// +build linux,cgo,!android,!gocrypt,!cmd_go_bootstrap,!msan
 +
 +// Package openssl provides access to OpenSSLCrypto implementation functions.
 +// Check the variable Enabled to find out whether OpenSSLCrypto is available.


### PR DESCRIPTION
`go-crypto-openssl` should not be used when cgo is disabled, as OpenSSL bindings require cgo.

This PR gates the OpenSSL backend behind the cgo build constraint so it is only used when building with `CGO_ENABLED=1`.

Updates #492