### PR TITLE
[cng] Support ECDH

### DIFF
--- a/patches/0003-Add-crypto-backend-foundation.patch
+++ b/patches/0003-Add-crypto-backend-foundation.patch
@@ -7,6 +7,8 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/aes/cipher.go                    |   2 +-
  src/crypto/aes/cipher_asm.go                |   2 +-
  src/crypto/boring/boring.go                 |   2 +-
+ src/crypto/ecdh/ecdh.go                     |   2 +-
+ src/crypto/ecdh/nist.go                     |   2 +-
  src/crypto/ecdsa/boring.go                  |   4 +-
  src/crypto/ecdsa/ecdsa.go                   |   4 +-
  src/crypto/ecdsa/notboring.go               |   2 +-
@@ -14,10 +16,10 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/hmac/hmac.go                     |   2 +-
  src/crypto/hmac/hmac_test.go                |   2 +-
  src/crypto/internal/backend/backend_test.go |  30 ++++++
- src/crypto/internal/backend/bbig/big.go     |  17 ++++
- src/crypto/internal/backend/common.go       |  65 +++++++++++++
+ src/crypto/internal/backend/bbig/big.go     |  17 +++
+ src/crypto/internal/backend/common.go       |  65 +++++++++++
  src/crypto/internal/backend/iscgo.go        |  10 ++
- src/crypto/internal/backend/nobackend.go    | 102 ++++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go    | 114 ++++++++++++++++++++
  src/crypto/internal/backend/nocgo.go        |  10 ++
  src/crypto/internal/backend/stub.s          |  10 ++
  src/crypto/rand/rand_unix.go                |   2 +-
@@ -35,7 +37,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/cipher_suites.go             |   2 +-
  src/go/build/deps_test.go                   |   2 +
  src/runtime/runtime_boring.go               |   5 +
