### PR TITLE
[openssl] Allow hash.Hash for OAEP and MGF1 to be specified independently

### DIFF
--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -441,7 +441,7 @@ index 00000000000000..9bbe3a59b65bbb
 +type PrivateKeyRSA = openssl.PrivateKeyRSA
 +
 +func DecryptRSAOAEP(h, mgfHash hash.Hash, priv *openssl.PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
-+	return openssl.DecryptRSAOAEP(h, priv, ciphertext, label)
++	return openssl.DecryptRSAOAEP_MGF1(h, mgfHash, priv, ciphertext, label)
 +}
 +
 +func DecryptRSAPKCS1(priv *openssl.PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
@@ -453,7 +453,7 @@ index 00000000000000..9bbe3a59b65bbb
 +}
 +
 +func EncryptRSAOAEP(h, mgfHash hash.Hash, pub *openssl.PublicKeyRSA, msg, label []byte) ([]byte, error) {
-+	return openssl.EncryptRSAOAEP(h, pub, msg, label)
++	return openssl.EncryptRSAOAEP_MGF1(h, mgfHash, pub, msg, label)
 +}
 +
 +func EncryptRSAPKCS1(pub *openssl.PublicKeyRSA, msg []byte) ([]byte, error) {
@@ -692,7 +692,7 @@ index 874b035dd2d574..583db20b19f2fd 100644
  go 1.20
  
  require (
-+	github.com/microsoft/go-crypto-openssl v0.2.1
++	github.com/microsoft/go-crypto-openssl v0.2.2
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.2.1-0.20221117215542-ecf7fda6a59e
  )
@@ -701,8 +701,8 @@ index 3ff1619712fac4..4bc18da6466301 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.2.1 h1:YFcvMkJeBXucC5wkNne/BbB7V02z1TjRxXbvGmEaFd4=
-+github.com/microsoft/go-crypto-openssl v0.2.1/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-openssl v0.2.2 h1:Et6hPiaoGW3UXZ4IdjGwN0j4ZoiT8Ffg+Han7+SiDgk=
++github.com/microsoft/go-crypto-openssl v0.2.2/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
  golang.org/x/net v0.2.1-0.20221117215542-ecf7fda6a59e h1:IVOjWZQH/57UDcpX19vSmMz8w3ohroOMWohn8qWpRkg=

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -441,7 +441,7 @@ index 00000000000000..9bbe3a59b65bbb
 +type PrivateKeyRSA = openssl.PrivateKeyRSA
 +
 +func DecryptRSAOAEP(h, mgfHash hash.Hash, priv *openssl.PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
-+	return openssl.DecryptRSAOAEP_MGF1(h, mgfHash, priv, ciphertext, label)
++	return openssl.DecryptRSAOAEPWithMGF1Hash(h, mgfHash, priv, ciphertext, label)
 +}
 +
 +func DecryptRSAPKCS1(priv *openssl.PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
@@ -453,7 +453,7 @@ index 00000000000000..9bbe3a59b65bbb
 +}
 +
 +func EncryptRSAOAEP(h, mgfHash hash.Hash, pub *openssl.PublicKeyRSA, msg, label []byte) ([]byte, error) {
-+	return openssl.EncryptRSAOAEP_MGF1(h, mgfHash, pub, msg, label)
++	return openssl.EncryptRSAOAEPWithMGF1Hash(h, mgfHash, pub, msg, label)
 +}
 +
 +func EncryptRSAPKCS1(pub *openssl.PublicKeyRSA, msg []byte) ([]byte, error) {

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -1063,7 +1063,7 @@ index 583db20b19f2fd..b567a544298e27 100644
  
  require (
  	github.com/microsoft/go-crypto-openssl v0.2.2
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327
++	github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.2.1-0.20221117215542-ecf7fda6a59e
  )
@@ -1074,8 +1074,8 @@ index 4bc18da6466301..a5359c3bdc0886 100644
 @@ -1,5 +1,7 @@
  github.com/microsoft/go-crypto-openssl v0.2.2 h1:Et6hPiaoGW3UXZ4IdjGwN0j4ZoiT8Ffg+Han7+SiDgk=
  github.com/microsoft/go-crypto-openssl v0.2.2/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327 h1:2VVjqz2wSETA9qAVcJvSEXbjTf0qvb0ONcX7zXJkxs0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1 h1:KqlMKMf4t+yh6I2FbFvJpaMQTRH6MtWw06+ME10xxy0=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
  golang.org/x/net v0.2.1-0.20221117215542-ecf7fda6a59e h1:IVOjWZQH/57UDcpX19vSmMz8w3ohroOMWohn8qWpRkg=

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -1062,8 +1062,8 @@ index 583db20b19f2fd..b567a544298e27 100644
 @@ -4,6 +4,7 @@ go 1.20
  
  require (
- 	github.com/microsoft/go-crypto-openssl v0.2.1
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1
+ 	github.com/microsoft/go-crypto-openssl v0.2.2
++	github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.2.1-0.20221117215542-ecf7fda6a59e
  )
@@ -1072,10 +1072,10 @@ index 4bc18da6466301..a5359c3bdc0886 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/microsoft/go-crypto-openssl v0.2.1 h1:YFcvMkJeBXucC5wkNne/BbB7V02z1TjRxXbvGmEaFd4=
- github.com/microsoft/go-crypto-openssl v0.2.1/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1 h1:KqlMKMf4t+yh6I2FbFvJpaMQTRH6MtWw06+ME10xxy0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
+ github.com/microsoft/go-crypto-openssl v0.2.2 h1:Et6hPiaoGW3UXZ4IdjGwN0j4ZoiT8Ffg+Han7+SiDgk=
+ github.com/microsoft/go-crypto-openssl v0.2.2/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327 h1:2VVjqz2wSETA9qAVcJvSEXbjTf0qvb0ONcX7zXJkxs0=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
  golang.org/x/net v0.2.1-0.20221117215542-ecf7fda6a59e h1:IVOjWZQH/57UDcpX19vSmMz8w3ohroOMWohn8qWpRkg=

--- a/patches/0007-Vendor-crypto-backends.patch
+++ b/patches/0007-Vendor-crypto-backends.patch
@@ -10,16 +10,16 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/bbig/big.go     |  38 ++
  .../go-crypto-openssl/openssl/big.go          |  13 +
  .../go-crypto-openssl/openssl/ecdsa.go        | 185 ++++++
- .../go-crypto-openssl/openssl/evpkey.go       | 300 +++++++++
+ .../go-crypto-openssl/openssl/evpkey.go       | 313 ++++++++++
  .../go-crypto-openssl/openssl/goopenssl.c     | 153 +++++
  .../go-crypto-openssl/openssl/goopenssl.h     | 147 +++++
- .../go-crypto-openssl/openssl/hmac.go         | 148 +++++
+ .../go-crypto-openssl/openssl/hmac.go         | 251 ++++++++
  .../openssl/internal/subtle/aliasing.go       |  32 +
  .../go-crypto-openssl/openssl/openssl.go      | 295 +++++++++
- .../go-crypto-openssl/openssl/openssl_funcs.h | 252 ++++++++
+ .../go-crypto-openssl/openssl/openssl_funcs.h | 279 +++++++++
  .../openssl/openssl_lock_setup.c              |  53 ++
  .../go-crypto-openssl/openssl/rand.go         |  24 +
- .../go-crypto-openssl/openssl/rsa.go          | 328 ++++++++++
+ .../go-crypto-openssl/openssl/rsa.go          | 336 ++++++++++
  .../go-crypto-openssl/openssl/sha.go          | 580 ++++++++++++++++++
  .../microsoft/go-crypto-winnative/LICENSE     |  21 +
  .../microsoft/go-crypto-winnative/cng/aes.go  | 359 +++++++++++
@@ -833,10 +833,10 @@ index 00000000000000..e5a3e03a390135
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 new file mode 100644
-index 00000000000000..ba232b27c14f94
+index 00000000000000..97e39c002e3052
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
-@@ -0,0 +1,300 @@
+@@ -0,0 +1,313 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -939,7 +939,7 @@ index 00000000000000..ba232b27c14f94
 +type verifyFunc func(C.GO_EVP_PKEY_CTX_PTR, *C.uchar, C.size_t, *C.uchar, C.size_t) error
 +
 +func setupEVP(withKey withKeyFunc, padding C.int,
-+	h hash.Hash, label []byte, saltLen C.int, ch crypto.Hash,
++	h, mgfHash hash.Hash, label []byte, saltLen C.int, ch crypto.Hash,
 +	init initFunc) (ctx C.GO_EVP_PKEY_CTX_PTR, err error) {
 +	defer func() {
 +		if err != nil {
@@ -977,12 +977,25 @@ index 00000000000000..ba232b27c14f94
 +		if md == nil {
 +			return nil, errors.New("crypto/rsa: unsupported hash function")
 +		}
++		var mgfMD C.GO_EVP_MD_PTR
++		if mgfHash != nil {
++			// mgfHash is optional, but if it is set it must match a supported hash function.
++			mgfMD = hashToMD(mgfHash)
++			if mgfMD == nil {
++				return nil, errors.New("crypto/rsa: unsupported hash function")
++			}
++		}
 +		// setPadding must happen before setting EVP_PKEY_CTRL_RSA_OAEP_MD.
 +		if err := setPadding(); err != nil {
 +			return nil, err
 +		}
 +		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_RSA_OAEP_MD, 0, unsafe.Pointer(md)) != 1 {
 +			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
++		}
++		if mgfHash != nil {
++			if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_RSA_MGF1_MD, 0, unsafe.Pointer(mgfMD)) != 1 {
++				return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
++			}
 +		}
 +		// ctx takes ownership of label, so malloc a copy for OpenSSL to free.
 +		// OpenSSL 1.1.1 and higher does not take ownership of the label if the length is zero,
@@ -1040,10 +1053,10 @@ index 00000000000000..ba232b27c14f94
 +}
 +
 +func cryptEVP(withKey withKeyFunc, padding C.int,
-+	h hash.Hash, label []byte, saltLen C.int, ch crypto.Hash,
++	h, mgfHash hash.Hash, label []byte, saltLen C.int, ch crypto.Hash,
 +	init initFunc, crypt cryptFunc, in []byte) ([]byte, error) {
 +
-+	ctx, err := setupEVP(withKey, padding, h, label, saltLen, ch, init)
++	ctx, err := setupEVP(withKey, padding, h, mgfHash, label, saltLen, ch, init)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -1066,7 +1079,7 @@ index 00000000000000..ba232b27c14f94
 +	init initFunc, verify verifyFunc,
 +	sig, in []byte) error {
 +
-+	ctx, err := setupEVP(withKey, padding, h, label, saltLen, ch, init)
++	ctx, err := setupEVP(withKey, padding, h, nil, label, saltLen, ch, init)
 +	if err != nil {
 +		return err
 +	}
@@ -1074,7 +1087,7 @@ index 00000000000000..ba232b27c14f94
 +	return verify(ctx, base(sig), C.size_t(len(sig)), base(in), C.size_t(len(in)))
 +}
 +
-+func evpEncrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
++func evpEncrypt(withKey withKeyFunc, padding C.int, h, mgfHash hash.Hash, label, msg []byte) ([]byte, error) {
 +	encryptInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
 +		if ret := C.go_openssl_EVP_PKEY_encrypt_init(ctx); ret != 1 {
 +			return newOpenSSLError("EVP_PKEY_encrypt_init failed")
@@ -1087,10 +1100,10 @@ index 00000000000000..ba232b27c14f94
 +		}
 +		return nil
 +	}
-+	return cryptEVP(withKey, padding, h, label, 0, 0, encryptInit, encrypt, msg)
++	return cryptEVP(withKey, padding, h, mgfHash, label, 0, 0, encryptInit, encrypt, msg)
 +}
 +
-+func evpDecrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
++func evpDecrypt(withKey withKeyFunc, padding C.int, h, mgfHash hash.Hash, label, msg []byte) ([]byte, error) {
 +	decryptInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
 +		if ret := C.go_openssl_EVP_PKEY_decrypt_init(ctx); ret != 1 {
 +			return newOpenSSLError("EVP_PKEY_decrypt_init failed")
@@ -1103,7 +1116,7 @@ index 00000000000000..ba232b27c14f94
 +		}
 +		return nil
 +	}
-+	return cryptEVP(withKey, padding, h, label, 0, 0, decryptInit, decrypt, msg)
++	return cryptEVP(withKey, padding, h, mgfHash, label, 0, 0, decryptInit, decrypt, msg)
 +}
 +
 +func evpSign(withKey withKeyFunc, padding C.int, saltLen C.int, h crypto.Hash, hashed []byte) ([]byte, error) {
@@ -1119,7 +1132,7 @@ index 00000000000000..ba232b27c14f94
 +		}
 +		return nil
 +	}
