### PR TITLE
Print OpenSSL version if GOFIPS can't be honored

### DIFF
--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -17,7 +17,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 ++
  src/crypto/internal/backend/nobackend.go      |   2 +-
- src/crypto/internal/backend/openssl_linux.go  | 192 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 194 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -38,7 +38,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 34 files changed, 286 insertions(+), 26 deletions(-)
+ 34 files changed, 288 insertions(+), 26 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -73,10 +73,10 @@ index f0e3575637c62a..0e9aceeb832d3b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 170de28411005e..a1482cd5112505 100644
+index 1ce8546bde668d..59aae5c749262e 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1271,18 +1271,22 @@ func (t *tester) cgoTest(dt *distTest) error {
+@@ -1242,18 +1242,22 @@ func (t *tester) cgoTest(dt *distTest) error {
  			if err := cmd.Run(); err != nil {
  				fmt.Println("No support for static linking found (lacks libc.a?), skip cgo static linking test.")
  			} else {
@@ -135,10 +135,10 @@ index a0a41a50de328d..509884b6ed1afd 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index fa2ee676a938c5..23b8004aff3d1b 100644
+index 89bd966f59e243..ff9ff432ae3b74 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
-@@ -1074,6 +1074,7 @@ var hostobj []Hostobj
+@@ -1082,6 +1082,7 @@ var hostobj []Hostobj
  // These packages can use internal linking mode.
  // Others trigger external mode.
  var internalpkg = []string{
@@ -255,10 +255,10 @@ index ae7295d8d13c2a..df1eb2d8c87c83 100644
  
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..4d461237ab8149
+index 00000000000000..7259368b274d84
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,192 @@
+@@ -0,0 +1,194 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -302,12 +302,14 @@ index 00000000000000..4d461237ab8149
 +	case "0":
 +		if openssl.FIPS() {
 +			if err = openssl.SetFIPS(false); err != nil {
++				println(openssl.VersionText())
 +				panic("opensslcrypto: can't disable FIPS mode: " + err.Error())
 +			}
 +		}
 +	case "1":
 +		if !openssl.FIPS() {
 +			if err = openssl.SetFIPS(true); err != nil {
++				println(openssl.VersionText())
 +				panic("opensslcrypto: can't enable FIPS mode: " + err.Error())
 +			}
 +		}
@@ -643,10 +645,10 @@ index f4d36d2446bf8a..c6febdb646bbbe 100644
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 h1:asZqf0wXastQr+DudYagQS8uBO8bHKeYD1vbAvGmFL8=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 0a1eb652d03a52..fa425269d516a3 100644
+index 443120e4ce61fe..810ad08e78d2a3 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -396,6 +396,8 @@ var depsRules = `
+@@ -402,6 +402,8 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -655,7 +657,7 @@ index 0a1eb652d03a52..fa425269d516a3 100644
  	< crypto/internal/boring
  	< crypto/internal/backend
  	< crypto/boring
-@@ -407,6 +409,7 @@ var depsRules = `
+@@ -413,6 +415,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -663,7 +665,7 @@ index 0a1eb652d03a52..fa425269d516a3 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -624,7 +627,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -653,7 +656,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -672,7 +674,7 @@ index 0a1eb652d03a52..fa425269d516a3 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -634,7 +637,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -663,7 +666,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}
@@ -712,7 +714,7 @@ index 00000000000000..a7f2712e9e1464
 +const OpenSSLCrypto = true
 +const OpenSSLCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 20d9c2da5d9605..355b7fe5931d39 100644
+index 16793f37ac5381..ce8ef353600910 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,7 @@ type Flags struct {
@@ -724,10 +726,10 @@ index 20d9c2da5d9605..355b7fe5931d39 100644
  	// Unified enables the compiler's unified IR construction
  	// experiment.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index 52001bf9e30ab4..e600f231dee153 100644
+index f38ce4e72c9a33..1911eb4dc04514 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
-@@ -13,6 +13,7 @@ import (
+@@ -14,6 +14,7 @@ import (
  	"errors"
  	"flag"
  	"fmt"
@@ -735,7 +737,7 @@ index 52001bf9e30ab4..e600f231dee153 100644
  	"internal/poll"
  	"internal/testenv"
  	"io"
-@@ -730,6 +731,14 @@ func TestExtraFiles(t *testing.T) {
+@@ -687,6 +688,14 @@ func TestExtraFiles(t *testing.T) {
  		t.Skipf("skipping test on %q", runtime.GOOS)
  	}
  


### PR DESCRIPTION
This PR adds a trace showing the loaded OpenSSL version before panicking in case `GOFIPS` can't be honored.

It will help debugging OpenSSL configuration issues.