### PR TITLE
Always use OpenSSL backend when opensslcrypto is set

### DIFF
--- a/patches/0004-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0004-Add-BoringSSL-crypto-backend.patch
@@ -1,12 +1,12 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Quim Muntal <qmuntaldiaz@microsoft.com>
 Date: Wed, 22 Jun 2022 12:16:05 +0000
-Subject: [PATCH] Add BoringSSL crypto module
+Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
- .../internal/backend/bbig/big_boring.go       | 12 ++++
- src/crypto/internal/backend/boring_linux.go   | 59 +++++++++++++++++++
- 2 files changed, 71 insertions(+)
+ .../internal/backend/bbig/big_boring.go       |  12 ++
+ src/crypto/internal/backend/boring_linux.go   | 116 ++++++++++++++++++
+ 2 files changed, 128 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..22e3c42cba5c05
+index 00000000000000..0bcc15506978a8
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,116 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -45,51 +45,108 @@ index 00000000000000..22e3c42cba5c05
 +// If BoringCrypto is not available, the functions in this package all panic.
 +package backend
 +
-+import "crypto/internal/boring"
++import (
++	"crypto"
++	"crypto/cipher"
++	"crypto/internal/boring"
++	"hash"
++)
 +
 +const Enabled = true
 +
 +const RandReader = boring.RandReader
 +
-+var NewSHA1 = boring.NewSHA1
-+var NewSHA224 = boring.NewSHA224
-+var NewSHA256 = boring.NewSHA256
-+var NewSHA384 = boring.NewSHA384
-+var NewSHA512 = boring.NewSHA512
++func NewSHA1() hash.Hash   { return boring.NewSHA1() }
++func NewSHA224() hash.Hash { return boring.NewSHA224() }
++func NewSHA256() hash.Hash { return boring.NewSHA256() }
++func NewSHA384() hash.Hash { return boring.NewSHA384() }
++func NewSHA512() hash.Hash { return boring.NewSHA512() }
 +
-+var SHA1 = boring.SHA1
-+var SHA224 = boring.SHA224
-+var SHA256 = boring.SHA256
-+var SHA384 = boring.SHA384
-+var SHA512 = boring.SHA512
++func SHA1(p []byte) (sum [20]byte)   { return boring.SHA1(p) }
++func SHA224(p []byte) (sum [28]byte) { return boring.SHA224(p) }
++func SHA256(p []byte) (sum [32]byte) { return boring.SHA256(p) }
++func SHA384(p []byte) (sum [48]byte) { return boring.SHA384(p) }
++func SHA512(p []byte) (sum [64]byte) { return boring.SHA512(p) }
 +
-+var NewHMAC = boring.NewHMAC
++func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return boring.NewHMAC(h, key) }
 +
-+var NewAESCipher = boring.NewAESCipher
-+var NewGCMTLS = boring.NewGCMTLS
++func NewAESCipher(key []byte) (cipher.Block, error) { return boring.NewAESCipher(key) }
++func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) { return boring.NewGCMTLS(c) }
 +
 +type PublicKeyECDSA = boring.PublicKeyECDSA
 +type PrivateKeyECDSA = boring.PrivateKeyECDSA
 +
-+var GenerateKeyECDSA = boring.GenerateKeyECDSA
-+var NewPrivateKeyECDSA = boring.NewPrivateKeyECDSA
-+var NewPublicKeyECDSA = boring.NewPublicKeyECDSA
-+var SignMarshalECDSA = boring.SignMarshalECDSA
-+var VerifyECDSA = boring.VerifyECDSA
++func GenerateKeyECDSA(curve string) (X, Y, D boring.BigInt, err error) {
++	return boring.GenerateKeyECDSA(curve)
++}
++
++func NewPrivateKeyECDSA(curve string, X, Y, D boring.BigInt) (*boring.PrivateKeyECDSA, error) {
++	return boring.NewPrivateKeyECDSA(curve, X, Y, D)
++}
++
++func NewPublicKeyECDSA(curve string, X, Y boring.BigInt) (*boring.PublicKeyECDSA, error) {
++	return boring.NewPublicKeyECDSA(curve, X, Y)
++}
++
++func SignMarshalECDSA(priv *boring.PrivateKeyECDSA, hash []byte) ([]byte, error) {
++	return boring.SignMarshalECDSA(priv, hash)
++}
++
++func VerifyECDSA(pub *boring.PublicKeyECDSA, hash []byte, sig []byte) bool {
++	return boring.VerifyECDSA(pub, hash, sig)
++}
 +
 +type PublicKeyRSA = boring.PublicKeyRSA
 +type PrivateKeyRSA = boring.PrivateKeyRSA
 +
