### PR TITLE
[microsoft/dev.boringcrypto.go1.17] Merge from 1.17

### DIFF
--- a/eng/init-pwsh.sh
+++ b/eng/init-pwsh.sh
@@ -9,9 +9,29 @@
 
 set -euo pipefail
 
-pwsh_version='7.1.3'
-pwsh_sha256='9f853fb8f7c7719005bd1054fa13ca4d925c519b893f439dd2574e84503e6a85'
-pwsh_url="https://github.com/PowerShell/PowerShell/releases/download/v$pwsh_version/powershell-$pwsh_version-linux-x64.tar.gz"
+# Default values for x64.
+pwsh_version='7.2.1'
+pwsh_sha256='337d9864799ad09b46d261071b9f835f69f078814409bc2681f4cc2857b6bda5'
+pwsh_arch='x64'
+
+# 'uname' approach adapted from .NET install script: https://github.com/dotnet/install-scripts/blob/df8f863720a462448ad244f03ffeb619f0631bad/src/dotnet-install.sh#L295-L315
+if command -v uname > /dev/null; then
+  CPUName=$(uname -m)
+  case $CPUName in
+    armv*l)
+      echo "armv*l was detected, but it is not supported by the microsoft/go build infrastructure."
+      exit 1
+      ;;
+    aarch64|arm64)
+      pwsh_sha256='f0d6c9c36d69e1466e5a9412085ef52cafd10b73f862d29479b806279a2975f4'
+      pwsh_arch='arm64'
+      ;;
+  esac
+else
+  echo "uname command not detected. Assuming $pwsh_arch."
+fi
+
+pwsh_url="https://github.com/PowerShell/PowerShell/releases/download/v$pwsh_version/powershell-$pwsh_version-linux-$pwsh_arch.tar.gz"
 
 # pwsh must be installed outside of the Go repo. If it's in the repo, longtest "TestAllDependencies"
 # fails. It tries to traverse the pwsh directory and can't handle the "no such file or directory"
@@ -22,6 +42,7 @@ download_complete_indicator="$pwsh_dir/.downloaded"
 
 if [ ! -f "$download_complete_indicator" ]; then
   echo "Downloading PowerShell $pwsh_version and extracting to '$pwsh_dir' ..."
+  echo "URL: $pwsh_url"
 
   # Clear existing dir in case it's in a broken state.
   rm -rf "$pwsh_dir"

--- a/eng/pipeline/jobs/go-builder-matrix-jobs.yml
+++ b/eng/pipeline/jobs/go-builder-matrix-jobs.yml
@@ -27,6 +27,10 @@ jobs:
           - { os: windows, arch: amd64, config: buildandpack }
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }
+          # Only build arm64 if we're running a signed (internal, rolling) build. Avoid contention
+          # with other projects' builds that use the same limited-capacity pool of arm64 agents.
+          - ${{ if eq(parameters.sign, true) }}:
+            - { os: linux, arch: arm64, config: buildandpack }
         - ${{ if eq(parameters.outerloop, true) }}:
           # Upstream builders.
           - { os: linux, arch: amd64, config: clang }

--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -19,19 +19,36 @@ jobs:
         vmImage: windows-2019
 
     ${{ if eq(parameters.builder.os, 'linux') }}:
-      pool:
-        # The VM image of the Docker host. This doesn't need to match the container image, but it may
-        # give slightly better coverage by matching the kernel version.
-        vmImage: ubuntu-18.04
-      # The image used for the container this job runs in. The tests run in this container, so it
-      # should match what we support as closely as possible.
-      ${{ if not(parameters.builder.distro) }}:
-        container: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
-      ${{ if eq(parameters.builder.distro, 'ubuntu') }}:
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+      ${{ if eq(parameters.builder.arch, 'amd64') }}:
+        pool:
+          # The VM image of the Docker host. This doesn't need to match the container image, but it may
+          # give slightly better coverage by matching the kernel version.
+          vmImage: ubuntu-18.04
+        # The image used for the container this job runs in. The tests run in this container, so it
+        # should match what we support as closely as possible.
+        ${{ if not(parameters.builder.distro) }}:
+          container: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
+        ${{ if eq(parameters.builder.distro, 'ubuntu') }}:
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+      ${{ if eq(parameters.builder.arch, 'arm64') }}:
+        pool:
+          name: Docker-Linux-Arm-Internal
+        ${{ if not(parameters.builder.distro) }}:
+          container: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
 
     steps:
       - ${{ if eq(parameters.builder.os, 'linux') }}:
+        # AzDO builds don't seem to set user ID in the running container, so files from a previous
+        # build might be owned by root and unable to be cleaned up by AzDO's cleanup step. Clean up
+        # the build dirs ourselves in another Docker container to avoid failures.
+        - script: |
+            set -x
+            echo 'Cleaning old build dirs with sudo in case of root ownership.'
+            sudo rm -v -rf a b s
+            mkdir a b s
+          workingDirectory: $(Agent.BuildDirectory)
+          displayName: Cleanup
+
         - template: ../steps/checkout-unix-task.yml
         - template: ../steps/init-pwsh-task.yml
 
@@ -52,7 +69,7 @@ jobs:
       - template: ../steps/init-submodule-task.yml
 
       # Create the source archive on one job only. The os choice is arbitrary.
-      - ${{ if and(eq(parameters.createSourceArchive, true), eq(parameters.builder.config, 'buildandpack'), eq(parameters.builder.os, 'linux')) }}:
+      - ${{ if and(eq(parameters.createSourceArchive, true), eq(parameters.builder.config, 'buildandpack'), eq(parameters.builder.os, 'linux'), eq(parameters.builder.arch, 'amd64')) }}:
         - pwsh: |
             git config --global user.name "microsoft-golang-bot"
             git config --global user.email "microsoft-golang-bot@users.noreply.github.com"
