### PR TITLE
Upgrade CNG backend and use it for ECDSA P-224

### DIFF
--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -487,7 +487,7 @@ GenerateKey generates a public and private key pair.
 
 `priv` is generated using [BCryptGenerateKeyPair].
 
-`priv` [algorithm identifier] is `BCRYPT_ECDSA_ALGORITHM ` and the [named elliptic curve] depends on the value of `c`:
+`priv` [algorithm identifier] is `BCRYPT_ECDSA_ALGORITHM` and the [named elliptic curve] depends on the value of `c`:
 
 - If `c.Params().Name == "P-224"` then curve is `BCRYPT_ECC_CURVE_NISTP224`.
 - If `c.Params().Name == "P-256"` then curve is `BCRYPT_ECC_CURVE_NISTP256`.

--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -487,11 +487,12 @@ GenerateKey generates a public and private key pair.
 
 `priv` is generated using [BCryptGenerateKeyPair].
 
-`priv` curve [algorithm identifier] depends on the value of `c`:
+`priv` [algorithm identifier] is `BCRYPT_ECDSA_ALGORITHM ` and the [named elliptic curve] depends on the value of `c`:
 
-- If `c.Params().Name == "P-256"` then curve is `BCRYPT_ECDSA_P256_ALGORITHM`.
-- If `c.Params().Name == "P-384"` then curve is `BCRYPT_ECDSA_P384_ALGORITHM`.
-- If `c.Params().Name == "P-521"` then curve is `BCRYPT_ECDSA_P521_ALGORITHM`.
+- If `c.Params().Name == "P-224"` then curve is `BCRYPT_ECC_CURVE_NISTP224`.
+- If `c.Params().Name == "P-256"` then curve is `BCRYPT_ECC_CURVE_NISTP256`.
+- If `c.Params().Name == "P-384"` then curve is `BCRYPT_ECC_CURVE_NISTP384`.
+- If `c.Params().Name == "P-521"` then curve is `BCRYPT_ECC_CURVE_NISTP521`.
 
 </details>
 
@@ -1301,6 +1302,7 @@ When using TLS in FIPS-only mode the TLS handshake has the following restriction
 [HMAC_Init_ex]: https://www.openssl.org/docs/man3.0/man3/HMAC_Init_ex.html
 
 [algorithm identifier]: https://docs.microsoft.com/en-us/windows/win32/seccng/cng-algorithm-identifiers
+[named elliptic curve]: https://docs.microsoft.com/en-us/windows/win32/seccng/cng-named-elliptic-curves
 [BCryptGenRandom]: https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom
 [BCryptGenerateSymmetricKey]: https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgeneratesymmetrickey
 [BCryptGenerateKeyPair]: https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgeneratekeypair

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -8,13 +8,13 @@ Subject: [PATCH] Add CNG crypto backend
  src/cmd/go/go_boring_test.go                  |   2 +-
  src/crypto/boring/boring.go                   |   2 +-
  src/crypto/ecdsa/boring.go                    |   2 +-
- src/crypto/ecdsa/ecdsa.go                     |  39 +++-
+ src/crypto/ecdsa/ecdsa.go                     |  23 +++
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 ++
  src/crypto/internal/backend/cng_windows.go    | 171 ++++++++++++++++++
- src/crypto/internal/backend/common.go         |  45 ++++-
+ src/crypto/internal/backend/common.go         |  38 +++-
  src/crypto/internal/backend/nobackend.go      |   2 +-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -50,7 +50,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 46 files changed, 410 insertions(+), 50 deletions(-)
+ 46 files changed, 391 insertions(+), 46 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -109,7 +109,7 @@ index 602cb894e20d39..bf9e77e06599f0 100644
  package ecdsa
  
 diff --git a/src/crypto/ecdsa/ecdsa.go b/src/crypto/ecdsa/ecdsa.go
