### PR TITLE
[microsoft/dev.boringcrypto.go1.18] Panic if GOFIPS=1 set but FIPS not supported

### DIFF
--- a/patches/0100-Add-OpenSSL-crypto-module.patch
+++ b/patches/0100-Add-OpenSSL-crypto-module.patch
@@ -6,15 +6,17 @@ Subject: [PATCH] Add OpenSSL crypto module
 github.com/microsoft/go-infra/cmd/git-go-patch command: patch number 0100
 ---
  src/crypto/internal/backend/backend_test.go  |  30 ++++
+ src/crypto/internal/backend/common.go        |  19 +++
  src/crypto/internal/backend/dummy.s          |  10 ++
  src/crypto/internal/backend/iscgo.go         |  10 ++
- src/crypto/internal/backend/nobackend.go     | 124 ++++++++++++++++
+ src/crypto/internal/backend/nobackend.go     | 123 ++++++++++++++++
  src/crypto/internal/backend/nocgo.go         |  10 ++
- src/crypto/internal/backend/openssl_linux.go | 145 +++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go | 141 +++++++++++++++++++
  src/go.mod                                   |   1 +
  src/go.sum                                   |   2 +
- 8 files changed, 332 insertions(+)
+ 9 files changed, 346 insertions(+)
  create mode 100644 src/crypto/internal/backend/backend_test.go
+ create mode 100644 src/crypto/internal/backend/common.go
  create mode 100644 src/crypto/internal/backend/dummy.s
  create mode 100644 src/crypto/internal/backend/iscgo.go
  create mode 100644 src/crypto/internal/backend/nobackend.go
@@ -57,6 +59,31 @@ index 0000000000..c2c06d3bff
 +func TestUnreachableExceptTests(t *testing.T) {
 +	UnreachableExceptTests()
 +}
+diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
+new file mode 100644
+index 0000000000..d703ba79e9
+--- /dev/null
++++ b/src/crypto/internal/backend/common.go
+@@ -0,0 +1,19 @@
++// Copyright 2022 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package backend
++
++import "syscall"
++
++func envgofips() (string, bool) {
++	if v, ok := syscall.Getenv("GOFIPS"); ok {
++		return v, true
++	}
++	// TODO: Decide which environment variable to use.
++	// See https://github.com/microsoft/go/issues/397.
++	if v, ok := syscall.Getenv("GOLANG_FIPS"); ok {
++		return v, true
++	}
++	return "", false
++}
 diff --git a/src/crypto/internal/backend/dummy.s b/src/crypto/internal/backend/dummy.s
 new file mode 100644
 index 0000000000..157adeeeb3
@@ -75,7 +102,7 @@ index 0000000000..157adeeeb3
 +// (because the implementation might be here).
 diff --git a/src/crypto/internal/backend/iscgo.go b/src/crypto/internal/backend/iscgo.go
 new file mode 100644
-index 0000000000..ab5227fb86
+index 0000000000..1e0d3cf8c1
 --- /dev/null
 +++ b/src/crypto/internal/backend/iscgo.go
 @@ -0,0 +1,10 @@
@@ -91,10 +118,10 @@ index 0000000000..ab5227fb86
 +const iscgo = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 0000000000..ed2155f2bd
+index 0000000000..475b98fd73
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,124 @@
+@@ -0,0 +1,123 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -111,13 +138,12 @@ index 0000000000..ed2155f2bd
 +	"hash"
 +	"math/big"
 +	"runtime"