-+var DecryptRSAOAEP = boring.DecryptRSAOAEP
-+var DecryptRSAPKCS1 = boring.DecryptRSAPKCS1
-+var DecryptRSANoPadding = boring.DecryptRSANoPadding
-+var EncryptRSAOAEP = boring.EncryptRSAOAEP
-+var EncryptRSAPKCS1 = boring.EncryptRSAPKCS1
-+var EncryptRSANoPadding = boring.EncryptRSANoPadding
-+var GenerateKeyRSA = boring.GenerateKeyRSA
-+var NewPrivateKeyRSA = boring.NewPrivateKeyRSA
-+var NewPublicKeyRSA = boring.NewPublicKeyRSA
-+var SignRSAPKCS1v15 = boring.SignRSAPKCS1v15
-+var SignRSAPSS = boring.SignRSAPSS
-+var VerifyRSAPKCS1v15 = boring.VerifyRSAPKCS1v15
-+var VerifyRSAPSS = boring.VerifyRSAPSS
++func DecryptRSAOAEP(h hash.Hash, priv *boring.PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
++	return boring.DecryptRSAOAEP(h, priv, ciphertext, label)
++}
++
++func DecryptRSAPKCS1(priv *boring.PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
++	return boring.DecryptRSAPKCS1(priv, ciphertext)
++}
++
++func DecryptRSANoPadding(priv *boring.PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
++	return boring.DecryptRSANoPadding(priv, ciphertext)
++}
++
++func EncryptRSAOAEP(h hash.Hash, pub *boring.PublicKeyRSA, msg, label []byte) ([]byte, error) {
++	return boring.EncryptRSAOAEP(h, pub, msg, label)
++}
++
++func EncryptRSAPKCS1(pub *boring.PublicKeyRSA, msg []byte) ([]byte, error) {
++	return boring.EncryptRSAPKCS1(pub, msg)
++}
++
++func EncryptRSANoPadding(pub *boring.PublicKeyRSA, msg []byte) ([]byte, error) {
++	return boring.EncryptRSANoPadding(pub, msg)
++}
++
++func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv boring.BigInt, err error) {
++	return boring.GenerateKeyRSA(bits)
++}
++
++func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv boring.BigInt) (*boring.PrivateKeyRSA, error) {
++	return boring.NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv)
++}
++
++func NewPublicKeyRSA(N, E boring.BigInt) (*boring.PublicKeyRSA, error) {
++	return boring.NewPublicKeyRSA(N, E)
++}
++
++func SignRSAPKCS1v15(priv *boring.PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte, error) {
++	return boring.SignRSAPKCS1v15(priv, h, hashed)
++}
++
++func SignRSAPSS(priv *boring.PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
++	return boring.SignRSAPSS(priv, h, hashed, saltLen)
++}
++
++func VerifyRSAPKCS1v15(pub *boring.PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
++	return boring.VerifyRSAPKCS1v15(pub, h, hashed, sig)
++}
++
++func VerifyRSAPSS(pub *boring.PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
++	return boring.VerifyRSAPSS(pub, h, hashed, sig, saltLen)
++}

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -606,24 +606,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 94380d656788f9..f2e6101d5016ab 100644
+index 94380d656788f9..289d02db9570f2 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.19
  
  require (
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20220726174527-136d210dacbd
++	github.com/microsoft/go-crypto-openssl v0.0.0-20220727182410-f0cde275907d
  	golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8
  	golang.org/x/net v0.0.0-20220517181318-183a9ca12b87
  )
 diff --git a/src/go.sum b/src/go.sum
-index a54b0565bdc97c..44c59f9f9d5b38 100644
+index a54b0565bdc97c..ffdac6bf5a16b2 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220726174527-136d210dacbd h1:Y2gKjqTjmoA8L0FsJmhtQBv1z5bUzIuWEWz+30YuVWE=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220726174527-136d210dacbd/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-openssl v0.0.0-20220727182410-f0cde275907d h1:bYrnqvch83JAniHNR1QlzrvBeTZCNNZmnj4EcnB2Uuo=
++github.com/microsoft/go-crypto-openssl v0.0.0-20220727182410-f0cde275907d/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8 h1:y+mHpWoQJNAHt26Nhh6JP7hvM71IRZureyvZhoVALIs=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220517181318-183a9ca12b87 h1:cCR+9mKLOGyX4Zx+uBZDXEDAQsvKQ/XbW4vreG5v1jU=

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -1,12 +1,12 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: qmuntal <qmuntaldiaz@microsoft.com>
 Date: Thu, 30 Jun 2022 10:06:19 +0200
-Subject: [PATCH] Add OpenSSL crypto module
+Subject: [PATCH] Add OpenSSL crypto backend
 
 ---
  src/cmd/api/goapi_boring_test.go              |   2 +-
  src/cmd/go/go_boring_test.go                  |   2 +-
- .../go/testdata/script/gopath_std_vendor.txt  |   9 ++
+ .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
  src/crypto/boring/boring.go                   |   2 +-
  src/crypto/ecdsa/boring.go                    |   2 +-
@@ -15,13 +15,12 @@ Subject: [PATCH] Add OpenSSL crypto module
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 ++
  src/crypto/internal/backend/nobackend.go      |   2 +-
- src/crypto/internal/backend/openssl_linux.go  | 119 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 184 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
  src/crypto/rsa/boring_test.go                 |   2 +-
  src/crypto/rsa/notboring.go                   |   2 +-
- src/crypto/sha1/boring.go                     |   2 +-
  src/crypto/tls/boring.go                      |   2 +-
  src/crypto/tls/boring_test.go                 |   2 +-
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
@@ -33,10 +32,10 @@ Subject: [PATCH] Add OpenSSL crypto module
  src/go.mod                                    |   1 +
  src/go.sum                                    |   2 +
  src/go/build/deps_test.go                     |   7 +-
- .../goexperiment/exp_opensslcrypto_off.go     |   9 ++
- .../goexperiment/exp_opensslcrypto_on.go      |   9 ++
+ .../goexperiment/exp_opensslcrypto_off.go     |   9 +
+ .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 32 files changed, 195 insertions(+), 23 deletions(-)
+ 31 files changed, 259 insertions(+), 22 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -88,7 +87,7 @@ index a0a41a50de328d..509884b6ed1afd 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index 565ff9d6349b83..82fa27268cd138 100644
+index 18910ddb850856..27d8bec4b575dc 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
 @@ -1073,6 +1073,7 @@ var hostobj []Hostobj
@@ -208,10 +207,10 @@ index 45d9702eb455c6..91d663a5613549 100644
  
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..1e6d2aa2cb7d1b
+index 00000000000000..7a5a248fed7a81
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,119 @@
+@@ -0,0 +1,184 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -224,38 +223,51 @@ index 00000000000000..1e6d2aa2cb7d1b
 +package backend
 +
 +import (
++	"crypto"
++	"crypto/cipher"
 +	"crypto/internal/boring/sig"
++	"hash"
 +	"syscall"
 +
 +	"github.com/microsoft/go-crypto-openssl/openssl"
 +)
 +
 +// Enabled controls whether FIPS crypto is enabled.
