### PR TITLE
[microsoft/dev.boringcrypto.go1.18] Enable gopath_std_vendor test and add specific fix

### DIFF
--- a/patches/0103-Adjust-Go-tests-to-work-with-crypto-module.patch
+++ b/patches/0103-Adjust-Go-tests-to-work-with-crypto-module.patch
@@ -7,13 +7,13 @@ use gocrypt tag for cgo static tests
 ---
  misc/cgo/test/pkg_test.go                        |  4 +++-
  src/cmd/dist/test.go                             |  6 ++++--
- src/cmd/go/testdata/script/gopath_std_vendor.txt |  1 +
+ src/cmd/go/testdata/script/gopath_std_vendor.txt |  9 ++++++++-
  src/crypto/boring/boring_test.go                 |  1 +
  src/go/build/deps_test.go                        | 13 ++++++++++---
- 5 files changed, 19 insertions(+), 6 deletions(-)
+ 5 files changed, 26 insertions(+), 7 deletions(-)
 
 diff --git a/misc/cgo/test/pkg_test.go b/misc/cgo/test/pkg_test.go
-index 14013a4cd9..83bb5f5323 100644
+index 14013a4cd9..62c2e95b09 100644
 --- a/misc/cgo/test/pkg_test.go
 +++ b/misc/cgo/test/pkg_test.go
 @@ -50,7 +50,9 @@ func TestCrossPackageTests(t *testing.T) {
@@ -28,7 +28,7 @@ index 14013a4cd9..83bb5f5323 100644
  		cmd.Args = append(cmd.Args, "-v")
  	}
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index f65d9bf980..564d870af3 100644
+index f65d9bf980..d66f15d6fc 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -1195,11 +1195,13 @@ func (t *tester) cgoTest(dt *distTest) error {
@@ -48,17 +48,25 @@ index f65d9bf980..564d870af3 100644
  				}
  			}
 diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
-index a0a41a50de..8c39d9a2bd 100644
+index a0a41a50de..2d28bd2cf9 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
 +++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
-@@ -1,6 +1,7 @@
- env GO111MODULE=off
+@@ -23,7 +23,14 @@ go list -deps -f '{{.ImportPath}} {{.Dir}}' .
+ stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
+ ! stdout $GOROOT[/\\]src[/\\]vendor
  
- [!gc] skip
-+skip 'This test uses a test program that is intended to import no vendored libraries other than golang.org/x/net/http2/hpack, but this is not true in microsoft/go boring 1.18+. https://github.com/microsoft/go/issues/481'
+-go list -test -deps -f '{{.ImportPath}} {{.Dir}}' .
++# Use build tag 'gocrypt' while evaluating test dependencies to avoid importing
++# vendored crypto module dependencies like go-crypto-openssl. This test script
++# is not set up to handle any vendored libraries being imported other than
++# golang.org/x/net/http2/hpack, so we must make sure it is the only one.
++#
++# See https://github.com/microsoft/go/issues/481 for more details, such as the
++# dependency chain that would cause the failure if the gocrypt tag isn't used.
++go list -tags=gocrypt -test -deps -f '{{.ImportPath}} {{.Dir}}' .
+ stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
+ ! stdout $GOROOT[/\\]src[/\\]vendor
  
- go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
- stdout $GOPATH[/\\]src[/\\]vendor
 diff --git a/src/crypto/boring/boring_test.go b/src/crypto/boring/boring_test.go
 index ace50de0c2..83ef05d872 100644
 --- a/src/crypto/boring/boring_test.go


### PR DESCRIPTION
* Improve the fix for https://github.com/microsoft/go/issues/481

* Based on https://github.com/microsoft/go/pull/485