### PR TITLE
Use variable group for cmdscan rules

### DIFF
--- a/eng/_core/cmd/cmdscan/cmdscan.go
+++ b/eng/_core/cmd/cmdscan/cmdscan.go
@@ -1,52 +1,131 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Cmdscan runs the command given to it in os.Args and monitors the output for text patterns that
-// should be elevated to AzDO Pipeline warnings using AzDO logging commands. Timeline events can be
-// discovered more easily in the UI and by automated tools like runfo.
-//
-// If the pattern is associated with a known issue, the warning includes a link.
-//
-// Uses the "log issue" pipeline logging command: https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning
 package main
 
 import (
 	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 )
 
-var filters = []filter{
-	{
-		"access denied",
-		"https://github.com/microsoft/go/issues/241",
-		regexp.MustCompile("(?i)Access is denied"),
-	},
+const description = `
+Cmdscan runs the command given to it as args and monitors the output for text patterns that should
+be elevated to AzDO Pipeline warnings using AzDO logging commands. Timeline events can be discovered
+more easily in the UI and by automated tools like runfo.
+
+Uses the "log issue" pipeline logging command to create timeline warnings:
+https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning
+
+To specify the rules to match, pass something like "GO_CMDSCAN_RULE_" to envprefix. This detects any
+env variables that start with that string and interprets their values as JSON specifying a rule. The
+part of the env var after the prefix is what the rule should be called in logs. If parsing is not
+successful, that rule is ignored. Cmdscan writes logs about what it finds.
+
+When using an AzDO pipeline, SHOUT_CASE is recommended so AzDO's env var naming conversion doesn't
+change the result:
+https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#environment-variables
+
+Use "--" to unambiguously separate the flag with the command to run.
+
+The format for a rule is a JSON object with regex string "pattern" and optionally a "url" string
+that contains more information about the issue. For example:
+
+  {"pattern": "(?i)Access is denied", "url": "https://github.com/microsoft/go/issues/241"}
+
+Example cmdscan call:
+
+  pwsh eng/run.ps1 cmdscan -envprefix GoCmdscanRule -- pwsh eng/run.ps1 build -test
+`
+
+type rule struct {
+	Pattern string `json:"pattern"`
+	URL     string `json:"url"`
 }
 
 type filter struct {
 	// name is a simple description of the detected error that should be uniquely searchable so
 	// runfo can keep track of this issue with "contains" searches on each timeline element.
 	name string
-	// trackingIssue is an optional URL that links to more information about this error.
-	trackingIssue string
+	// url is an optional URL that links to more information about this error.
+	url string
 	// regexp is the regex that is matched against each line of output to find an issue.
 	regexp *regexp.Regexp
 }
 
+var filters []filter
+
 func main() {
+	help := flag.Bool("h", false, "Print this help message.")
+	prefix := flag.String("envprefix", "", "The env var prefix to use to find scan rules.")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n", description)
+	}
+
+	flag.Parse()
+	if *help {
+		flag.Usage()
+		return
+	}
+
+	if *prefix != "" {
+		log.Printf("Searching for rules with env var prefix %v...\n", *prefix)
+		for _, e := range os.Environ() {
+			if envName, envValue, ok := strings.Cut(e, "="); ok {
+				if before, ruleName, ok := strings.Cut(envName, *prefix); ok && before == "" && ruleName != "" {
+					f, err := parseFilter(ruleName, envValue)
+					if err != nil {
+						log.Printf("Failed to parse rule %q: %v\n", envName, err)
+						continue
+					}
+					log.Printf("Parsed rule %q: %q (%v)\n", envName, f.regexp.String(), f.url)
+					filters = append(filters, *f)
+				}
+			}
+		}
+		log.Printf("Found %v rules defined by env vars.\n", len(filters))
+	}
+
 	if err := run(); err != nil {
 		log.Fatalln(err)
 	}
 }
 
+func parseFilter(name, envValue string) (*filter, error) {
+	var r rule
+
+	if err := json.Unmarshal([]byte(envValue), &r); err != nil {
+		return nil, err
+	}
+	if r.Pattern == "" {
+		return nil, errors.New("rule defines no pattern")
+	}
+
+	exp, err := regexp.Compile(r.Pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse rule regex: %v", err)
+	}
+
+	return &filter{
+		name:   name,
+		url:    r.URL,
+		regexp: exp,
+	}, nil
+}
+
 func run() error {
-	cmd := exec.Command(os.Args[1], os.Args[2:]...)
-	log.Printf("Detected %v scan patterns defined in eng/_core/cmd/cmdscan/cmdscan.go\n", len(filters))
+	cmd := exec.Command(flag.Args()[0], flag.Args()[1:]...)
 	log.Printf("Running: %v\n", cmd)
 
 	outPipe, err := cmd.StdoutPipe()
@@ -93,8 +172,8 @@ func scan(r io.Reader, commands, echo *os.File) error {
 
 func warn(f *filter, line string) string {
 	var issueLink string
-	if f.trackingIssue != "" {
-		issueLink = " (" + f.trackingIssue + ")"
+	if f.url != "" {
+		issueLink = " (" + f.url + ")"
 	}
 
 	return fmt.Sprintf("##vso[task.logissue type=warning]%q%v: %v\n", f.name, issueLink, line)

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -49,6 +49,9 @@ stages:
             ${{ if not(parameters.builder.distro) }}:
               container: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
 
+        variables:
+          - group: go-cmdscan-rules
+
         steps:
           - ${{ if eq(parameters.builder.os, 'linux') }}:
             # AzDO builds don't seem to set user ID in the running container, so files from a previous
@@ -112,7 +115,7 @@ stages:
           # download its external module dependencies.
           - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
             - pwsh: |
-                eng/run.ps1 cmdscan `
+                eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -- `
                   pwsh eng/run.ps1 build -pack
               displayName: Build and Pack
 
@@ -133,7 +136,7 @@ stages:
                   ) -join ';'
                 }
 
-                eng/run.ps1 cmdscan `
+                eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -- `
                   pwsh eng/run.ps1 run-builder `
                     -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
                     $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `


### PR DESCRIPTION
* Followup from https://github.com/microsoft/go/pull/687

We now have a variable group to hold our scan rules, so we can change it at any time across all branches without touching our code. (Unfortunately, the variable groups in the internal and public projects are isolated. However, since runfo is only looking at the public data, it's not terrible if the internal side gets out of date.)

* https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=162&path=go-cmdscan-rules
* https://dnceng.visualstudio.com/public/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=163&path=go-cmdscan-rules

These are injected into the job as env vars like this:

```
GO_CMDSCAN_RULE_ACCESS_DENIED='{"pattern": "(?i)Access is denied", "url": "https://github.com/microsoft/go/issues/241"}'
```

Cmdscan takes `-envprefix GO_CMDSCAN_RULE_` and looks for all env vars with that prefix to parse as rules. This makes it easy to add new rules: just add a new variable group entry. (Don't need to also modify a list that points to each env var.)

I tried to make sure the command won't crash given bad input so we don't break CI by tweaking the variable groups incorrectly. Also, if one rule is bad, the others still get loaded.