### PR TITLE
Add FIPS mode builders

### DIFF
--- a/eng/_util/cmd/run-builder/systemfips_fallback.go
+++ b/eng/_util/cmd/run-builder/systemfips_fallback.go
@@ -6,8 +6,11 @@
 
 package main
 
-// enableSystemWideFIPS is a no-op because the current platform either doesn't support or doesn't
-// require system-wide FIPS to be enabled to run tests.
+import "log"
+
+// enableSystemWideFIPS fallback is a no-op because the current platform either doesn't support or
+// doesn't require system-wide FIPS to be enabled to run tests.
 func enableSystemWideFIPS() (restore func(), err error) {
+	log.Println("Using fallback (no-op) for enableSystemWideFIPS. It either isn't supported on this platform or isn't necessary.")
 	return nil, nil
 }

--- a/eng/_util/cmd/run-builder/systemfips_fallback.go
+++ b/eng/_util/cmd/run-builder/systemfips_fallback.go
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build !windows
+// +build !windows
+
+package main
+
+// enableSystemWideFIPS is a no-op because the current platform either doesn't support or doesn't
+// require system-wide FIPS to be enabled to run tests.
+func enableSystemWideFIPS() (restore func(), err error) {
+	return nil, nil
+}

--- a/eng/_util/cmd/run-builder/systemfips_windows.go
+++ b/eng/_util/cmd/run-builder/systemfips_windows.go
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// enableSystemWideFIPS enables Windows system-wide FIPS and returns a state-restoring func in case
+// the host will be used later by another process. If the host is simultaneously shared, enabling
+// system-wide FIPS may interfere because this policy is a machine setting.
+func enableSystemWideFIPS() (restore func(), err error) {
+	key, err := registry.OpenKey(
+		registry.LOCAL_MACHINE,
+		`SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy`,
+		registry.QUERY_VALUE|registry.SET_VALUE)
+	if err != nil {
+		return nil, err
+	}
+
+	enabled, enabledType, err := key.GetIntegerValue("Enabled")
+	if err != nil {
+		return nil, err
+	}
+
+	if enabledType != registry.DWORD {
+		return nil, fmt.Errorf("unexpected FIPS algorithm policy Enabled key type: %v", enabledType)
+	}
+
+	if enabled == 1 {
+		log.Println("FIPS algorithm policy already enabled.")
+		return nil, nil
+	}
+
+	log.Printf("Found FIPS algorithm policy Enabled value: %v\n", enabled)
+	if err := key.SetDWordValue("Enabled", 1); err != nil {
+		return nil, err
+	}
+
+	log.Println("Enabled FIPS algorithm policy.")
+
+	return func() {
+		defer key.Close()
+		err := key.SetDWordValue("Enabled", uint32(enabled))
+		if err != nil {
+			log.Printf("Unable to set FIPS algorithm policy to original value %v: %v\n", enabled, err)
+			return
+		}
+		log.Printf("Successfully reset FIPS algorithm policy back to original value %v: %v\n", enabled, err)
+	}, nil
+}

--- a/eng/_util/go.mod
+++ b/eng/_util/go.mod
@@ -9,6 +9,7 @@ go 1.16
 require (
 	github.com/microsoft/go-infra v0.0.0-20220419195018-e437e0d7a6f9
 	github.com/microsoft/go/_core v0.0.0
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	gotest.tools/gotestsum v1.6.5-0.20210515201937-ecb7c6956f6d
 )
 

--- a/eng/pipeline/jobs/go-builder-matrix-jobs.yml
+++ b/eng/pipeline/jobs/go-builder-matrix-jobs.yml
@@ -25,6 +25,7 @@ jobs:
           - { os: linux, arch: amd64, config: test }
           - { os: linux, arch: amd64, config: test, distro: ubuntu }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, fips: true }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
@@ -32,6 +33,7 @@ jobs:
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test }
+          - { experiment: cngcrypto, os: windows, arch: amd64, config: test, fips: true }
           - { os: linux, arch: arm, hostArch: amd64, config: buildandpack }
           # Only build arm64 if we're running a signed (internal, rolling) build. Avoid contention
           # with other projects' builds that use the same limited-capacity pool of arm64 agents.

--- a/eng/pipeline/jobs/run-job.yml
+++ b/eng/pipeline/jobs/run-job.yml
@@ -5,7 +5,7 @@
 # This job runs a builder for any OS.
 
 parameters:
-  # { id, os, arch, hostArch, config, distro?, experiment? }
+  # { id, os, arch, hostArch, config, distro?, experiment?, fips? }
   builder: {}
   createSourceArchive: false
 
@@ -13,7 +13,7 @@ jobs:
   - job: ${{ parameters.builder.id }}
     # For display name, try for readability. Use some parameters set by
     # shorthand-builders-to-builders.yml that let us add some formatting.
-    displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }}
+    displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.fipsAcronym }}
     workspace:
       clean: all
 
@@ -131,6 +131,7 @@ jobs:
             eng/run.ps1 run-builder `
               -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
               $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
+              $(if ('${{ parameters.builder.fips }}') { '-fipsmode' }) `
               -junitfile '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml'
           displayName: Run ${{ parameters.builder.config }}
 
@@ -140,7 +141,7 @@ jobs:
           inputs:
             testResultsFormat: JUnit
             testResultsFiles: $(Build.SourcesDirectory)/eng/artifacts/TestResults.xml
-            testRunTitle: ${{ parameters.builder.id }}
+            testRunTitle: $(System.JobDisplayName)
             buildPlatform: ${{ parameters.builder.arch }}
             buildConfiguration: ${{ parameters.builder.config }}
             publishRunAttachments: true

--- a/eng/pipeline/jobs/shorthand-builders-to-builders.yml
+++ b/eng/pipeline/jobs/shorthand-builders-to-builders.yml
@@ -17,7 +17,7 @@ parameters:
   shorthandBuilders: []
   # The inner jobs template to pass the filed-out builders into.
   #
-  # It should accept parameter "builders", [] of { id, os, arch, hostArch, config, distro? }
+  # It should accept parameter "builders", [] of { id, os, arch, hostArch, config, distro?, fips? }
   jobsTemplate: ""
   jobsParameters: {}
 
@@ -30,7 +30,7 @@ jobs:
           - ${{ insert }}: ${{ builder }}
             # Use 'default' in place of null to define ID. This value just needs to be unique and
             # only contain "[A-z_]+".
-            id: ${{ builder.os }}_${{ coalesce(builder.distro, 'default') }}_${{ coalesce(builder.hostArch, 'default') }}_${{ builder.arch }}_${{ builder.config }}_${{ coalesce(builder.experiment, 'default') }}
+            id: ${{ builder.os }}_${{ coalesce(builder.distro, 'default') }}_${{ coalesce(builder.hostArch, 'default') }}_${{ builder.arch }}_${{ builder.config }}_${{ coalesce(builder.experiment, 'default') }}_${{ coalesce(builder.fips, false) }}
             ${{ if not(builder.hostArch) }}:
               hostArch: ${{ builder.arch }}
             # Set up some parameters that are for display purposes. AzDO YAML expressions can't
@@ -41,5 +41,5 @@ jobs:
               hostParens: (${{ builder.hostArch }} host)
             ${{ if builder.experiment }}:
               experimentBrackets: '[${{ builder.experiment }}]'
-
-
+            ${{ if builder.fips }}:
+              fipsAcronym: 'FIPS'


### PR DESCRIPTION
* Add new `fips` optional bool in builder list.
* On any platform, handle `fips: true` by passing run-builder a `-fipsmode` flag that sets `GOFIPS=true` before running tests.
* On Windows, also enable system-wide FIPS using the `registry` package.
* Change the test run names from the job ID mess:  
  `linux_default_default_amd64_test_default_False` to the human-readable name, instead:
  `linux-amd64 test`
  * `linux-amd64 test [opensslcrypto] FIPS`
  * `windows-amd64 test [cngcrypto] FIPS`

---

This actually fills a gap in our Linux/OpenSSL tests since the boring branch merge. The boring branch used an image that sets GOFIPS=true:

https://github.com/microsoft/go/blob/ae8300fc957c60070df9846e4571085df9db128b/eng/pipeline/jobs/run-job.yml#L29-L30

And this isn't the case in `microsoft/main`:

https://github.com/microsoft/go/blob/39476b4a06b19a3b241c3c3e7a036632254aec66/eng/pipeline/jobs/run-job.yml#L38-L39

We need to run both in FIPS and not in FIPS in `microsoft/main`, so we need flexibility, and I think putting it in `run-builder` is a reasonable place, rather than picking different base images in the yml.