-+	return cryptEVP(withKey, padding, nil, nil, saltLen, h, signtInit, sign, hashed)
++	return cryptEVP(withKey, padding, nil, nil, nil, saltLen, h, signtInit, sign, hashed)
 +}
 +
 +func evpVerify(withKey withKeyFunc, padding C.int, saltLen C.int, h crypto.Hash, sig, hashed []byte) error {
@@ -1452,10 +1465,10 @@ index 00000000000000..03aed43e001d54
 \ No newline at end of file
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
 new file mode 100644
-index 00000000000000..80f320b041f7e0
+index 00000000000000..81918cde673cee
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,251 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -1470,6 +1483,11 @@ index 00000000000000..80f320b041f7e0
 +	"hash"
 +	"runtime"
 +	"unsafe"
++)
++
++var (
++	paramAlgHMAC = C.CString("HMAC")
++	paramDigest  = C.CString("digest")
 +)
 +
 +// NewHMAC returns a new HMAC using OpenSSL.
@@ -1496,19 +1514,19 @@ index 00000000000000..80f320b041f7e0
 +		// we pass an "empty" key.
 +		hkey = make([]byte, C.GO_EVP_MAX_MD_SIZE)
 +	}
-+	hmac := &opensslHMAC{
-+		md:        md,
-+		size:      ch.Size(),
-+		blockSize: ch.BlockSize(),
-+		key:       hkey,
-+		ctx:       hmacCtxNew(),
++	switch vMajor {
++	case 1:
++		return newHMAC1(hkey, ch, md)
++	case 3:
++		return newHMAC3(hkey, ch, md)
++	default:
++		panic(errUnsuportedVersion())
 +	}
-+	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
-+	hmac.Reset()
-+	return hmac
 +}
 +
