### PR TITLE
[microsoft/dev.boringcrypto.go1.16] Use FIPS-enabled Mariner image when running CI tests

### DIFF
--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -26,7 +26,7 @@ jobs:
       # The image used for the container this job runs in. The tests run in this container, so it
       # should match what we support as closely as possible.
       ${{ if not(parameters.builder.distro) }}:
-        container: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
+        container: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-fips-20211206-e78b6d3
       ${{ if eq(parameters.builder.distro, 'ubuntu') }}:
         container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
 


### PR DESCRIPTION
Same as #520 but for go1.16 branch.