-+var Enabled = false
++const Enabled = true
 +
 +func init() {
-+	if !needFIPS() {
-+		return
-+	}
 +	err := openssl.Init()
 +	if err != nil {
-+		panic(err)
++		panic("opensslcrypto: can't initialize OpenSSL: " + err.Error())
 +	}
-+
-+	if !openssl.FIPS() {
-+		if err = openssl.SetFIPS(true); err != nil {
-+			panic(err)
++	// 0: FIPS opt-out: abort the process if it is enabled and can't be disabled.
++	// 1: FIPS required: abort the process if it is not enabled and can't be enabled.
++	// other values: do not override OpenSSL configured FIPS mode.
++	var fips string
++	if v, ok := envGoFIPS(); ok {
++		fips = v
++	} else if systemFIPSMode() {
++		// System configuration can only force FIPS mode.
++		fips = "1"
++	}
++	switch fips {
++	case "0":
++		if openssl.FIPS() {
++			if err = openssl.SetFIPS(false); err != nil {
++				panic("opensslcrypto: can't disable FIPS mode: " + err.Error())
++			}
++		}
++	case "1":
++		if !openssl.FIPS() {
++			if err = openssl.SetFIPS(true); err != nil {
++				panic("opensslcrypto: can't enable FIPS mode: " + err.Error())
++			}
 +		}
 +	}
-+
-+	Enabled = true
 +	sig.BoringCrypto()
 +}
 +
-+func needFIPS() bool {
-+	if v, ok := envGoFIPS(); ok {
-+		return v != "0"
-+	}
++func systemFIPSMode() bool {
 +	var fd int
 +	for {
 +		var err error
@@ -289,48 +301,100 @@ index 00000000000000..1e6d2aa2cb7d1b
 +
 +const RandReader = openssl.RandReader
 +
-+var NewSHA1 = openssl.NewSHA1
-+var NewSHA224 = openssl.NewSHA224
-+var NewSHA256 = openssl.NewSHA256
-+var NewSHA384 = openssl.NewSHA384
-+var NewSHA512 = openssl.NewSHA512
++func NewSHA1() hash.Hash   { return openssl.NewSHA1() }
++func NewSHA224() hash.Hash { return openssl.NewSHA224() }
++func NewSHA256() hash.Hash { return openssl.NewSHA256() }
++func NewSHA384() hash.Hash { return openssl.NewSHA384() }
++func NewSHA512() hash.Hash { return openssl.NewSHA512() }
 +
-+var SHA1 = openssl.SHA1
-+var SHA224 = openssl.SHA224
-+var SHA256 = openssl.SHA256
-+var SHA384 = openssl.SHA384
-+var SHA512 = openssl.SHA512
++func SHA1(p []byte) (sum [20]byte)   { return openssl.SHA1(p) }
++func SHA224(p []byte) (sum [28]byte) { return openssl.SHA224(p) }
++func SHA256(p []byte) (sum [32]byte) { return openssl.SHA256(p) }
++func SHA384(p []byte) (sum [48]byte) { return openssl.SHA384(p) }
++func SHA512(p []byte) (sum [64]byte) { return openssl.SHA512(p) }
 +
-+var NewHMAC = openssl.NewHMAC
++func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return openssl.NewHMAC(h, key) }
 +
-+var NewAESCipher = openssl.NewAESCipher
-+var NewGCMTLS = openssl.NewGCMTLS
++func NewAESCipher(key []byte) (cipher.Block, error) { return openssl.NewAESCipher(key) }
++func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) { return openssl.NewGCMTLS(c) }
 +
 +type PublicKeyECDSA = openssl.PublicKeyECDSA
 +type PrivateKeyECDSA = openssl.PrivateKeyECDSA
 +
-+var GenerateKeyECDSA = openssl.GenerateKeyECDSA
-+var NewPrivateKeyECDSA = openssl.NewPrivateKeyECDSA
-+var NewPublicKeyECDSA = openssl.NewPublicKeyECDSA
-+var SignMarshalECDSA = openssl.SignMarshalECDSA
-+var VerifyECDSA = openssl.VerifyECDSA
++func GenerateKeyECDSA(curve string) (X, Y, D openssl.BigInt, err error) {
++	return openssl.GenerateKeyECDSA(curve)
++}
++
++func NewPrivateKeyECDSA(curve string, X, Y, D openssl.BigInt) (*openssl.PrivateKeyECDSA, error) {
++	return openssl.NewPrivateKeyECDSA(curve, X, Y, D)
++}
++
++func NewPublicKeyECDSA(curve string, X, Y openssl.BigInt) (*openssl.PublicKeyECDSA, error) {
++	return openssl.NewPublicKeyECDSA(curve, X, Y)
++}
++
++func SignMarshalECDSA(priv *openssl.PrivateKeyECDSA, hash []byte) ([]byte, error) {
++	return openssl.SignMarshalECDSA(priv, hash)
++}
++
++func VerifyECDSA(pub *openssl.PublicKeyECDSA, hash []byte, sig []byte) bool {
++	return openssl.VerifyECDSA(pub, hash, sig)
++}
 +
 +type PublicKeyRSA = openssl.PublicKeyRSA
 +type PrivateKeyRSA = openssl.PrivateKeyRSA
 +
-+var DecryptRSAOAEP = openssl.DecryptRSAOAEP
-+var DecryptRSAPKCS1 = openssl.DecryptRSAPKCS1
-+var DecryptRSANoPadding = openssl.DecryptRSANoPadding
-+var EncryptRSAOAEP = openssl.EncryptRSAOAEP
-+var EncryptRSAPKCS1 = openssl.EncryptRSAPKCS1
-+var EncryptRSANoPadding = openssl.EncryptRSANoPadding
-+var GenerateKeyRSA = openssl.GenerateKeyRSA
-+var NewPrivateKeyRSA = openssl.NewPrivateKeyRSA
-+var NewPublicKeyRSA = openssl.NewPublicKeyRSA
-+var SignRSAPKCS1v15 = openssl.SignRSAPKCS1v15
-+var SignRSAPSS = openssl.SignRSAPSS
-+var VerifyRSAPKCS1v15 = openssl.VerifyRSAPKCS1v15
-+var VerifyRSAPSS = openssl.VerifyRSAPSS
++func DecryptRSAOAEP(h hash.Hash, priv *openssl.PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
++	return openssl.DecryptRSAOAEP(h, priv, ciphertext, label)
++}
++
++func DecryptRSAPKCS1(priv *openssl.PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
++	return openssl.DecryptRSAPKCS1(priv, ciphertext)
++}
++
++func DecryptRSANoPadding(priv *openssl.PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
++	return openssl.DecryptRSANoPadding(priv, ciphertext)
++}
++
++func EncryptRSAOAEP(h hash.Hash, pub *openssl.PublicKeyRSA, msg, label []byte) ([]byte, error) {
++	return openssl.EncryptRSAOAEP(h, pub, msg, label)
++}
++
++func EncryptRSAPKCS1(pub *openssl.PublicKeyRSA, msg []byte) ([]byte, error) {
++	return openssl.EncryptRSAPKCS1(pub, msg)
++}
++
++func EncryptRSANoPadding(pub *openssl.PublicKeyRSA, msg []byte) ([]byte, error) {
++	return openssl.EncryptRSANoPadding(pub, msg)
++}
++
++func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv openssl.BigInt, err error) {
++	return openssl.GenerateKeyRSA(bits)
++}
++
++func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv openssl.BigInt) (*openssl.PrivateKeyRSA, error) {
++	return openssl.NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv)
++}
++
++func NewPublicKeyRSA(N, E openssl.BigInt) (*openssl.PublicKeyRSA, error) {
++	return openssl.NewPublicKeyRSA(N, E)
++}
++
++func SignRSAPKCS1v15(priv *openssl.PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte, error) {
++	return openssl.SignRSAPKCS1v15(priv, h, hashed)
++}
++
++func SignRSAPSS(priv *openssl.PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
++	return openssl.SignRSAPSS(priv, h, hashed, saltLen)
++}
++
++func VerifyRSAPKCS1v15(pub *openssl.PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
++	return openssl.VerifyRSAPKCS1v15(pub, h, hashed, sig)
++}
++
++func VerifyRSAPSS(pub *openssl.PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
++	return openssl.VerifyRSAPSS(pub, h, hashed, sig, saltLen)
++}
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
 index f2e5a503eaacb6..1dc7116efdff2e 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