-+type opensslHMAC struct {
++// hmac1 implements hash.Hash
++// using functions available in OpenSSL 1.
++type hmac1 struct {
 +	md        C.GO_EVP_MD_PTR
 +	ctx       C.GO_HMAC_CTX_PTR
 +	size      int
@@ -1517,8 +1535,21 @@ index 00000000000000..80f320b041f7e0
 +	sum       []byte
 +}
 +
-+func (h *opensslHMAC) Reset() {
-+	hmacCtxReset(h.ctx)
++func newHMAC1(key []byte, h hash.Hash, md C.GO_EVP_MD_PTR) *hmac1 {
++	hmac := &hmac1{
++		md:        md,
++		size:      h.Size(),
++		blockSize: h.BlockSize(),
++		key:       key,
++		ctx:       hmac1CtxNew(),
++	}
++	runtime.SetFinalizer(hmac, (*hmac1).finalize)
++	hmac.Reset()
++	return hmac
++}
++
++func (h *hmac1) Reset() {
++	hmac1CtxReset(h.ctx)
 +
 +	if C.go_openssl_HMAC_Init_ex(h.ctx, unsafe.Pointer(&h.key[0]), C.int(len(h.key)), h.md, nil) == 0 {
 +		panic("openssl: HMAC_Init failed")
@@ -1531,11 +1562,11 @@ index 00000000000000..80f320b041f7e0
 +	h.sum = nil
 +}
 +
-+func (h *opensslHMAC) finalize() {
-+	hmacCtxFree(h.ctx)
++func (h *hmac1) finalize() {
++	hmac1CtxFree(h.ctx)
 +}
 +
-+func (h *opensslHMAC) Write(p []byte) (int, error) {
++func (h *hmac1) Write(p []byte) (int, error) {
 +	if len(p) > 0 {
 +		C.go_openssl_HMAC_Update(h.ctx, base(p), C.size_t(len(p)))
 +	}
@@ -1543,15 +1574,15 @@ index 00000000000000..80f320b041f7e0
 +	return len(p), nil
 +}
 +
-+func (h *opensslHMAC) Size() int {
++func (h *hmac1) Size() int {
 +	return h.size
 +}
 +
-+func (h *opensslHMAC) BlockSize() int {
++func (h *hmac1) BlockSize() int {
 +	return h.blockSize
 +}
 +
-+func (h *opensslHMAC) Sum(in []byte) []byte {
++func (h *hmac1) Sum(in []byte) []byte {
 +	if h.sum == nil {
 +		size := h.Size()
 +		h.sum = make([]byte, size)
@@ -1560,8 +1591,8 @@ index 00000000000000..80f320b041f7e0
 +	// that Sum has no effect on the underlying stream.
 +	// In particular it is OK to Sum, then Write more, then Sum again,
 +	// and the second Sum acts as if the first didn't happen.
-+	ctx2 := hmacCtxNew()
-+	defer hmacCtxFree(ctx2)
++	ctx2 := hmac1CtxNew()
++	defer hmac1CtxFree(ctx2)
 +	if C.go_openssl_HMAC_CTX_copy(ctx2, h.ctx) == 0 {
 +		panic("openssl: HMAC_CTX_copy failed")
 +	}
@@ -1569,7 +1600,7 @@ index 00000000000000..80f320b041f7e0
 +	return append(in, h.sum...)
 +}
 +
-+func hmacCtxNew() C.GO_HMAC_CTX_PTR {
++func hmac1CtxNew() C.GO_HMAC_CTX_PTR {
 +	if vMajor == 1 && vMinor == 0 {
 +		// 0x120 is the sizeof value when building against OpenSSL 1.0.2 on Ubuntu 16.04.
 +		ctx := (C.GO_HMAC_CTX_PTR)(C.malloc(0x120))
@@ -1581,7 +1612,7 @@ index 00000000000000..80f320b041f7e0
 +	return C.go_openssl_HMAC_CTX_new()
 +}
 +
-+func hmacCtxReset(ctx C.GO_HMAC_CTX_PTR) {
++func hmac1CtxReset(ctx C.GO_HMAC_CTX_PTR) {
 +	if ctx == nil {
 +		return
 +	}
@@ -1593,7 +1624,7 @@ index 00000000000000..80f320b041f7e0
 +	C.go_openssl_HMAC_CTX_reset(ctx)
 +}
 +
-+func hmacCtxFree(ctx C.GO_HMAC_CTX_PTR) {
++func hmac1CtxFree(ctx C.GO_HMAC_CTX_PTR) {
 +	if ctx == nil {
 +		return
 +	}
@@ -1603,6 +1634,91 @@ index 00000000000000..80f320b041f7e0
 +		return
 +	}
 +	C.go_openssl_HMAC_CTX_free(ctx)
++}
++
++// hmac3 implements hash.Hash
++// using functions available in OpenSSL 3.
++type hmac3 struct {
++	md        C.GO_EVP_MAC_PTR
++	ctx       C.GO_EVP_MAC_CTX_PTR
++	params    [2]C.OSSL_PARAM
++	size      int
++	blockSize int
++	key       []byte
++	sum       []byte
++}
++
++func newHMAC3(key []byte, h hash.Hash, md C.GO_EVP_MD_PTR) *hmac3 {
++	mac := C.go_openssl_EVP_MAC_fetch(nil, paramAlgHMAC, nil)
++	ctx := C.go_openssl_EVP_MAC_CTX_new(mac)
++	if ctx == nil {
++		panic("openssl: EVP_MAC_CTX_new failed")
++	}
++	digest := C.go_openssl_EVP_MD_get0_name(md)
++	params := [2]C.OSSL_PARAM{
++		C.go_openssl_OSSL_PARAM_construct_utf8_string(paramDigest, digest, 0),
++		C.go_openssl_OSSL_PARAM_construct_end(),
++	}
++	hmac := &hmac3{
++		md:        mac,
++		ctx:       ctx,
++		params:    params,
++		size:      h.Size(),
++		blockSize: h.BlockSize(),
++		key:       key,
++	}
++	runtime.SetFinalizer(hmac, (*hmac3).finalize)
++	hmac.Reset()
++	return hmac
++}
++
++func (h *hmac3) Reset() {
++	if C.go_openssl_EVP_MAC_init(h.ctx, base(h.key), C.size_t(len(h.key)), &h.params[0]) == 0 {
++		panic(newOpenSSLError("EVP_MAC_init failed"))
++	}
++	runtime.KeepAlive(h) // Next line will keep h alive too; just making doubly sure.
++	h.sum = nil
++}
++
++func (h *hmac3) finalize() {
++	if h.ctx == nil {
++		return
++	}
++	C.go_openssl_EVP_MAC_CTX_free(h.ctx)
++}
++
++func (h *hmac3) Write(p []byte) (int, error) {
++	if len(p) > 0 {
++		C.go_openssl_EVP_MAC_update(h.ctx, base(p), C.size_t(len(p)))
++	}
++	runtime.KeepAlive(h)
++	return len(p), nil
++}
++
++func (h *hmac3) Size() int {
++	return h.size
++}
++
++func (h *hmac3) BlockSize() int {
++	return h.blockSize
++}
++
++func (h *hmac3) Sum(in []byte) []byte {
++	if h.sum == nil {
++		size := h.Size()
++		h.sum = make([]byte, size)
++	}
++	// Make copy of context because Go hash.Hash mandates
++	// that Sum has no effect on the underlying stream.
++	// In particular it is OK to Sum, then Write more, then Sum again,
++	// and the second Sum acts as if the first didn't happen.
++	ctx2 := C.go_openssl_EVP_MAC_CTX_dup(h.ctx)
++	if ctx2 == nil {
++		panic("openssl: EVP_MAC_CTX_dup failed")
++	}
++	defer C.go_openssl_EVP_MAC_CTX_free(ctx2)
++	C.go_openssl_EVP_MAC_final(ctx2, base(h.sum), nil, C.size_t(len(h.sum)))
++	return append(in, h.sum...)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go
 new file mode 100644
@@ -1945,10 +2061,10 @@ index 00000000000000..95f3e888bb4cc0
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 new file mode 100644
-index 00000000000000..9abe8adb8ec7a2
+index 00000000000000..d6fc72a5ef1fff
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
-@@ -0,0 +1,252 @@
+@@ -0,0 +1,279 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2013,6 +2129,7 @@ index 00000000000000..9abe8adb8ec7a2
 +    GO_EVP_PKEY_CTRL_RSA_PADDING = 0x1001,
 +    GO_EVP_PKEY_CTRL_RSA_PSS_SALTLEN = 0x1002,
 +    GO_EVP_PKEY_CTRL_RSA_KEYGEN_BITS = 0x1003,
++    GO_EVP_PKEY_CTRL_RSA_MGF1_MD = 0x1005,
 +    GO_EVP_PKEY_CTRL_RSA_OAEP_MD = 0x1009,
 +    GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL = 0x100A
 +};
@@ -2034,6 +2151,21 @@ index 00000000000000..9abe8adb8ec7a2
 +typedef void* GO_EC_POINT_PTR;
 +typedef void* GO_EC_GROUP_PTR;
 +typedef void* GO_RSA_PTR;
++typedef void* GO_EVP_MAC_PTR;
++typedef void* GO_EVP_MAC_CTX_PTR;
++
++// OSSL_PARAM does not follow the GO_FOO_PTR pattern
++// because it is not passed around as a pointer but on the stack.
++// We can't abstract it away by using a void*.
++// Copied from
++// https://github.com/openssl/openssl/blob/fcae2ae4f675def607d338b7945b9af1dd9bb746/include/openssl/core.h#L82-L88.
++typedef struct {
++    const char *key;
++    unsigned int data_type;
++    void *data;
++    size_t data_size;
++    size_t return_size;
++} OSSL_PARAM;
 +
 +// List of all functions from the libcrypto that are used in this package.
 +// Forgetting to add a function here results in build failure with message reporting the function
@@ -2109,6 +2241,7 @@ index 00000000000000..9abe8adb8ec7a2
 +DEFINEFUNC(int, EVP_MD_CTX_copy_ex, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
 +DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
 +DEFINEFUNC_RENAMED_1_1(int, EVP_MD_CTX_reset, EVP_MD_CTX_cleanup, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
++DEFINEFUNC_3_0(const char *, EVP_MD_get0_name, (const GO_EVP_MD_PTR md), (md)) \
 +DEFINEFUNC(const GO_EVP_MD_PTR, EVP_md5, (void), ()) \
 +DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha1, (void), ()) \
 +DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha224, (void), ()) \
@@ -2200,7 +2333,17 @@ index 00000000000000..9abe8adb8ec7a2
 +DEFINEFUNC(int, EVP_PKEY_encrypt_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EVP_PKEY_sign_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EVP_PKEY_verify_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
-+DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4))
++DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4)) \
++DEFINEFUNC_3_0(GO_EVP_MAC_PTR, EVP_MAC_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
++DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_new, (GO_EVP_MAC_PTR arg0), (arg0)) \
++DEFINEFUNC_3_0(void, EVP_MAC_CTX_free, (GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
++DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_dup, (const GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
++DEFINEFUNC_3_0(int, EVP_MAC_init, (GO_EVP_MAC_CTX_PTR ctx, const unsigned char *key, size_t keylen, const OSSL_PARAM params[]), (ctx, key, keylen, params)) \
++DEFINEFUNC_3_0(int, EVP_MAC_update, (GO_EVP_MAC_CTX_PTR ctx, const unsigned char *data, size_t datalen), (ctx, data, datalen)) \
++DEFINEFUNC_3_0(int, EVP_MAC_final, (GO_EVP_MAC_CTX_PTR ctx, unsigned char *out, size_t *outl, size_t outsize), (ctx, out, outl, outsize)) \
++DEFINEFUNC_3_0(OSSL_PARAM, OSSL_PARAM_construct_utf8_string, (const char *key, char *buf, size_t bsize), (key, buf, bsize)) \
++DEFINEFUNC_3_0(OSSL_PARAM, OSSL_PARAM_construct_end, (void), ()) \
++
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c
 new file mode 100644
 index 00000000000000..5cd7275f4075ed
@@ -2292,10 +2435,10 @@ index 00000000000000..17f64a52ae5255
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 new file mode 100644
-index 00000000000000..d80e00a14a1a05
+index 00000000000000..cfc6e40fcf41e2
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
-@@ -0,0 +1,328 @@
+@@ -0,0 +1,336 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2425,23 +2568,31 @@ index 00000000000000..d80e00a14a1a05
 +}
 +
 +func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
-+	return evpDecrypt(priv.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, ciphertext)
++	return evpDecrypt(priv.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, nil, label, ciphertext)
 +}
 +
 +func EncryptRSAOAEP(h hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
-+	return evpEncrypt(pub.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, msg)
++	return evpEncrypt(pub.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, nil, label, msg)
++}
++
++func DecryptRSAOAEPWithMGF1Hash(h, mgfHash hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
++	return evpDecrypt(priv.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, mgfHash, label, ciphertext)
++}
++
++func EncryptRSAOAEPWithMGF1Hash(h, mgfHash hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
++	return evpEncrypt(pub.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, mgfHash, label, msg)
 +}
 +
 +func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
-+	return evpDecrypt(priv.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, ciphertext)
++	return evpDecrypt(priv.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, nil, ciphertext)
 +}
 +
 +func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
-+	return evpEncrypt(pub.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, msg)
++	return evpEncrypt(pub.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, nil, msg)
 +}
 +
 +func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
-+	ret, err := evpDecrypt(priv.withKey, C.GO_RSA_NO_PADDING, nil, nil, ciphertext)
++	ret, err := evpDecrypt(priv.withKey, C.GO_RSA_NO_PADDING, nil, nil, nil, ciphertext)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -2465,7 +2616,7 @@ index 00000000000000..d80e00a14a1a05
 +}
 +
 +func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
-+	return evpEncrypt(pub.withKey, C.GO_RSA_NO_PADDING, nil, nil, msg)
++	return evpEncrypt(pub.withKey, C.GO_RSA_NO_PADDING, nil, nil, nil, msg)
 +}
 +
 +func saltLength(saltLen int, sign bool) (C.int, error) {
@@ -5806,7 +5957,7 @@ index 0854beacdd92eb..90869b5102d695 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,15 @@
-+# github.com/microsoft/go-crypto-openssl v0.2.1
++# github.com/microsoft/go-crypto-openssl v0.2.2
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig


### PR DESCRIPTION
This PR updates the OpenSSL backend to honor the MGF1 hash parameter, which was recently added in https://go-review.googlesource.com/c/go/+/418874.

This change requires upgrading `go-crypto-openssl` to [v0.2.2](https://github.com/microsoft/go-crypto-openssl/releases/tag/v0.2.2).