### PR TITLE
Update `microsoft/main` to latest upstream with translation layer for NewGCMTLS

### DIFF
--- a/patches/0005-Add-OpenSSL-crypto-module.patch
+++ b/patches/0005-Add-OpenSSL-crypto-module.patch
@@ -10,14 +10,14 @@ Subject: [PATCH] Add OpenSSL crypto module
  .../internal/backend/bbig/big_openssl.go      |  12 ++
  src/crypto/internal/backend/common.go         |  34 ++++
  src/crypto/internal/backend/iscgo.go          |  10 ++
- src/crypto/internal/backend/nobackend.go      | 115 ++++++++++++++
+ src/crypto/internal/backend/nobackend.go      | 116 +++++++++++++
  src/crypto/internal/backend/nocgo.go          |  10 ++
- src/crypto/internal/backend/openssl_linux.go  | 145 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 159 ++++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 ++
  src/go.mod                                    |   1 +
  src/go.sum                                    |   2 +
  src/runtime/runtime_boring.go                 |   5 +
- 13 files changed, 403 insertions(+)
+ 13 files changed, 418 insertions(+)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
@@ -31,7 +31,7 @@ Subject: [PATCH] Add OpenSSL crypto module
 
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644
-index 00000000000..c2c06d3bff8
+index 0000000000..c2c06d3bff
 --- /dev/null
 +++ b/src/crypto/internal/backend/backend_test.go
 @@ -0,0 +1,30 @@
@@ -67,7 +67,7 @@ index 00000000000..c2c06d3bff8
 +}
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
 new file mode 100644
-index 00000000000..51bc3c68048
+index 0000000000..51bc3c6804
 --- /dev/null
 +++ b/src/crypto/internal/backend/bbig/big.go
 @@ -0,0 +1,17 @@
@@ -90,7 +90,7 @@ index 00000000000..51bc3c68048
 +}
 diff --git a/src/crypto/internal/backend/bbig/big_boring.go b/src/crypto/internal/backend/bbig/big_boring.go
 new file mode 100644
-index 00000000000..0b62cef6854
+index 0000000000..0b62cef685
 --- /dev/null
 +++ b/src/crypto/internal/backend/bbig/big_boring.go
 @@ -0,0 +1,12 @@
@@ -108,7 +108,7 @@ index 00000000000..0b62cef6854
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/bbig/big_openssl.go b/src/crypto/internal/backend/bbig/big_openssl.go
 new file mode 100644
-index 00000000000..61ef3fdd90b
+index 0000000000..61ef3fdd90
 --- /dev/null
 +++ b/src/crypto/internal/backend/bbig/big_openssl.go
 @@ -0,0 +1,12 @@
@@ -126,7 +126,7 @@ index 00000000000..61ef3fdd90b
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000..11ac2df4089
+index 0000000000..11ac2df408
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
 @@ -0,0 +1,34 @@
@@ -166,7 +166,7 @@ index 00000000000..11ac2df4089
 +}
 diff --git a/src/crypto/internal/backend/iscgo.go b/src/crypto/internal/backend/iscgo.go
 new file mode 100644
-index 00000000000..1e0d3cf8c18
+index 0000000000..1e0d3cf8c1
 --- /dev/null
 +++ b/src/crypto/internal/backend/iscgo.go
 @@ -0,0 +1,10 @@
@@ -182,10 +182,10 @@ index 00000000000..1e0d3cf8c18
 +const iscgo = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000..337107921bc
+index 0000000000..0fd83b3b6d
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,115 @@
+@@ -0,0 +1,116 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -239,6 +239,7 @@ index 00000000000..337107921bc
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { panic("opensslcrypto: not available") }
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) { panic("opensslcrypto: not available") }
++func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) { panic("opensslcrypto: not available") }
 +
 +type PublicKeyECDSA struct{ _ int }
 +type PrivateKeyECDSA struct{ _ int }
@@ -303,7 +304,7 @@ index 00000000000..337107921bc
 +}
 diff --git a/src/crypto/internal/backend/nocgo.go b/src/crypto/internal/backend/nocgo.go
 new file mode 100644
-index 00000000000..63c13fc4b01
+index 0000000000..63c13fc4b0
 --- /dev/null
 +++ b/src/crypto/internal/backend/nocgo.go
 @@ -0,0 +1,10 @@
