### PR TITLE
[go1.18] Bump go-crypto-openssl to v0.1.1

### DIFF
--- a/patches/0100-Add-OpenSSL-crypto-module.patch
+++ b/patches/0100-Add-OpenSSL-crypto-module.patch
@@ -414,24 +414,24 @@ index 0000000000..8d140dc62b
 +var VerifyRSAPKCS1v15 = openssl.VerifyRSAPKCS1v15
 +var VerifyRSAPSS = openssl.VerifyRSAPSS
 diff --git a/src/go.mod b/src/go.mod
-index bd6308add02..813c9722ba8 100644
+index bd6308add021dc..cfe8862fe42b64 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.18
  
  require (
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20220420170843-a127057fb794
++	github.com/microsoft/go-crypto-openssl v0.1.1
  	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
  	golang.org/x/net v0.0.0-20211209124913-491a49abca63
  )
 diff --git a/src/go.sum b/src/go.sum
-index 8bf08531de6..63885283829 100644
+index 8bf08531de62dd..1bbc2eb739f58b 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220420170843-a127057fb794 h1:wKgYWu1182SANsEy946ijVOck8VGbSMXuvg5YtDJdM8=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20220420170843-a127057fb794/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-openssl v0.1.1 h1:tAO2hN5ln/DbRw4gM6owWAOsmHAIWa5lh+8XVofIedA=
++github.com/microsoft/go-crypto-openssl v0.1.1/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
  golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
  golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20211209124913-491a49abca63 h1:iocB37TsdFuN6IBRZ+ry36wrkoV51/tl5vOWqkcPGvY=

--- a/patches/0102-Vendor-OpenSSL-crypto-library.patch
+++ b/patches/0102-Vendor-OpenSSL-crypto-library.patch
@@ -10,7 +10,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/ecdsa.go        | 214 +++++++
  .../go-crypto-openssl/openssl/evpkey.go       | 279 +++++++++
  .../go-crypto-openssl/openssl/goopenssl.c     | 153 +++++
- .../go-crypto-openssl/openssl/goopenssl.h     | 127 +++++
+ .../go-crypto-openssl/openssl/goopenssl.h     | 133 +++++
  .../go-crypto-openssl/openssl/hmac.go         | 147 +++++
  .../openssl/internal/subtle/aliasing.go       |  32 ++
  .../go-crypto-openssl/openssl/openssl.go      | 260 +++++++++
@@ -20,7 +20,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/rsa.go          | 303 ++++++++++
  .../go-crypto-openssl/openssl/sha.go          | 534 ++++++++++++++++++
  src/vendor/modules.txt                        |   4 +
- 15 files changed, 2859 insertions(+)
+ 15 files changed, 2865 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
@@ -1201,10 +1201,10 @@ index 00000000000..7bbf7418512
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
 new file mode 100644
-index 00000000000..745637d63cf
+index 00000000000000..9191b512e3192d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
-@@ -0,0 +1,127 @@
+@@ -0,0 +1,133 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -1284,13 +1284,16 @@ index 00000000000..745637d63cf
 +                                       unsigned char *out,
 +                                       const unsigned char *nonce,
 +                                       const unsigned char *in, int in_len,
-+                                       const unsigned char *add, int add_len)
++                                       const unsigned char *aad, int aad_len)
 +{
++    if (in_len == 0) in = "";
++    if (aad_len == 0) aad = "";
++
 +    if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_ENCRYPT) != 1)
 +        return 0;
 +
 +    int discard_len, out_len;
-+    if (go_openssl_EVP_EncryptUpdate(ctx, NULL, &discard_len, add, add_len) != 1
++    if (go_openssl_EVP_EncryptUpdate(ctx, NULL, &discard_len, aad, aad_len) != 1
 +        || go_openssl_EVP_EncryptUpdate(ctx, out, &out_len, in, in_len) != 1
 +        || go_openssl_EVP_EncryptFinal_ex(ctx, out + out_len, &discard_len) != 1)
 +    {
@@ -1308,14 +1311,17 @@ index 00000000000..745637d63cf
 +                                       unsigned char *out,
 +                                       const unsigned char *nonce,
 +                                       const unsigned char *in, int in_len,
-+                                       const unsigned char *add, int add_len,
++                                       const unsigned char *aad, int aad_len,
 +                                       const unsigned char *tag)
 +{
++    if (in_len == 0) in = "";
++    if (aad_len == 0) aad = "";
++
 +    if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_DECRYPT) != 1)
 +        return 0;
 +
 +    int discard_len, out_len;
-+    if (go_openssl_EVP_DecryptUpdate(ctx, NULL, &discard_len, add, add_len) != 1
++    if (go_openssl_EVP_DecryptUpdate(ctx, NULL, &discard_len, aad, aad_len) != 1
 +        || go_openssl_EVP_DecryptUpdate(ctx, out, &out_len, in, in_len) != 1)
 +    {
 +        return 0;
@@ -2977,11 +2983,11 @@ index 00000000000..c5b0189efc8
 +	return b[4:], x
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 3a975cde9e8..24024396ae5 100644
+index 3a975cde9e838a..7868f581af2854 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,7 @@
-+# github.com/microsoft/go-crypto-openssl v0.0.0-20220420170843-a127057fb794
++# github.com/microsoft/go-crypto-openssl v0.1.1
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/internal/subtle


### PR DESCRIPTION
This PR updates go-crypto-openssl to version [v0.1.1](https://github.com/microsoft/go-crypto-openssl/releases/tag/v0.1.1).

The only changes coming with the new version is this:

- [v0.1] Backport https://github.com/microsoft/go-crypto-openssl/pull/34 - Initialize empty AES-GCM inputs by @qmuntal in https://github.com/microsoft/go-crypto-openssl/pull/35