@@ -395,19 +459,6 @@ index 34c22c8fbba7da..933ac569e034a8 100644
 +//go:build !boringcrypto && !goexperiment.opensslcrypto
  
  package rsa
- 
-diff --git a/src/crypto/sha1/boring.go b/src/crypto/sha1/boring.go
-index e82a21c44a57c8..4aa5d04e8f9a28 100644
---- a/src/crypto/sha1/boring.go
-+++ b/src/crypto/sha1/boring.go
-@@ -16,7 +16,7 @@ import (
- 	"hash"
- )
- 
--const boringEnabled = boring.Enabled
-+var boringEnabled = boring.Enabled
- 
- func boringNewSHA1() hash.Hash { return boring.NewSHA1() }
  
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
 index 1827f764589b58..70baa62d63754a 100644

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -605,24 +605,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 94380d656788f9..e81a456f1777f1 100644
+index 94380d656788f9..f2e6101d5016ab 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.19
  
  require (
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20220620233145-561693b272da
++	github.com/microsoft/go-crypto-openssl v0.0.0-20220726174527-136d210dacbd
  	golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8
  	golang.org/x/net v0.0.0-20220517181318-183a9ca12b87
  )
 diff --git a/src/go.sum b/src/go.sum
-index a54b0565bdc97c..e66aa6b178645a 100644
+index a54b0565bdc97c..44c59f9f9d5b38 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220620233145-561693b272da h1:NyH0aMKbHqrs00Q01E/EI/clS/59gUK8slhMiApnQHE=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220620233145-561693b272da/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-openssl v0.0.0-20220726174527-136d210dacbd h1:Y2gKjqTjmoA8L0FsJmhtQBv1z5bUzIuWEWz+30YuVWE=
++github.com/microsoft/go-crypto-openssl v0.0.0-20220726174527-136d210dacbd/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8 h1:y+mHpWoQJNAHt26Nhh6JP7hvM71IRZureyvZhoVALIs=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220517181318-183a9ca12b87 h1:cCR+9mKLOGyX4Zx+uBZDXEDAQsvKQ/XbW4vreG5v1jU=

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
 ---
  misc/cgo/test/pkg_test.go                     |   4 +-
  src/cmd/api/goapi_boring_test.go              |   2 +-
