### PR TITLE
Detect failure during devscript builder

### DIFF
--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -120,7 +120,9 @@ func main() {
 		// validate the run.ps1 script with "build" tool works to build and test Go. It runs a
 		// subset of the "test" builder's tests, but it uses the dev workflow.
 		testCmdline := append(buildCmdline, "-skipbuild", "-test")
-		runTest(testCmdline, *jUnitFile)
+		if err := runTest(testCmdline, *jUnitFile); err != nil {
+			log.Fatal(err)
+		}
 
 	default:
 		// Most builder configurations use "bin/go tool dist test" directly, which is the default.


### PR DESCRIPTION
Fix missing return value handling to make the devscript builder job fail when the dist tests fail. Tested the failure case locally by adding `xexit(1)` early in `go/src/cmd/dist/test.go`, and now the return value is correct.

Saw this problem on https://github.com/microsoft/go/pull/777: unexpected success in a windows-386 devscript test job that logged test failures: https://dev.azure.com/dnceng-public/public/_build/results?buildId=56551&view=logs&j=6278d556-87bd-5fc4-318d-48319be86c04&t=503d7602-2bf0-5a46-6b07-9abf78d82794&l=1609 

I don't know any situation where we would hit a devscript builder error during "dist test" that we wouldn't hit in the test builder, but it's good to have this coverage.