-index 58d3bc69568f35..ed13bac062a3ff 100644
+index 58d3bc69568f35..43cb533e98ad0a 100644
 --- a/src/crypto/ecdsa/ecdsa.go
 +++ b/src/crypto/ecdsa/ecdsa.go
 @@ -29,6 +29,7 @@ import (
@@ -120,15 +120,7 @@ index 58d3bc69568f35..ed13bac062a3ff 100644
  	"io"
  	"math/big"
  
-@@ -109,11 +110,25 @@ func (priv *PrivateKey) Equal(x crypto.PrivateKey) bool {
- // where the private part is kept in, for example, a hardware module. Common
- // uses can use the SignASN1 function in this package directly.
- func (priv *PrivateKey) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
--	if boring.Enabled && rand == boring.RandReader {
-+	if boring.Enabled && rand == boring.RandReader &&
-+		boring.IsCurveSupported(priv.Params().Name) {
-+
- 		b, err := boringPrivateKey(priv)
+@@ -114,6 +115,18 @@ func (priv *PrivateKey) Sign(rand io.Reader, digest []byte, opts crypto.SignerOp
  		if err != nil {
  			return nil, err
  		}
@@ -147,26 +139,7 @@ index 58d3bc69568f35..ed13bac062a3ff 100644
  		return boring.SignMarshalECDSA(b, digest)
  	}
  	boring.UnreachableExceptTests()
-@@ -154,7 +169,9 @@ func randFieldElement(c elliptic.Curve, rand io.Reader) (k *big.Int, err error)
- 
- // GenerateKey generates a public and private key pair.
- func GenerateKey(c elliptic.Curve, rand io.Reader) (*PrivateKey, error) {
--	if boring.Enabled && rand == boring.RandReader {
-+	if boring.Enabled && rand == boring.RandReader &&
-+		boring.IsCurveSupported(c.Params().Name) {
-+
- 		x, y, d, err := boring.GenerateKeyECDSA(c.Params().Name)
- 		if err != nil {
- 			return nil, err
-@@ -214,11 +231,20 @@ var errZeroParam = errors.New("zero parameter")
- func Sign(rand io.Reader, priv *PrivateKey, hash []byte) (r, s *big.Int, err error) {
- 	randutil.MaybeReadByte(rand)
- 
--	if boring.Enabled && rand == boring.RandReader {
-+	if boring.Enabled && rand == boring.RandReader &&
-+		boring.IsCurveSupported(priv.Params().Name) {
-+
- 		b, err := boringPrivateKey(priv)
+@@ -219,6 +232,13 @@ func Sign(rand io.Reader, priv *PrivateKey, hash []byte) (r, s *big.Int, err err
  		if err != nil {
  			return nil, nil, err
  		}
@@ -180,15 +153,7 @@ index 58d3bc69568f35..ed13bac062a3ff 100644
  		sig, err := boring.SignMarshalECDSA(b, hash)
  		if err != nil {
  			return nil, nil, err
-@@ -333,11 +359,16 @@ func SignASN1(rand io.Reader, priv *PrivateKey, hash []byte) ([]byte, error) {
- // return value records whether the signature is valid. Most applications should
- // use VerifyASN1 instead of dealing directly with r, s.
- func Verify(pub *PublicKey, hash []byte, r, s *big.Int) bool {
--	if boring.Enabled {
-+	if boring.Enabled &&
-+		boring.IsCurveSupported(pub.Params().Name) {
-+
- 		key, err := boringPublicKey(pub)
+@@ -338,6 +358,9 @@ func Verify(pub *PublicKey, hash []byte, r, s *big.Int) bool {
  		if err != nil {
  			return false
  		}
@@ -435,7 +400,7 @@ index 00000000000000..63bbc4fc9dc8c3
 +	return cng.VerifyRSAPSS(pub, h, hashed, sig, saltLen)
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
-index 007d8070538247..168ea5831a985e 100644
+index 007d8070538247..114f72c3d10ee4 100644
 --- a/src/crypto/internal/backend/common.go
 +++ b/src/crypto/internal/backend/common.go
 @@ -5,16 +5,19 @@
@@ -473,17 +438,10 @@ index 007d8070538247..168ea5831a985e 100644
  		name := runtime_arg0()
  		// If ran on Windows we'd need to allow _test.exe and .test.exe as well.
  		if !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
-@@ -63,3 +70,35 @@ func UnreachableExceptTests() {
+@@ -63,3 +70,28 @@ func UnreachableExceptTests() {
  		}
  	}
  }
-+
-+func IsCurveSupported(name string) bool {
-+	if goexperiment.CNGCrypto {
-+		return name != "P-224"
-+	}
-+	return true
-+}
 +
 +func IsRSAKeySupported(primes int) bool {
 +	if goexperiment.CNGCrypto {
@@ -841,7 +799,7 @@ index bc169888786321..e0d6f4c5040d91 100644
  
  		h := New()
 diff --git a/src/crypto/sha256/sha256.go b/src/crypto/sha256/sha256.go
-index eb704df3f3ae12..c462c3820b32aa 100644
+index 81ef91b7ffa30c..e678d0b129675a 100644
 --- a/src/crypto/sha256/sha256.go
 +++ b/src/crypto/sha256/sha256.go
 @@ -158,7 +158,7 @@ func New() hash.Hash {
@@ -1101,34 +1059,34 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 396d81817839c5..23d975190813c5 100644
+index 396d81817839c5..713d87aa2753d1 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.20
  
  require (
  	github.com/microsoft/go-crypto-openssl v0.2.1
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20221003180653-84bf0c539a8e
++	github.com/microsoft/go-crypto-winnative v0.0.0-20221011160345-d61e0765182d
  	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
  	golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9
  )
 diff --git a/src/go.sum b/src/go.sum
-index c6febdb646bbbe..24cf4f1b6a2bcc 100644
+index c6febdb646bbbe..df14273ff593be 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/microsoft/go-crypto-openssl v0.2.1 h1:YFcvMkJeBXucC5wkNne/BbB7V02z1TjRxXbvGmEaFd4=
  github.com/microsoft/go-crypto-openssl v0.2.1/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221003180653-84bf0c539a8e h1:9iYvunmn8z1LIbUG7qtD3O3cuPlbjWY90Vn6ox/divM=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221003180653-84bf0c539a8e/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221011160345-d61e0765182d h1:TFKhEIqvg//DLOnP/leJug6krAM0bgEiGic0nLV80Vs=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221011160345-d61e0765182d/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 h1:asZqf0wXastQr+DudYagQS8uBO8bHKeYD1vbAvGmFL8=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index d0da2efb34112d..68b4aaf25e775b 100644
+index 82357ddda60e9b..1324c251ca221f 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -398,6 +398,10 @@ var depsRules = `
+@@ -399,6 +399,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1139,7 +1097,7 @@ index d0da2efb34112d..68b4aaf25e775b 100644
  	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
  	< github.com/microsoft/go-crypto-openssl/openssl
  	< crypto/internal/boring
-@@ -411,6 +415,7 @@ var depsRules = `
+@@ -412,6 +416,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big

--- a/patches/0007-Vendor-crypto-backends.patch
+++ b/patches/0007-Vendor-crypto-backends.patch
@@ -27,18 +27,18 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../microsoft/go-crypto-winnative/cng/big.go  |  30 +
  .../microsoft/go-crypto-winnative/cng/cng.go  | 130 ++++
  .../microsoft/go-crypto-winnative/cng/ecdh.go | 257 ++++++++
- .../go-crypto-winnative/cng/ecdsa.go          | 173 ++++++
+ .../go-crypto-winnative/cng/ecdsa.go          | 175 ++++++
  .../microsoft/go-crypto-winnative/cng/hmac.go |  55 ++
  .../microsoft/go-crypto-winnative/cng/keys.go | 161 +++++
  .../microsoft/go-crypto-winnative/cng/rand.go |  28 +
  .../microsoft/go-crypto-winnative/cng/rsa.go  | 374 +++++++++++
  .../microsoft/go-crypto-winnative/cng/sha.go  | 199 ++++++
- .../internal/bcrypt/bcrypt_windows.go         | 222 +++++++
+ .../internal/bcrypt/bcrypt_windows.go         | 221 +++++++
  .../internal/bcrypt/zsyscall_windows.go       | 372 +++++++++++
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  12 +
- 33 files changed, 5552 insertions(+)
+ 33 files changed, 5553 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
@@ -4076,10 +4076,10 @@ index 00000000000000..f15f958054b2e8
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
 new file mode 100644
-index 00000000000000..a6630e3b0df946
+index 00000000000000..a77ff97bb8f521
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
-@@ -0,0 +1,173 @@
+@@ -0,0 +1,175 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -4096,32 +4096,34 @@ index 00000000000000..a6630e3b0df946
 +)
 +
 +var errUnknownCurve = errors.New("cng: unknown elliptic curve")
-+var errUnsupportedCurve = errors.New("cng: unsupported elliptic curve")
 +
 +type ecdsaAlgorithm struct {
 +	handle bcrypt.ALG_HANDLE
-+	id     string
 +}
 +
 +func loadECDSA(curve string) (h ecdsaAlgorithm, bits uint32, err error) {
 +	var id string
 +	switch curve {
 +	case "P-224":
-+		err = errUnsupportedCurve
++		id, bits = bcrypt.ECC_CURVE_NISTP224, 224
 +	case "P-256":
-+		id, bits = bcrypt.ECDSA_P256_ALGORITHM, 256
++		id, bits = bcrypt.ECC_CURVE_NISTP256, 256
 +	case "P-384":
-+		id, bits = bcrypt.ECDSA_P384_ALGORITHM, 384
++		id, bits = bcrypt.ECC_CURVE_NISTP384, 384
 +	case "P-521":
-+		id, bits = bcrypt.ECDSA_P521_ALGORITHM, 521
++		id, bits = bcrypt.ECC_CURVE_NISTP521, 521
 +	default:
 +		err = errUnknownCurve
 +	}
 +	if err != nil {
 +		return
 +	}
-+	v, err := loadOrStoreAlg(id, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
-+		return ecdsaAlgorithm{h, id}, nil
++	v, err := loadOrStoreAlg(bcrypt.ECDSA_ALGORITHM, bcrypt.ALG_NONE_FLAG, id, func(h bcrypt.ALG_HANDLE) (interface{}, error) {
++		err := setString(bcrypt.HANDLE(h), bcrypt.ECC_CURVE_NAME, id)
++		if err != nil {
++			return nil, err
++		}
++		return ecdsaAlgorithm{h}, nil
 +	})
 +	if err != nil {
 +		return ecdsaAlgorithm{}, 0, err
@@ -4171,7 +4173,7 @@ index 00000000000000..a6630e3b0df946
 +	if err != nil {
 +		return nil, err
 +	}
-+	hkey, err := importECCKey(h.handle, h.id, bits, X, Y, nil)
++	hkey, err := importECCKey(h.handle, bcrypt.ECDSA_ALGORITHM, bits, X, Y, nil)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -4193,7 +4195,7 @@ index 00000000000000..a6630e3b0df946
 +	if err != nil {
 +		return nil, err
 +	}
-+	hkey, err := importECCKey(h.handle, h.id, bits, X, Y, D)
++	hkey, err := importECCKey(h.handle, bcrypt.ECDSA_ALGORITHM, bits, X, Y, D)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -4316,7 +4318,7 @@ index 00000000000000..736472d5b4e700
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
 new file mode 100644
-index 00000000000000..b87ed7ec61d3fb
+index 00000000000000..766768e9d46b41
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
 @@ -0,0 +1,161 @@
@@ -4423,7 +4425,7 @@ index 00000000000000..b87ed7ec61d3fb
 +		return nil, errors.New("cng: invalid parameters")
 +	}
 +	switch id {
-+	case bcrypt.ECDSA_P256_ALGORITHM, bcrypt.ECDSA_P384_ALGORITHM, bcrypt.ECDSA_P521_ALGORITHM:
++	case bcrypt.ECDSA_ALGORITHM:
 +		if D == nil {
 +			hdr.Magic = bcrypt.ECDSA_PUBLIC_GENERIC_MAGIC
 +		} else {
@@ -5102,10 +5104,10 @@ index 00000000000000..a0ed5a10c70afd
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000000..cdd7f9fdf0aed2
+index 00000000000000..f3100669d53d3f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
-@@ -0,0 +1,222 @@
+@@ -0,0 +1,221 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -5119,21 +5121,20 @@ index 00000000000000..cdd7f9fdf0aed2
 +)
 +
 +const (
-+	SHA1_ALGORITHM       = "SHA1"
-+	SHA256_ALGORITHM     = "SHA256"
-+	SHA384_ALGORITHM     = "SHA384"
-+	SHA512_ALGORITHM     = "SHA512"
-+	AES_ALGORITHM        = "AES"
-+	RSA_ALGORITHM        = "RSA"
-+	MD5_ALGORITHM        = "MD5"
-+	ECDSA_P256_ALGORITHM = "ECDSA_P256"
-+	ECDSA_P384_ALGORITHM = "ECDSA_P384"
-+	ECDSA_P521_ALGORITHM = "ECDSA_P521"
-+	ECDH_ALGORITHM       = "ECDH"
++	SHA1_ALGORITHM   = "SHA1"
++	SHA256_ALGORITHM = "SHA256"
++	SHA384_ALGORITHM = "SHA384"
++	SHA512_ALGORITHM = "SHA512"
++	AES_ALGORITHM    = "AES"
++	RSA_ALGORITHM    = "RSA"
++	MD5_ALGORITHM    = "MD5"
++	ECDSA_ALGORITHM  = "ECDSA"
++	ECDH_ALGORITHM   = "ECDH"
 +)
 +
 +const (
 +	ECC_CURVE_25519    = "curve25519"
++	ECC_CURVE_NISTP224 = "nistP224"
 +	ECC_CURVE_NISTP256 = "nistP256"
 +	ECC_CURVE_NISTP384 = "nistP384"
 +	ECC_CURVE_NISTP521 = "nistP521"
@@ -5806,7 +5807,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 0d746403f3fa08..9e9b782b419313 100644
+index 0d746403f3fa08..2da884980a0c99 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,15 @@
@@ -5815,7 +5816,7 @@ index 0d746403f3fa08..9e9b782b419313 100644
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig
 +github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20221003180653-84bf0c539a8e
++# github.com/microsoft/go-crypto-winnative v0.0.0-20221011160345-d61e0765182d
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
CNG supports ECDSA P-224 curve after https://github.com/microsoft/go-crypto-winnative/pull/29 landed.

This PR updates the CNG patch to remove the Go crypto fallback when creating ECDSA P-224 private keys.

FIPS docs are also updated to account for the new implementation.