- 31 files changed, 277 insertions(+), 26 deletions(-)
+ 33 files changed, 291 insertions(+), 28 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
@@ -83,6 +85,32 @@ index 097c37e343fdb8..1cf43edba40359 100644
  
  // Enabled reports whether BoringCrypto handles supported crypto operations.
  func Enabled() bool {
+diff --git a/src/crypto/ecdh/ecdh.go b/src/crypto/ecdh/ecdh.go
+index d78b4d44324c24..4bf64dcf3c4122 100644
+--- a/src/crypto/ecdh/ecdh.go
++++ b/src/crypto/ecdh/ecdh.go
+@@ -8,7 +8,7 @@ package ecdh
+ 
+ import (
+ 	"crypto"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/subtle"
+ 	"io"
+ 	"sync"
+diff --git a/src/crypto/ecdh/nist.go b/src/crypto/ecdh/nist.go
+index 01354fa2cf0af2..1d198df6e382d4 100644
+--- a/src/crypto/ecdh/nist.go
++++ b/src/crypto/ecdh/nist.go
+@@ -5,7 +5,7 @@
+ package ecdh
+ 
+ import (
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/internal/nistec"
+ 	"crypto/internal/randutil"
+ 	"encoding/binary"
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
 index 275c60b4de49eb..61e70f981db4eb 100644
 --- a/src/crypto/ecdsa/boring.go
@@ -314,10 +342,10 @@ index 00000000000000..1e0d3cf8c18b55
 +const iscgo = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..091fe22347e363
+index 00000000000000..5cbd86907a135b
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,114 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -420,6 +448,18 @@ index 00000000000000..091fe22347e363
 +func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
 +	panic("cryptobackend: not available")
 +}
++
++type PublicKeyECDH struct{}
++type PrivateKeyECDH struct{}
++
++func ECDH(*PrivateKeyECDH, *PublicKeyECDH) ([]byte, error)    { panic("cryptobackend: not available") }
++func GenerateKeyECDH(string) (*PrivateKeyECDH, []byte, error) { panic("cryptobackend: not available") }
++func NewPrivateKeyECDH(string, []byte) (*PrivateKeyECDH, error) {
++	panic("cryptobackend: not available")
++}
++func NewPublicKeyECDH(string, []byte) (*PublicKeyECDH, error) { panic("cryptobackend: not available") }
++func (*PublicKeyECDH) Bytes() []byte                          { panic("cryptobackend: not available") }
++func (*PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error)    { panic("cryptobackend: not available") }
 diff --git a/src/crypto/internal/backend/nocgo.go b/src/crypto/internal/backend/nocgo.go
 new file mode 100644
 index 00000000000000..63c13fc4b01cba
@@ -520,7 +560,7 @@ index f7d23b55ef811a..f2f2a64ed35e23 100644
  	"hash"
  	"io"
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index 88a5e28e626028..a383e4b92b4e57 100644
+index 11f87e8e4973e3..512e4a4d6616e5 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
 @@ -27,9 +27,9 @@ package rsa

--- a/patches/0004-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0004-Add-BoringSSL-crypto-backend.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 ++
- src/crypto/internal/backend/boring_linux.go   | 116 ++++++++++++++++++
- 2 files changed, 128 insertions(+)
+ src/crypto/internal/backend/boring_linux.go   | 135 ++++++++++++++++++
+ 2 files changed, 147 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..e66671003479b7
+index 00000000000000..b22886bb6cc88f
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,135 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -149,4 +149,23 @@ index 00000000000000..e66671003479b7
 +
 +func VerifyRSAPSS(pub *boring.PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
 +	return boring.VerifyRSAPSS(pub, h, hashed, sig, saltLen)
++}
++
++type PublicKeyECDH = boring.PublicKeyECDH
++type PrivateKeyECDH = boring.PrivateKeyECDH
++
++func ECDH(priv *boring.PrivateKeyECDH, pub *boring.PublicKeyECDH) ([]byte, error) {
++	return boring.ECDH(priv, pub)
++}
++
++func GenerateKeyECDH(curve string) (*boring.PrivateKeyECDH, []byte, error) {
++	return boring.GenerateKeyECDH(curve)
++}
++
++func NewPrivateKeyECDH(curve string, bytes []byte) (*boring.PrivateKeyECDH, error) {
++	return boring.NewPrivateKeyECDH(curve, bytes)
++}
++
++func NewPublicKeyECDH(curve string, bytes []byte) (*boring.PublicKeyECDH, error) {
++	return boring.NewPublicKeyECDH(curve, bytes)
 +}

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -10,13 +10,14 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
  src/crypto/boring/boring.go                   |   2 +-
+ src/crypto/ecdh/nist.go                       |  17 +-
  src/crypto/ecdsa/boring.go                    |   2 +-
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/ed25519/ed25519_test.go            |   6 +
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 ++
  src/crypto/internal/backend/nobackend.go      |   2 +-
- src/crypto/internal/backend/openssl_linux.go  | 184 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 194 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -38,7 +39,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 34 files changed, 277 insertions(+), 25 deletions(-)
+ 35 files changed, 298 insertions(+), 31 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -140,6 +141,72 @@ index 1cf43edba40359..7b04f14ebdd618 100644
  
  // Package boring exposes functions that are only available when building with
  // Go+BoringCrypto. This package is available on all targets as long as the
+diff --git a/src/crypto/ecdh/nist.go b/src/crypto/ecdh/nist.go
+index 1d198df6e382d4..3309b6d4c15110 100644
+--- a/src/crypto/ecdh/nist.go
++++ b/src/crypto/ecdh/nist.go
+@@ -10,6 +10,7 @@ import (
+ 	"crypto/internal/randutil"
+ 	"encoding/binary"
+ 	"errors"
++	"internal/goexperiment"
+ 	"io"
+ 	"math/bits"
+ )
+@@ -36,7 +37,7 @@ func (c *nistCurve[Point]) String() string {
+ var errInvalidPrivateKey = errors.New("crypto/ecdh: invalid private key")
+ 
+ func (c *nistCurve[Point]) GenerateKey(rand io.Reader) (*PrivateKey, error) {
+-	if boring.Enabled && rand == boring.RandReader {
++	if boring.Enabled && rand == boring.RandReader && !goexperiment.OpenSSLCrypto {
+ 		key, bytes, err := boring.GenerateKeyECDH(c.name)
+ 		if err != nil {
+ 			return nil, err
+@@ -79,7 +80,7 @@ func (c *nistCurve[Point]) NewPrivateKey(key []byte) (*PrivateKey, error) {
+ 	if isZero(key) || !isLess(key, c.scalarOrder) {
+ 		return nil, errInvalidPrivateKey
+ 	}
+-	if boring.Enabled {
++	if boring.Enabled && !goexperiment.OpenSSLCrypto {
+ 		bk, err := boring.NewPrivateKeyECDH(c.name, key)
+ 		if err != nil {
+ 			return nil, err
+@@ -103,7 +104,9 @@ func newBoringPrivateKey(c Curve, bk *boring.PrivateKeyECDH, privateKey []byte)
+ }
+ 
+ func (c *nistCurve[Point]) privateKeyToPublicKey(key *PrivateKey) *PublicKey {
+-	boring.Unreachable()
++	if !goexperiment.OpenSSLCrypto {
++		boring.Unreachable()
++	}
+ 	if key.curve != c {
+ 		panic("crypto/ecdh: internal error: converting the wrong key type")
+ 	}
+@@ -173,7 +176,7 @@ func (c *nistCurve[Point]) NewPublicKey(key []byte) (*PublicKey, error) {
+ 		curve:     c,
+ 		publicKey: append([]byte{}, key...),
+ 	}
+-	if boring.Enabled {
++	if boring.Enabled && !goexperiment.OpenSSLCrypto {
+ 		bk, err := boring.NewPublicKeyECDH(c.name, k.publicKey)
+ 		if err != nil {
+ 			return nil, err
+@@ -196,11 +199,13 @@ func (c *nistCurve[Point]) ecdh(local *PrivateKey, remote *PublicKey) ([]byte, e
+ 	// only be the result of a scalar multiplication if one of the inputs is the
+ 	// zero scalar or the point at infinity.
+ 
+-	if boring.Enabled {
++	if boring.Enabled && !goexperiment.OpenSSLCrypto {
+ 		return boring.ECDH(local.boring, remote.boring)
+ 	}
+ 
+-	boring.Unreachable()
++	if !goexperiment.OpenSSLCrypto {
++		boring.Unreachable()
++	}
+ 	p, err := c.newPoint().SetBytes(remote.publicKey)
+ 	if err != nil {
+ 		return nil, err
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
 index 61e70f981db4eb..602cb894e20d39 100644
 --- a/src/crypto/ecdsa/boring.go
@@ -222,7 +289,7 @@ index 00000000000000..61ef3fdd90b607
 +var Enc = bbig.Enc
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-index 091fe22347e363..f5f908806241b2 100644
+index 5cbd86907a135b..fcdea7f8ab5a9d 100644
 --- a/src/crypto/internal/backend/nobackend.go
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -2,7 +2,7 @@
@@ -236,10 +303,10 @@ index 091fe22347e363..f5f908806241b2 100644
  
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..51061653064c2d
+index 00000000000000..9bbe3a59b65bbb
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,184 @@
+@@ -0,0 +1,194 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -424,6 +491,16 @@ index 00000000000000..51061653064c2d
 +func VerifyRSAPSS(pub *openssl.PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
 +	return openssl.VerifyRSAPSS(pub, h, hashed, sig, saltLen)
 +}
++
++type PublicKeyECDH struct{}
++type PrivateKeyECDH struct{}
++
++func ECDH(*PrivateKeyECDH, *PublicKeyECDH) ([]byte, error)      { panic("boringcrypto: not available") }
++func GenerateKeyECDH(string) (*PrivateKeyECDH, []byte, error)   { panic("boringcrypto: not available") }
++func NewPrivateKeyECDH(string, []byte) (*PrivateKeyECDH, error) { panic("boringcrypto: not available") }
++func NewPublicKeyECDH(string, []byte) (*PublicKeyECDH, error)   { panic("boringcrypto: not available") }
++func (*PublicKeyECDH) Bytes() []byte                            { panic("boringcrypto: not available") }
++func (*PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error)      { panic("boringcrypto: not available") }
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
 index f2e5a503eaacb6..1dc7116efdff2e 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -11,8 +11,8 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
- src/crypto/internal/backend/bbig/big_cng.go   |  12 ++
- src/crypto/internal/backend/cng_windows.go    | 186 ++++++++++++++++++
+ src/crypto/internal/backend/bbig/big_cng.go   |  12 +
+ src/crypto/internal/backend/cng_windows.go    | 205 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  38 +++-
  src/crypto/internal/backend/nobackend.go      |   2 +-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
@@ -49,7 +49,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 45 files changed, 387 insertions(+), 47 deletions(-)
+ 45 files changed, 406 insertions(+), 47 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -168,10 +168,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..a37572238371ce
+index 00000000000000..9d1bbf010c0fb6
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,186 @@
+@@ -0,0 +1,205 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -358,6 +358,25 @@ index 00000000000000..a37572238371ce
 +func VerifyRSAPSS(pub *cng.PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
 +	return cng.VerifyRSAPSS(pub, h, hashed, sig, saltLen)
 +}
++
++type PrivateKeyECDH = cng.PrivateKeyECDH
++type PublicKeyECDH = cng.PublicKeyECDH
++
++func ECDH(priv *cng.PrivateKeyECDH, pub *cng.PublicKeyECDH) ([]byte, error) {
++	return cng.ECDH(priv, pub)
++}
++
++func GenerateKeyECDH(curve string) (*cng.PrivateKeyECDH, []byte, error) {
++	return cng.GenerateKeyECDH(curve)
++}
++
++func NewPrivateKeyECDH(curve string, bytes []byte) (*cng.PrivateKeyECDH, error) {
++	return cng.NewPrivateKeyECDH(curve, bytes)
++}
++
++func NewPublicKeyECDH(curve string, bytes []byte) (*cng.PublicKeyECDH, error) {
++	return cng.NewPublicKeyECDH(curve, bytes)
++}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 index 007d8070538247..114f72c3d10ee4 100644
 --- a/src/crypto/internal/backend/common.go
@@ -427,7 +446,7 @@ index 007d8070538247..114f72c3d10ee4 100644
 +	return !goexperiment.CNGCrypto
 +}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-index f5f908806241b2..e3e71c9f2f5984 100644
+index fcdea7f8ab5a9d..503e49212f972c 100644
 --- a/src/crypto/internal/backend/nobackend.go
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -2,7 +2,7 @@
@@ -626,7 +645,7 @@ index cf03e3cb7ed2cc..361eab5db6137d 100644
  		t.Fatal(err)
  	}
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index a383e4b92b4e57..f11e30d320c33b 100644
+index 512e4a4d6616e5..284db01c221d93 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
 @@ -36,6 +36,7 @@ import (
@@ -1037,26 +1056,26 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 583db20b19f2fd..dd28e155f3d4b9 100644
+index 583db20b19f2fd..b567a544298e27 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.20
  
  require (
  	github.com/microsoft/go-crypto-openssl v0.2.1
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327
++	github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.2.1-0.20221117215542-ecf7fda6a59e
  )
 diff --git a/src/go.sum b/src/go.sum
-index 4bc18da6466301..e47f50019aeeed 100644
+index 4bc18da6466301..a5359c3bdc0886 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/microsoft/go-crypto-openssl v0.2.1 h1:YFcvMkJeBXucC5wkNne/BbB7V02z1TjRxXbvGmEaFd4=
  github.com/microsoft/go-crypto-openssl v0.2.1/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327 h1:2VVjqz2wSETA9qAVcJvSEXbjTf0qvb0ONcX7zXJkxs0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1 h1:KqlMKMf4t+yh6I2FbFvJpaMQTRH6MtWw06+ME10xxy0=
++github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
  golang.org/x/net v0.2.1-0.20221117215542-ecf7fda6a59e h1:IVOjWZQH/57UDcpX19vSmMz8w3ohroOMWohn8qWpRkg=

--- a/patches/0007-Vendor-crypto-backends.patch
+++ b/patches/0007-Vendor-crypto-backends.patch
@@ -26,7 +26,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-winnative/cng/bbig/big.go       |  31 +
  .../microsoft/go-crypto-winnative/cng/big.go  |  30 +
  .../microsoft/go-crypto-winnative/cng/cng.go  | 130 ++++
- .../microsoft/go-crypto-winnative/cng/ecdh.go | 257 ++++++++
+ .../microsoft/go-crypto-winnative/cng/ecdh.go | 252 ++++++++
  .../go-crypto-winnative/cng/ecdsa.go          | 175 ++++++
  .../microsoft/go-crypto-winnative/cng/hmac.go |  55 ++
  .../microsoft/go-crypto-winnative/cng/keys.go | 161 +++++
@@ -38,7 +38,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  12 +
- 33 files changed, 5553 insertions(+)
+ 33 files changed, 5548 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
@@ -3813,10 +3813,10 @@ index 00000000000000..844c087287cabe
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go
 new file mode 100644
-index 00000000000000..f15f958054b2e8
+index 00000000000000..c3fa6dd766e34e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go
-@@ -0,0 +1,257 @@
+@@ -0,0 +1,252 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -3942,25 +3942,19 @@ index 00000000000000..f15f958054b2e8
 +		return nil, nil, err
 +	}
 +
-+	// GenerateKeyECDH returns the public key as as byte slice.
-+	// To get it we need to export the raw CNG key blob
-+	// and prepend the encoding prefix.
-+	hdr, blob, err := exportECCKey(hkey, false)
++	// GenerateKeyECDH returns the private key as a byte slice.
++	// To get it we need to export the raw CNG key bytes.
++	hdr, bytes, err := exportECCKey(hkey, true)
 +	if err != nil {
 +		bcrypt.DestroyKey(hkey)
 +		return nil, nil, err
 +	}
++	// Only take the private component of the key,
++	// which is the last of the three equally-sized chunks.
++	bytes = bytes[hdr.KeySize*2:]
++
 +	k := &PrivateKeyECDH{hkey, isNIST(curve)}
 +	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
-+	var bytes []byte
-+	if k.isNIST {
-+		bytes = append([]byte{ecdhUncompressedPrefix}, blob...)
-+	} else {
-+		// X25519 bytes must only contain the X coordinate,
-+		// but BCrypt might export X and Y.
-+		// Slice blob so it only contains X.
-+		bytes = blob[:hdr.KeySize]
-+	}
 +	return k, bytes, nil
 +}
 +
@@ -4034,14 +4028,15 @@ index 00000000000000..f15f958054b2e8
 +	if err != nil {
 +		return nil, err
 +	}
-+	pub := new(PublicKeyECDH)
++	var bytes []byte
 +	if k.isNIST {
 +		// Include X and Y.
-+		pub.bytes = append([]byte{ecdhUncompressedPrefix}, data...)
++		bytes = append([]byte{ecdhUncompressedPrefix}, data...)
 +	} else {
 +		// Only include X.
-+		pub.bytes = data[:hdr.KeySize]
++		bytes = data[:hdr.KeySize]
 +	}
++	pub := &PublicKeyECDH{k.hkey, bytes}
 +	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
 +	return pub, nil
 +}
@@ -5807,7 +5802,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 0854beacdd92eb..0e89d78f2236a2 100644
+index 0854beacdd92eb..90869b5102d695 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,15 @@
@@ -5816,7 +5811,7 @@ index 0854beacdd92eb..0e89d78f2236a2 100644
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig
 +github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20221018054840-63fe3bdaa327
++# github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
This PR updates the `crypto/ecdh` package so it points to `crypto/internal/backend`. It also implements ECDH support for the CNG and the Boring backends. OpenSSL support will come later, as `go-crypto-openssl` still doesn't support it.