### PR TITLE
Update go-crypto-winnative

### DIFF
--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -1087,26 +1087,26 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 289d02db9570f2..d0834f5862d4ee 100644
+index 289d02db9570f2..137df47710d3a2 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.19
  
  require (
  	github.com/microsoft/go-crypto-openssl v0.0.0-20220727182410-f0cde275907d
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20220726170635-fe29f52e5c2a
++	github.com/microsoft/go-crypto-winnative v0.0.0-20220801182431-51d11294fcae
  	golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8
  	golang.org/x/net v0.0.0-20220517181318-183a9ca12b87
  )
 diff --git a/src/go.sum b/src/go.sum
-index ffdac6bf5a16b2..23f6e5d41e54cb 100644
+index ffdac6bf5a16b2..b4a3b67ab4482a 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,9 +1,12 @@
  github.com/microsoft/go-crypto-openssl v0.0.0-20220727182410-f0cde275907d h1:bYrnqvch83JAniHNR1QlzrvBeTZCNNZmnj4EcnB2Uuo=
  github.com/microsoft/go-crypto-openssl v0.0.0-20220727182410-f0cde275907d/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20220726170635-fe29f52e5c2a h1:ARzANUrMO8DCW1Zd9kuFnvBvsx1G652HOjxQULTPGLo=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20220726170635-fe29f52e5c2a/go.mod h1:mKWmQEP0n/WamRi8zKYzN6gonQQ0jVY1CHpGAUPxj/k=
++github.com/microsoft/go-crypto-winnative v0.0.0-20220801182431-51d11294fcae h1:Gvis94qpbGzzd2QioCVjVA6avSpl7v0R2p1KH0lEFAM=
++github.com/microsoft/go-crypto-winnative v0.0.0-20220801182431-51d11294fcae/go.mod h1:mKWmQEP0n/WamRi8zKYzN6gonQQ0jVY1CHpGAUPxj/k=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8 h1:y+mHpWoQJNAHt26Nhh6JP7hvM71IRZureyvZhoVALIs=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220517181318-183a9ca12b87 h1:cCR+9mKLOGyX4Zx+uBZDXEDAQsvKQ/XbW4vreG5v1jU=
@@ -1116,10 +1116,10 @@ index ffdac6bf5a16b2..23f6e5d41e54cb 100644
  golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/text v0.3.8-0.20220509174342-b4bca84b0361 h1:h+pU/hCb7sEApigI6eII3/Emx5ZHaFWS+nulUp0Az/k=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 9b532b18023198..c6d0407ce5b199 100644
+index c6c33a7975eb61..4d7bc0d853f009 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -414,6 +414,10 @@ var depsRules = `
+@@ -416,6 +416,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1130,7 +1130,7 @@ index 9b532b18023198..c6d0407ce5b199 100644
  	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
  	< github.com/microsoft/go-crypto-openssl/openssl
  	< crypto/internal/boring
-@@ -427,6 +431,7 @@ var depsRules = `
+@@ -429,6 +433,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big, embed

--- a/patches/0007-Vendor-crypto-backends.patch
+++ b/patches/0007-Vendor-crypto-backends.patch
@@ -22,21 +22,21 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/rsa.go          | 302 +++++++++
  .../go-crypto-openssl/openssl/sha.go          | 580 ++++++++++++++++++
  .../microsoft/go-crypto-winnative/LICENSE     |  21 +
- .../microsoft/go-crypto-winnative/cng/aes.go  | 375 +++++++++++
+ .../microsoft/go-crypto-winnative/cng/aes.go  | 359 +++++++++++
  .../go-crypto-winnative/cng/bbig/big.go       |  31 +
  .../microsoft/go-crypto-winnative/cng/big.go  |  14 +
- .../microsoft/go-crypto-winnative/cng/cng.go  |  99 +++
- .../go-crypto-winnative/cng/ecdsa.go          | 258 ++++++++
+ .../microsoft/go-crypto-winnative/cng/cng.go  | 123 ++++
+ .../go-crypto-winnative/cng/ecdsa.go          | 256 ++++++++
  .../microsoft/go-crypto-winnative/cng/hmac.go |  55 ++
  .../microsoft/go-crypto-winnative/cng/rand.go |  28 +
- .../microsoft/go-crypto-winnative/cng/rsa.go  | 358 +++++++++++
+ .../microsoft/go-crypto-winnative/cng/rsa.go  | 372 +++++++++++
  .../microsoft/go-crypto-winnative/cng/sha.go  | 198 ++++++
  .../internal/bcrypt/bcrypt_windows.go         | 207 +++++++
  .../internal/bcrypt/zsyscall_windows.go       | 341 ++++++++++
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  12 +
- 31 files changed, 5094 insertions(+)
+ 31 files changed, 5114 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
@@ -619,7 +619,7 @@ index 00000000000000..1214e1097ef56d
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 new file mode 100644
-index 00000000000000..c6856c7bc25dc3
+index 00000000000000..7207bde01c9d94
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 @@ -0,0 +1,13 @@
@@ -3204,10 +3204,10 @@ index 00000000000000..9e841e7a26e4eb
 +    SOFTWARE
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
 new file mode 100644
