### PR TITLE
Support test retries in run-builder

### DIFF
--- a/eng/_core/buildutil/buildutil.go
+++ b/eng/_core/buildutil/buildutil.go
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package buildutil
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+)
+
+// Retry runs f until it succeeds or the attempt limit is reached.
+func Retry(attempts int, f func() error) error {
+	var i = 0
+	for ; i < attempts; i++ {
+		if attempts > 1 {
+			fmt.Printf("---- Running attempt %v of %v...\n", i+1, attempts)
+		}
+		err := f()
+		if err != nil {
+			if i+1 < attempts {
+				fmt.Printf("---- Attempt failed with error: %v\n", err)
+				continue
+			}
+			fmt.Printf("---- Final attempt failed.\n")
+			return err
+		}
+		break
+	}
+	fmt.Printf("---- Successful on attempt %v of %v.\n", i+1, attempts)
+	return nil
+}
+
+// MaxMakeRetryAttemptsOrExit returns max retry attempts for the Go build according to an env var.
+func MaxMakeRetryAttemptsOrExit() int {
+	return maxAttemptsOrExit("GO_MAKE_MAX_RETRY_ATTEMPTS")
+}
+
+// MaxTestRetryAttemptsOrExit returns the max test retry attempts according to an env var. Shared
+// between the build command and run-builder command.
+func MaxTestRetryAttemptsOrExit() int {
+	return maxAttemptsOrExit("GO_TEST_MAX_RETRY_ATTEMPTS")
+}
+
+func maxAttemptsOrExit(varName string) int {
+	attempts, err := getEnvIntOrDefault(varName, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if attempts <= 0 {
+		log.Fatalf("Expected positive integer for environment variable %q, but found: %v\n", varName, attempts)
+	}
+	return attempts
+}
+
+func getEnvIntOrDefault(varName string, defaultValue int) (int, error) {
+	a, err := getEnvOrDefault(varName, strconv.Itoa(defaultValue))
+	if err != nil {
+		return 0, err
+	}
+	i, err := strconv.Atoi(a)
+	if err != nil {
+		return 0, fmt.Errorf("env var %q is not an int: %w", varName, err)
+	}
+	return i, nil
+}
+
+// getEnvOrDefault find an environment variable with name varName and returns its value. If the env
+// var is not set, returns defaultValue.
+//
+// If the env var is found and its value is empty string, returns an error. This can't happen on
+// Windows because setting an env var to empty string deletes it. However, on Linux, it is possible.
+// It's likely a mistake, so we let the user know what happened with an error. For example, the env
+// var might be empty string because it was set by "example=$(someCommand)" and someCommand
+// encountered an error and didn't send any output to stdout.
+func getEnvOrDefault(varName, defaultValue string) (string, error) {
+	v, ok := os.LookupEnv(varName)
+	if !ok {
+		return defaultValue, nil
+	}
+	if v == "" {
+		return "", fmt.Errorf(
+			"env var %q is empty, not a valid string. To use the default string %v, unset the env var",
+			varName, defaultValue)
+	}
+	return v, nil
+}

--- a/eng/_core/buildutil/buildutil.go
+++ b/eng/_core/buildutil/buildutil.go
@@ -56,7 +56,7 @@ func maxAttemptsOrExit(varName string) int {
 }
 
 func getEnvIntOrDefault(varName string, defaultValue int) (int, error) {
-	a, err := getEnvOrDefault(varName, strconv.Itoa(defaultValue))
+	a, err := GetEnvOrDefault(varName, strconv.Itoa(defaultValue))
 	if err != nil {
 		return 0, err
 	}
@@ -67,7 +67,7 @@ func getEnvIntOrDefault(varName string, defaultValue int) (int, error) {
 	return i, nil
 }
 
-// getEnvOrDefault find an environment variable with name varName and returns its value. If the env
+// GetEnvOrDefault find an environment variable with name varName and returns its value. If the env
 // var is not set, returns defaultValue.
 //
 // If the env var is found and its value is empty string, returns an error. This can't happen on
@@ -75,7 +75,7 @@ func getEnvIntOrDefault(varName string, defaultValue int) (int, error) {
 // It's likely a mistake, so we let the user know what happened with an error. For example, the env
 // var might be empty string because it was set by "example=$(someCommand)" and someCommand
 // encountered an error and didn't send any output to stdout.
-func getEnvOrDefault(varName, defaultValue string) (string, error) {
+func GetEnvOrDefault(varName, defaultValue string) (string, error) {
 	v, ok := os.LookupEnv(varName)
 	if !ok {
 		return defaultValue, nil

--- a/eng/_core/cmd/build/build.go
+++ b/eng/_core/cmd/build/build.go
@@ -115,11 +115,11 @@ func build(o *options) error {
 	// runtime value, this means we're doing a cross-compiled build. These values are used for
 	// capability checks and to make sure that if Pack is enabled, the output archive is formatted
 	// correctly and uses the right filename.
-	targetOS, err := getEnvOrDefault("GOOS", runtime.GOOS)
+	targetOS, err := buildutil.GetEnvOrDefault("GOOS", runtime.GOOS)
 	if err != nil {
 		return err
 	}
-	targetArch, err := getEnvOrDefault("GOARCH", runtime.GOARCH)
+	targetArch, err := buildutil.GetEnvOrDefault("GOARCH", runtime.GOARCH)
 	if err != nil {
 		return err
 	}

--- a/eng/_util/go.mod
+++ b/eng/_util/go.mod
@@ -8,5 +8,8 @@ go 1.16
 
 require (
 	github.com/microsoft/go-infra v0.0.0-20220419195018-e437e0d7a6f9
+	github.com/microsoft/go/_core v0.0.0
 	gotest.tools/gotestsum v1.6.5-0.20210515201937-ecb7c6956f6d
 )
+
+replace github.com/microsoft/go/_core => ../_core


### PR DESCRIPTION
@qmuntal and I both recently saw a Windows test job fail--the `windows-amd64-test` job doesn't have built-in retries, only the `windows-amd64-devscript` job. This is because `eng/_core/cmd/build` implements test retries but `eng/_util/cmd/run-builder` doesn't. So, our flakiness on Windows is somewhat mitigated--I suppose halved--but we can do better.

This PR makes them share the retry logic and env var lookup. It was a little complicated to set this up because the `eng/_core` and `eng/_util` dirs are different modules. This is the weird part to have checked in, `eng/_util/go.mod`'s reference to `_core`:

```
require (
	github.com/microsoft/go-infra v0.0.0-20220419195018-e437e0d7a6f9
	github.com/microsoft/go/_core v0.0.0
	gotest.tools/gotestsum v1.6.5-0.20210515201937-ecb7c6956f6d
)

replace github.com/microsoft/go/_core => ../_core
```

I'm not sure if this will cause any problems for us... we could skip this PR for now (the failure is rare) and wait until:
* https://github.com/microsoft/go/issues/402