### PR TITLE
[microsoft/dev.boringcrypto.go1.18] Update OpenSSL crypto backend

### DIFF
--- a/patches/0100-Add-OpenSSL-crypto-module.patch
+++ b/patches/0100-Add-OpenSSL-crypto-module.patch
@@ -414,24 +414,24 @@ index 00000000000000..659104006e84da
 +var VerifyRSAPKCS1v15 = openssl.VerifyRSAPKCS1v15
 +var VerifyRSAPSS = openssl.VerifyRSAPSS
 diff --git a/src/go.mod b/src/go.mod
-index 8ca3c5fb702d50..940264313794cf 100644
+index 8ca3c5fb702d50..f2289f6cb50757 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.18
  
  require (
-+	github.com/microsoft/go-crypto-openssl v0.1.2-0.20220923165405-26ba1404ada1
++	github.com/microsoft/go-crypto-openssl v0.1.2
  	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
  	golang.org/x/net v0.0.0-20211209124913-491a49abca63
  )
 diff --git a/src/go.sum b/src/go.sum
-index 7c93a59725711b..635bce4efdb023 100644
+index 7c93a59725711b..eba56a61e7034d 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.1.2-0.20220923165405-26ba1404ada1 h1:GXOSkm/jZxI8v6AhScgFDb/p3PQ1BNBc0pzfPTZK29g=
-+github.com/microsoft/go-crypto-openssl v0.1.2-0.20220923165405-26ba1404ada1/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-openssl v0.1.2 h1:1JO/O62aLFCGpKWKrxdxzIITNJJ00hkBL0v/LLpEZUM=
++github.com/microsoft/go-crypto-openssl v0.1.2/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
  golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
  golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20211209124913-491a49abca63 h1:iocB37TsdFuN6IBRZ+ry36wrkoV51/tl5vOWqkcPGvY=

--- a/patches/0100-Add-OpenSSL-crypto-module.patch
+++ b/patches/0100-Add-OpenSSL-crypto-module.patch
@@ -25,7 +25,7 @@ github.com/microsoft/go-infra/cmd/git-go-patch command: patch number 0100
 
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644
-index 0000000000..c2c06d3bff
+index 00000000000000..c2c06d3bff8c74
 --- /dev/null
 +++ b/src/crypto/internal/backend/backend_test.go
 @@ -0,0 +1,30 @@
@@ -61,7 +61,7 @@ index 0000000000..c2c06d3bff
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 0000000000..d33bafd1b0
+index 00000000000000..9d39130dba8f43
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
 @@ -0,0 +1,35 @@
@@ -102,7 +102,7 @@ index 0000000000..d33bafd1b0
 +}
 diff --git a/src/crypto/internal/backend/dummy.s b/src/crypto/internal/backend/dummy.s
 new file mode 100644
-index 0000000000..157adeeeb3
+index 00000000000000..157adeeeb37b21
 --- /dev/null
 +++ b/src/crypto/internal/backend/dummy.s
 @@ -0,0 +1,10 @@
@@ -118,7 +118,7 @@ index 0000000000..157adeeeb3
 +// (because the implementation might be here).
 diff --git a/src/crypto/internal/backend/iscgo.go b/src/crypto/internal/backend/iscgo.go
 new file mode 100644
-index 0000000000..1e0d3cf8c1
+index 00000000000000..1e0d3cf8c18b55
 --- /dev/null
 +++ b/src/crypto/internal/backend/iscgo.go
 @@ -0,0 +1,10 @@
@@ -134,7 +134,7 @@ index 0000000000..1e0d3cf8c1
 +const iscgo = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 0000000000..4de8d404f8
+index 00000000000000..4de8d404f8682c
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -0,0 +1,112 @@
@@ -252,7 +252,7 @@ index 0000000000..4de8d404f8
 +}
 diff --git a/src/crypto/internal/backend/nocgo.go b/src/crypto/internal/backend/nocgo.go
 new file mode 100644
