### PR TITLE
[microsoft/dev.boringcrypto.go1.17] Rearrange FIPS patches, start at 0100

### DIFF
--- a/patches/0100-Add-OpenSSL-crypto-module.patch
+++ b/patches/0100-Add-OpenSSL-crypto-module.patch
@@ -1,159 +1,22 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
-Date: Thu, 27 Jan 2022 11:45:14 -0600
-Subject: [PATCH] Integrate OpenSSL crypto module
+Date: Wed, 30 Mar 2022 18:54:05 -0500
+Subject: [PATCH] Add OpenSSL crypto module
 
+github.com/microsoft/go-infra/cmd/git-go-patch command: patch number 0100
 ---
- src/cmd/link/internal/ld/lib.go              |   2 +-
- src/crypto/aes/cipher.go                     |   2 +-
- src/crypto/aes/cipher_asm.go                 |   2 +-
- src/crypto/boring/boring.go                  |   2 +-
- src/crypto/boring/boring_test.go             |   1 +
- src/crypto/ecdsa/boring.go                   |   2 +-
- src/crypto/ecdsa/ecdsa.go                    |   2 +-
- src/crypto/hmac/hmac.go                      |   2 +-
- src/crypto/hmac/hmac_test.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go  |  30 ++++
  src/crypto/internal/backend/dummy.s          |  10 ++
  src/crypto/internal/backend/nobackend.go     | 112 ++++++++++++++
  src/crypto/internal/backend/openssl_linux.go | 145 +++++++++++++++++++
- src/crypto/rand/rand_unix.go                 |   2 +-
- src/crypto/rsa/boring.go                     |   2 +-
- src/crypto/rsa/pkcs1v15.go                   |   2 +-
- src/crypto/rsa/pss.go                        |   2 +-
- src/crypto/rsa/rsa.go                        |   2 +-
- src/crypto/rsa/rsa_test.go                   |   2 +-
- src/crypto/sha1/boring.go                    |   4 +-
- src/crypto/sha1/sha1_test.go                 |   2 +-
- src/crypto/sha256/sha256.go                  |   2 +-
- src/crypto/sha256/sha256_test.go             |   2 +-
- src/crypto/sha512/sha512.go                  |   2 +-
- src/crypto/sha512/sha512_test.go             |   2 +-
- src/crypto/tls/cipher_suites.go              |   2 +-
- src/go/build/deps_test.go                    |  13 +-
- src/runtime/runtime_boring.go                |   5 +
- 28 files changed, 335 insertions(+), 25 deletions(-)
+ src/go.mod                                   |   1 +
+ src/go.sum                                   |   2 +
+ 6 files changed, 300 insertions(+)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/dummy.s
  create mode 100644 src/crypto/internal/backend/nobackend.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
 
-diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index d7e408669e..09c5dd152c 100644
---- a/src/cmd/link/internal/ld/lib.go
-+++ b/src/cmd/link/internal/ld/lib.go
-@@ -1013,7 +1013,7 @@ var hostobj []Hostobj
- // These packages can use internal linking mode.
- // Others trigger external mode.
- var internalpkg = []string{
--	"crypto/internal/boring",
-+	"vendor/github.com/microsoft/go-crypto-openssl/openssl",
- 	"crypto/x509",
- 	"net",
- 	"os/user",
-diff --git a/src/crypto/aes/cipher.go b/src/crypto/aes/cipher.go
-index 29d01796eb..f3680ad6b4 100644
---- a/src/crypto/aes/cipher.go
-+++ b/src/crypto/aes/cipher.go
-@@ -10,7 +10,7 @@ import (
- 	"strconv"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // The AES block size in bytes.
- const BlockSize = 16
-diff --git a/src/crypto/aes/cipher_asm.go b/src/crypto/aes/cipher_asm.go
-index 846f56ab56..e8666b40b6 100644
---- a/src/crypto/aes/cipher_asm.go
-+++ b/src/crypto/aes/cipher_asm.go
-@@ -13,7 +13,7 @@ import (
- 	"internal/cpu"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // defined in asm_*.s
- 
-diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
-index 19e2a0876f..2829231f4a 100644
---- a/src/crypto/boring/boring.go
-+++ b/src/crypto/boring/boring.go
-@@ -11,7 +11,7 @@
- // is satisfied, so that applications can tag files that use this package.
- package boring
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // Enabled reports whether BoringCrypto handles supported crypto operations.
- func Enabled() bool {
-diff --git a/src/crypto/boring/boring_test.go b/src/crypto/boring/boring_test.go
-index ace50de0c2..83ef05d872 100644
---- a/src/crypto/boring/boring_test.go
-+++ b/src/crypto/boring/boring_test.go
-@@ -11,6 +11,7 @@ import (
- )
- 
- func TestEnabled(t *testing.T) {
-+	t.Skip("upstream assumes boring is enabled at build time, we don't")
- 	supportedPlatform := runtime.GOOS == "linux" && runtime.GOARCH == "amd64"
- 	if supportedPlatform && !boring.Enabled() {
- 		t.Error("Enabled returned false on a supported platform")
-diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
-index fa15ecb850..92c42e28d5 100644
---- a/src/crypto/ecdsa/boring.go
-+++ b/src/crypto/ecdsa/boring.go
-@@ -5,7 +5,7 @@
- package ecdsa
- 
- import (
--	"crypto/internal/boring"
-+	boring "crypto/internal/backend"
- 	"math/big"
- 	"sync/atomic"
- 	"unsafe"
-diff --git a/src/crypto/ecdsa/ecdsa.go b/src/crypto/ecdsa/ecdsa.go
-index 1a7635ec2b..6d27b818dd 100644
---- a/src/crypto/ecdsa/ecdsa.go
-+++ b/src/crypto/ecdsa/ecdsa.go
-@@ -42,7 +42,7 @@ import (
- )
- 
- import (
--	"crypto/internal/boring"
-+	boring "crypto/internal/backend"
- 	"unsafe"
- )
- 
-diff --git a/src/crypto/hmac/hmac.go b/src/crypto/hmac/hmac.go
-index 34805765d5..79fd58d0da 100644
---- a/src/crypto/hmac/hmac.go
-+++ b/src/crypto/hmac/hmac.go
-@@ -26,7 +26,7 @@ import (
- 	"hash"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // FIPS 198-1:
- // https://csrc.nist.gov/publications/fips/fips198-1/FIPS-198-1_final.pdf
-diff --git a/src/crypto/hmac/hmac_test.go b/src/crypto/hmac/hmac_test.go
-index 55415abf02..904925377b 100644
---- a/src/crypto/hmac/hmac_test.go
-+++ b/src/crypto/hmac/hmac_test.go
-@@ -6,7 +6,7 @@ package hmac
- 
- import (
- 	"bytes"
--	"crypto/internal/boring"
-+	boring "crypto/internal/backend"
- 	"crypto/md5"
- 	"crypto/sha1"
- 	"crypto/sha256"
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644
 index 0000000000..c2c06d3bff
@@ -475,228 +338,25 @@ index 0000000000..9fa156894a
 +var SignRSAPSS = openssl.SignRSAPSS
 +var VerifyRSAPKCS1v15 = openssl.VerifyRSAPKCS1v15
 +var VerifyRSAPSS = openssl.VerifyRSAPSS
-diff --git a/src/crypto/rand/rand_unix.go b/src/crypto/rand/rand_unix.go
-index 34f4481a9b..486d71e7a3 100644
---- a/src/crypto/rand/rand_unix.go
-+++ b/src/crypto/rand/rand_unix.go
-@@ -23,7 +23,7 @@ import (
- 	"time"
+diff --git a/src/go.mod b/src/go.mod
+index af435fa335..b251be6e34 100644
+--- a/src/go.mod
++++ b/src/go.mod
+@@ -3,6 +3,7 @@ module std
+ go 1.17
+ 
+ require (
++	github.com/microsoft/go-crypto-openssl v0.0.0-20220124101237-183c44c3cf71
+ 	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e
+ 	golang.org/x/net v0.0.0-20220106012031-21a9c9cfe9c3
  )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- const urandomDevice = "/dev/urandom"
- 
-diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
-index 0f362a2f16..856bc26aea 100644
---- a/src/crypto/rsa/boring.go
-+++ b/src/crypto/rsa/boring.go
-@@ -5,7 +5,7 @@
- package rsa
- 
- import (
--	"crypto/internal/boring"
-+	boring "crypto/internal/backend"
- 	"math/big"
- 	"sync/atomic"
- 	"unsafe"
-diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
-index 213ddb4add..5a44b4a71c 100644
---- a/src/crypto/rsa/pkcs1v15.go
-+++ b/src/crypto/rsa/pkcs1v15.go
-@@ -14,7 +14,7 @@ import (
- 	"crypto/internal/randutil"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // This file implements encryption and decryption using PKCS #1 v1.5 padding.
- 
-diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
-index 16ebc0e6a7..54afa8992e 100644
---- a/src/crypto/rsa/pss.go
-+++ b/src/crypto/rsa/pss.go
-@@ -15,7 +15,7 @@ import (
- 	"math/big"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // Per RFC 8017, Section 9.1
- //
-diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index eef967f826..550e66fdd9 100644
---- a/src/crypto/rsa/rsa.go
-+++ b/src/crypto/rsa/rsa.go
-@@ -36,7 +36,7 @@ import (
- )
- 
- import (
--	"crypto/internal/boring"
-+	boring "crypto/internal/backend"
- 	"unsafe"
- )
- 
-diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 766d9a954f..f2602b94ab 100644
---- a/src/crypto/rsa/rsa_test.go
-+++ b/src/crypto/rsa/rsa_test.go
-@@ -15,7 +15,7 @@ import (
- 	"testing"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- func TestKeyGeneration(t *testing.T) {
- 	for _, size := range []int{128, 1024, 2048, 3072} {
-diff --git a/src/crypto/sha1/boring.go b/src/crypto/sha1/boring.go
-index 44c26092ee..ed00d7cd8f 100644
---- a/src/crypto/sha1/boring.go
-+++ b/src/crypto/sha1/boring.go
-@@ -11,11 +11,11 @@
- package sha1
- 
- import (
--	"crypto/internal/boring"
-+	boring "crypto/internal/backend"
- 	"hash"
- )
- 
--const boringEnabled = boring.Enabled
-+var boringEnabled = boring.Enabled
- 
- func boringNewSHA1() hash.Hash { return boring.NewSHA1() }
- 
-diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
-index e369c3b7f4..af10f68853 100644
---- a/src/crypto/sha1/sha1_test.go
-+++ b/src/crypto/sha1/sha1_test.go
-@@ -16,7 +16,7 @@ import (
- 	"testing"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- type sha1Test struct {
- 	out       string
-diff --git a/src/crypto/sha256/sha256.go b/src/crypto/sha256/sha256.go
-index 8b54a427d7..c6aa7a3788 100644
---- a/src/crypto/sha256/sha256.go
-+++ b/src/crypto/sha256/sha256.go
-@@ -13,7 +13,7 @@ import (
- 	"hash"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- func init() {
- 	crypto.RegisterHash(crypto.SHA224, New224)
-diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index 91a4edde04..71eacf53a7 100644
---- a/src/crypto/sha256/sha256_test.go
-+++ b/src/crypto/sha256/sha256_test.go
-@@ -16,7 +16,7 @@ import (
- 	"testing"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- type sha256Test struct {
- 	out       string
-diff --git a/src/crypto/sha512/sha512.go b/src/crypto/sha512/sha512.go
-index 1a2cef317c..b6b390a1b8 100644
---- a/src/crypto/sha512/sha512.go
-+++ b/src/crypto/sha512/sha512.go
-@@ -17,7 +17,7 @@ import (
- 	"hash"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- func init() {
- 	crypto.RegisterHash(crypto.SHA384, New384)
-diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index 966cd51d15..44e3769b0b 100644
---- a/src/crypto/sha512/sha512_test.go
-+++ b/src/crypto/sha512/sha512_test.go
-@@ -17,7 +17,7 @@ import (
- 	"testing"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- type sha512Test struct {
- 	out       string
-diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
-index e07d742bd3..3f72b1e5a0 100644
---- a/src/crypto/tls/cipher_suites.go
-+++ b/src/crypto/tls/cipher_suites.go
-@@ -4,7 +4,7 @@
- 
- package tls
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- import (
- 	"crypto"
-diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index c399946435..ed5b74ee7b 100644
---- a/src/go/build/deps_test.go
-+++ b/src/go/build/deps_test.go
-@@ -400,7 +400,14 @@ var depsRules = `
- 	< crypto/ed25519/internal/edwards25519
- 	< crypto/cipher
- 	< encoding/asn1
--	< crypto/internal/boring
-+	< CRYPTO;
-+
-+	CRYPTO < crypto/internal/boring;
-+	
-+	CRYPTO
-+	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
-+	< github.com/microsoft/go-crypto-openssl/openssl
-+	< crypto/internal/backend
- 	< crypto/aes, crypto/des, crypto/hmac, crypto/md5, crypto/rc4,
- 	  crypto/sha1, crypto/sha256, crypto/sha512
- 	< crypto/rand
-@@ -430,7 +437,7 @@ var depsRules = `
- 	crypto/internal/boring/sig, crypto/internal/boring/fipstls
- 	< crypto/tls/fipsonly;
- 
--	crypto/internal/boring
-+	crypto/internal/backend
- 	< crypto/boring;
- 
- 	# crypto-aware packages
-@@ -623,7 +630,7 @@ var buildIgnore = []byte("\n// +build ignore")
- 
- func findImports(pkg string) ([]string, error) {
- 	vpkg := pkg
--	if strings.HasPrefix(pkg, "golang.org") {
-+	if strings.HasPrefix(pkg, "golang.org") || strings.HasPrefix(pkg, "github.com") {
- 		vpkg = "vendor/" + pkg
- 	}
- 	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
-index 5a98b20253..9042f2c279 100644
---- a/src/runtime/runtime_boring.go
-+++ b/src/runtime/runtime_boring.go
-@@ -17,3 +17,8 @@ func boring_runtime_arg0() string {
- 
- //go:linkname fipstls_runtime_arg0 crypto/internal/boring/fipstls.runtime_arg0
- func fipstls_runtime_arg0() string { return boring_runtime_arg0() }
-+
-+//go:linkname crypto_backend_runtime_arg0 crypto/internal/backend.runtime_arg0
-+func crypto_backend_runtime_arg0() string {
-+	return boring_runtime_arg0()
-+}
+diff --git a/src/go.sum b/src/go.sum
+index 3e3fa7989f..8ab0218786 100644
+--- a/src/go.sum
++++ b/src/go.sum
+@@ -1,3 +1,5 @@
++github.com/microsoft/go-crypto-openssl v0.0.0-20220124101237-183c44c3cf71 h1:NO1CTk7yHEtgUjfV7eqU4+sRe8OHRqZAznWe8WpVj7I=
++github.com/microsoft/go-crypto-openssl v0.0.0-20220124101237-183c44c3cf71/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
+ golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e h1:1SzTfNOXwIS2oWiMF+6qu0OUDKb0dauo6MoDUQyu+yU=
+ golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/patches/0101-Integrate-OpenSSL-module.patch
+++ b/patches/0101-Integrate-OpenSSL-module.patch
@@ -1,0 +1,321 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+Date: Wed, 30 Mar 2022 18:55:16 -0500
+Subject: [PATCH] Integrate OpenSSL module
+
+---
+ src/cmd/link/internal/ld/lib.go  | 2 +-
+ src/crypto/aes/cipher.go         | 2 +-
+ src/crypto/aes/cipher_asm.go     | 2 +-
+ src/crypto/boring/boring.go      | 2 +-
+ src/crypto/ecdsa/boring.go       | 2 +-
+ src/crypto/ecdsa/ecdsa.go        | 2 +-
+ src/crypto/hmac/hmac.go          | 2 +-
+ src/crypto/hmac/hmac_test.go     | 2 +-
+ src/crypto/rand/rand_unix.go     | 2 +-
+ src/crypto/rsa/boring.go         | 2 +-
+ src/crypto/rsa/pkcs1v15.go       | 2 +-
+ src/crypto/rsa/pss.go            | 2 +-
+ src/crypto/rsa/rsa.go            | 2 +-
+ src/crypto/rsa/rsa_test.go       | 2 +-
+ src/crypto/sha1/boring.go        | 4 ++--
+ src/crypto/sha1/sha1_test.go     | 2 +-
+ src/crypto/sha256/sha256.go      | 2 +-
+ src/crypto/sha256/sha256_test.go | 2 +-
+ src/crypto/sha512/sha512.go      | 2 +-
+ src/crypto/sha512/sha512_test.go | 2 +-
+ src/crypto/tls/cipher_suites.go  | 2 +-
+ src/runtime/runtime_boring.go    | 5 +++++
+ 22 files changed, 27 insertions(+), 22 deletions(-)
+
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 0c277f5424..5e83150181 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1013,7 +1013,7 @@ var hostobj []Hostobj
+ // These packages can use internal linking mode.
+ // Others trigger external mode.
+ var internalpkg = []string{
+-	"crypto/internal/boring",
++	"vendor/github.com/microsoft/go-crypto-openssl/openssl",
+ 	"crypto/x509",
+ 	"net",
+ 	"os/user",
+diff --git a/src/crypto/aes/cipher.go b/src/crypto/aes/cipher.go
+index 29d01796eb..f3680ad6b4 100644
+--- a/src/crypto/aes/cipher.go
++++ b/src/crypto/aes/cipher.go
+@@ -10,7 +10,7 @@ import (
+ 	"strconv"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ // The AES block size in bytes.
+ const BlockSize = 16
+diff --git a/src/crypto/aes/cipher_asm.go b/src/crypto/aes/cipher_asm.go
+index 846f56ab56..e8666b40b6 100644
+--- a/src/crypto/aes/cipher_asm.go
++++ b/src/crypto/aes/cipher_asm.go
+@@ -13,7 +13,7 @@ import (
+ 	"internal/cpu"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ // defined in asm_*.s
+ 
+diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
+index 19e2a0876f..2829231f4a 100644
+--- a/src/crypto/boring/boring.go
++++ b/src/crypto/boring/boring.go
+@@ -11,7 +11,7 @@
+ // is satisfied, so that applications can tag files that use this package.
+ package boring
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ // Enabled reports whether BoringCrypto handles supported crypto operations.
+ func Enabled() bool {
+diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
+index fa15ecb850..92c42e28d5 100644
+--- a/src/crypto/ecdsa/boring.go
++++ b/src/crypto/ecdsa/boring.go
+@@ -5,7 +5,7 @@
+ package ecdsa
+ 
+ import (
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"math/big"
+ 	"sync/atomic"
+ 	"unsafe"
+diff --git a/src/crypto/ecdsa/ecdsa.go b/src/crypto/ecdsa/ecdsa.go
+index 1a7635ec2b..6d27b818dd 100644
+--- a/src/crypto/ecdsa/ecdsa.go
++++ b/src/crypto/ecdsa/ecdsa.go
+@@ -42,7 +42,7 @@ import (
+ )
+ 
+ import (
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"unsafe"
+ )
+ 
+diff --git a/src/crypto/hmac/hmac.go b/src/crypto/hmac/hmac.go
+index 34805765d5..79fd58d0da 100644
+--- a/src/crypto/hmac/hmac.go
++++ b/src/crypto/hmac/hmac.go
+@@ -26,7 +26,7 @@ import (
+ 	"hash"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ // FIPS 198-1:
+ // https://csrc.nist.gov/publications/fips/fips198-1/FIPS-198-1_final.pdf
+diff --git a/src/crypto/hmac/hmac_test.go b/src/crypto/hmac/hmac_test.go
+index 55415abf02..904925377b 100644
+--- a/src/crypto/hmac/hmac_test.go
++++ b/src/crypto/hmac/hmac_test.go
+@@ -6,7 +6,7 @@ package hmac
+ 
+ import (
+ 	"bytes"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/md5"
+ 	"crypto/sha1"
+ 	"crypto/sha256"
+diff --git a/src/crypto/rand/rand_unix.go b/src/crypto/rand/rand_unix.go
+index 34f4481a9b..486d71e7a3 100644
+--- a/src/crypto/rand/rand_unix.go
++++ b/src/crypto/rand/rand_unix.go
+@@ -23,7 +23,7 @@ import (
+ 	"time"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ const urandomDevice = "/dev/urandom"
+ 
+diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
+index 0f362a2f16..856bc26aea 100644
+--- a/src/crypto/rsa/boring.go
++++ b/src/crypto/rsa/boring.go
+@@ -5,7 +5,7 @@
+ package rsa
+ 
+ import (
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"math/big"
+ 	"sync/atomic"
+ 	"unsafe"
+diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
+index 213ddb4add..5a44b4a71c 100644
+--- a/src/crypto/rsa/pkcs1v15.go
++++ b/src/crypto/rsa/pkcs1v15.go
+@@ -14,7 +14,7 @@ import (
+ 	"crypto/internal/randutil"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ // This file implements encryption and decryption using PKCS #1 v1.5 padding.
+ 
+diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
+index 16ebc0e6a7..54afa8992e 100644
+--- a/src/crypto/rsa/pss.go
++++ b/src/crypto/rsa/pss.go
+@@ -15,7 +15,7 @@ import (
+ 	"math/big"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ // Per RFC 8017, Section 9.1
+ //
+diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
+index eef967f826..550e66fdd9 100644
+--- a/src/crypto/rsa/rsa.go
++++ b/src/crypto/rsa/rsa.go
+@@ -36,7 +36,7 @@ import (
+ )
+ 
+ import (
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"unsafe"
+ )
+ 
+diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
+index 766d9a954f..f2602b94ab 100644
+--- a/src/crypto/rsa/rsa_test.go
++++ b/src/crypto/rsa/rsa_test.go
+@@ -15,7 +15,7 @@ import (
+ 	"testing"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ func TestKeyGeneration(t *testing.T) {
+ 	for _, size := range []int{128, 1024, 2048, 3072} {
+diff --git a/src/crypto/sha1/boring.go b/src/crypto/sha1/boring.go
+index 44c26092ee..ed00d7cd8f 100644
+--- a/src/crypto/sha1/boring.go
++++ b/src/crypto/sha1/boring.go
+@@ -11,11 +11,11 @@
+ package sha1
+ 
+ import (
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"hash"
+ )
+ 
+-const boringEnabled = boring.Enabled
++var boringEnabled = boring.Enabled
+ 
+ func boringNewSHA1() hash.Hash { return boring.NewSHA1() }
+ 
+diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
+index e369c3b7f4..af10f68853 100644
+--- a/src/crypto/sha1/sha1_test.go
++++ b/src/crypto/sha1/sha1_test.go
+@@ -16,7 +16,7 @@ import (
+ 	"testing"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ type sha1Test struct {
+ 	out       string
+diff --git a/src/crypto/sha256/sha256.go b/src/crypto/sha256/sha256.go
+index 8b54a427d7..c6aa7a3788 100644
+--- a/src/crypto/sha256/sha256.go
++++ b/src/crypto/sha256/sha256.go
+@@ -13,7 +13,7 @@ import (
+ 	"hash"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ func init() {
+ 	crypto.RegisterHash(crypto.SHA224, New224)
+diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
+index 91a4edde04..71eacf53a7 100644
+--- a/src/crypto/sha256/sha256_test.go
++++ b/src/crypto/sha256/sha256_test.go
+@@ -16,7 +16,7 @@ import (
+ 	"testing"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ type sha256Test struct {
+ 	out       string
+diff --git a/src/crypto/sha512/sha512.go b/src/crypto/sha512/sha512.go
+index 1a2cef317c..b6b390a1b8 100644
+--- a/src/crypto/sha512/sha512.go
++++ b/src/crypto/sha512/sha512.go
+@@ -17,7 +17,7 @@ import (
+ 	"hash"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ func init() {
+ 	crypto.RegisterHash(crypto.SHA384, New384)
+diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
+index 966cd51d15..44e3769b0b 100644
+--- a/src/crypto/sha512/sha512_test.go
++++ b/src/crypto/sha512/sha512_test.go
+@@ -17,7 +17,7 @@ import (
+ 	"testing"
+ )
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ type sha512Test struct {
+ 	out       string
+diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
+index e07d742bd3..3f72b1e5a0 100644
+--- a/src/crypto/tls/cipher_suites.go
++++ b/src/crypto/tls/cipher_suites.go
+@@ -4,7 +4,7 @@
+ 
+ package tls
+ 
+-import "crypto/internal/boring"
++import boring "crypto/internal/backend"
+ 
+ import (
+ 	"crypto"
+diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
+index 5a98b20253..9042f2c279 100644
+--- a/src/runtime/runtime_boring.go
++++ b/src/runtime/runtime_boring.go
+@@ -17,3 +17,8 @@ func boring_runtime_arg0() string {
+ 
+ //go:linkname fipstls_runtime_arg0 crypto/internal/boring/fipstls.runtime_arg0
+ func fipstls_runtime_arg0() string { return boring_runtime_arg0() }
++
++//go:linkname crypto_backend_runtime_arg0 crypto/internal/backend.runtime_arg0
++func crypto_backend_runtime_arg0() string {
++	return boring_runtime_arg0()
++}

--- a/patches/0102-Vendor-OpenSSL-crypto-library.patch
+++ b/patches/0102-Vendor-OpenSSL-crypto-library.patch
@@ -1,11 +1,10 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
-Date: Thu, 27 Jan 2022 11:44:32 -0600
-Subject: [PATCH] Add vendored go-crypto-openssl module
+Date: Wed, 30 Mar 2022 18:56:01 -0500
+Subject: [PATCH] Vendor OpenSSL crypto library
 
+To reproduce, run 'go mod vendor' in 'go/src'.
 ---
- src/go.mod                                    |   1 +
- src/go.sum                                    |   2 +
  .../microsoft/go-crypto-openssl/LICENSE       |  21 +
  .../go-crypto-openssl/openssl/aes.go          | 487 ++++++++++++++++++
  .../go-crypto-openssl/openssl/apibridge_1_1.c | 291 +++++++++++
@@ -22,7 +21,7 @@ Subject: [PATCH] Add vendored go-crypto-openssl module
  .../go-crypto-openssl/openssl/rsa.go          | 397 ++++++++++++++
  .../go-crypto-openssl/openssl/sha.go          | 477 +++++++++++++++++
  src/vendor/modules.txt                        |   4 +
- 18 files changed, 2939 insertions(+)
+ 16 files changed, 2936 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/apibridge_1_1.c
@@ -39,28 +38,6 @@ Subject: [PATCH] Add vendored go-crypto-openssl module
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 
-diff --git a/src/go.mod b/src/go.mod
-index af435fa335..b251be6e34 100644
---- a/src/go.mod
-+++ b/src/go.mod
-@@ -3,6 +3,7 @@ module std
- go 1.17
- 
- require (
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20220124101237-183c44c3cf71
- 	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e
- 	golang.org/x/net v0.0.0-20220106012031-21a9c9cfe9c3
- )
-diff --git a/src/go.sum b/src/go.sum
-index 3e3fa7989f..8ab0218786 100644
---- a/src/go.sum
-+++ b/src/go.sum
-@@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220124101237-183c44c3cf71 h1:NO1CTk7yHEtgUjfV7eqU4+sRe8OHRqZAznWe8WpVj7I=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220124101237-183c44c3cf71/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
- golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e h1:1SzTfNOXwIS2oWiMF+6qu0OUDKb0dauo6MoDUQyu+yU=
- golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
- golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE b/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
 new file mode 100644
 index 0000000000..9e841e7a26

--- a/patches/0103-Adjust-Go-tests-to-work-with-crypto-module.patch
+++ b/patches/0103-Adjust-Go-tests-to-work-with-crypto-module.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+Date: Wed, 30 Mar 2022 18:56:30 -0500
+Subject: [PATCH] Adjust Go tests to work with crypto module
+
+---
+ src/crypto/boring/boring_test.go |  1 +
+ src/go/build/deps_test.go        | 13 ++++++++++---
+ 2 files changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/src/crypto/boring/boring_test.go b/src/crypto/boring/boring_test.go
+index ace50de0c2..83ef05d872 100644
+--- a/src/crypto/boring/boring_test.go
++++ b/src/crypto/boring/boring_test.go
+@@ -11,6 +11,7 @@ import (
+ )
+ 
+ func TestEnabled(t *testing.T) {
++	t.Skip("upstream assumes boring is enabled at build time, we don't")
+ 	supportedPlatform := runtime.GOOS == "linux" && runtime.GOARCH == "amd64"
+ 	if supportedPlatform && !boring.Enabled() {
+ 		t.Error("Enabled returned false on a supported platform")
+diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
+index c399946435..ed5b74ee7b 100644
+--- a/src/go/build/deps_test.go
++++ b/src/go/build/deps_test.go
+@@ -400,7 +400,14 @@ var depsRules = `
+ 	< crypto/ed25519/internal/edwards25519
+ 	< crypto/cipher
+ 	< encoding/asn1
+-	< crypto/internal/boring
++	< CRYPTO;
++
++	CRYPTO < crypto/internal/boring;
++	
++	CRYPTO
++	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
++	< github.com/microsoft/go-crypto-openssl/openssl
++	< crypto/internal/backend
+ 	< crypto/aes, crypto/des, crypto/hmac, crypto/md5, crypto/rc4,
+ 	  crypto/sha1, crypto/sha256, crypto/sha512
+ 	< crypto/rand
+@@ -430,7 +437,7 @@ var depsRules = `
+ 	crypto/internal/boring/sig, crypto/internal/boring/fipstls
+ 	< crypto/tls/fipsonly;
+ 
+-	crypto/internal/boring
++	crypto/internal/backend
+ 	< crypto/boring;
+ 
+ 	# crypto-aware packages
+@@ -623,7 +630,7 @@ var buildIgnore = []byte("\n// +build ignore")
+ 
+ func findImports(pkg string) ([]string, error) {
+ 	vpkg := pkg
+-	if strings.HasPrefix(pkg, "golang.org") {
++	if strings.HasPrefix(pkg, "golang.org") || strings.HasPrefix(pkg, "github.com") {
+ 		vpkg = "vendor/" + pkg
+ 	}
+ 	dir := filepath.Join(Default.GOROOT, "src", vpkg)


### PR DESCRIPTION
* See https://github.com/microsoft/go/pull/513