### PR TITLE
Update Linux CI host from 18.04 to 20.04

### DIFF
--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -35,8 +35,8 @@ stages:
           ${{ if eq(parameters.builder.hostArch, 'amd64') }}:
             pool:
               # The VM image of the Docker host. This doesn't need to match the container image, but it may
-              # give slightly better coverage by matching the kernel version.
-              vmImage: ubuntu-18.04
+              # give slightly better coverage by matching the kernel version when possible.
+              vmImage: ubuntu-20.04
             # The image used for the container this job runs in. The tests run in this container, so it
             # should match what we support as closely as possible.
             ${{ if not(parameters.builder.distro) }}:


### PR DESCRIPTION
* For https://github.com/actions/runner-images/issues/6002

We started getting warnings in our builds because we're using the `ubuntu-18.04` vmImage for our host, so upgrade to the next Ubuntu LTS. There are also brownout periods (failed builds!) scheduled, starting on August 22.

Note: we're still using the same Docker containers, so as far as I know, this should only affect the kernel version. (As far as I know our builds aren't sensitive to this, I just had some theoretical concerns about test coverage with old OSes and it's noted in the YAML comment.)