- src/cmd/dist/test.go                          |   8 +-
+ src/cmd/dist/test.go                          |  10 +-
  src/cmd/go/go_boring_test.go                  |   2 +-
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
@@ -38,7 +38,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 34 files changed, 277 insertions(+), 25 deletions(-)
+ 34 files changed, 278 insertions(+), 26 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -73,28 +73,35 @@ index f0e3575637c62a..0e9aceeb832d3b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index f974631e55682f..a90b018cd0c3d4 100644
+index f974631e55682f..5e54cbdf6ea0ba 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1262,12 +1262,16 @@ func (t *tester) cgoTest(dt *distTest) error {
+@@ -1255,18 +1255,22 @@ func (t *tester) cgoTest(dt *distTest) error {
+ 			if err := cmd.Run(); err != nil {
+ 				fmt.Println("No support for static linking found (lacks libc.a?), skip cgo static linking test.")
+ 			} else {
+-				if goos != "android" {
++				// Don't test static builds with OpenSSLCrypto.
++				// It makes TestSetgid hang in certain gcc versions.
++				// See go.dev/issues/52141.
++				staticSupported := !strings.Contains(goexperiment, "opensslcrypto")
++				if goos != "android" && staticSupported {
+ 					t.addCmd(dt, "misc/cgo/testtls", t.goTest(), "-ldflags", `-linkmode=external -extldflags "-static -pthread"`, ".")
+ 				}
+ 				t.addCmd(dt, "misc/cgo/nocgo", t.goTest(), ".")
  				t.addCmd(dt, "misc/cgo/nocgo", t.goTest(), "-ldflags", `-linkmode=external`, ".")
- 				if goos != "android" {
+-				if goos != "android" {
++				if goos != "android" && staticSupported {
  					t.addCmd(dt, "misc/cgo/nocgo", t.goTest(), "-ldflags", `-linkmode=external -extldflags "-static -pthread"`, ".")
--					t.addCmd(dt, "misc/cgo/test", t.goTest(), "-tags=static", "-ldflags", `-linkmode=external -extldflags "-static -pthread"`, ".")
-+					// Use 'GOEXPERIMENT=none' to avoid importing go-crypto-openssl, which makes TestSetgid hang.
-+					// See go.dev/issues/52141.
-+					cmd := t.addCmd(dt, "misc/cgo/test", t.goTest(), "-tags=static", "-ldflags", `-linkmode=external -extldflags "-static -pthread"`, ".")
-+					setEnv(cmd, "GOEXPERIMENT", "none")
+ 					t.addCmd(dt, "misc/cgo/test", t.goTest(), "-tags=static", "-ldflags", `-linkmode=external -extldflags "-static -pthread"`, ".")
  					// -static in CGO_LDFLAGS triggers a different code path
  					// than -static in -extldflags, so test both.
  					// See issue #16651.
 -					cmd := t.addCmd(dt, "misc/cgo/test", t.goTest(), "-tags=static", ".")
 +					cmd = t.addCmd(dt, "misc/cgo/test", t.goTest(), "-tags=static", ".")
  					setEnv(cmd, "CGO_LDFLAGS", "-static -pthread")
-+					setEnv(cmd, "GOEXPERIMENT", "none")
  				}
  			}
- 
 diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
 index ed0fbf3d53d75b..5376227f74cfaa 100644
 --- a/src/cmd/go/go_boring_test.go

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -4,7 +4,9 @@ Date: Thu, 30 Jun 2022 10:06:19 +0200
 Subject: [PATCH] Add OpenSSL crypto backend
 
 ---
+ misc/cgo/test/pkg_test.go                     |   4 +-
  src/cmd/api/goapi_boring_test.go              |   2 +-
+ src/cmd/dist/test.go                          |   8 +-
  src/cmd/go/go_boring_test.go                  |   2 +-
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
@@ -35,12 +37,27 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_off.go     |   9 +
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 31 files changed, 259 insertions(+), 22 deletions(-)
+ 33 files changed, 268 insertions(+), 25 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_on.go
 
+diff --git a/misc/cgo/test/pkg_test.go b/misc/cgo/test/pkg_test.go
+index 14013a4cd962b6..64d39561b65aa3 100644
+--- a/misc/cgo/test/pkg_test.go
++++ b/misc/cgo/test/pkg_test.go
+@@ -58,7 +58,9 @@ func TestCrossPackageTests(t *testing.T) {
+ 		cmd.Args = append(cmd.Args, "-short")
+ 	}
+ 	cmd.Dir = modRoot
+-	cmd.Env = append(os.Environ(), "GOPATH="+GOPATH, "PWD="+cmd.Dir)
++	// Use 'GOEXPERIMENT=none' to avoid importing go-crypto-openssl, which makes TestSetgid hang.
++	// See go.dev/issues/52141.
++	cmd.Env = append(os.Environ(), "GOPATH="+GOPATH, "PWD="+cmd.Dir, "GOEXPERIMENT=none")
+ 	out, err := cmd.CombinedOutput()
+ 	if err == nil {
+ 		t.Logf("%s:\n%s", strings.Join(cmd.Args, " "), out)
 diff --git a/src/cmd/api/goapi_boring_test.go b/src/cmd/api/goapi_boring_test.go
 index f0e3575637c62a..0e9aceeb832d3b 100644
 --- a/src/cmd/api/goapi_boring_test.go
@@ -53,6 +70,29 @@ index f0e3575637c62a..0e9aceeb832d3b 100644
 +//go:build boringcrypto || goexperiment.opensslcrypto
  
  package main
+ 
+diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
+index f974631e55682f..a90b018cd0c3d4 100644
+--- a/src/cmd/dist/test.go
++++ b/src/cmd/dist/test.go
+@@ -1262,12 +1262,16 @@ func (t *tester) cgoTest(dt *distTest) error {
+ 				t.addCmd(dt, "misc/cgo/nocgo", t.goTest(), "-ldflags", `-linkmode=external`, ".")
+ 				if goos != "android" {
+ 					t.addCmd(dt, "misc/cgo/nocgo", t.goTest(), "-ldflags", `-linkmode=external -extldflags "-static -pthread"`, ".")
+-					t.addCmd(dt, "misc/cgo/test", t.goTest(), "-tags=static", "-ldflags", `-linkmode=external -extldflags "-static -pthread"`, ".")
++					// Use 'GOEXPERIMENT=none' to avoid importing go-crypto-openssl, which makes TestSetgid hang.
++					// See go.dev/issues/52141.
++					cmd := t.addCmd(dt, "misc/cgo/test", t.goTest(), "-tags=static", "-ldflags", `-linkmode=external -extldflags "-static -pthread"`, ".")
++					setEnv(cmd, "GOEXPERIMENT", "none")
+ 					// -static in CGO_LDFLAGS triggers a different code path
+ 					// than -static in -extldflags, so test both.
+ 					// See issue #16651.
+-					cmd := t.addCmd(dt, "misc/cgo/test", t.goTest(), "-tags=static", ".")
++					cmd = t.addCmd(dt, "misc/cgo/test", t.goTest(), "-tags=static", ".")
+ 					setEnv(cmd, "CGO_LDFLAGS", "-static -pthread")
++					setEnv(cmd, "GOEXPERIMENT", "none")
+ 				}
+ 			}
  
 diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
 index ed0fbf3d53d75b..5376227f74cfaa 100644

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -37,7 +37,8 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_off.go     |   9 +
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 33 files changed, 268 insertions(+), 25 deletions(-)
+ src/os/exec/exec_test.go                      |   9 +
+ 34 files changed, 277 insertions(+), 25 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -707,3 +708,30 @@ index 20d9c2da5d9605..355b7fe5931d39 100644
  
  	// Unified enables the compiler's unified IR construction
  	// experiment.
+diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
+index 8f79b19eb60ac9..45512b08d6cc8e 100644
+--- a/src/os/exec/exec_test.go
++++ b/src/os/exec/exec_test.go
+@@ -13,6 +13,7 @@ import (
+ 	"context"
+ 	"flag"
+ 	"fmt"
++	"internal/goexperiment"
+ 	"internal/poll"
+ 	"internal/testenv"
+ 	"io"
+@@ -730,6 +731,14 @@ func TestExtraFiles(t *testing.T) {
+ 		t.Skipf("skipping test on %q", runtime.GOOS)
+ 	}
+ 
++	if goexperiment.OpenSSLCrypto {
++		// OpenSSL default behavior is to maintain open FDs to any
++		// random devices that get used by the random number library.
++		// Since those FDs are not marked FD_CLOEXEC or O_CLOEXEC,
++		// they also get inherited by children.
++		t.Skip("skipping test because test was run with OpenSSLCrypto")
++	}
++
+ 	// Force network usage, to verify the epoll (or whatever) fd
+ 	// doesn't leak to the child,
+ 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -10,19 +10,19 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/bbig/big.go     |  38 ++
  .../go-crypto-openssl/openssl/big.go          |  13 +
  .../go-crypto-openssl/openssl/ecdsa.go        | 185 ++++++
- .../go-crypto-openssl/openssl/evpkey.go       | 279 +++++++++
+ .../go-crypto-openssl/openssl/evpkey.go       | 300 +++++++++
  .../go-crypto-openssl/openssl/goopenssl.c     | 153 +++++
  .../go-crypto-openssl/openssl/goopenssl.h     | 141 +++++
  .../go-crypto-openssl/openssl/hmac.go         | 147 +++++
  .../openssl/internal/subtle/aliasing.go       |  32 +
  .../go-crypto-openssl/openssl/openssl.go      | 295 +++++++++
- .../go-crypto-openssl/openssl/openssl_funcs.h | 245 ++++++++
+ .../go-crypto-openssl/openssl/openssl_funcs.h | 248 ++++++++
  .../openssl/openssl_lock_setup.c              |  53 ++
  .../go-crypto-openssl/openssl/rand.go         |  24 +
  .../go-crypto-openssl/openssl/rsa.go          | 302 +++++++++
- .../go-crypto-openssl/openssl/sha.go          | 584 ++++++++++++++++++
+ .../go-crypto-openssl/openssl/sha.go          | 580 ++++++++++++++++++
  src/vendor/modules.txt                        |   5 +
- 17 files changed, 2989 insertions(+)
+ 17 files changed, 3009 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
@@ -591,7 +591,7 @@ index 00000000000000..1214e1097ef56d
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 new file mode 100644
-index 00000000000000..c6856c7bc25dc3
+index 00000000000000..7207bde01c9d94
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 @@ -0,0 +1,13 @@
@@ -801,10 +801,10 @@ index 00000000000000..e5a3e03a390135
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 new file mode 100644
-index 00000000000000..03a652aef13931
+index 00000000000000..4db567a646b4b1
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
-@@ -0,0 +1,279 @@
+@@ -0,0 +1,300 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -902,9 +902,9 @@ index 00000000000000..03a652aef13931
 +}
 +
 +type withKeyFunc func(func(C.GO_EVP_PKEY_PTR) C.int) C.int
-+type initFunc func(C.GO_EVP_PKEY_CTX_PTR) C.int
-+type cryptFunc func(C.GO_EVP_PKEY_CTX_PTR, *C.uchar, *C.size_t, *C.uchar, C.size_t) C.int
-+type verifyFunc func(C.GO_EVP_PKEY_CTX_PTR, *C.uchar, C.size_t, *C.uchar, C.size_t) C.int
++type initFunc func(C.GO_EVP_PKEY_CTX_PTR) error
++type cryptFunc func(C.GO_EVP_PKEY_CTX_PTR, *C.uchar, *C.size_t, *C.uchar, C.size_t) error
++type verifyFunc func(C.GO_EVP_PKEY_CTX_PTR, *C.uchar, C.size_t, *C.uchar, C.size_t) error
 +
 +func setupEVP(withKey withKeyFunc, padding C.int,
 +	h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
@@ -925,8 +925,8 @@ index 00000000000000..03a652aef13931
 +	if ctx == nil {
 +		return nil, newOpenSSLError("EVP_PKEY_CTX_new failed")
 +	}
-+	if init(ctx) != 1 {
-+		return nil, newOpenSSLError("EVP_PKEY_operation_init failed")
++	if err := init(ctx); err != nil {
++		return nil, err
 +	}
 +	if padding == 0 {
 +		return ctx, nil
@@ -1021,8 +1021,8 @@ index 00000000000000..03a652aef13931
 +	})
 +	outLen := C.size_t(pkeySize)
 +	out := make([]byte, pkeySize)
-+	if crypt(ctx, base(out), &outLen, base(in), C.size_t(len(in))) != 1 {
-+		return nil, newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
++	if err := crypt(ctx, base(out), &outLen, base(in), C.size_t(len(in))); err != nil {
++		return nil, err
 +	}
 +	// The size returned by EVP_PKEY_get_size() is only preliminary and not exact,
 +	// so the final contents of the out buffer may be smaller.
@@ -1039,48 +1039,69 @@ index 00000000000000..03a652aef13931
 +		return err
 +	}
 +	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
-+	if verify(ctx, base(sig), C.size_t(len(sig)), base(in), C.size_t(len(in))) != 1 {
-+		return newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
-+	}
-+	return nil
++	return verify(ctx, base(sig), C.size_t(len(sig)), base(in), C.size_t(len(in)))
 +}
 +
 +func evpEncrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
-+	encryptInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) C.int {
-+		return C.go_openssl_EVP_PKEY_encrypt_init(ctx)
++	encryptInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
++		if ret := C.go_openssl_EVP_PKEY_encrypt_init(ctx); ret != 1 {
++			return newOpenSSLError("EVP_PKEY_encrypt_init failed")
++		}
++		return nil
 +	}
-+	encrypt := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen *C.size_t, in *C.uchar, inLen C.size_t) C.int {
-+		return C.go_openssl_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen)
++	encrypt := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen *C.size_t, in *C.uchar, inLen C.size_t) error {
++		if ret := C.go_openssl_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen); ret != 1 {
++			return newOpenSSLError("EVP_PKEY_encrypt failed")
++		}
++		return nil
 +	}
 +	return cryptEVP(withKey, padding, h, label, 0, 0, encryptInit, encrypt, msg)
 +}
 +
 +func evpDecrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
-+	decryptInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) C.int {
-+		return C.go_openssl_EVP_PKEY_decrypt_init(ctx)
++	decryptInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
++		if ret := C.go_openssl_EVP_PKEY_decrypt_init(ctx); ret != 1 {
++			return newOpenSSLError("EVP_PKEY_decrypt_init failed")
++		}
++		return nil
 +	}