-index 0000000000..63c13fc4b0
+index 00000000000000..63c13fc4b01cba
 --- /dev/null
 +++ b/src/crypto/internal/backend/nocgo.go
 @@ -0,0 +1,10 @@
@@ -268,7 +268,7 @@ index 0000000000..63c13fc4b0
 +const iscgo = false
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 0000000000..8d140dc62b
+index 00000000000000..659104006e84da
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,141 @@
@@ -414,24 +414,24 @@ index 0000000000..8d140dc62b
 +var VerifyRSAPKCS1v15 = openssl.VerifyRSAPKCS1v15
 +var VerifyRSAPSS = openssl.VerifyRSAPSS
 diff --git a/src/go.mod b/src/go.mod
-index bd6308add021dc..cfe8862fe42b64 100644
+index 8ca3c5fb702d50..940264313794cf 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.18
  
  require (
-+	github.com/microsoft/go-crypto-openssl v0.1.1
++	github.com/microsoft/go-crypto-openssl v0.1.2-0.20220923165405-26ba1404ada1
  	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
  	golang.org/x/net v0.0.0-20211209124913-491a49abca63
  )
 diff --git a/src/go.sum b/src/go.sum
-index 8bf08531de62dd..1bbc2eb739f58b 100644
+index 7c93a59725711b..635bce4efdb023 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.1.1 h1:tAO2hN5ln/DbRw4gM6owWAOsmHAIWa5lh+8XVofIedA=
-+github.com/microsoft/go-crypto-openssl v0.1.1/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-openssl v0.1.2-0.20220923165405-26ba1404ada1 h1:GXOSkm/jZxI8v6AhScgFDb/p3PQ1BNBc0pzfPTZK29g=
++github.com/microsoft/go-crypto-openssl v0.1.2-0.20220923165405-26ba1404ada1/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
  golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
  golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20211209124913-491a49abca63 h1:iocB37TsdFuN6IBRZ+ry36wrkoV51/tl5vOWqkcPGvY=

--- a/patches/0102-Vendor-OpenSSL-crypto-library.patch
+++ b/patches/0102-Vendor-OpenSSL-crypto-library.patch
@@ -11,7 +11,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/evpkey.go       | 279 +++++++++
  .../go-crypto-openssl/openssl/goopenssl.c     | 153 +++++
  .../go-crypto-openssl/openssl/goopenssl.h     | 133 +++++
- .../go-crypto-openssl/openssl/hmac.go         | 147 +++++
+ .../go-crypto-openssl/openssl/hmac.go         | 148 +++++
  .../openssl/internal/subtle/aliasing.go       |  32 ++
  .../go-crypto-openssl/openssl/openssl.go      | 260 +++++++++
  .../go-crypto-openssl/openssl/openssl_funcs.h | 242 ++++++++
@@ -20,7 +20,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/rsa.go          | 303 ++++++++++
  .../go-crypto-openssl/openssl/sha.go          | 534 ++++++++++++++++++
  src/vendor/modules.txt                        |   4 +
- 15 files changed, 2865 insertions(+)
+ 15 files changed, 2866 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
@@ -38,7 +38,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
 
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE b/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
 new file mode 100644
-index 00000000000..9e841e7a26e
+index 00000000000000..9e841e7a26e4eb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
 @@ -0,0 +1,21 @@
@@ -65,7 +65,7 @@ index 00000000000..9e841e7a26e
 +    SOFTWARE
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
 new file mode 100644
-index 00000000000..3177c0d37c8
+index 00000000000000..3177c0d37c8e5f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
 @@ -0,0 +1,466 @@
@@ -537,7 +537,7 @@ index 00000000000..3177c0d37c8
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 new file mode 100644
-index 00000000000..84f82e903ce
+index 00000000000000..84f82e903ce185
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 @@ -0,0 +1,214 @@
@@ -757,7 +757,7 @@ index 00000000000..84f82e903ce
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 new file mode 100644
-index 00000000000..03a652aef13
+index 00000000000000..03a652aef13931
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 @@ -0,0 +1,279 @@
@@ -1042,7 +1042,7 @@ index 00000000000..03a652aef13
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
 new file mode 100644