-+	"syscall"
 +)
 +
 +const Enabled = false
 +
 +func init() {
-+	if v, ok := syscall.Getenv("GOFIPS"); ok && v == "1" {
++	if v, _ := envgofips(); v == "1" {
 +		if runtime.GOOS != "linux" {
 +			panic("FIPS mode requested (GOFIPS=1) but not supported on " + runtime.GOOS)
 +		} else if !iscgo {
@@ -221,7 +247,7 @@ index 0000000000..ed2155f2bd
 +}
 diff --git a/src/crypto/internal/backend/nocgo.go b/src/crypto/internal/backend/nocgo.go
 new file mode 100644
-index 0000000000..f035e3f41b
+index 0000000000..63c13fc4b0
 --- /dev/null
 +++ b/src/crypto/internal/backend/nocgo.go
 @@ -0,0 +1,10 @@
@@ -237,10 +263,10 @@ index 0000000000..f035e3f41b
 +const iscgo = false
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 0000000000..9fa156894a
+index 0000000000..8d140dc62b
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,141 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -283,12 +309,8 @@ index 0000000000..9fa156894a
 +}
 +
 +func needFIPS() bool {
-+	if envFips, ok := syscall.Getenv("GOFIPS"); ok {
-+		return envFips != "0"
-+	}
-+	// TODO: Remove GOLANG_FIPS once our CI uses GOFIPS.
-+	if envFips, ok := syscall.Getenv("GOLANG_FIPS"); ok {
-+		return envFips != "0"
++	if v, ok := envgofips(); ok {
++		return v != "0"
 +	}
 +	var fd int
 +	for {

--- a/patches/0100-Add-OpenSSL-crypto-module.patch
+++ b/patches/0100-Add-OpenSSL-crypto-module.patch
@@ -6,15 +6,15 @@ Subject: [PATCH] Add OpenSSL crypto module
 github.com/microsoft/go-infra/cmd/git-go-patch command: patch number 0100
 ---
  src/crypto/internal/backend/backend_test.go  |  30 ++++
- src/crypto/internal/backend/common.go        |  19 +++
+ src/crypto/internal/backend/common.go        |  35 +++++
  src/crypto/internal/backend/dummy.s          |  10 ++
  src/crypto/internal/backend/iscgo.go         |  10 ++
- src/crypto/internal/backend/nobackend.go     | 123 ++++++++++++++++
+ src/crypto/internal/backend/nobackend.go     | 112 +++++++++++++++
  src/crypto/internal/backend/nocgo.go         |  10 ++
  src/crypto/internal/backend/openssl_linux.go | 141 +++++++++++++++++++
  src/go.mod                                   |   1 +
  src/go.sum                                   |   2 +
- 9 files changed, 346 insertions(+)
+ 9 files changed, 351 insertions(+)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/common.go
  create mode 100644 src/crypto/internal/backend/dummy.s
@@ -61,17 +61,33 @@ index 0000000000..c2c06d3bff
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 0000000000..d703ba79e9
+index 0000000000..d33bafd1b0
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,35 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
++//go:build !cmd_go_bootstrap && !msan && !gocrypt
++// +build !cmd_go_bootstrap,!msan,!gocrypt
++
 +package backend
 +
-+import "syscall"
++import (
++	"runtime"
++	"syscall"
++)
++
++func init() {
++	if v, _ := envgofips(); v == "1" {
++		if runtime.GOOS != "linux" {
++			panic("FIPS mode requested (GOFIPS=1) but not supported on " + runtime.GOOS)
++		} else if !iscgo {
++			panic("FIPS mode requested (GOFIPS=1) but not supported with cgo disabled")
++		}
++	}
++}
 +
 +func envgofips() (string, bool) {
 +	if v, ok := syscall.Getenv("GOFIPS"); ok {
@@ -118,10 +134,10 @@ index 0000000000..1e0d3cf8c1
 +const iscgo = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 0000000000..475b98fd73
+index 0000000000..4de8d404f8
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,123 @@
+@@ -0,0 +1,112 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -137,20 +153,9 @@ index 0000000000..475b98fd73
 +	"crypto/internal/boring/sig"
 +	"hash"
 +	"math/big"
-+	"runtime"
 +)
 +
 +const Enabled = false
-+
-+func init() {
-+	if v, _ := envgofips(); v == "1" {
-+		if runtime.GOOS != "linux" {
-+			panic("FIPS mode requested (GOFIPS=1) but not supported on " + runtime.GOOS)
-+		} else if !iscgo {
-+			panic("FIPS mode requested (GOFIPS=1) but not supported with cgo disabled")
-+		}
-+	}
-+}
 +
 +// Unreachable marks code that should be unreachable
 +// when OpenSSLCrypto is in use. It is a no-op without OpenSSLCrypto.

--- a/patches/0100-Add-OpenSSL-crypto-module.patch
+++ b/patches/0100-Add-OpenSSL-crypto-module.patch
@@ -7,14 +7,18 @@ github.com/microsoft/go-infra/cmd/git-go-patch command: patch number 0100
 ---
  src/crypto/internal/backend/backend_test.go  |  30 ++++
  src/crypto/internal/backend/dummy.s          |  10 ++
- src/crypto/internal/backend/nobackend.go     | 112 ++++++++++++++
+ src/crypto/internal/backend/iscgo.go         |  10 ++
+ src/crypto/internal/backend/nobackend.go     | 124 ++++++++++++++++
+ src/crypto/internal/backend/nocgo.go         |  10 ++
  src/crypto/internal/backend/openssl_linux.go | 145 +++++++++++++++++++
  src/go.mod                                   |   1 +
  src/go.sum                                   |   2 +
- 6 files changed, 300 insertions(+)
+ 8 files changed, 332 insertions(+)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/dummy.s
+ create mode 100644 src/crypto/internal/backend/iscgo.go
  create mode 100644 src/crypto/internal/backend/nobackend.go
+ create mode 100644 src/crypto/internal/backend/nocgo.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
 
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
@@ -69,12 +73,28 @@ index 0000000000..157adeeeb3
 +// Having this assembly file keeps the go command
 +// from complaining about the missing body
 +// (because the implementation might be here).
+diff --git a/src/crypto/internal/backend/iscgo.go b/src/crypto/internal/backend/iscgo.go
+new file mode 100644
+index 0000000000..ab5227fb86
+--- /dev/null
++++ b/src/crypto/internal/backend/iscgo.go
+@@ -0,0 +1,10 @@
++// Copyright 2022 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build cgo
++// +build cgo
++
++package backend
++
++const iscgo = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 0000000000..4de8d404f8
+index 0000000000..ed2155f2bd
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,124 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -90,9 +110,21 @@ index 0000000000..4de8d404f8
 +	"crypto/internal/boring/sig"
 +	"hash"
 +	"math/big"
++	"runtime"
++	"syscall"
 +)
 +
 +const Enabled = false
++
++func init() {
++	if v, ok := syscall.Getenv("GOFIPS"); ok && v == "1" {
++		if runtime.GOOS != "linux" {
++			panic("FIPS mode requested (GOFIPS=1) but not supported on " + runtime.GOOS)
++		} else if !iscgo {
++			panic("FIPS mode requested (GOFIPS=1) but not supported with cgo disabled")
++		}
++	}
++}
 +
 +// Unreachable marks code that should be unreachable
 +// when OpenSSLCrypto is in use. It is a no-op without OpenSSLCrypto.
@@ -187,6 +219,22 @@ index 0000000000..4de8d404f8
 +func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
 +	panic("opensslcrypto: not available")
 +}
+diff --git a/src/crypto/internal/backend/nocgo.go b/src/crypto/internal/backend/nocgo.go
+new file mode 100644
+index 0000000000..f035e3f41b
+--- /dev/null
++++ b/src/crypto/internal/backend/nocgo.go
+@@ -0,0 +1,10 @@
++// Copyright 2022 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !cgo
++// +build !cgo
++
++package backend
++
++const iscgo = false
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
 index 0000000000..9fa156894a

--- a/patches/0100-Add-OpenSSL-crypto-module.patch
+++ b/patches/0100-Add-OpenSSL-crypto-module.patch
@@ -80,7 +80,7 @@ index 0000000000..d33bafd1b0
 +)
 +
 +func init() {
-+	if v, _ := envgofips(); v == "1" {
++	if v, _ := envGoFIPS(); v == "1" {
 +		if runtime.GOOS != "linux" {
 +			panic("FIPS mode requested (GOFIPS=1) but not supported on " + runtime.GOOS)
 +		} else if !iscgo {
@@ -89,7 +89,7 @@ index 0000000000..d33bafd1b0
 +	}
 +}
 +
-+func envgofips() (string, bool) {
++func envGoFIPS() (string, bool) {
 +	if v, ok := syscall.Getenv("GOFIPS"); ok {
 +		return v, true
 +	}
@@ -314,7 +314,7 @@ index 0000000000..8d140dc62b
 +}
 +
 +func needFIPS() bool {
-+	if v, ok := envgofips(); ok {
++	if v, ok := envGoFIPS(); ok {
 +		return v != "0"
 +	}
 +	var fd int


### PR DESCRIPTION
This PR adds a runtime check that verifies the crypto backend does not fallback to Go crypto if FIPS mode is requested via GOFIPS environment variable and FIPS mode is not supported.

Fixes #494
Updates #428