### PR TITLE
Improve crypto backends build tags handling

### DIFF
--- a/patches/0003-Add-crypto-backend-foundation.patch
+++ b/patches/0003-Add-crypto-backend-foundation.patch
@@ -322,7 +322,7 @@ index 00000000000000..ae7295d8d13c2a
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !boringcrypto || !linux || !cgo || android || cmd_go_bootstrap || msan
++//go:build (linux && !(cgo && boringcrypto && !msan && (amd64 || arm64))) || !linux || android || cmd_go_bootstrap
 +
 +package backend
 +

--- a/patches/0004-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0004-Add-BoringSSL-crypto-backend.patch
@@ -38,7 +38,7 @@ index 00000000000000..0726163033bcae
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.boringcrypto && linux && cgo && amd64 && !android && !cmd_go_bootstrap && !msan
++//go:build goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +
 +// Package boring provides access to BoringCrypto implementation functions.
 +// Check the variable Enabled to find out whether BoringCrypto is available.

--- a/patches/0004-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0004-Add-BoringSSL-crypto-backend.patch
@@ -30,7 +30,7 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..0726163033bcae
+index 00000000000000..26cb4bd0fee5ee
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
 @@ -0,0 +1,124 @@

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/cmd/api/goapi_boring_test.go              |   2 +-
  src/cmd/dist/test.go                          |  10 +-
  src/cmd/go/go_boring_test.go                  |   2 +-
- .../testdata/script/crypto_backend_cross.txt  |  35 ++++
+ .../testdata/script/crypto_backend_cross.txt  |  25 +++
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
  src/crypto/boring/boring.go                   |   2 +-
@@ -39,7 +39,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 35 files changed, 321 insertions(+), 26 deletions(-)
+ 35 files changed, 311 insertions(+), 26 deletions(-)
  create mode 100644 src/cmd/go/testdata/script/crypto_backend_cross.txt
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
@@ -119,10 +119,10 @@ index ed0fbf3d53d75b..5376227f74cfaa 100644
  
 diff --git a/src/cmd/go/testdata/script/crypto_backend_cross.txt b/src/cmd/go/testdata/script/crypto_backend_cross.txt
 new file mode 100644
-index 00000000000000..dab0e4a3b460e6
+index 00000000000000..020f33ca869897
 --- /dev/null
 +++ b/src/cmd/go/testdata/script/crypto_backend_cross.txt
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,25 @@
 +# Test cross compiling with unsupported crypto backends
 +
 +# On Windows, we should fallback to Go standard crypto
@@ -130,7 +130,7 @@ index 00000000000000..dab0e4a3b460e6
 +env GOOS=windows
 +
 +env GOEXPERIMENT=opensslcrypto
-+go run m/foo
++go build main.go
 +
 +# On Linux, we should fallback to Go standard crypto
 +# when CGO is disabled.
@@ -138,24 +138,14 @@ index 00000000000000..dab0e4a3b460e6
 +
 +env CGO_ENABLED=0
 +env GOEXPERIMENT=opensslcrypto
-+go run m/foo
++go build main.go
 +
-+-- go.mod --
-+module m
++-- main.go --
++package main
 +
-+go 1.18
-+-- foo/x.go --
-+package foo
-+
-+import (
-+	"crypto/boring"
-+	"crypto/sha256"
-+)
++import "crypto/sha256"
 +
 +func main() {
-+	if boring.Enabled() {
-+		panic("crypto backend should be disabled")
-+	}
 +	sha256.Sum256([]byte("foo"))
 +}
 \ No newline at end of file

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -8,6 +8,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/cmd/api/goapi_boring_test.go              |   2 +-
  src/cmd/dist/test.go                          |  10 +-
  src/cmd/go/go_boring_test.go                  |   2 +-
+ .../testdata/script/crypto_backend_cross.txt  |  35 ++++
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
  src/crypto/boring/boring.go                   |   2 +-
