### PR TITLE
Add longer timeout on Windows

### DIFF
--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/microsoft/go/_core/buildutil"
@@ -69,6 +70,7 @@ func main() {
 	fmt.Printf("Found os '%s', arch '%s', config '%s'\n", goos, goarch, config)
 
 	maxTestRetries := buildutil.MaxTestRetryAttemptsOrExit()
+	timeoutScale := 1
 
 	// Some builder configurations need extra env variables set up during the build, not just while
 	// running tests:
@@ -77,7 +79,7 @@ func main() {
 		env("CC", "/usr/bin/clang-3.9")
 	case "longtest":
 		env("GO_TEST_SHORT", "false")
-		env("GO_TEST_TIMEOUT_SCALE", "5")
+		timeoutScale *= 5
 	case "nocgo":
 		env("CGO_ENABLED", "0")
 	case "noopt":
@@ -88,6 +90,16 @@ func main() {
 		env("GO_GCFLAGS", "-d=ssa/check/on,dclstack")
 	case "staticlockranking":
 		buildutil.AppendExperimentEnv("staticlockranking")
+	}
+
+	// Some Windows builders are slower than others and require more time for the runtime dist tests
+	// in "GOMAXPROCS=2 runtime -cpu=1,2,4 -quick" mode. https://github.com/microsoft/go/issues/700
+	if goos == "windows" {
+		timeoutScale *= 2
+	}
+
+	if timeoutScale != 1 {
+		env("GO_TEST_TIMEOUT_SCALE", strconv.Itoa(timeoutScale))
 	}
 
 	buildCmdline := []string{"pwsh", "eng/run.ps1", "build"}


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/700

I think our builders simply run more slowly than upstream's. Start out with increasing the timeout.

https://github.com/golang/go/blob/833367e98af838a2511ee7e4e19dc8f1da7b8ed7/src/cmd/dist/test.go#L553 includes `t.timeout(300)`, which should enable the multiplier to work in this case. (Some dist tests don't have this and would need something like it to be patched in to work.)