-index 00000000000..7bbf7418512
+index 00000000000000..7bbf74185128dd
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
 @@ -0,0 +1,153 @@
@@ -1341,10 +1341,10 @@ index 00000000000000..9191b512e3192d
 \ No newline at end of file
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
 new file mode 100644
-index 00000000000..204c94cd94f
+index 00000000000000..80f320b041f7e0
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
-@@ -0,0 +1,147 @@
+@@ -0,0 +1,148 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -1392,6 +1392,7 @@ index 00000000000..204c94cd94f
 +		key:       hkey,
 +		ctx:       hmacCtxNew(),
 +	}
++	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
 +	hmac.Reset()
 +	return hmac
 +}
@@ -1494,7 +1495,7 @@ index 00000000000..204c94cd94f
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go
 new file mode 100644
-index 00000000000..db09e4aae64
+index 00000000000000..db09e4aae64f8c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go
 @@ -0,0 +1,32 @@
@@ -1532,7 +1533,7 @@ index 00000000000..db09e4aae64
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
 new file mode 100644
-index 00000000000..2c354e1df0f
+index 00000000000000..2c354e1df0f818
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
 @@ -0,0 +1,260 @@
@@ -1798,7 +1799,7 @@ index 00000000000..2c354e1df0f
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 new file mode 100644
-index 00000000000..95024cf8ecb
+index 00000000000000..95024cf8ecb72c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 @@ -0,0 +1,242 @@
@@ -2046,7 +2047,7 @@ index 00000000000..95024cf8ecb
 +DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4))
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c
 new file mode 100644
-index 00000000000..5cd7275f407
+index 00000000000000..5cd7275f4075ed
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c
 @@ -0,0 +1,53 @@
@@ -2105,7 +2106,7 @@ index 00000000000..5cd7275f407
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go
 new file mode 100644
-index 00000000000..17f64a52ae5
+index 00000000000000..17f64a52ae5255
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go
 @@ -0,0 +1,24 @@
@@ -2135,7 +2136,7 @@ index 00000000000..17f64a52ae5
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 new file mode 100644
-index 00000000000..05ff62cd739
+index 00000000000000..05ff62cd7399af
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 @@ -0,0 +1,303 @@
@@ -2444,7 +2445,7 @@ index 00000000000..05ff62cd739
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 new file mode 100644
-index 00000000000..c5b0189efc8
+index 00000000000000..c5b0189efc8132
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 @@ -0,0 +1,534 @@
@@ -2983,11 +2984,11 @@ index 00000000000..c5b0189efc8
 +	return b[4:], x
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 3a975cde9e838a..7868f581af2854 100644
+index 4714b1d38605dc..29a9c0f693e99f 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,7 @@
-+# github.com/microsoft/go-crypto-openssl v0.1.1
++# github.com/microsoft/go-crypto-openssl v0.1.2-0.20220923165405-26ba1404ada1
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/internal/subtle

--- a/patches/0102-Vendor-OpenSSL-crypto-library.patch
+++ b/patches/0102-Vendor-OpenSSL-crypto-library.patch
@@ -2984,11 +2984,11 @@ index 00000000000000..c5b0189efc8132
 +	return b[4:], x
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 4714b1d38605dc..29a9c0f693e99f 100644
+index 4714b1d38605dc..64b77392bad61a 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,7 @@
-+# github.com/microsoft/go-crypto-openssl v0.1.2-0.20220923165405-26ba1404ada1
++# github.com/microsoft/go-crypto-openssl v0.1.2
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/internal/subtle


### PR DESCRIPTION
Includes one fix:

* https://github.com/microsoft/go-crypto-openssl/compare/v0.1.1...v0.1.2