-+	decrypt := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen *C.size_t, in *C.uchar, inLen C.size_t) C.int {
-+		return C.go_openssl_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen)
++	decrypt := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen *C.size_t, in *C.uchar, inLen C.size_t) error {
++		if ret := C.go_openssl_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen); ret != 1 {
++			return newOpenSSLError("EVP_PKEY_decrypt failed")
++		}
++		return nil
 +	}
 +	return cryptEVP(withKey, padding, h, label, 0, 0, decryptInit, decrypt, msg)
 +}
 +
 +func evpSign(withKey withKeyFunc, padding C.int, saltLen int, h crypto.Hash, hashed []byte) ([]byte, error) {
-+	signtInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) C.int {
-+		return C.go_openssl_EVP_PKEY_sign_init(ctx)
++	signtInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
++		if ret := C.go_openssl_EVP_PKEY_sign_init(ctx); ret != 1 {
++			return newOpenSSLError("EVP_PKEY_sign_init failed")
++		}
++		return nil
 +	}
-+	sign := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen *C.size_t, in *C.uchar, inLen C.size_t) C.int {
-+		return C.go_openssl_EVP_PKEY_sign(ctx, out, outLen, in, inLen)
++	sign := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen *C.size_t, in *C.uchar, inLen C.size_t) error {
++		if ret := C.go_openssl_EVP_PKEY_sign(ctx, out, outLen, in, inLen); ret != 1 {
++			return newOpenSSLError("EVP_PKEY_sign failed")
++		}
++		return nil
 +	}
 +	return cryptEVP(withKey, padding, nil, nil, saltLen, h, signtInit, sign, hashed)
 +}
 +
 +func evpVerify(withKey withKeyFunc, padding C.int, saltLen int, h crypto.Hash, sig, hashed []byte) error {
-+	verifyInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) C.int {
-+		return C.go_openssl_EVP_PKEY_verify_init(ctx)
++	verifyInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
++		if ret := C.go_openssl_EVP_PKEY_verify_init(ctx); ret != 1 {
++			return newOpenSSLError("EVP_PKEY_verify_init failed")
++		}
++		return nil
 +	}