@@ -319,10 +320,10 @@ index 00000000000..63c13fc4b01
 +const iscgo = false
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000..4fb400ea521
+index 0000000000..59aa1f86b1
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,159 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -335,6 +336,7 @@ index 00000000000..4fb400ea521
 +package backend
 +
 +import (
++	"crypto/cipher"
 +	"crypto/internal/boring/sig"
 +	"syscall"
 +
@@ -442,6 +444,19 @@ index 00000000000..4fb400ea521
 +var NewHMAC = openssl.NewHMAC
 +
 +var NewAESCipher = openssl.NewAESCipher
++var NewGCMTLS = func(aes cipher.Block) (cipher.AEAD, error) {
++	// This is a translation layer that bridges the gap for an upstream refactor. Based on before:
++	// https://github.com/golang/go/commit/ea5d7cbc2644643331bd675b1ebdf0aaac7419f1#diff-fa1ebabc009bcc9a9f27168612adf5b4d56f9f40d613a62f86830861acb85803
++	type gcmtls interface {
++		// Invented for BoringCrypto.
++		NewGCMTLS() (cipher.AEAD, error)
++	}
++	if aesTLS, ok := aes.(gcmtls); ok {
++		return aesTLS.NewGCMTLS()
++	}
++	Unreachable()
++	return cipher.NewGCM(aes)
++}
 +
 +type PublicKeyECDSA = openssl.PublicKeyECDSA
 +type PrivateKeyECDSA = openssl.PrivateKeyECDSA
@@ -470,7 +485,7 @@ index 00000000000..4fb400ea521
 +var VerifyRSAPSS = openssl.VerifyRSAPSS
 diff --git a/src/crypto/internal/backend/stub.s b/src/crypto/internal/backend/stub.s
 new file mode 100644
-index 00000000000..157adeeeb37
+index 0000000000..157adeeeb3
 --- /dev/null
 +++ b/src/crypto/internal/backend/stub.s
 @@ -0,0 +1,10 @@
@@ -485,7 +500,7 @@ index 00000000000..157adeeeb37
 +// from complaining about the missing body
 +// (because the implementation might be here).
 diff --git a/src/go.mod b/src/go.mod
-index 2b4d8b4b753..b757201682f 100644
+index 2b4d8b4b75..b757201682 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -497,7 +512,7 @@ index 2b4d8b4b753..b757201682f 100644
  	golang.org/x/net v0.0.0-20220517181318-183a9ca12b87
  )
 diff --git a/src/go.sum b/src/go.sum
-index 5c710268b85..ab78e52ded8 100644
+index 5c710268b8..ab78e52ded 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
@@ -507,7 +522,7 @@ index 5c710268b85..ab78e52ded8 100644
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220517181318-183a9ca12b87 h1:cCR+9mKLOGyX4Zx+uBZDXEDAQsvKQ/XbW4vreG5v1jU=
 diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
