### PR TITLE
Use AzDO "else" to remove duplicate yml logic

### DIFF
--- a/eng/pipeline/stages/pool-core.yml
+++ b/eng/pipeline/stages/pool-core.yml
@@ -23,22 +23,22 @@ stages:
         ${{ if parameters.public }}:
           ${{ if parameters.servicing }}:
             name: NetCore-Svc-Public
-          ${{ if not(parameters.servicing) }}:
+          ${{ else }}:
             name: NetCore-Public
-        ${{ if not(parameters.public) }}:
+        ${{ else }}:
           ${{ if parameters.servicing }}:
             name: NetCore1ESPool-Svc-Internal
-          ${{ if not(parameters.servicing) }}:
+          ${{ else }}:
             name: NetCore1ESPool-Internal
 
         # Pick images. https://helix.dot.net/#1esPools
         demands:
           ${{ if parameters.public }}:
             windows: ImageOverride -equals 1es-windows-2019-open
-          ${{ if not(parameters.public) }}:
+          ${{ else }}:
             windows: ImageOverride -equals 1es-windows-2019
 
           ${{ if parameters.public }}:
             linux: ImageOverride -equals 1es-ubuntu-2004-open
-          ${{ if not(parameters.public) }}:
+          ${{ else }}:
             linux: ImageOverride -equals 1es-ubuntu-2004

--- a/eng/pipeline/stages/publish-stage.yml
+++ b/eng/pipeline/stages/publish-stage.yml
@@ -14,7 +14,7 @@ stages:
   - stage: Publish${{ parameters.public }}
     ${{ if parameters.public }}:
       displayName: Publish Public
-    ${{ if not(parameters.public) }}:
+    ${{ else }}:
       displayName: Publish Internal
     dependsOn: Sign
     jobs:
@@ -29,7 +29,7 @@ stages:
               value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft'
             - name: blobSASArg
               value: --sas-token '$(dotnetbuildoutput-golang-write-sas-query)'
-          - ${{ if not(parameters.public) }}:
+          - ${{ else }}:
             - name: blobContainer
               value: 'https://golangartifacts.blob.core.windows.net/microsoft'
             - name: blobSASArg
@@ -88,7 +88,7 @@ stages:
             displayName: Publish build asset JSON to pipeline
             ${{ if parameters.public }}:
               artifact: BuildAssets
-            ${{ if not(parameters.public) }}:
+            ${{ else }}:
               artifact: BuildAssetsInternal
 
           - task: AzureCLI@2

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -127,7 +127,7 @@ stages:
 
           # Use run-builder for any configuration that includes tests. run-builder uses the "gotestsum"
           # module to convert test results to a JUnit file that Azure DevOps can understand.
-          - ${{ if ne(parameters.builder.config, 'buildandpack') }}:
+          - ${{ else }}:
             - pwsh: |
                 if ($IsWindows) {
                   Write-Host "Removing Git usr\bin from PATH to avoid running a Linux test that would fail, 'TestScript/script_wait'..."

--- a/eng/pipeline/steps/init-submodule-task.yml
+++ b/eng/pipeline/steps/init-submodule-task.yml
@@ -22,5 +22,5 @@ steps:
       env:
         FETCH_BEARER_TOKEN: $(System.AccessToken)
       displayName: Set up submodule from internal mirror
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    ${{ else }}:
       displayName: Set up submodule


### PR DESCRIPTION
Applying the FYI from https://github.com/microsoft/go/pull/709#pullrequestreview-1086609430.

Use `else` to remove duplicated+inverted yml logic. This means if we have to change a condition or make it more complex, we don't have to make the change twice. It also makes it clear that the *intent* is `else`, and it isn't just a coincidence to have inverted conditions in a nearby `if`.

No behavior change is expected with this PR, it's just a small tweak for the future.