### PR TITLE
Add windows/386 builders

### DIFF
--- a/eng/_core/cmd/build/build.go
+++ b/eng/_core/cmd/build/build.go
@@ -169,9 +169,9 @@ func build(o *options) error {
 		}
 
 		// The race runtime requires cgo.
-		// It isn't supported on arm.
+		// It isn't supported on arm or 386.
 		// It's supported on arm64, but the official linux-arm64 distribution doesn't include it.
-		if os.Getenv("CGO_ENABLED") != "0" && targetArch != "arm" && targetArch != "arm64" {
+		if os.Getenv("CGO_ENABLED") != "0" && targetArch != "arm" && targetArch != "arm64" && targetArch != "386" {
 			fmt.Println("---- Building race runtime...")
 			err := runCommandLine(
 				filepath.Join("..", "bin", "go"+executableExtension),

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -32,18 +32,16 @@ stages:
           - { os: windows, arch: amd64, config: buildandpack }
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }
-          - { os: windows, hostArch: amd64, arch: 386, config: devscript }
+          - { os: windows, hostArch: amd64, arch: 386, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test, fips: true }
-          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: devscript, fips: true }
-          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: devscript }
+          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: test, fips: true }
+          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: test }
           - { os: linux, arch: arm, hostArch: amd64, config: buildandpack }
           # Only build arm64 if we're running a signed (internal, rolling) build. Avoid contention
           # with other projects' builds that use the same limited-capacity pool of arm64 agents.
           - ${{ if eq(parameters.sign, true) }}:
             - { os: linux, arch: arm64, config: buildandpack }
-          - ${{ else }}:
-            - { os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if eq(parameters.outerloop, true) }}:
           # Upstream builders.
           # - { os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -32,16 +32,15 @@ stages:
           - { os: windows, arch: amd64, config: buildandpack }
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }
-          - { os: windows, hostArch: amd64, arch: 386, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test, fips: true }
-          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: test, fips: true }
-          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: test }
           - { os: linux, arch: arm, hostArch: amd64, config: buildandpack }
           # Only build arm64 if we're running a signed (internal, rolling) build. Avoid contention
           # with other projects' builds that use the same limited-capacity pool of arm64 agents.
           - ${{ if eq(parameters.sign, true) }}:
             - { os: linux, arch: arm64, config: buildandpack }
+          - ${{ else }}:
+            - { os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if eq(parameters.outerloop, true) }}:
           # Upstream builders.
           # - { os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -32,8 +32,11 @@ stages:
           - { os: windows, arch: amd64, config: buildandpack }
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }
+          - { os: windows, hostArch: amd64, arch: 386, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test, fips: true }
+          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: test, fips: true }
+          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: test }
           - { os: linux, arch: arm, hostArch: amd64, config: buildandpack }
           # Only build arm64 if we're running a signed (internal, rolling) build. Avoid contention
           # with other projects' builds that use the same limited-capacity pool of arm64 agents.

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -32,16 +32,18 @@ stages:
           - { os: windows, arch: amd64, config: buildandpack }
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }
-          - { os: windows, hostArch: amd64, arch: 386, config: test }
+          - { os: windows, hostArch: amd64, arch: 386, config: devscript }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test, fips: true }
-          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: test, fips: true }
-          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: test }
+          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: devscript, fips: true }
+          - { experiment: cngcrypto, os: windows, hostArch: amd64, arch: 386, config: devscript }
           - { os: linux, arch: arm, hostArch: amd64, config: buildandpack }
           # Only build arm64 if we're running a signed (internal, rolling) build. Avoid contention
           # with other projects' builds that use the same limited-capacity pool of arm64 agents.
           - ${{ if eq(parameters.sign, true) }}:
             - { os: linux, arch: arm64, config: buildandpack }
+          - ${{ else }}:
+            - { os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if eq(parameters.outerloop, true) }}:
           # Upstream builders.
           # - { os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -111,6 +111,10 @@ stages:
             - ${{ if eq(parameters.builder.arch, 'arm') }}:
               - pwsh: Write-Host "##vso[task.setvariable variable=GOARM]6"
                 displayName: Set GOARM for cross-compile
+            - ${{ if and(eq(parameters.builder.os, 'windows'), eq(parameters.builder.arch, '386')) }}:
+              # Based on upstream builder: https://github.com/golang/build/blob/beb2f29cbc8f8b26e2a2e9680810fd6274cd4956/dashboard/builders.go#L2140
+              - pwsh: Write-Host "##vso[task.setvariable variable=GOHOSTARCH]386"
+                displayName: Set GOHOSTARCH=386 to use WOW
 
           # Use build script directly for "buildandpack". If we used run-builder, we would need to
           # download its external module dependencies.

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -111,10 +111,6 @@ stages:
             - ${{ if eq(parameters.builder.arch, 'arm') }}:
               - pwsh: Write-Host "##vso[task.setvariable variable=GOARM]6"
                 displayName: Set GOARM for cross-compile