-index 00000000000000..d58a995f3de843
+index 00000000000000..e3b865ab7823d1
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
-@@ -0,0 +1,375 @@
+@@ -0,0 +1,359 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -3229,8 +3229,8 @@ index 00000000000000..d58a995f3de843
 +const aesBlockSize = 16
 +
 +type aesAlgorithm struct {
-+	handle          bcrypt.ALG_HANDLE
-+	allowedKeySizes []int
++	handle            bcrypt.ALG_HANDLE
++	allowedKeyLengths bcrypt.KEY_LENGTHS_STRUCT
 +}
 +
 +func loadAes(mode string) (aesAlgorithm, error) {
@@ -3241,20 +3241,11 @@ index 00000000000000..d58a995f3de843
 +		if err != nil {
 +			return nil, err
 +		}
-+		var info bcrypt.KEY_LENGTHS_STRUCT
-+		var discard uint32
-+		err = bcrypt.GetProperty(bcrypt.HANDLE(h), utf16PtrFromString(bcrypt.KEY_LENGTHS), (*[unsafe.Sizeof(info)]byte)(unsafe.Pointer(&info))[:], &discard, 0)
++		lengths, err := getKeyLengths(bcrypt.HANDLE(h))
 +		if err != nil {
 +			return nil, err
 +		}
-+		if info.Increment == 0 || info.MinLength > info.MaxLength {
-+			return nil, errors.New("invalid BCRYPT_KEY_LENGTHS_STRUCT")
-+		}
-+		var allowedKeySizes []int
-+		for size := info.MinLength; size <= info.MaxLength; size += info.Increment {
-+			allowedKeySizes = append(allowedKeySizes, int(size))
-+		}
-+		return aesAlgorithm{h, allowedKeySizes}, nil
++		return aesAlgorithm{h, lengths}, nil
 +	})
 +	if err != nil {
 +		return aesAlgorithm{}, nil
@@ -3272,14 +3263,7 @@ index 00000000000000..d58a995f3de843
 +	if err != nil {
 +		return nil, err
 +	}
-+	var allowedKeySize bool
-+	for _, size := range h.allowedKeySizes {
-+		if len(key)*8 == size {
-+			allowedKeySize = true
-+			break
-+		}
-+	}
-+	if !allowedKeySize {
++	if !keyIsAllowed(h.allowedKeyLengths, uint32(len(key)*8)) {
 +		return nil, errors.New("crypto/cipher: invalid key size")
 +	}
 +	c := &aesCipher{key: make([]byte, len(key))}
@@ -3642,10 +3626,10 @@ index 00000000000000..0069d31976e4f5
 +type BigInt []byte
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go
 new file mode 100644
-index 00000000000000..46e4f383cc613d
+index 00000000000000..2d96b448972c07
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go
-@@ -0,0 +1,99 @@
+@@ -0,0 +1,123 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -3655,6 +3639,7 @@ index 00000000000000..46e4f383cc613d
 +package cng
 +
 +import (
++	"errors"
 +	"math"
 +	"reflect"
 +	"runtime"
@@ -3745,12 +3730,35 @@ index 00000000000000..46e4f383cc613d
 +	err := bcrypt.GetProperty(h, utf16PtrFromString(name), (*[4]byte)(unsafe.Pointer(&prop))[:], &discard, 0)
 +	return prop, err
 +}
++
++func getKeyLengths(h bcrypt.HANDLE) (lengths bcrypt.KEY_LENGTHS_STRUCT, err error) {
++	var discard uint32
++	err = bcrypt.GetProperty(bcrypt.HANDLE(h), utf16PtrFromString(bcrypt.KEY_LENGTHS), (*[unsafe.Sizeof(lengths)]byte)(unsafe.Pointer(&lengths))[:], &discard, 0)
++	if err != nil {
++		return
++	}
++	if lengths.MinLength > lengths.MaxLength || (lengths.Increment == 0 && lengths.MinLength != lengths.MaxLength) {
++		err = errors.New("invalid BCRYPT_KEY_LENGTHS_STRUCT")
++		return
++	}
++	return lengths, nil
++}
++
++func keyIsAllowed(lengths bcrypt.KEY_LENGTHS_STRUCT, bits uint32) bool {
++	if bits < lengths.MinLength || bits > lengths.MaxLength {
++		return false
++	}
++	if lengths.Increment == 0 {
++		return bits == lengths.MinLength
++	}
++	return (bits-lengths.MinLength)%lengths.Increment == 0
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
 new file mode 100644
-index 00000000000000..71058891c750cd
+index 00000000000000..c73e82fe67d3a0
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
-@@ -0,0 +1,258 @@
+@@ -0,0 +1,256 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -3767,23 +3775,21 @@ index 00000000000000..71058891c750cd
 +	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
 +)
 +
-+var errUnknownCurve = errors.New("openssl: unknown elliptic curve")
-+var errUnsupportedCurve = errors.New("openssl: unsupported elliptic curve")
++var errUnknownCurve = errors.New("cng: unknown elliptic curve")
++var errUnsupportedCurve = errors.New("cng: unsupported elliptic curve")
 +
 +type ecdsaAlgorithm struct {
 +	handle bcrypt.ALG_HANDLE
 +}
 +
 +func loadEcdsa(id string) (h ecdsaAlgorithm, err error) {
-+	if v, ok := algCache.Load(id); ok {
-+		return v.(ecdsaAlgorithm), nil
-+	}
-+	err = bcrypt.OpenAlgorithmProvider(&h.handle, utf16PtrFromString(id), nil, bcrypt.ALG_NONE_FLAG)
++	v, err := loadOrStoreAlg(id, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
++		return ecdsaAlgorithm{h}, nil
++	})
 +	if err != nil {
-+		return
++		return ecdsaAlgorithm{}, err
 +	}
-+	algCache.Store(id, h)
-+	return
++	return v.(ecdsaAlgorithm), nil
 +}
 +
 +const sizeOfECCBlobHeader = uint32(unsafe.Sizeof(bcrypt.ECCKEY_BLOB{}))
@@ -4106,10 +4112,10 @@ index 00000000000000..5265394c936a82
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
 new file mode 100644
-index 00000000000000..a3bd4eefeed653
+index 00000000000000..5b9559e489c62b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
-@@ -0,0 +1,358 @@
+@@ -0,0 +1,372 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -4129,12 +4135,17 @@ index 00000000000000..a3bd4eefeed653
 +)
 +
 +type rsaAlgorithm struct {
-+	handle bcrypt.ALG_HANDLE
++	handle            bcrypt.ALG_HANDLE
++	allowedKeyLengths bcrypt.KEY_LENGTHS_STRUCT
 +}
 +
 +func loadRsa() (rsaAlgorithm, error) {
 +	v, err := loadOrStoreAlg(bcrypt.RSA_ALGORITHM, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
-+		return rsaAlgorithm{h}, nil
++		lengths, err := getKeyLengths(bcrypt.HANDLE(h))
++		if err != nil {
++			return nil, err
++		}
++		return rsaAlgorithm{h, lengths}, nil
 +	})
 +	if err != nil {
 +		return rsaAlgorithm{}, err
@@ -4151,6 +4162,9 @@ index 00000000000000..a3bd4eefeed653
 +	h, err := loadRsa()
 +	if err != nil {
 +		return bad(err)
++	}
++	if !keyIsAllowed(h.allowedKeyLengths, uint32(bits)) {
++		return bad(errors.New("crypto/rsa: invalid key size"))
 +	}
 +	var hkey bcrypt.KEY_HANDLE
 +	err = bcrypt.GenerateKeyPair(h.handle, &hkey, uint32(bits), 0)
@@ -4210,6 +4224,9 @@ index 00000000000000..a3bd4eefeed653
 +	if err != nil {
 +		return nil, err
 +	}
++	if !keyIsAllowed(h.allowedKeyLengths, uint32(len(N)*8)) {
++		return nil, errors.New("crypto/rsa: invalid key size")
++	}
 +	blob, err := encodeRSAKey(N, E, nil, nil, nil, nil, nil, nil)
 +	if err != nil {
 +		return nil, err
@@ -4239,6 +4256,9 @@ index 00000000000000..a3bd4eefeed653
 +	h, err := loadRsa()
 +	if err != nil {
 +		return nil, err
++	}
++	if !keyIsAllowed(h.allowedKeyLengths, uint32(len(N)*8)) {
++		return nil, errors.New("crypto/rsa: invalid key size")
 +	}
 +	blob, err := encodeRSAKey(N, E, D, P, Q, Dp, Dq, Qinv)
 +	if err != nil {
@@ -5332,7 +5352,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index dfb87abf137cca..efc8c345050dbc 100644
+index dfb87abf137cca..2bdd60921229d7 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,15 @@
@@ -5341,7 +5361,7 @@ index dfb87abf137cca..efc8c345050dbc 100644
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig
 +github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20220726170635-fe29f52e5c2a
++# github.com/microsoft/go-crypto-winnative v0.0.0-20220801182431-51d11294fcae
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
https://github.com/microsoft/go-crypto-winnative/compare/fe29f52e5c2a...51d11294fcae

* https://github.com/microsoft/go-crypto-winnative/pull/18
* https://github.com/microsoft/go-crypto-winnative/pull/25

To do the update, I ran `git go-patch rebase`, set the CNG patches to `e` mode, then `go get github.com/microsoft/go-crypto-winnative@latest` `go mod tidy` for the first patch and `go mod vendor` for the second.