-+	verify := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen C.size_t, in *C.uchar, inLen C.size_t) C.int {
-+		return C.go_openssl_EVP_PKEY_verify(ctx, out, outLen, in, inLen)
++	verify := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen C.size_t, in *C.uchar, inLen C.size_t) error {
++		if ret := C.go_openssl_EVP_PKEY_verify(ctx, out, outLen, in, inLen); ret != 1 {
++			return newOpenSSLError("EVP_PKEY_verify failed")
++		}
++		return nil
 +	}
 +	return verifyEVP(withKey, padding, nil, nil, saltLen, h, verifyInit, verify, sig, hashed)
 +}
@@ -1885,10 +1906,10 @@ index 00000000000000..95f3e888bb4cc0
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 new file mode 100644
-index 00000000000000..f52d86360f3a5b
+index 00000000000000..2072a0b8851bda
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
-@@ -0,0 +1,245 @@
+@@ -0,0 +1,248 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2035,12 +2056,15 @@ index 00000000000000..f52d86360f3a5b
 +DEFINEFUNC_3_0(int, EVP_set_default_properties, (GO_OSSL_LIB_CTX_PTR libctx, const char *propq), (libctx, propq)) \
 +DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 +DEFINEFUNC(int, RAND_bytes, (unsigned char* arg0, int arg1), (arg0, arg1)) \
++DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \
 +DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
 +DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
 +DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
++DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
 +DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (), ()) \
 +DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 +DEFINEFUNC(int, EVP_MD_CTX_copy_ex, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
++DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
 +DEFINEFUNC_RENAMED_1_1(int, EVP_MD_CTX_reset, EVP_MD_CTX_cleanup, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 +DEFINEFUNC(const GO_EVP_MD_PTR, EVP_md5, (void), ()) \
 +DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha1, (void), ()) \
@@ -2533,10 +2557,10 @@ index 00000000000000..3d4aa1440a1de6
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 new file mode 100644
-index 00000000000000..c00e68de020e29
+index 00000000000000..bb96a9bcaee7d4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
-@@ -0,0 +1,584 @@
+@@ -0,0 +1,580 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2644,10 +2668,8 @@ index 00000000000000..c00e68de020e29
 +func (h *evpHash) Reset() {
 +	// There is no need to reset h.ctx2 because it is always reset after
 +	// use in evpHash.sum.
-+	C.go_openssl_EVP_MD_CTX_reset(h.ctx)
-+
-+	if C.go_openssl_EVP_DigestInit_ex(h.ctx, h.md, nil) != 1 {
-+		panic("openssl: EVP_DigestInit_ex failed")
++	if C.go_openssl_EVP_DigestInit(h.ctx, h.md) != 1 {
++		panic("openssl: EVP_DigestInit failed")
 +	}
 +	runtime.KeepAlive(h)
 +}
@@ -2673,14 +2695,12 @@ index 00000000000000..c00e68de020e29
 +	// that Sum has no effect on the underlying stream.
 +	// In particular it is OK to Sum, then Write more, then Sum again,
 +	// and the second Sum acts as if the first didn't happen.
-+	C.go_openssl_EVP_DigestInit_ex(h.ctx2, h.md, nil)
-+	if C.go_openssl_EVP_MD_CTX_copy_ex(h.ctx2, h.ctx) != 1 {
-+		panic("openssl: EVP_MD_CTX_copy_ex failed")
++	if C.go_openssl_EVP_MD_CTX_copy(h.ctx2, h.ctx) != 1 {
++		panic("openssl: EVP_MD_CTX_copy failed")
 +	}
-+	if C.go_openssl_EVP_DigestFinal_ex(h.ctx2, (*C.uchar)(noescape(unsafe.Pointer(base(out)))), nil) != 1 {
-+		panic("openssl: EVP_DigestFinal_ex failed")
++	if C.go_openssl_EVP_DigestFinal(h.ctx2, (*C.uchar)(noescape(unsafe.Pointer(base(out)))), nil) != 1 {
++		panic("openssl: EVP_DigestFinal failed")
 +	}
-+	C.go_openssl_EVP_MD_CTX_reset(h.ctx2)
 +	runtime.KeepAlive(h)
 +}
 +
@@ -3122,11 +3142,11 @@ index 00000000000000..c00e68de020e29
 +	return b[4:], x
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index dfb87abf137cca..aaf314ad08f070 100644
+index dfb87abf137cca..7c875b12cd3afb 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,8 @@
-+# github.com/microsoft/go-crypto-openssl v0.0.0-20220620233145-561693b272da
++# github.com/microsoft/go-crypto-openssl v0.0.0-20220726174527-136d210dacbd
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -12,7 +12,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/ecdsa.go        | 185 ++++++
  .../go-crypto-openssl/openssl/evpkey.go       | 300 +++++++++
  .../go-crypto-openssl/openssl/goopenssl.c     | 153 +++++
- .../go-crypto-openssl/openssl/goopenssl.h     | 141 +++++
+ .../go-crypto-openssl/openssl/goopenssl.h     | 147 +++++
  .../go-crypto-openssl/openssl/hmac.go         | 147 +++++
  .../openssl/internal/subtle/aliasing.go       |  32 +
  .../go-crypto-openssl/openssl/openssl.go      | 295 +++++++++
@@ -22,7 +22,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/rsa.go          | 302 +++++++++
  .../go-crypto-openssl/openssl/sha.go          | 580 ++++++++++++++++++
  src/vendor/modules.txt                        |   5 +
- 17 files changed, 3009 insertions(+)
+ 17 files changed, 3015 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
@@ -1266,10 +1266,10 @@ index 00000000000000..7bbf74185128dd
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
 new file mode 100644
-index 00000000000000..f0c915d541dbb5
+index 00000000000000..03aed43e001d54
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
-@@ -0,0 +1,141 @@
+@@ -0,0 +1,147 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -1363,13 +1363,16 @@ index 00000000000000..f0c915d541dbb5
 +                                       unsigned char *out,
 +                                       const unsigned char *nonce,
 +                                       const unsigned char *in, int in_len,
-+                                       const unsigned char *add, int add_len)
++                                       const unsigned char *aad, int aad_len)
 +{
++    if (in_len == 0) in = "";
++    if (aad_len == 0) aad = "";
++
 +    if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_ENCRYPT) != 1)
 +        return 0;
 +
 +    int discard_len, out_len;
-+    if (go_openssl_EVP_EncryptUpdate(ctx, NULL, &discard_len, add, add_len) != 1
++    if (go_openssl_EVP_EncryptUpdate(ctx, NULL, &discard_len, aad, aad_len) != 1
 +        || go_openssl_EVP_EncryptUpdate(ctx, out, &out_len, in, in_len) != 1
 +        || go_openssl_EVP_EncryptFinal_ex(ctx, out + out_len, &discard_len) != 1)
 +    {
@@ -1387,14 +1390,17 @@ index 00000000000000..f0c915d541dbb5
 +                                       unsigned char *out,
 +                                       const unsigned char *nonce,
 +                                       const unsigned char *in, int in_len,
-+                                       const unsigned char *add, int add_len,
++                                       const unsigned char *aad, int aad_len,
 +                                       const unsigned char *tag)
 +{
++    if (in_len == 0) in = "";
++    if (aad_len == 0) aad = "";
++
 +    if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_DECRYPT) != 1)
 +        return 0;
 +
 +    int discard_len, out_len;
-+    if (go_openssl_EVP_DecryptUpdate(ctx, NULL, &discard_len, add, add_len) != 1
++    if (go_openssl_EVP_DecryptUpdate(ctx, NULL, &discard_len, aad, aad_len) != 1
 +        || go_openssl_EVP_DecryptUpdate(ctx, out, &out_len, in, in_len) != 1)
 +    {
 +        return 0;
@@ -3142,11 +3148,11 @@ index 00000000000000..bb96a9bcaee7d4
 +	return b[4:], x
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index dfb87abf137cca..7c875b12cd3afb 100644
+index dfb87abf137cca..b7474d5a9f9233 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,8 @@
-+# github.com/microsoft/go-crypto-openssl v0.0.0-20220726174527-136d210dacbd
++# github.com/microsoft/go-crypto-openssl v0.0.0-20220727182410-f0cde275907d
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Quim Muntal <qmuntaldiaz@microsoft.com>
 Date: Mon, 23 May 2022 12:59:36 +0000
-Subject: [PATCH] Vendor crypto modules
+Subject: [PATCH] Vendor crypto backends
 
 To reproduce, run 'go mod vendor' in 'go/src'.
 ---


### PR DESCRIPTION
This PR changes how OpenSSL backend and FIPS more are enabled:

- OpenSSL backend is always used when `goexperiment=opensslcrypto` is set. We were previously falling back to Go crypto if OpenSSL shared libraries were not found or OpenSSL could not be initialized.
- The process will be aborted if FIPS mode can't be enabled and either `GOFIPS=1` or FIPS mode is enabled system system-wide.
- The process will be aborted if FIPS mode can't be disabled and `GOFIPS=0`.
- The FIPS mode will be whatever is configured in OpenSSL if neither GOFIPS nor system-wide FIPS are set.

This PR also updates the openssl and boring shims. They are defined as functions instead of variables. The compiler missed some optimizations because function variables can be redefined, therefore they are not constant.

Updates #654 (@dagood)
Updates #641