### PR TITLE
Add GOEXPERIMENT=opensslcrypto builders

### DIFF
--- a/eng/_core/buildutil/buildutil.go
+++ b/eng/_core/buildutil/buildutil.go
@@ -87,3 +87,15 @@ func GetEnvOrDefault(varName, defaultValue string) (string, error) {
 	}
 	return v, nil
 }
+
+// AppendExperimentEnv sets the GOEXPERIMENT env var to the given value, or if GOEXPERIMENT is
+// already set, appends a comma separator and then the given value.
+func AppendExperimentEnv(experiment string) {
+	if v, ok := os.LookupEnv("GOEXPERIMENT"); ok {
+		experiment = v + "," + experiment
+	}
+	fmt.Printf("Setting GOEXPERIMENT: %v\n", experiment)
+	if err := os.Setenv("GOEXPERIMENT", experiment); err != nil {
+		panic(err)
+	}
+}

--- a/eng/_core/cmd/build/build.go
+++ b/eng/_core/cmd/build/build.go
@@ -48,6 +48,8 @@ func main() {
 		"Refresh Go submodule: clean untracked files, reset tracked files, and apply patches before building.\n"+
 			"For more refresh options, use the top level 'submodule-refresh' command instead of 'build'.")
 
+	flag.StringVar(&o.Experiment, "experiment", "", "Include this string in GOEXPERIMENT.")
+
 	o.MaxMakeAttempts = buildutil.MaxMakeRetryAttemptsOrExit()
 	o.MaxTestAttempts = buildutil.MaxTestRetryAttemptsOrExit()
 
@@ -73,11 +75,12 @@ func main() {
 }
 
 type options struct {
-	SkipBuild bool
-	Test      bool
-	JSON      bool
-	Pack      bool
-	Refresh   bool
+	SkipBuild  bool
+	Test       bool
+	JSON       bool
+	Pack       bool
+	Refresh    bool
+	Experiment string
 
 	MaxMakeAttempts int
 	MaxTestAttempts int
@@ -128,6 +131,10 @@ func build(o *options) error {
 	// they instantly fail. Change the current process dir so that we can run them.
 	if err := os.Chdir("go/src"); err != nil {
 		return err
+	}
+
+	if o.Experiment != "" {
+		buildutil.AppendExperimentEnv(o.Experiment)
 	}
 
 	if !o.SkipBuild {

--- a/eng/pipeline/jobs/builders-to-jobs.yml
+++ b/eng/pipeline/jobs/builders-to-jobs.yml
@@ -5,7 +5,7 @@
 # This template expands a list of builders into a list of jobs.
 
 parameters:
-  # [] of { id, os, arch, hostarch, config, distro? }
+  # [] of { id, os, arch, hostarch, config, distro?, experiment? }
   builders: []
   # If true, include a signing job that depends on all 'buildandpack' builder jobs finishing. This
   # lets us start the lengthy tasks of signing and testing in parallel.

--- a/eng/pipeline/jobs/go-builder-matrix-jobs.yml
+++ b/eng/pipeline/jobs/go-builder-matrix-jobs.yml
@@ -24,6 +24,8 @@ jobs:
           - { os: linux, arch: amd64, config: devscript }
           - { os: linux, arch: amd64, config: test }
           - { os: linux, arch: amd64, config: test, distro: ubuntu }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: windows, arch: amd64, config: buildandpack }
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }
@@ -43,3 +45,9 @@ jobs:
           - { os: linux, arch: amd64, config: regabi }
           - { os: linux, arch: amd64, config: ssacheck }
           - { os: linux, arch: amd64, config: staticlockranking }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: clang }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: longtest }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: race }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: regabi }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: ssacheck }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: staticlockranking }

--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -5,12 +5,15 @@
 # This job runs a builder for any OS.
 
 parameters:
-  # { id, os, arch, hostArch, config, distro? }
+  # { id, os, arch, hostArch, config, distro?, experiment? }
   builder: {}
   createSourceArchive: false
 
 jobs:
   - job: ${{ parameters.builder.id }}
+    # For display name, try for readability. Use some parameters set by
+    # shorthand-builders-to-builders.yml that let us add some formatting.
+    displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }}
     workspace:
       clean: all
 
@@ -119,6 +122,7 @@ jobs:
 
             eng/run.ps1 run-builder `
               -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
+              $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
               -junitfile '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml'
           displayName: Run ${{ parameters.builder.config }}
 

--- a/eng/pipeline/jobs/shorthand-builders-to-builders.yml
+++ b/eng/pipeline/jobs/shorthand-builders-to-builders.yml
@@ -11,8 +11,9 @@
 # to be used by template expressions, as of writing.
 
 parameters:
-  # [] of { os, arch, hostArch, config, distro? }
+  # [] of { os, arch, hostArch, config, distro?, experiment? }
   # If hostArch is not defined, defaults to the arch value.
+  # The job ID is generated based on these values.
   shorthandBuilders: []
   # The inner jobs template to pass the filed-out builders into.
   #
@@ -27,11 +28,18 @@ jobs:
       builders:
         - ${{ each builder in parameters.shorthandBuilders }}:
           - ${{ insert }}: ${{ builder }}
-            ${{ if builder.distro }}:
-              id: ${{ builder.os }}_${{ builder.distro }}_${{ builder.arch }}_${{ builder.config }}
-            ${{ if not(builder.distro) }}:
-              id: ${{ builder.os }}_${{ builder.arch }}_${{ builder.config }}
+            # Use 'default' in place of null to define ID. This value just needs to be unique and
+            # only contain "[A-z_]+".
+            id: ${{ builder.os }}_${{ coalesce(builder.distro, 'default') }}_${{ coalesce(builder.hostArch, 'default') }}_${{ builder.arch }}_${{ builder.config }}_${{ coalesce(builder.experiment, 'default') }}
             ${{ if not(builder.hostArch) }}:
               hostArch: ${{ builder.arch }}
+            # Set up some parameters that are for display purposes. AzDO YAML expressions can't
+            # branch, so we must to prepare these values here rather than where they're used.
+            ${{ if builder.distro }}:
+              distroParens: (${{ builder.distro }})
+            ${{ if builder.hostArch }}:
+              hostParens: (${{ builder.hostArch }} host)
+            ${{ if builder.experiment }}:
+              experimentBrackets: '[${{ builder.experiment }}]'
 
 

--- a/eng/pipeline/jobs/sign-job.yml
+++ b/eng/pipeline/jobs/sign-job.yml
@@ -6,7 +6,7 @@
 # publishes the signed files and signatures into a consolidated pipeline artifact.
 
 parameters:
-  # [] of { id, os, arch, config, distro? }
+  # [] of { id, os, arch, config, distro?, experiment? }
   builders: []
 
 jobs:


### PR DESCRIPTION
We have to be a bit surprisingly careful about where we actually set `GOEXPERIMENT=opensslcrypto`. We can't set it when we still need to `go build` some `_core` or `_util` tools, because our bootstrap version of Go doesn't have this experiment. Instead, pass it through with an arg and set it just before building or calling into the built `go` to run tests.

This also appends to GOEXPERIMENT rather than just setting it. This accounts for the existing outerloop builders that also set their own GOEXPERIMENT.

Example rolling build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1768645&view=results
(This includes some fixes to the outerloop test jobs that I've reverted for this PR, but shows the job naming and the experiment job basics, at least. I'll submit outerloop test fixes separately. They are existing issues, not related to this PR.)