### PR TITLE
Add cmdscan to elevate logs to warnings

### DIFF
--- a/eng/_core/cmd/cmdscan/cmdscan.go
+++ b/eng/_core/cmd/cmdscan/cmdscan.go
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Cmdscan runs the command given to it in os.Args and monitors the output for text patterns that
+// should be elevated to AzDO Pipeline warnings, and uses AzDO logging commands to do so. Timeline
+// events can be discovered more easily in the UI and by automated tools like runfo.
+//
+// If the pattern is associated with a known issue, the warning includes a link.
+//
+// Uses the "log issue" pipeline logging command: https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+)
+
+var filters = []filter{
+	{
+		"access denied",
+		"https://github.com/microsoft/go/issues/241",
+		regexp.MustCompile("(?i)Access is denied"),
+	},
+}
+
+type filter struct {
+	// name is a simple description of the detected error that should be uniquely searchable so
+	// runfo can keep track of this issue with "contains" searches on each timeline element.
+	name string
+	// trackingIssue is an optional URL that links to more information about this error.
+	trackingIssue string
+	// regexp is the regex that is matched against each line of output to find an issue.
+	regexp *regexp.Regexp
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func run() error {
+	cmd := exec.Command(os.Args[1], os.Args[2:]...)
+	log.Printf("Detected %v scan patterns defined in eng/_core/cmd/cmdscan/cmdscan.go\n", len(filters))
+	log.Printf("Running: %v\n", cmd)
+
+	outPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	errPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	go func() {
+		if err := scan(outPipe, os.Stdout, os.Stdout); err != nil {
+			log.Fatalf("Failed to scan stdout pipe: %v\n", err)
+		}
+	}()
+	go func() {
+		if err := scan(errPipe, os.Stdout, os.Stderr); err != nil {
+			log.Fatalf("Failed to scan stderr pipe: %v\n", err)
+		}
+	}()
+
+	return cmd.Wait()
+}
+
+func scan(r io.Reader, commands, echo *os.File) error {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		fmt.Fprintf(echo, "%v\n", s.Text())
+		for _, f := range filters {
+			if f.regexp.MatchString(s.Text()) {
+				fmt.Fprintf(echo, "Found pattern '%v'\n", f.regexp)
+				fmt.Fprintf(commands, warn(&f, s.Text()))
+			}
+		}
+	}
+	return s.Err()
+}
+
+func warn(f *filter, line string) string {
+	issueLink := ""
+	if f.trackingIssue != "" {
+		issueLink = " (" + f.trackingIssue + ")"
+	}
+
+	return fmt.Sprintf("##vso[task.logissue type=warning]%q%v: %v\n", f.name, issueLink, line)
+}

--- a/eng/_core/cmd/cmdscan/cmdscan.go
+++ b/eng/_core/cmd/cmdscan/cmdscan.go
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 // Cmdscan runs the command given to it in os.Args and monitors the output for text patterns that
-// should be elevated to AzDO Pipeline warnings, and uses AzDO logging commands to do so. Timeline
-// events can be discovered more easily in the UI and by automated tools like runfo.
+// should be elevated to AzDO Pipeline warnings using AzDO logging commands. Timeline events can be
+// discovered more easily in the UI and by automated tools like runfo.
 //
 // If the pattern is associated with a known issue, the warning includes a link.
 //
@@ -92,7 +92,7 @@ func scan(r io.Reader, commands, echo *os.File) error {
 }
 
 func warn(f *filter, line string) string {
-	issueLink := ""
+	var issueLink string
 	if f.trackingIssue != "" {
 		issueLink = " (" + f.trackingIssue + ")"
 	}

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -112,7 +112,8 @@ stages:
           # download its external module dependencies.
           - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
             - pwsh: |
-                eng/run.ps1 build -pack
+                eng/run.ps1 cmdscan `
+                  pwsh eng/run.ps1 build -pack
               displayName: Build and Pack
 
             - publish: eng/artifacts/bin
@@ -132,11 +133,12 @@ stages:
                   ) -join ';'
                 }
 
-                eng/run.ps1 run-builder `
-                  -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
-                  $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
-                  $(if ('${{ parameters.builder.fips }}') { '-fipsmode' }) `
-                  -junitfile '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml'
+                eng/run.ps1 cmdscan `
+                  pwsh eng/run.ps1 run-builder `
+                    -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
+                    $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
+                    $(if ('${{ parameters.builder.fips }}') { '-fipsmode' }) `
+                    -junitfile '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml'
               displayName: Run ${{ parameters.builder.config }}
 
             - task: PublishTestResults@2


### PR DESCRIPTION
`cmdscan` runs a command and listens to its output to pull out warnings for runfo.

These are only warnings because if the retry works, the original error might not actually cause the build to fail.

Example build:

https://dev.azure.com/dnceng/public/_build/results?buildId=1924212&view=results

> ![image](https://user-images.githubusercontent.com/12819531/183135329-556376d3-14c2-40e6-a9b5-71193b517b04.png)

```
Building Go toolchain3 using go_bootstrap and Go toolchain2.
go install cmd/compile: copying C:\Users\VSSADM~1\AppData\Local\Temp\go-build2959388607\b103\exe\a.out.exe: open D:\a\1\s\go\pkg\tool\windows_amd64\compile.exe: Access is denied.
##[warning]"access denied" (https://github.com/microsoft/go/issues/241): go install cmd/compile: copying C:\Users\VSSADM~1\AppData\Local\Temp\go-build2959388607\b103\exe\a.out.exe: open D:\a\1\s\go\pkg\tool\windows_amd64\compile.exe: Access is denied.
##[debug]Processed: ##vso[task.logissue type=warning]"access denied" (https://github.com/microsoft/go/issues/241): go install cmd/compile: copying C:\Users\VSSADM~1\AppData\Local\Temp\go-build2959388607\b103\exe\a.out.exe: open D:\a\1\s\go\pkg\tool\windows_amd64\compile.exe: Access is denied.
Found pattern '(?i)Access is denied'
go tool dist: FAILED: D:\a\1\s\go\pkg\tool\windows_amd64\go_bootstrap install -a -i cmd/asm cmd/cgo cmd/compile cmd/link: exit status 1
---- Attempt failed with error: exit status 1
```

This tracking issue automatically gets updates from runfo:

* https://github.com/dagood/go/issues/3

(To avoid adding runfo to the Microsoft GitHub org, I've just set it up with my own user/repo for now.)

We could also add other patterns to the tool if it makes it easier to debug common test failures, even if they aren't related to flakiness.