-index 5a98b202531..9042f2c2795 100644
+index 5a98b20253..9042f2c279 100644
 --- a/src/runtime/runtime_boring.go
 +++ b/src/runtime/runtime_boring.go
 @@ -17,3 +17,8 @@ func boring_runtime_arg0() string {

--- a/patches/0005-Add-OpenSSL-crypto-module.patch
+++ b/patches/0005-Add-OpenSSL-crypto-module.patch
@@ -10,14 +10,14 @@ Subject: [PATCH] Add OpenSSL crypto module
  .../internal/backend/bbig/big_openssl.go      |  12 ++
  src/crypto/internal/backend/common.go         |  34 ++++
  src/crypto/internal/backend/iscgo.go          |  10 ++
- src/crypto/internal/backend/nobackend.go      | 116 +++++++++++++
+ src/crypto/internal/backend/nobackend.go      | 116 ++++++++++++++
  src/crypto/internal/backend/nocgo.go          |  10 ++
- src/crypto/internal/backend/openssl_linux.go  | 159 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 146 ++++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 ++
  src/go.mod                                    |   1 +
  src/go.sum                                    |   2 +
  src/runtime/runtime_boring.go                 |   5 +
- 13 files changed, 418 insertions(+)
+ 13 files changed, 405 insertions(+)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
@@ -320,10 +320,10 @@ index 0000000000..63c13fc4b0
 +const iscgo = false
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 0000000000..59aa1f86b1
+index 0000000000..a247345bce
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,159 @@
+@@ -0,0 +1,146 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -336,7 +336,6 @@ index 0000000000..59aa1f86b1
 +package backend
 +
 +import (
-+	"crypto/cipher"
 +	"crypto/internal/boring/sig"
 +	"syscall"
 +
@@ -444,19 +443,7 @@ index 0000000000..59aa1f86b1
 +var NewHMAC = openssl.NewHMAC
 +
 +var NewAESCipher = openssl.NewAESCipher
-+var NewGCMTLS = func(aes cipher.Block) (cipher.AEAD, error) {
-+	// This is a translation layer that bridges the gap for an upstream refactor. Based on before:
-+	// https://github.com/golang/go/commit/ea5d7cbc2644643331bd675b1ebdf0aaac7419f1#diff-fa1ebabc009bcc9a9f27168612adf5b4d56f9f40d613a62f86830861acb85803
-+	type gcmtls interface {
-+		// Invented for BoringCrypto.
-+		NewGCMTLS() (cipher.AEAD, error)
-+	}
-+	if aesTLS, ok := aes.(gcmtls); ok {
-+		return aesTLS.NewGCMTLS()
-+	}
-+	Unreachable()
-+	return cipher.NewGCM(aes)
-+}
++var NewGCMTLS = openssl.NewGCMTLS
 +
 +type PublicKeyECDSA = openssl.PublicKeyECDSA
 +type PrivateKeyECDSA = openssl.PrivateKeyECDSA
@@ -500,24 +487,24 @@ index 0000000000..157adeeeb3
 +// from complaining about the missing body
 +// (because the implementation might be here).
 diff --git a/src/go.mod b/src/go.mod
-index 2b4d8b4b75..b757201682 100644
+index 2b4d8b4b75..d4f1e6716d 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.19
  
  require (
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20220524182516-dd1444e81452
++	github.com/microsoft/go-crypto-openssl v0.0.0-20220620233145-561693b272da
  	golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8
  	golang.org/x/net v0.0.0-20220517181318-183a9ca12b87
  )
 diff --git a/src/go.sum b/src/go.sum
-index 5c710268b8..ab78e52ded 100644
+index 5c710268b8..32dd91636c 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220524182516-dd1444e81452 h1:UjLCxXwcQiLgMnLP0d45UBzCkcMhE8n0dzeiHwFSwKc=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220524182516-dd1444e81452/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-openssl v0.0.0-20220620233145-561693b272da h1:NyH0aMKbHqrs00Q01E/EI/clS/59gUK8slhMiApnQHE=
++github.com/microsoft/go-crypto-openssl v0.0.0-20220620233145-561693b272da/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8 h1:y+mHpWoQJNAHt26Nhh6JP7hvM71IRZureyvZhoVALIs=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220517181318-183a9ca12b87 h1:cCR+9mKLOGyX4Zx+uBZDXEDAQsvKQ/XbW4vreG5v1jU=

--- a/patches/0006-Integrate-OpenSSL-module.patch
+++ b/patches/0006-Integrate-OpenSSL-module.patch
@@ -44,7 +44,7 @@ Subject: [PATCH] Integrate OpenSSL module
  37 files changed, 53 insertions(+), 50 deletions(-)
 
 diff --git a/src/cmd/api/goapi_boring_test.go b/src/cmd/api/goapi_boring_test.go
-index f0e3575637c..0e9aceeb832 100644
+index f0e3575637..0e9aceeb83 100644
 --- a/src/cmd/api/goapi_boring_test.go
 +++ b/src/cmd/api/goapi_boring_test.go
 @@ -2,7 +2,7 @@
@@ -57,7 +57,7 @@ index f0e3575637c..0e9aceeb832 100644
  package main
  
 diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
-index ed0fbf3d53d..5376227f74c 100644
+index ed0fbf3d53..5376227f74 100644
 --- a/src/cmd/go/go_boring_test.go
 +++ b/src/cmd/go/go_boring_test.go
 @@ -2,7 +2,7 @@
@@ -70,7 +70,7 @@ index ed0fbf3d53d..5376227f74c 100644
  package main_test
  
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index 19678adbd56..e036f02c31d 100644
+index 9a5d89a6f7..68206def96 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
 @@ -1059,6 +1059,7 @@ var hostobj []Hostobj
@@ -82,33 +82,33 @@ index 19678adbd56..e036f02c31d 100644
  	"crypto/internal/boring/syso",
  	"crypto/x509",
 diff --git a/src/crypto/aes/cipher.go b/src/crypto/aes/cipher.go
-index 29d01796eb3..f3680ad6b43 100644
+index db0ee38b78..19b0f52249 100644
 --- a/src/crypto/aes/cipher.go
 +++ b/src/crypto/aes/cipher.go
-@@ -10,7 +10,7 @@ import (
+@@ -6,7 +6,7 @@ package aes
+ 
+ import (
+ 	"crypto/cipher"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/internal/subtle"
  	"strconv"
  )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // The AES block size in bytes.
- const BlockSize = 16
 diff --git a/src/crypto/aes/cipher_asm.go b/src/crypto/aes/cipher_asm.go
-index b7e59d7edb6..994749c10c8 100644
+index 1482b22d08..5f545148bb 100644
 --- a/src/crypto/aes/cipher_asm.go
 +++ b/src/crypto/aes/cipher_asm.go
-@@ -13,7 +13,7 @@ import (
+@@ -8,7 +8,7 @@ package aes
+ 
+ import (
+ 	"crypto/cipher"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/internal/subtle"
+ 	"internal/cpu"
  	"internal/goarch"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // defined in asm_*.s
- 
 diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
-index 097c37e343f..7b04f14ebdd 100644
+index 097c37e343..7b04f14ebd 100644
 --- a/src/crypto/boring/boring.go
 +++ b/src/crypto/boring/boring.go
 @@ -2,7 +2,7 @@
@@ -130,7 +130,7 @@ index 097c37e343f..7b04f14ebdd 100644
  // Enabled reports whether BoringCrypto handles supported crypto operations.
  func Enabled() bool {
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
-index edb723fe0ee..c98044d38ca 100644
+index edb723fe0e..c98044d38c 100644
 --- a/src/crypto/ecdsa/boring.go
 +++ b/src/crypto/ecdsa/boring.go
 @@ -2,13 +2,14 @@
@@ -163,28 +163,22 @@ index edb723fe0ee..c98044d38ca 100644
  func init() {
  	pubCache.Register()
 diff --git a/src/crypto/ecdsa/ecdsa.go b/src/crypto/ecdsa/ecdsa.go
-index 7ce7542872c..e12e8410eee 100644
+index d0e52ad864..58d3bc6956 100644
 --- a/src/crypto/ecdsa/ecdsa.go
 +++ b/src/crypto/ecdsa/ecdsa.go
-@@ -24,14 +24,14 @@ import (
+@@ -24,8 +24,8 @@ import (
  	"crypto/aes"
  	"crypto/cipher"
  	"crypto/elliptic"
+-	"crypto/internal/boring"
 -	"crypto/internal/boring/bbig"
++	boring "crypto/internal/backend"
 +	"crypto/internal/backend/bbig"
  	"crypto/internal/randutil"
  	"crypto/sha512"
  	"errors"
- 	"io"
- 	"math/big"
- 
--	"crypto/internal/boring"
-+	boring "crypto/internal/backend"
- 
- 	"golang.org/x/crypto/cryptobyte"
- 	"golang.org/x/crypto/cryptobyte/asn1"
 diff --git a/src/crypto/ecdsa/notboring.go b/src/crypto/ecdsa/notboring.go
-index 039bd82ed21..3cc16ecab56 100644
+index 039bd82ed2..3cc16ecab5 100644
 --- a/src/crypto/ecdsa/notboring.go
 +++ b/src/crypto/ecdsa/notboring.go
 @@ -2,11 +2,11 @@
@@ -202,7 +196,7 @@ index 039bd82ed21..3cc16ecab56 100644
  func boringPublicKey(*PublicKey) (*boring.PublicKeyECDSA, error) {
  	panic("boringcrypto: not available")
 diff --git a/src/crypto/ed25519/ed25519_test.go b/src/crypto/ed25519/ed25519_test.go
-index 7c5181788f6..bf29780070c 100644
+index 7c5181788f..bf29780070 100644
 --- a/src/crypto/ed25519/ed25519_test.go
 +++ b/src/crypto/ed25519/ed25519_test.go
 @@ -9,7 +9,7 @@ import (
@@ -215,20 +209,20 @@ index 7c5181788f6..bf29780070c 100644
  	"encoding/hex"
  	"os"
 diff --git a/src/crypto/hmac/hmac.go b/src/crypto/hmac/hmac.go
-index 34805765d55..79fd58d0da4 100644
+index ed3ebc0602..99eeac3def 100644
 --- a/src/crypto/hmac/hmac.go
 +++ b/src/crypto/hmac/hmac.go
-@@ -26,7 +26,7 @@ import (
+@@ -22,7 +22,7 @@ timing side-channels:
+ package hmac
+ 
+ import (
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/subtle"
  	"hash"
  )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // FIPS 198-1:
- // https://csrc.nist.gov/publications/fips/fips198-1/FIPS-198-1_final.pdf
 diff --git a/src/crypto/hmac/hmac_test.go b/src/crypto/hmac/hmac_test.go
-index 55415abf020..904925377bb 100644
+index 55415abf02..904925377b 100644
 --- a/src/crypto/hmac/hmac_test.go
 +++ b/src/crypto/hmac/hmac_test.go
 @@ -6,7 +6,7 @@ package hmac
@@ -241,7 +235,7 @@ index 55415abf020..904925377bb 100644
  	"crypto/sha1"
  	"crypto/sha256"
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
-index f2e5a503eaa..1dc7116efdf 100644
+index f2e5a503ea..1dc7116efd 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
 +++ b/src/crypto/internal/boring/fipstls/stub.s
 @@ -2,7 +2,7 @@
@@ -254,7 +248,7 @@ index f2e5a503eaa..1dc7116efdf 100644
  // runtime_arg0 is declared in tls.go without a body.
  // It's provided by package runtime,
 diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
-index 701700e4e3a..703df619b77 100644
+index 701700e4e3..703df619b7 100644
 --- a/src/crypto/internal/boring/fipstls/tls.go
 +++ b/src/crypto/internal/boring/fipstls/tls.go
 @@ -2,7 +2,7 @@
@@ -267,20 +261,20 @@ index 701700e4e3a..703df619b77 100644
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
  // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
 diff --git a/src/crypto/rand/rand_unix.go b/src/crypto/rand/rand_unix.go
-index 830983c74ac..d293683a0c7 100644
+index 746e90cc91..1bd1ccefd8 100644
 --- a/src/crypto/rand/rand_unix.go
 +++ b/src/crypto/rand/rand_unix.go
-@@ -19,7 +19,7 @@ import (
- 	"time"
- )
+@@ -10,7 +10,7 @@
+ package rand
  
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- const urandomDevice = "/dev/urandom"
- 
+ import (
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"errors"
+ 	"io"
+ 	"os"
 diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
-index fc2842fb341..5c6f44f2c9c 100644
+index fc2842fb34..5c6f44f2c9 100644
 --- a/src/crypto/rsa/boring.go
 +++ b/src/crypto/rsa/boring.go
 @@ -2,13 +2,14 @@
@@ -313,7 +307,7 @@ index fc2842fb341..5c6f44f2c9c 100644
  func init() {
  	pubCache.Register()
 diff --git a/src/crypto/rsa/boring_test.go b/src/crypto/rsa/boring_test.go
-index 6223244283f..b8ecc1b50be 100644
+index 6223244283..b8ecc1b50b 100644
 --- a/src/crypto/rsa/boring_test.go
 +++ b/src/crypto/rsa/boring_test.go
 @@ -2,7 +2,7 @@
@@ -326,7 +320,7 @@ index 6223244283f..b8ecc1b50be 100644
  // Note: Can run these tests against the non-BoringCrypto
  // version of the code by using "CGO_ENABLED=0 go test".
 diff --git a/src/crypto/rsa/notboring.go b/src/crypto/rsa/notboring.go
-index 2abc0436405..933ac569e03 100644
+index 2abc043640..933ac569e0 100644
 --- a/src/crypto/rsa/notboring.go
 +++ b/src/crypto/rsa/notboring.go
 @@ -2,11 +2,11 @@
@@ -344,33 +338,33 @@ index 2abc0436405..933ac569e03 100644
  func boringPublicKey(*PublicKey) (*boring.PublicKeyRSA, error) {
  	panic("boringcrypto: not available")
 diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
-index 8cf3b6e255b..22a11207272 100644
+index ab19229a6c..99b3dba5df 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
-@@ -14,7 +14,7 @@ import (
+@@ -6,7 +6,7 @@ package rsa
+ 
+ import (
+ 	"crypto"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
  	"crypto/internal/randutil"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // This file implements encryption and decryption using PKCS #1 v1.5 padding.
- 
+ 	"crypto/subtle"
+ 	"errors"
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
-index 16ebc0e6a7f..54afa8992e9 100644
+index 29e79bd342..372248f046 100644
 --- a/src/crypto/rsa/pss.go
 +++ b/src/crypto/rsa/pss.go
-@@ -15,7 +15,7 @@ import (
- 	"math/big"
- )
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- // Per RFC 8017, Section 9.1
- //
+@@ -9,7 +9,7 @@ package rsa
+ import (
+ 	"bytes"
+ 	"crypto"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"errors"
+ 	"hash"
+ 	"io"
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index c941124fb26..5ef07fdbe9e 100644
+index c941124fb2..5ef07fdbe9 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
 @@ -24,8 +24,8 @@ package rsa
@@ -385,7 +379,7 @@ index c941124fb26..5ef07fdbe9e 100644
  	"crypto/rand"
  	"crypto/subtle"
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 766d9a954f8..f2602b94ab8 100644
+index 766d9a954f..f2602b94ab 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -15,7 +15,7 @@ import (
@@ -398,7 +392,7 @@ index 766d9a954f8..f2602b94ab8 100644
  func TestKeyGeneration(t *testing.T) {
  	for _, size := range []int{128, 1024, 2048, 3072} {
 diff --git a/src/crypto/sha1/boring.go b/src/crypto/sha1/boring.go
-index b5786d1bf4e..4aa5d04e8f9 100644
+index b5786d1bf4..4aa5d04e8f 100644
 --- a/src/crypto/sha1/boring.go
 +++ b/src/crypto/sha1/boring.go
 @@ -12,11 +12,11 @@
@@ -416,7 +410,7 @@ index b5786d1bf4e..4aa5d04e8f9 100644
  func boringNewSHA1() hash.Hash { return boring.NewSHA1() }
  
 diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
-index 85ed1260915..bc169888786 100644
+index 85ed126091..bc16988878 100644
 --- a/src/crypto/sha1/sha1_test.go
 +++ b/src/crypto/sha1/sha1_test.go
 @@ -8,7 +8,7 @@ package sha1
@@ -429,7 +423,7 @@ index 85ed1260915..bc169888786 100644
  	"encoding"
  	"fmt"
 diff --git a/src/crypto/sha256/sha256.go b/src/crypto/sha256/sha256.go
-index e3c15e66ca3..e071a0fa2e6 100644
+index e3c15e66ca..e071a0fa2e 100644
 --- a/src/crypto/sha256/sha256.go
 +++ b/src/crypto/sha256/sha256.go
 @@ -8,7 +8,7 @@ package sha256
@@ -442,7 +436,7 @@ index e3c15e66ca3..e071a0fa2e6 100644
  	"errors"
  	"hash"
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index 7304678346b..7437655bade 100644
+index 7304678346..7437655bad 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -8,7 +8,7 @@ package sha256
@@ -455,7 +449,7 @@ index 7304678346b..7437655bade 100644
  	"encoding"
  	"fmt"
 diff --git a/src/crypto/sha512/sha512.go b/src/crypto/sha512/sha512.go
-index c800a294a27..008c0475459 100644
+index c800a294a2..008c047545 100644
 --- a/src/crypto/sha512/sha512.go
 +++ b/src/crypto/sha512/sha512.go
 @@ -12,7 +12,7 @@ package sha512
@@ -468,7 +462,7 @@ index c800a294a27..008c0475459 100644
  	"errors"
  	"hash"
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index 921cdbb7bbd..2fef7ddae07 100644
+index 921cdbb7bb..2fef7ddae0 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -8,7 +8,7 @@ package sha512
@@ -481,7 +475,7 @@ index 921cdbb7bbd..2fef7ddae07 100644
  	"encoding"
  	"encoding/hex"
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 1827f764589..70baa62d637 100644
+index 1827f76458..70baa62d63 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -2,7 +2,7 @@
@@ -494,7 +488,7 @@ index 1827f764589..70baa62d637 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index f743fc8e9fb..2131a76ca74 100644
+index f743fc8e9f..2131a76ca7 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -507,20 +501,20 @@ index f743fc8e9fb..2131a76ca74 100644
  package tls
  
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
-index 3004b31698d..ce0a1426ead 100644
+index 9a1fa3104b..74f027ebae 100644
 --- a/src/crypto/tls/cipher_suites.go
 +++ b/src/crypto/tls/cipher_suites.go
-@@ -4,7 +4,7 @@
- 
- package tls
- 
--import "crypto/internal/boring"
-+import boring "crypto/internal/backend"
- 
- import (
- 	"crypto"
+@@ -10,7 +10,7 @@ import (
+ 	"crypto/cipher"
+ 	"crypto/des"
+ 	"crypto/hmac"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/rc4"
+ 	"crypto/sha1"
+ 	"crypto/sha256"
 diff --git a/src/crypto/tls/fipsonly/fipsonly.go b/src/crypto/tls/fipsonly/fipsonly.go
-index e5e47835e2f..1a94656dfee 100644
+index e5e47835e2..1a94656dfe 100644
 --- a/src/crypto/tls/fipsonly/fipsonly.go
 +++ b/src/crypto/tls/fipsonly/fipsonly.go
 @@ -2,7 +2,7 @@
@@ -533,7 +527,7 @@ index e5e47835e2f..1a94656dfee 100644
  // Package fipsonly restricts all TLS configuration to FIPS-approved settings.
  //
 diff --git a/src/crypto/tls/fipsonly/fipsonly_test.go b/src/crypto/tls/fipsonly/fipsonly_test.go
-index f8485dc3ca1..9c1d3d279c4 100644
+index f8485dc3ca..9c1d3d279c 100644
 --- a/src/crypto/tls/fipsonly/fipsonly_test.go
 +++ b/src/crypto/tls/fipsonly/fipsonly_test.go
 @@ -2,7 +2,7 @@
@@ -546,7 +540,7 @@ index f8485dc3ca1..9c1d3d279c4 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index 7d85b39c593..1aaabd5ef48 100644
+index 7d85b39c59..1aaabd5ef4 100644
 --- a/src/crypto/tls/notboring.go
 +++ b/src/crypto/tls/notboring.go
 @@ -2,7 +2,7 @@
@@ -559,7 +553,7 @@ index 7d85b39c593..1aaabd5ef48 100644
  package tls
  
 diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
-index 4aae90570d7..24add90c720 100644
+index 4aae90570d..24add90c72 100644
 --- a/src/crypto/x509/boring.go
 +++ b/src/crypto/x509/boring.go
 @@ -2,7 +2,7 @@
@@ -572,7 +566,7 @@ index 4aae90570d7..24add90c720 100644
  package x509
  
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index 7010f44b320..b61b90bdd95 100644
+index 7010f44b32..b61b90bdd9 100644
 --- a/src/crypto/x509/boring_test.go
 +++ b/src/crypto/x509/boring_test.go
 @@ -2,7 +2,7 @@
@@ -585,7 +579,7 @@ index 7010f44b320..b61b90bdd95 100644
  package x509
  
 diff --git a/src/crypto/x509/notboring.go b/src/crypto/x509/notboring.go
-index c83a7272c9f..a0548a7f917 100644
+index c83a7272c9..a0548a7f91 100644
 --- a/src/crypto/x509/notboring.go
 +++ b/src/crypto/x509/notboring.go
 @@ -2,7 +2,7 @@

--- a/patches/0007-Vendor-OpenSSL-crypto-library.patch
+++ b/patches/0007-Vendor-OpenSSL-crypto-library.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Vendor OpenSSL crypto library
 To reproduce, run 'go mod vendor' in 'go/src'.
 ---
  .../microsoft/go-crypto-openssl/LICENSE       |  21 +
- .../go-crypto-openssl/openssl/aes.go          | 466 ++++++++++++++
+ .../go-crypto-openssl/openssl/aes.go          | 472 ++++++++++++++
  .../go-crypto-openssl/openssl/bbig/big.go     |  38 ++
  .../go-crypto-openssl/openssl/big.go          |  13 +
  .../go-crypto-openssl/openssl/ecdsa.go        | 185 ++++++
@@ -22,7 +22,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/rsa.go          | 302 +++++++++
  .../go-crypto-openssl/openssl/sha.go          | 584 ++++++++++++++++++
  src/vendor/modules.txt                        |   5 +
- 17 files changed, 2983 insertions(+)
+ 17 files changed, 2989 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
@@ -42,7 +42,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
 
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE b/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
 new file mode 100644
-index 00000000000..9e841e7a26e
+index 0000000000..9e841e7a26
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
 @@ -0,0 +1,21 @@
@@ -69,10 +69,10 @@ index 00000000000..9e841e7a26e
 +    SOFTWARE
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
 new file mode 100644
-index 00000000000..3177c0d37c8
+index 0000000000..89268b471a
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
-@@ -0,0 +1,466 @@
+@@ -0,0 +1,472 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -371,6 +371,12 @@ index 00000000000..3177c0d37c8
 +	return c.newGCM(false)
 +}
 +
++// NewGCMTLS returns a GCM cipher specific to TLS
++// and should not be used for non-TLS purposes.
++func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) {
++	return c.(*aesCipher).NewGCMTLS()
++}
++
 +func (c *aesCipher) NewGCMTLS() (cipher.AEAD, error) {
 +	return c.newGCM(true)
 +}
@@ -541,7 +547,7 @@ index 00000000000..3177c0d37c8
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
 new file mode 100644
-index 00000000000..1214e1097ef
+index 0000000000..1214e1097e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
 @@ -0,0 +1,38 @@
@@ -585,7 +591,7 @@ index 00000000000..1214e1097ef
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 new file mode 100644
-index 00000000000..7207bde01c9
+index 0000000000..7207bde01c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 @@ -0,0 +1,13 @@
@@ -604,7 +610,7 @@ index 00000000000..7207bde01c9
 +type BigInt []uint
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 new file mode 100644
-index 00000000000..e5a3e03a390
+index 0000000000..e5a3e03a39
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 @@ -0,0 +1,185 @@
@@ -795,7 +801,7 @@ index 00000000000..e5a3e03a390
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 new file mode 100644
-index 00000000000..03a652aef13
+index 0000000000..03a652aef1
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 @@ -0,0 +1,279 @@
@@ -1080,7 +1086,7 @@ index 00000000000..03a652aef13
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
 new file mode 100644
-index 00000000000..7bbf7418512
+index 0000000000..7bbf741851
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
 @@ -0,0 +1,153 @@
@@ -1239,7 +1245,7 @@ index 00000000000..7bbf7418512
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
 new file mode 100644
-index 00000000000..f0c915d541d
+index 0000000000..f0c915d541
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
 @@ -0,0 +1,141 @@
@@ -1387,7 +1393,7 @@ index 00000000000..f0c915d541d
 \ No newline at end of file
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
 new file mode 100644
-index 00000000000..204c94cd94f
+index 0000000000..204c94cd94
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
 @@ -0,0 +1,147 @@
@@ -1540,7 +1546,7 @@ index 00000000000..204c94cd94f
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go
 new file mode 100644
-index 00000000000..db09e4aae64
+index 0000000000..db09e4aae6
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go
 @@ -0,0 +1,32 @@
@@ -1578,7 +1584,7 @@ index 00000000000..db09e4aae64
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
 new file mode 100644
-index 00000000000..95f3e888bb4
+index 0000000000..95f3e888bb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
 @@ -0,0 +1,295 @@
@@ -1879,7 +1885,7 @@ index 00000000000..95f3e888bb4
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 new file mode 100644
-index 00000000000..f52d86360f3
+index 0000000000..f52d86360f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 @@ -0,0 +1,245 @@
@@ -2130,7 +2136,7 @@ index 00000000000..f52d86360f3
 +DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4))
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c
 new file mode 100644
-index 00000000000..5cd7275f407
+index 0000000000..5cd7275f40
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c
 @@ -0,0 +1,53 @@
@@ -2189,7 +2195,7 @@ index 00000000000..5cd7275f407
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go
 new file mode 100644
-index 00000000000..17f64a52ae5
+index 0000000000..17f64a52ae
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go
 @@ -0,0 +1,24 @@
@@ -2219,7 +2225,7 @@ index 00000000000..17f64a52ae5
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 new file mode 100644
-index 00000000000..3d4aa1440a1
+index 0000000000..3d4aa1440a
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 @@ -0,0 +1,302 @@
@@ -2527,7 +2533,7 @@ index 00000000000..3d4aa1440a1
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 new file mode 100644
-index 00000000000..c00e68de020
+index 0000000000..c00e68de02
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 @@ -0,0 +1,584 @@
@@ -3116,11 +3122,11 @@ index 00000000000..c00e68de020
 +	return b[4:], x
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index d0fe779a5c8..a00c0fec42f 100644
+index d0fe779a5c..b91ee394e8 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,8 @@
-+# github.com/microsoft/go-crypto-openssl v0.0.0-20220524182516-dd1444e81452
++# github.com/microsoft/go-crypto-openssl v0.0.0-20220620233145-561693b272da
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig


### PR DESCRIPTION
Addresses a refactor that happened in upstream that broke our build:

* https://github.com/microsoft/go/pull/596

~~This PR fixes the problem with a patch to the openssl backend file to add logic there. We should have this logic in go-crypto-openssl instead. (It would also be less awkward because we wouldn't have to work around the API being semi-non-exported with the type assertion.)~~ Reverted.

This PR uses this new API in go-crypto-openssl to implement `NewGCMTLS`:
* https://github.com/microsoft/go-crypto-openssl/pull/30