@@ -106,3 +123,15 @@ jobs:
             buildPlatform: ${{ parameters.builder.arch }}
             buildConfiguration: ${{ parameters.builder.config }}
             publishRunAttachments: true
+
+      - ${{ if eq(parameters.builder.os, 'linux') }}:
+        # Files may be owned by root because builds don't set user ID. If this build is running on a
+        # persistent machine, later builds may fail to clean up this build's directory as as
+        # result--even if it also uses a build container. This step prevents that kind of failure by
+        # using chown to make sure the machine's agent user can access/delete the files.
+        - script: |
+            sudo chown -R $(id -u):$(id -g) *
+          workingDirectory: $(Agent.BuildDirectory)
+          displayName: Update file ownership from root to build agent account
+          continueOnError: true
+          condition: succeededOrFailed()

--- a/eng/pipeline/steps/init-pwsh-task.yml
+++ b/eng/pipeline/steps/init-pwsh-task.yml
@@ -12,4 +12,6 @@ steps:
 
       . eng/init-pwsh.sh
       echo "##vso[task.prependpath]$pwsh_dir"
+      # Enable invariant mode to make .NET/PowerShell work without libicu installed.
+      echo "##vso[task.setvariable variable=DOTNET_SYSTEM_GLOBALIZATION_INVARIANT]1"
     displayName: Init PowerShell

--- a/eng/utilities.ps1
+++ b/eng/utilities.ps1
@@ -24,14 +24,33 @@ function Get-Stage0GoRoot() {
   # pre-installed. This CI script installs a consistent, official version of Go to a directory in
   # $HOME to handle this. This also makes it easier to locally repro issues in CI that involve a
   # specific version of Go. The downloaded copy of Go is called the "stage 0" version.
-  $stage0_go_version = '1.16.5'
+  $stage0_go_version = '1.17.8'
 
+  $proc_arch = ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture).ToString().ToLowerInvariant()
   if ($IsWindows) {
-    $stage0_go_sha256 = '0a3fa279ae5b91bc8c88017198c8f1ba5d9925eb6e5d7571316e567c73add39d'
-    $stage0_go_suffix = 'windows-amd64.zip'
+    switch ($proc_arch) {
+      'x64' {
+        $stage0_go_sha256 = '85ccf2608dca6ea9a46b6538c9e75e7cf2aebdf502379843b248e26b8bb110be'
+        $stage0_go_suffix = 'windows-amd64.zip'
+      }
+      'arm64' {
+        $stage0_go_sha256 = '4a0d960f5c0cbff1edaf54f333cf857a2779f6ae4c8e759b7872b44fde5ae43f'
+        $stage0_go_suffix = 'windows-arm64.zip'
+      }
+      Default { throw "Unable to match Windows '$proc_arch' to an architecture supported by the Microsoft scripts to build Go." }
+    }
   } elseif ($IsLinux) {
-    $stage0_go_sha256 = 'b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061'
-    $stage0_go_suffix = 'linux-amd64.tar.gz'
+    switch ($proc_arch) {
+      'x64' {
+        $stage0_go_sha256 = '980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99'
+        $stage0_go_suffix = 'linux-amd64.tar.gz'
+      }
+      'arm64' {
+        $stage0_go_sha256 = '57a9171682e297df1a5bd287be056ed0280195ad079af90af16dcad4f64710cb'
+        $stage0_go_suffix = 'linux-arm64.tar.gz'
+      }
+      Default { throw "Unable to match Linux '$proc_arch' to an architecture supported by the Microsoft scripts to build Go." }
+    }
   } else {
     throw "Current OS/Platform is not supported by the Microsoft scripts to build Go."
   }

--- a/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
+++ b/patches/0001-cmd-dist-add-JSON-output-support-for-some-tests.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
 Date: Tue, 4 Jan 2022 11:23:27 -0600
 Subject: [PATCH] cmd/dist: add JSON output support for some tests
 

--- a/patches/0002-net-Skip-TestDialCancel-on-linux-arm64.patch
+++ b/patches/0002-net-Skip-TestDialCancel-on-linux-arm64.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+Date: Thu, 24 Feb 2022 17:57:24 -0600
+Subject: [PATCH] net: Skip TestDialCancel on linux-arm64
+
+The test is flaky on our linux-arm64 builder and gets "network is unreachable". See https://github.com/golang/go/issues/37330
+---
+ src/net/dial_test.go | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/net/dial_test.go b/src/net/dial_test.go
+index b9aead0371..f4f383a365 100644
+--- a/src/net/dial_test.go
++++ b/src/net/dial_test.go
+@@ -758,6 +758,10 @@ func TestDialerKeepAlive(t *testing.T) {
+ func TestDialCancel(t *testing.T) {
+ 	mustHaveExternalNetwork(t)
+ 
++	if strings.HasPrefix(testenv.Builder(), "linux-arm64") {
++		t.Skip("skipping on linux-arm64-*; incompatible network config? issue 37330")
++	}
++
+ 	blackholeIPPort := JoinHostPort(slowDst4, "1234")
+ 	if !supportsIPv4() {
+ 		blackholeIPPort = JoinHostPort(slowDst6, "1234")


### PR DESCRIPTION
Add linux-arm64 builds by merging support from non-FIPS 1.17 branch. Test build (because we don't have public arm64 builders): https://dev.azure.com/dnceng/internal/_build/results?buildId=1693504&view=results

No conflicts except the submodule that needed to be reset to its original commit, as expected.