-            - ${{ if and(eq(parameters.builder.os, 'windows'), eq(parameters.builder.arch, '386')) }}:
-              # Based on upstream builder: https://github.com/golang/build/blob/beb2f29cbc8f8b26e2a2e9680810fd6274cd4956/dashboard/builders.go#L2140
-              - pwsh: Write-Host "##vso[task.setvariable variable=GOHOSTARCH]386"
-                displayName: Set GOHOSTARCH=386 to use WOW
 
           # Use build script directly for "buildandpack". If we used run-builder, we would need to
           # download its external module dependencies.

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -841,7 +841,7 @@ index bc169888786321..e0d6f4c5040d91 100644
  
  		h := New()
 diff --git a/src/crypto/sha256/sha256.go b/src/crypto/sha256/sha256.go
-index eb704df3f3ae12..c462c3820b32aa 100644
+index 81ef91b7ffa30c..e678d0b129675a 100644
 --- a/src/crypto/sha256/sha256.go
 +++ b/src/crypto/sha256/sha256.go
 @@ -158,7 +158,7 @@ func New() hash.Hash {
@@ -1101,34 +1101,34 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 396d81817839c5..23d975190813c5 100644
+index 396d81817839c5..2a8a6554035b2a 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.20
  
  require (
  	github.com/microsoft/go-crypto-openssl v0.2.1
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20221003180653-84bf0c539a8e
++	github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327
  	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
  	golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9
  )
 diff --git a/src/go.sum b/src/go.sum
-index c6febdb646bbbe..24cf4f1b6a2bcc 100644
+index c6febdb646bbbe..68ef5d2a38d34c 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/microsoft/go-crypto-openssl v0.2.1 h1:YFcvMkJeBXucC5wkNne/BbB7V02z1TjRxXbvGmEaFd4=
  github.com/microsoft/go-crypto-openssl v0.2.1/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221003180653-84bf0c539a8e h1:9iYvunmn8z1LIbUG7qtD3O3cuPlbjWY90Vn6ox/divM=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221003180653-84bf0c539a8e/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327 h1:2VVjqz2wSETA9qAVcJvSEXbjTf0qvb0ONcX7zXJkxs0=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 h1:asZqf0wXastQr+DudYagQS8uBO8bHKeYD1vbAvGmFL8=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index d0da2efb34112d..68b4aaf25e775b 100644
+index 810ad08e78d2a3..1eb6edb7cc24c0 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -398,6 +398,10 @@ var depsRules = `
+@@ -402,6 +402,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1139,7 +1139,7 @@ index d0da2efb34112d..68b4aaf25e775b 100644
  	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
  	< github.com/microsoft/go-crypto-openssl/openssl
  	< crypto/internal/boring
-@@ -411,6 +415,7 @@ var depsRules = `
+@@ -415,6 +419,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -1213,7 +1213,7 @@ index 00000000000000..99ee2542ca38a9
 +const CNGCrypto = true
 +const CNGCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index ff7ca1db4a8b89..343f9b70c89ddf 100644
+index ce8ef353600910..3711f4965f2497 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,7 @@ type Flags struct {

--- a/patches/0007-Vendor-crypto-backends.patch
+++ b/patches/0007-Vendor-crypto-backends.patch
@@ -27,18 +27,18 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../microsoft/go-crypto-winnative/cng/big.go  |  30 +
  .../microsoft/go-crypto-winnative/cng/cng.go  | 130 ++++
  .../microsoft/go-crypto-winnative/cng/ecdh.go | 257 ++++++++
- .../go-crypto-winnative/cng/ecdsa.go          | 173 ++++++
+ .../go-crypto-winnative/cng/ecdsa.go          | 175 ++++++
  .../microsoft/go-crypto-winnative/cng/hmac.go |  55 ++
  .../microsoft/go-crypto-winnative/cng/keys.go | 161 +++++
  .../microsoft/go-crypto-winnative/cng/rand.go |  28 +
  .../microsoft/go-crypto-winnative/cng/rsa.go  | 374 +++++++++++
  .../microsoft/go-crypto-winnative/cng/sha.go  | 199 ++++++
- .../internal/bcrypt/bcrypt_windows.go         | 222 +++++++
+ .../internal/bcrypt/bcrypt_windows.go         | 221 +++++++
  .../internal/bcrypt/zsyscall_windows.go       | 372 +++++++++++
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  12 +
- 33 files changed, 5552 insertions(+)
+ 33 files changed, 5553 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
@@ -3677,7 +3677,7 @@ index 00000000000000..36f0e0c6e278bc
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go
 new file mode 100644
-index 00000000000000..a2a54443033013
+index 00000000000000..844c087287cabe
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go
 @@ -0,0 +1,130 @@
@@ -3708,11 +3708,11 @@ index 00000000000000..a2a54443033013
 +	return enabled, nil
 +}
 +
-+// lenU32 clamps s length so it can fit into a Win32 ULONG,
-+// which is a 32-bit unsigned integer, without overflowing.
-+func lenU32(s []byte) int {
-+	if len(s) > math.MaxUint32 {
-+		return math.MaxUint32
++// len32 clamps s length so it can fit into a Win32 LONG,
++// which is a 32-bit signed integer, without overflowing.
++func len32(s []byte) int {
++	if len(s) > math.MaxInt32 {
++		return math.MaxInt32
 +	}
 +	return len(s)
 +}
@@ -4076,10 +4076,10 @@ index 00000000000000..f15f958054b2e8
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
 new file mode 100644
-index 00000000000000..a6630e3b0df946
+index 00000000000000..a77ff97bb8f521
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
-@@ -0,0 +1,173 @@
+@@ -0,0 +1,175 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -4096,32 +4096,34 @@ index 00000000000000..a6630e3b0df946
 +)
 +
 +var errUnknownCurve = errors.New("cng: unknown elliptic curve")
-+var errUnsupportedCurve = errors.New("cng: unsupported elliptic curve")
 +
 +type ecdsaAlgorithm struct {
 +	handle bcrypt.ALG_HANDLE
-+	id     string
 +}
 +
 +func loadECDSA(curve string) (h ecdsaAlgorithm, bits uint32, err error) {
 +	var id string
 +	switch curve {
 +	case "P-224":
-+		err = errUnsupportedCurve
++		id, bits = bcrypt.ECC_CURVE_NISTP224, 224
 +	case "P-256":
-+		id, bits = bcrypt.ECDSA_P256_ALGORITHM, 256
++		id, bits = bcrypt.ECC_CURVE_NISTP256, 256
 +	case "P-384":
-+		id, bits = bcrypt.ECDSA_P384_ALGORITHM, 384
++		id, bits = bcrypt.ECC_CURVE_NISTP384, 384
 +	case "P-521":
-+		id, bits = bcrypt.ECDSA_P521_ALGORITHM, 521
++		id, bits = bcrypt.ECC_CURVE_NISTP521, 521
 +	default:
 +		err = errUnknownCurve
 +	}
 +	if err != nil {
 +		return
 +	}
-+	v, err := loadOrStoreAlg(id, bcrypt.ALG_NONE_FLAG, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
-+		return ecdsaAlgorithm{h, id}, nil
++	v, err := loadOrStoreAlg(bcrypt.ECDSA_ALGORITHM, bcrypt.ALG_NONE_FLAG, id, func(h bcrypt.ALG_HANDLE) (interface{}, error) {
++		err := setString(bcrypt.HANDLE(h), bcrypt.ECC_CURVE_NAME, id)
++		if err != nil {
++			return nil, err
++		}
++		return ecdsaAlgorithm{h}, nil
 +	})
 +	if err != nil {
 +		return ecdsaAlgorithm{}, 0, err
@@ -4171,7 +4173,7 @@ index 00000000000000..a6630e3b0df946
 +	if err != nil {
 +		return nil, err
 +	}
-+	hkey, err := importECCKey(h.handle, h.id, bits, X, Y, nil)
++	hkey, err := importECCKey(h.handle, bcrypt.ECDSA_ALGORITHM, bits, X, Y, nil)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -4193,7 +4195,7 @@ index 00000000000000..a6630e3b0df946
 +	if err != nil {
 +		return nil, err
 +	}
-+	hkey, err := importECCKey(h.handle, h.id, bits, X, Y, D)
++	hkey, err := importECCKey(h.handle, bcrypt.ECDSA_ALGORITHM, bits, X, Y, D)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -4316,7 +4318,7 @@ index 00000000000000..736472d5b4e700
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
 new file mode 100644
-index 00000000000000..b87ed7ec61d3fb
+index 00000000000000..766768e9d46b41
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
 @@ -0,0 +1,161 @@
@@ -4423,7 +4425,7 @@ index 00000000000000..b87ed7ec61d3fb
 +		return nil, errors.New("cng: invalid parameters")
 +	}
 +	switch id {
-+	case bcrypt.ECDSA_P256_ALGORITHM, bcrypt.ECDSA_P384_ALGORITHM, bcrypt.ECDSA_P521_ALGORITHM:
++	case bcrypt.ECDSA_ALGORITHM:
 +		if D == nil {
 +			hdr.Magic = bcrypt.ECDSA_PUBLIC_GENERIC_MAGIC
 +		} else {
@@ -4483,7 +4485,7 @@ index 00000000000000..b87ed7ec61d3fb
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go
 new file mode 100644
-index 00000000000000..5265394c936a82
+index 00000000000000..cdd845ab5bea98
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go
 @@ -0,0 +1,28 @@
@@ -4505,7 +4507,7 @@ index 00000000000000..5265394c936a82
 +	if len(b) == 0 {
 +		return 0, nil
 +	}
-+	n := lenU32(b)
++	n := len32(b)
 +	const flags = bcrypt.USE_SYSTEM_PREFERRED_RNG
 +	err := bcrypt.GenRandom(0, b[:n], flags)
 +	if err != nil {
@@ -4897,7 +4899,7 @@ index 00000000000000..7e3f7abe3487cb
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go
 new file mode 100644
-index 00000000000000..a0ed5a10c70afd
+index 00000000000000..0ab3c9e9ce06fb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go
 @@ -0,0 +1,199 @@
@@ -5062,7 +5064,7 @@ index 00000000000000..a0ed5a10c70afd
 +
 +func (h *shaXHash) Write(p []byte) (n int, err error) {
 +	for n < len(p) && err == nil {
-+		nn := lenU32(p[n:])
++		nn := len32(p[n:])
 +		err = bcrypt.HashData(h.ctx, p[n:n+nn], 0)
 +		n += nn
 +	}
@@ -5102,10 +5104,10 @@ index 00000000000000..a0ed5a10c70afd
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000000..cdd7f9fdf0aed2
+index 00000000000000..f3100669d53d3f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
-@@ -0,0 +1,222 @@
+@@ -0,0 +1,221 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -5119,21 +5121,20 @@ index 00000000000000..cdd7f9fdf0aed2
 +)
 +
 +const (
-+	SHA1_ALGORITHM       = "SHA1"
-+	SHA256_ALGORITHM     = "SHA256"
-+	SHA384_ALGORITHM     = "SHA384"
-+	SHA512_ALGORITHM     = "SHA512"
-+	AES_ALGORITHM        = "AES"
-+	RSA_ALGORITHM        = "RSA"
-+	MD5_ALGORITHM        = "MD5"
-+	ECDSA_P256_ALGORITHM = "ECDSA_P256"
-+	ECDSA_P384_ALGORITHM = "ECDSA_P384"
-+	ECDSA_P521_ALGORITHM = "ECDSA_P521"
-+	ECDH_ALGORITHM       = "ECDH"
++	SHA1_ALGORITHM   = "SHA1"
++	SHA256_ALGORITHM = "SHA256"
++	SHA384_ALGORITHM = "SHA384"
++	SHA512_ALGORITHM = "SHA512"
++	AES_ALGORITHM    = "AES"
++	RSA_ALGORITHM    = "RSA"
++	MD5_ALGORITHM    = "MD5"
++	ECDSA_ALGORITHM  = "ECDSA"
++	ECDH_ALGORITHM   = "ECDH"
 +)
 +
 +const (
 +	ECC_CURVE_25519    = "curve25519"
++	ECC_CURVE_NISTP224 = "nistP224"
 +	ECC_CURVE_NISTP256 = "nistP256"
 +	ECC_CURVE_NISTP384 = "nistP384"
 +	ECC_CURVE_NISTP521 = "nistP521"
@@ -5806,7 +5807,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 0d746403f3fa08..9e9b782b419313 100644
+index 0d746403f3fa08..74af86e066f07a 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,15 @@
@@ -5815,7 +5816,7 @@ index 0d746403f3fa08..9e9b782b419313 100644
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig
 +github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20221003180653-84bf0c539a8e
++# github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
* Resolves https://github.com/microsoft/go/issues/773

* Upgrade CNG backend (https://github.com/microsoft/go-crypto-winnative/compare/d61e0765182d...63fe3bdaa327) to get https://github.com/microsoft/go-crypto-winnative/pull/32.

* I think we should merge https://github.com/microsoft/go/pull/770 first. Then I can resolve the conflict here, where all I'm doing is an upgrade with no related patch changes.

I'm not sure if the tests will be happy to run on an amd64 host with GOARCH=386, although it seems likely. If it doesn't work and it isn't something we need to support, we can just change these to a `buildandpack` builder in an `- ${{ else }}:` block after the `- ${{ if eq(parameters.sign, true) }}:` section.