### PR TITLE
SDL: Remove extracted artifact dir version numbers

### DIFF
--- a/eng/compliance/Guardian/execute-go-sdl-tools.ps1
+++ b/eng/compliance/Guardian/execute-go-sdl-tools.ps1
@@ -10,6 +10,21 @@ $dotGitHubDirectory = Join-Path $srcDir ".github"
 # Official build artifacts, downloaded from the build job that completed earlier.
 $downloadedArtifactsDirectory = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "artifacts"
 
+# Remove verison number from the artifact path to make path-based issue suppression more reliable.
+foreach ($item in Get-ChildItem -Directory $downloadedArtifactsDirectory)
+{
+  if ($item.Name.StartsWith("go.") -and $item.Name.EndsWith(".extracted"))
+  {
+    $oldName = $item.FullName
+    $newName = $item.FullName -replace '\\go\.[0-9]+\.[0-9]+\.', '\go.'
+    if ($oldName -ne $newName)
+    {
+      Write-Host "Renaming '$oldName' to '$newName'"
+      Move-Item $oldName $newName
+    }
+  }
+}
+
 # Create a file for PoliCheck's ListFile option. The extension must be ".txt", and this file must
 # contain full paths, one per line, with no duplicates. The list should contain each microsoft/go
 # file but no upstream files. Sort and print it for debug purposes.


### PR DESCRIPTION
Credscan false positives were popping up, and there's intended to be a way to suppress the issues on the issue tracking side, but it wasn't working and the same issues would be opened repeatedly after dismissal. This PR tries to fix it by making the absolute paths of the files stay the same.

It seems to work: https://dev.azure.com/dnceng/internal/_build/results?buildId=1981497&view=results opened new issues with the more-static absolute path, and when I closed them as "external", a subsequent build shows a failure status but didn't open any new issues: https://dev.azure.com/dnceng/internal/_build/results?buildId=1981612&view=results. (See the first few lines of the `Execute SDL` for the renaming logs.)