### PR TITLE
Use dnceng/1ES pools; template for common logic

### DIFF
--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -93,6 +93,12 @@ func main() {
 		buildutil.AppendExperimentEnv("staticlockranking")
 	}
 
+	// Some Windows builders are slower than others and require more time for the runtime dist tests
+	// in "GOMAXPROCS=2 runtime -cpu=1,2,4 -quick" mode. https://github.com/microsoft/go/issues/700
+	if goos == "windows" {
+		timeoutScale *= 2
+	}
+
 	if timeoutScale != 1 {
 		env("GO_TEST_TIMEOUT_SCALE", strconv.Itoa(timeoutScale))
 	}

--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -70,6 +70,7 @@ func main() {
 	fmt.Printf("Found os '%s', arch '%s', config '%s'\n", goos, goarch, config)
 
 	maxTestRetries := buildutil.MaxTestRetryAttemptsOrExit()
+	// Scale this variable to increase timeout time based on scenario or builder speed.
 	timeoutScale := 1
 
 	// Some builder configurations need extra env variables set up during the build, not just while
@@ -90,12 +91,6 @@ func main() {
 		env("GO_GCFLAGS", "-d=ssa/check/on,dclstack")
 	case "staticlockranking":
 		buildutil.AppendExperimentEnv("staticlockranking")
-	}
-
-	// Some Windows builders are slower than others and require more time for the runtime dist tests
-	// in "GOMAXPROCS=2 runtime -cpu=1,2,4 -quick" mode. https://github.com/microsoft/go/issues/700
-	if goos == "windows" {
-		timeoutScale *= 2
 	}
 
 	if timeoutScale != 1 {

--- a/eng/pipeline/README.md
+++ b/eng/pipeline/README.md
@@ -23,6 +23,10 @@ to update the web-UI-based AzDO pipeline to point at the new file. Each web UI
 pipeline can only point at one YAML file, so this breaks old branches that
 haven't renamed the file. It would be nice to avoid this.)
 
+For more information about the style of these pipeline and template YAML files
+and the quirks involved with the way they're implemented, visit
+[pipeline-yml-style.md in microsoft/go-infra](https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md).
+
 ## Templates
 
 The subdirectories hold AzDO pipeline YAML templates, based on type of template.

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -21,10 +21,16 @@ stages:
       createSourceArchive: true
 
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/')) }}:
-    - template: stages/publish-stage.yml
+    - template: stages/pool.yml
       parameters:
-        public: true
+        inner:
+          template: publish-stage.yml
+          parameters:
+            public: true
 
-  - template: stages/publish-stage.yml
+  - template: stages/pool.yml
     parameters:
-      public: false
+      inner:
+        template: publish-stage.yml
+        parameters:
+          public: false

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -15,15 +15,21 @@ parameters:
 
 stages:
   - ${{ each builder in parameters.builders }}:
-    - template: run-stage.yml
+    - template: pool.yml
       parameters:
-        builder: ${{ builder }}
-        createSourceArchive: ${{ parameters.createSourceArchive }}
+        inner:
+          template: run-stage.yml
+          parameters:
+            builder: ${{ builder }}
+            createSourceArchive: ${{ parameters.createSourceArchive }}
 
   - ${{ if eq(parameters.sign, true) }}:
-    - template: sign-stage.yml
+    - template: pool.yml
       parameters:
-        builders:
-          - ${{ each builder in parameters.builders }}:
-            - ${{ if eq(builder.config, 'buildandpack') }}:
-              - ${{ builder }}
+        inner:
+          template: sign-stage.yml
+          parameters:
+            builders:
+              - ${{ each builder in parameters.builders }}:
+                - ${{ if eq(builder.config, 'buildandpack') }}:
+                  - ${{ builder }}

--- a/eng/pipeline/stages/pool-core.yml
+++ b/eng/pipeline/stages/pool-core.yml
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This template defines common pool names for dnceng agents for various platforms.
+
+parameters:
+  - name: public
+    type: boolean
+  - name: servicing
+    type: boolean
+  # The inner template: { template string, parameters object }
+  - name: inner
+    type: object
+
+stages:
+  - template: ${{ parameters.inner.template }}
+    parameters:
+      ${{ insert }}: ${{ parameters.inner.parameters }}
+
+      dncengPool:
+        # Pick pool. https://github.com/dotnet/arcade/blob/0db07252ccb18afdf94820ba6125da6de729ec04/Documentation/AzureDevOps/AzureDevOpsOnboarding.md#agent-queues
+        ${{ if parameters.public }}:
+          ${{ if parameters.servicing }}:
+            name: NetCore1ESPool-Svc-Public
+          ${{ if not(parameters.servicing) }}:
+            name: NetCore1ESPool-Public
+        ${{ if not(parameters.public) }}:
+          ${{ if parameters.servicing }}:
+            name: NetCore1ESPool-Svc-Internal
+          ${{ if not(parameters.servicing) }}:
+            name: NetCore1ESPool-Internal
+
+        # Pick images. https://helix.dot.net/#1esPools
+        demands:
+          ${{ if parameters.public }}:
+            windows: ImageOverride -equals 1es-windows-2019-open
+          ${{ if not(parameters.public) }}:
+            windows: ImageOverride -equals 1es-windows-2019
+
+          ${{ if parameters.public }}:
+            linux: ImageOverride -equals 1es-ubuntu-2004-open
+          ${{ if not(parameters.public) }}:
+            linux: ImageOverride -equals 1es-ubuntu-2004

--- a/eng/pipeline/stages/pool.yml
+++ b/eng/pipeline/stages/pool.yml
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This template determines the correct pool names and agent demands based on the current branch and
+# AzDO project and passes them into the provided inner stages template.
+#
+# The "public" (vs. internal) and "servicing" (vs. R&D) conditions are evaluated here and then
+# passed into an inner template so the values can be reused to determine the pools to use.
+#
+# See pool-core.yml for the list of pool names and demands and the reasons behind the choices.
+
+parameters:
+  # The inner template: { template string, parameters object }
+  # Note: the template path is relative to this file (inside "stages/"), not the caller's file path.
+  - name: inner
+    type: object
+
+stages:
+  - template: pool-core.yml
+    parameters:
+      public: ${{ eq(variables['System.TeamProject'], 'public') }}
+      servicing: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/microsoft/release-branch') }}
+      inner: ${{ parameters.inner }}

--- a/eng/pipeline/stages/publish-stage.yml
+++ b/eng/pipeline/stages/publish-stage.yml
@@ -6,9 +6,9 @@
 
 parameters:
   - name: public
-    # Specify type so AzDO doesn't convert bool inputs into strings.
     type: boolean
-    default: false
+  - name: dncengPool
+    type: object
 
 stages:
   - stage: Publish${{ parameters.public }}
@@ -20,8 +20,8 @@ stages:
     jobs:
       - job: Publish
         pool:
-          # This is a utility job: use generic recent LTS for publishing.
-          vmImage: ubuntu-20.04
+          name: ${{ parameters.dncengPool.name }}
+          demands: ${{ parameters.dncengPool.demands.linux }}
 
         variables:
           - ${{ if parameters.public }}:

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -29,14 +29,15 @@ stages:
 
         ${{ if eq(parameters.builder.os, 'windows') }}:
           pool:
-            vmImage: windows-2019
+            name: ${{ parameters.dncengPool.name }}
+            demands: ${{ parameters.dncengPool.demands.windows }}
 
         ${{ if eq(parameters.builder.os, 'linux') }}:
           ${{ if eq(parameters.builder.hostArch, 'amd64') }}:
+            # Docker host agent.
             pool:
-              # The VM image of the Docker host. This doesn't need to match the container image, but it may
-              # give slightly better coverage by matching the kernel version when possible.
-              vmImage: ubuntu-20.04
+              name: ${{ parameters.dncengPool.name }}
+              demands: ${{ parameters.dncengPool.demands.linux }}
             # The image used for the container this job runs in. The tests run in this container, so it
             # should match what we support as closely as possible.
             ${{ if not(parameters.builder.distro) }}:

--- a/eng/pipeline/stages/sign-stage.yml
+++ b/eng/pipeline/stages/sign-stage.yml
@@ -19,9 +19,9 @@ stages:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
         - job: Sign
           pool:
-            # This is a utility job that doesn't use Go: use a pool that supports signing.
-            name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals build.windows.10.amd64.vs2019
+            name: ${{ parameters.dncengPool.name }}
+            # This is a utility job that doesn't use Go, but must support signing.
+            demands: ${{ parameters.dncengPool.demands.windows }}
           variables:
             - name: TeamName
               value: golang


### PR DESCRIPTION
Use dnceng / 1ES pools throughout pipelines.

* For https://github.com/microsoft/go/issues/700. The machines in the dnceng pools have more uniform performance than Azure hosted machines (see quotes from the FR thread). I removed the larger Windows timeout (earlier workaround) to make sure this helps the way it should.

* For https://github.com/microsoft/go/issues/407. We never ended up with a deadline for this (like .NET's), but it's something we should do at some point. This seemed like a good opportunity now that it makes sense to put *everything* on dnceng pools for perf/reliability reasons.

* I wrote a doc describing some of the quirks at play here (https://github.com/microsoft/go-infra/pull/61) and linked from here. Should merge that first to avoid a dead link.

Internal build test (for publish + signing jobs particularly): https://dev.azure.com/dnceng/internal/_build/results?buildId=1967499&view=results