@@ -38,7 +39,8 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 34 files changed, 286 insertions(+), 26 deletions(-)
+ 35 files changed, 321 insertions(+), 26 deletions(-)
+ create mode 100644 src/cmd/go/testdata/script/crypto_backend_cross.txt
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -73,10 +75,10 @@ index f0e3575637c62a..0e9aceeb832d3b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 170de28411005e..a1482cd5112505 100644
+index 3d966d9a160cb7..9f814cb14f2dfc 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1271,18 +1271,22 @@ func (t *tester) cgoTest(dt *distTest) error {
+@@ -1264,18 +1264,22 @@ func (t *tester) cgoTest(dt *distTest) error {
  			if err := cmd.Run(); err != nil {
  				fmt.Println("No support for static linking found (lacks libc.a?), skip cgo static linking test.")
  			} else {
@@ -115,6 +117,48 @@ index ed0fbf3d53d75b..5376227f74cfaa 100644
  
  package main_test
  
+diff --git a/src/cmd/go/testdata/script/crypto_backend_cross.txt b/src/cmd/go/testdata/script/crypto_backend_cross.txt
+new file mode 100644
+index 00000000000000..dab0e4a3b460e6
+--- /dev/null
++++ b/src/cmd/go/testdata/script/crypto_backend_cross.txt
+@@ -0,0 +1,35 @@
++# Test cross compiling with unsupported crypto backends
++
++# On Windows, we should fallback to Go standard crypto
++# when using the OpenSSL backend.
++env GOOS=windows
++
++env GOEXPERIMENT=opensslcrypto
++go run m/foo
++
++# On Linux, we should fallback to Go standard crypto
++# when CGO is disabled.
++env GOOS=linux
++
++env CGO_ENABLED=0
++env GOEXPERIMENT=opensslcrypto
++go run m/foo
++
++-- go.mod --
++module m
++
++go 1.18
++-- foo/x.go --
++package foo
++
++import (
++	"crypto/boring"
++	"crypto/sha256"
++)
++
++func main() {
++	if boring.Enabled() {
++		panic("crypto backend should be disabled")
++	}
++	sha256.Sum256([]byte("foo"))
++}
+\ No newline at end of file
 diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
 index a0a41a50de328d..509884b6ed1afd 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
@@ -135,7 +179,7 @@ index a0a41a50de328d..509884b6ed1afd 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index fa2ee676a938c5..23b8004aff3d1b 100644
+index d971234d878b37..04e8bd05584222 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
 @@ -1074,6 +1074,7 @@ var hostobj []Hostobj
@@ -241,15 +285,15 @@ index 00000000000000..61ef3fdd90b607
 +var Enc = bbig.Enc
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-index ae7295d8d13c2a..df1eb2d8c87c83 100644
+index c9350336667a96..32aff0a0021ed8 100644
 --- a/src/crypto/internal/backend/nobackend.go
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
  
--//go:build !boringcrypto || !linux || !cgo || android || cmd_go_bootstrap || msan
-+//go:build (!boringcrypto && !goexperiment.opensslcrypto) || !linux || !cgo || android || cmd_go_bootstrap || msan
+-//go:build (linux && !(cgo && boringcrypto && !msan && (amd64 || arm64))) || !linux || android || cmd_go_bootstrap
++//go:build (linux && !(cgo && (goexperiment.opensslcrypto || (boringcrypto && !msan && (amd64 || arm64))))) || !linux || android || cmd_go_bootstrap
  
  package backend
  
@@ -643,10 +687,10 @@ index f4d36d2446bf8a..c6febdb646bbbe 100644
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 h1:asZqf0wXastQr+DudYagQS8uBO8bHKeYD1vbAvGmFL8=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 0a1eb652d03a52..fa425269d516a3 100644
+index 9e942f3836459a..82357ddda60e9b 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -396,6 +396,8 @@ var depsRules = `
+@@ -399,6 +399,8 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -655,7 +699,7 @@ index 0a1eb652d03a52..fa425269d516a3 100644
  	< crypto/internal/boring
  	< crypto/internal/backend
  	< crypto/boring
-@@ -407,6 +409,7 @@ var depsRules = `
+@@ -410,6 +412,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -663,7 +707,7 @@ index 0a1eb652d03a52..fa425269d516a3 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -624,7 +627,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -670,7 +673,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -672,7 +716,7 @@ index 0a1eb652d03a52..fa425269d516a3 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -634,7 +637,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -680,7 +683,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}
@@ -712,7 +756,7 @@ index 00000000000000..a7f2712e9e1464
 +const OpenSSLCrypto = true
 +const OpenSSLCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 20d9c2da5d9605..355b7fe5931d39 100644
+index 8faaf1684d0b0f..ff7ca1db4a8b89 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,7 @@ type Flags struct {
@@ -724,10 +768,10 @@ index 20d9c2da5d9605..355b7fe5931d39 100644
  	// Unified enables the compiler's unified IR construction
  	// experiment.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index 52001bf9e30ab4..e600f231dee153 100644
+index d79befa19a13fe..1d5d2ea36750a9 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
-@@ -13,6 +13,7 @@ import (
+@@ -14,6 +14,7 @@ import (
  	"errors"
  	"flag"
  	"fmt"
@@ -735,7 +779,7 @@ index 52001bf9e30ab4..e600f231dee153 100644
  	"internal/poll"
  	"internal/testenv"
  	"io"
-@@ -730,6 +731,14 @@ func TestExtraFiles(t *testing.T) {
+@@ -686,6 +687,14 @@ func TestExtraFiles(t *testing.T) {
  		t.Skipf("skipping test on %q", runtime.GOOS)
  	}
  

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -84,11 +84,11 @@ index 5376227f74cfaa..492ccf79d66b45 100644
  package main_test
  
 diff --git a/src/cmd/go/testdata/script/crypto_backend_cross.txt b/src/cmd/go/testdata/script/crypto_backend_cross.txt
-index dab0e4a3b460e6..117085a28add49 100644
+index 020f33ca869897..5245a78b73122d 100644
 --- a/src/cmd/go/testdata/script/crypto_backend_cross.txt
 +++ b/src/cmd/go/testdata/script/crypto_backend_cross.txt
 @@ -8,9 +8,12 @@ env GOEXPERIMENT=opensslcrypto
- go run m/foo
+ go build main.go
  
  # On Linux, we should fallback to Go standard crypto
 -# when CGO is disabled.
@@ -96,11 +96,11 @@ index dab0e4a3b460e6..117085a28add49 100644
  env GOOS=linux
  
 +env GOEXPERIMENT=cngcrypto
-+go run m/foo
++go build main.go
 +
  env CGO_ENABLED=0
  env GOEXPERIMENT=opensslcrypto
- go run m/foo
+ go build main.go
 diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
 index 7b04f14ebdd618..8bdafb72f2c51a 100644
 --- a/src/crypto/boring/boring.go

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -6,6 +6,7 @@ Subject: [PATCH] Add CNG crypto backend
 ---
  src/cmd/api/goapi_boring_test.go              |   2 +-
  src/cmd/go/go_boring_test.go                  |   2 +-
+ .../testdata/script/crypto_backend_cross.txt  |   5 +-
  src/crypto/boring/boring.go                   |   2 +-
  src/crypto/ecdsa/boring.go                    |   2 +-
  src/crypto/ecdsa/ecdsa.go                     |  39 +++-
@@ -50,7 +51,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 46 files changed, 410 insertions(+), 50 deletions(-)
+ 47 files changed, 414 insertions(+), 51 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -82,6 +83,24 @@ index 5376227f74cfaa..492ccf79d66b45 100644
  
  package main_test
  
+diff --git a/src/cmd/go/testdata/script/crypto_backend_cross.txt b/src/cmd/go/testdata/script/crypto_backend_cross.txt
+index dab0e4a3b460e6..117085a28add49 100644
+--- a/src/cmd/go/testdata/script/crypto_backend_cross.txt
++++ b/src/cmd/go/testdata/script/crypto_backend_cross.txt
+@@ -8,9 +8,12 @@ env GOEXPERIMENT=opensslcrypto
+ go run m/foo
+ 
+ # On Linux, we should fallback to Go standard crypto
+-# when CGO is disabled.
++# when CGO is disabled or using the CNG backend.
+ env GOOS=linux
+ 
++env GOEXPERIMENT=cngcrypto
++go run m/foo
++
+ env CGO_ENABLED=0
+ env GOEXPERIMENT=opensslcrypto
+ go run m/foo
 diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
 index 7b04f14ebdd618..8bdafb72f2c51a 100644
 --- a/src/crypto/boring/boring.go
@@ -510,15 +529,15 @@ index 007d8070538247..168ea5831a985e 100644
 +	return !goexperiment.CNGCrypto
 +}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-index df1eb2d8c87c83..e0263df3ddcca0 100644
+index 32aff0a0021ed8..69209d84469627 100644
 --- a/src/crypto/internal/backend/nobackend.go
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
  
--//go:build (!boringcrypto && !goexperiment.opensslcrypto) || !linux || !cgo || android || cmd_go_bootstrap || msan
-+//go:build (!boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto) || (!linux && !windows) || (linux && !cgo) || android || cmd_go_bootstrap || msan
+-//go:build (linux && !(cgo && (goexperiment.opensslcrypto || (boringcrypto && !msan && (amd64 || arm64))))) || !linux || android || cmd_go_bootstrap
++//go:build (linux && !(cgo && (goexperiment.opensslcrypto || (boringcrypto && !msan && (amd64 || arm64))))) || (windows && !goexperiment.cngcrypto) || !(linux || windows) || android || cmd_go_bootstrap
  
  package backend
  
@@ -841,7 +860,7 @@ index bc169888786321..e0d6f4c5040d91 100644
  
  		h := New()
 diff --git a/src/crypto/sha256/sha256.go b/src/crypto/sha256/sha256.go
-index eb704df3f3ae12..c462c3820b32aa 100644
+index 81ef91b7ffa30c..e678d0b129675a 100644
 --- a/src/crypto/sha256/sha256.go
 +++ b/src/crypto/sha256/sha256.go
 @@ -158,7 +158,7 @@ func New() hash.Hash {
@@ -1125,10 +1144,10 @@ index c6febdb646bbbe..24cf4f1b6a2bcc 100644
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 h1:asZqf0wXastQr+DudYagQS8uBO8bHKeYD1vbAvGmFL8=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index d0da2efb34112d..68b4aaf25e775b 100644
+index 82357ddda60e9b..1324c251ca221f 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -398,6 +398,10 @@ var depsRules = `
+@@ -399,6 +399,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1139,7 +1158,7 @@ index d0da2efb34112d..68b4aaf25e775b 100644
  	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
  	< github.com/microsoft/go-crypto-openssl/openssl
  	< crypto/internal/boring
-@@ -411,6 +415,7 @@ var depsRules = `
+@@ -412,6 +416,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big


### PR DESCRIPTION
This PR contains the following built tags changes:

- Boring backend now supports `arm64`. It is supported upstream in master.
- OpenSSL and Windows backends support `msan` build tag. It was previously unsupported because Boring syso does not work well with msan and we blindly disable msan for CNG and OpenSSL too.
- Windows fallbacks to Go standard crypto when `GOEXPERIMENT` is either `opensslcrypto` or `boringcrypto`. Those backends are not supported on Windows, and upstream pattern is to fallback in this situation.
- Linux fallbacks to Go standard crypto when `GOEXPERIMENT=cngcrypto`. Same as before.
