### PR TITLE
[openssl] Support ECDH

### DIFF
--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -10,14 +10,13 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
  src/crypto/boring/boring.go                   |   2 +-
- src/crypto/ecdh/nist.go                       |  17 +-
  src/crypto/ecdsa/boring.go                    |   2 +-
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/ed25519/ed25519_test.go            |   6 +
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 ++
  src/crypto/internal/backend/nobackend.go      |   2 +-
- src/crypto/internal/backend/openssl_linux.go  | 194 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 203 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -39,14 +38,14 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 35 files changed, 298 insertions(+), 31 deletions(-)
+ 34 files changed, 296 insertions(+), 25 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_on.go
 
 diff --git a/src/cmd/api/boring_test.go b/src/cmd/api/boring_test.go
-index f0e3575637c62a..0e9aceeb832d3b 100644
+index a9ec6e6bfef..01765f01736 100644
 --- a/src/cmd/api/boring_test.go
 +++ b/src/cmd/api/boring_test.go
 @@ -2,7 +2,7 @@
@@ -59,10 +58,10 @@ index f0e3575637c62a..0e9aceeb832d3b 100644
  package api
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index cedd337c124432..47973840fd50fb 100644
+index 77e89305597..a80132abacc 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1347,15 +1347,18 @@ func (t *tester) registerCgoTests() {
+@@ -1330,15 +1330,18 @@ func (t *tester) registerCgoTests() {
  					return false
  				}
  			}
@@ -85,7 +84,7 @@ index cedd337c124432..47973840fd50fb 100644
  				cgoTest("test-static", "test", "external", "static", staticCheck)
  				// -static in CGO_LDFLAGS triggers a different code path
 diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
-index ed0fbf3d53d75b..5376227f74cfaa 100644
+index ed0fbf3d53d..5376227f74c 100644
 --- a/src/cmd/go/go_boring_test.go
 +++ b/src/cmd/go/go_boring_test.go
 @@ -2,7 +2,7 @@
@@ -98,7 +97,7 @@ index ed0fbf3d53d75b..5376227f74cfaa 100644
  package main_test
  
 diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
-index 4aaf46b5d0f0dc..e2ac54f96db1e8 100644
+index 4aaf46b5d0f..e2ac54f96db 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
 +++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
 @@ -1,5 +1,14 @@
@@ -117,7 +116,7 @@ index 4aaf46b5d0f0dc..e2ac54f96db1e8 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index d225a8a163f18e..7e6e664c1406f9 100644
+index c0730179db4..6cff17f652b 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
 @@ -1102,6 +1102,7 @@ var hostobj []Hostobj
@@ -129,7 +128,7 @@ index d225a8a163f18e..7e6e664c1406f9 100644
  	"crypto/internal/boring/syso",
  	"crypto/x509",
 diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
-index 1cf43edba40359..7b04f14ebdd618 100644
+index 1cf43edba40..7b04f14ebdd 100644
 --- a/src/crypto/boring/boring.go
 +++ b/src/crypto/boring/boring.go
 @@ -2,7 +2,7 @@
@@ -141,74 +140,8 @@ index 1cf43edba40359..7b04f14ebdd618 100644
  
  // Package boring exposes functions that are only available when building with
  // Go+BoringCrypto. This package is available on all targets as long as the
-diff --git a/src/crypto/ecdh/nist.go b/src/crypto/ecdh/nist.go
-index 1d198df6e382d4..3309b6d4c15110 100644
---- a/src/crypto/ecdh/nist.go
-+++ b/src/crypto/ecdh/nist.go
-@@ -10,6 +10,7 @@ import (
- 	"crypto/internal/randutil"
- 	"encoding/binary"
- 	"errors"
-+	"internal/goexperiment"
- 	"io"
- 	"math/bits"
- )
-@@ -36,7 +37,7 @@ func (c *nistCurve[Point]) String() string {
- var errInvalidPrivateKey = errors.New("crypto/ecdh: invalid private key")
- 
- func (c *nistCurve[Point]) GenerateKey(rand io.Reader) (*PrivateKey, error) {
--	if boring.Enabled && rand == boring.RandReader {
-+	if boring.Enabled && rand == boring.RandReader && !goexperiment.OpenSSLCrypto {
- 		key, bytes, err := boring.GenerateKeyECDH(c.name)
- 		if err != nil {
- 			return nil, err
-@@ -79,7 +80,7 @@ func (c *nistCurve[Point]) NewPrivateKey(key []byte) (*PrivateKey, error) {
- 	if isZero(key) || !isLess(key, c.scalarOrder) {
- 		return nil, errInvalidPrivateKey
- 	}
--	if boring.Enabled {
-+	if boring.Enabled && !goexperiment.OpenSSLCrypto {
- 		bk, err := boring.NewPrivateKeyECDH(c.name, key)
- 		if err != nil {
- 			return nil, err
-@@ -103,7 +104,9 @@ func newBoringPrivateKey(c Curve, bk *boring.PrivateKeyECDH, privateKey []byte)
- }
- 
- func (c *nistCurve[Point]) privateKeyToPublicKey(key *PrivateKey) *PublicKey {
--	boring.Unreachable()
-+	if !goexperiment.OpenSSLCrypto {
-+		boring.Unreachable()
-+	}
- 	if key.curve != c {
- 		panic("crypto/ecdh: internal error: converting the wrong key type")
- 	}
-@@ -173,7 +176,7 @@ func (c *nistCurve[Point]) NewPublicKey(key []byte) (*PublicKey, error) {
- 		curve:     c,
- 		publicKey: append([]byte{}, key...),
- 	}
--	if boring.Enabled {
-+	if boring.Enabled && !goexperiment.OpenSSLCrypto {
- 		bk, err := boring.NewPublicKeyECDH(c.name, k.publicKey)
- 		if err != nil {
- 			return nil, err
-@@ -196,11 +199,13 @@ func (c *nistCurve[Point]) ecdh(local *PrivateKey, remote *PublicKey) ([]byte, e
- 	// only be the result of a scalar multiplication if one of the inputs is the
- 	// zero scalar or the point at infinity.
- 
--	if boring.Enabled {
-+	if boring.Enabled && !goexperiment.OpenSSLCrypto {
- 		return boring.ECDH(local.boring, remote.boring)
- 	}
- 
--	boring.Unreachable()
-+	if !goexperiment.OpenSSLCrypto {
-+		boring.Unreachable()
-+	}
- 	p, err := c.newPoint().SetBytes(remote.publicKey)
- 	if err != nil {
- 		return nil, err
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
-index 61e70f981db4eb..602cb894e20d39 100644
+index 61e70f981db..602cb894e20 100644
 --- a/src/crypto/ecdsa/boring.go
 +++ b/src/crypto/ecdsa/boring.go
 @@ -2,7 +2,7 @@
@@ -221,7 +154,7 @@ index 61e70f981db4eb..602cb894e20d39 100644
  package ecdsa
  
 diff --git a/src/crypto/ecdsa/notboring.go b/src/crypto/ecdsa/notboring.go
-index 19188518e85e65..3cc16ecab567a0 100644
+index 19188518e85..3cc16ecab56 100644
 --- a/src/crypto/ecdsa/notboring.go
 +++ b/src/crypto/ecdsa/notboring.go
 @@ -2,7 +2,7 @@
@@ -234,7 +167,7 @@ index 19188518e85e65..3cc16ecab567a0 100644
  package ecdsa
  
 diff --git a/src/crypto/ed25519/ed25519_test.go b/src/crypto/ed25519/ed25519_test.go
-index 4a818e0319d55e..da6e4c64e6c5ee 100644
+index 4a818e0319d..da6e4c64e6c 100644
 --- a/src/crypto/ed25519/ed25519_test.go
 +++ b/src/crypto/ed25519/ed25519_test.go
 @@ -13,6 +13,7 @@ import (
@@ -258,7 +191,7 @@ index 4a818e0319d55e..da6e4c64e6c5ee 100644
  
  	if allocs := testing.AllocsPerRun(100, func() {
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
-index 85bd3ed083f5b2..51bc3c68048d51 100644
+index 85bd3ed083f..51bc3c68048 100644
 --- a/src/crypto/internal/backend/bbig/big.go
 +++ b/src/crypto/internal/backend/bbig/big.go
 @@ -2,7 +2,7 @@
@@ -272,7 +205,7 @@ index 85bd3ed083f5b2..51bc3c68048d51 100644
  
 diff --git a/src/crypto/internal/backend/bbig/big_openssl.go b/src/crypto/internal/backend/bbig/big_openssl.go
 new file mode 100644
-index 00000000000000..61ef3fdd90b607
+index 00000000000..61ef3fdd90b
 --- /dev/null
 +++ b/src/crypto/internal/backend/bbig/big_openssl.go
 @@ -0,0 +1,12 @@
@@ -289,7 +222,7 @@ index 00000000000000..61ef3fdd90b607
 +var Enc = bbig.Enc
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-index 5cbd86907a135b..fcdea7f8ab5a9d 100644
+index 5cbd86907a1..fcdea7f8ab5 100644
 --- a/src/crypto/internal/backend/nobackend.go
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -2,7 +2,7 @@
@@ -303,10 +236,10 @@ index 5cbd86907a135b..fcdea7f8ab5a9d 100644
  
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..9bbe3a59b65bbb
+index 00000000000..68ea43ea892
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,194 @@
+@@ -0,0 +1,203 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -492,17 +425,26 @@ index 00000000000000..9bbe3a59b65bbb
 +	return openssl.VerifyRSAPSS(pub, h, hashed, sig, saltLen)
 +}
 +
-+type PublicKeyECDH struct{}
-+type PrivateKeyECDH struct{}
++type PublicKeyECDH = openssl.PublicKeyECDH
++type PrivateKeyECDH = openssl.PrivateKeyECDH
 +
-+func ECDH(*PrivateKeyECDH, *PublicKeyECDH) ([]byte, error)      { panic("boringcrypto: not available") }
-+func GenerateKeyECDH(string) (*PrivateKeyECDH, []byte, error)   { panic("boringcrypto: not available") }
-+func NewPrivateKeyECDH(string, []byte) (*PrivateKeyECDH, error) { panic("boringcrypto: not available") }
-+func NewPublicKeyECDH(string, []byte) (*PublicKeyECDH, error)   { panic("boringcrypto: not available") }
-+func (*PublicKeyECDH) Bytes() []byte                            { panic("boringcrypto: not available") }
-+func (*PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error)      { panic("boringcrypto: not available") }
++func ECDH(priv *openssl.PrivateKeyECDH, pub *openssl.PublicKeyECDH) ([]byte, error) {
++	return openssl.ECDH(priv, pub)
++}
++
++func GenerateKeyECDH(curve string) (*openssl.PrivateKeyECDH, []byte, error) {
++	return openssl.GenerateKeyECDH(curve)
++}
++
++func NewPrivateKeyECDH(curve string, bytes []byte) (*openssl.PrivateKeyECDH, error) {
++	return openssl.NewPrivateKeyECDH(curve, bytes)
++}
++
++func NewPublicKeyECDH(curve string, bytes []byte) (*openssl.PublicKeyECDH, error) {
++	return openssl.NewPublicKeyECDH(curve, bytes)
++}
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
-index f2e5a503eaacb6..1dc7116efdff2e 100644
+index f2e5a503eaa..1dc7116efdf 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
 +++ b/src/crypto/internal/boring/fipstls/stub.s
 @@ -2,7 +2,7 @@
@@ -515,7 +457,7 @@ index f2e5a503eaacb6..1dc7116efdff2e 100644
  // runtime_arg0 is declared in tls.go without a body.
  // It's provided by package runtime,
 diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
-index 3bf1471fb0bce9..4e629a4db8f7c7 100644
+index 3bf1471fb0b..4e629a4db8f 100644
 --- a/src/crypto/internal/boring/fipstls/tls.go
 +++ b/src/crypto/internal/boring/fipstls/tls.go
 @@ -2,7 +2,7 @@
@@ -528,7 +470,7 @@ index 3bf1471fb0bce9..4e629a4db8f7c7 100644
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
  // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
 diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
-index ecb43aaf264743..220f8c05c3d94b 100644
+index ecb43aaf264..220f8c05c3d 100644
 --- a/src/crypto/rsa/boring.go
 +++ b/src/crypto/rsa/boring.go
 @@ -2,7 +2,7 @@
@@ -541,7 +483,7 @@ index ecb43aaf264743..220f8c05c3d94b 100644
  package rsa
  
 diff --git a/src/crypto/rsa/boring_test.go b/src/crypto/rsa/boring_test.go
-index 2234d079f0d9e7..82a9d220e139af 100644
+index 2234d079f0d..82a9d220e13 100644
 --- a/src/crypto/rsa/boring_test.go
 +++ b/src/crypto/rsa/boring_test.go
 @@ -2,7 +2,7 @@
@@ -554,7 +496,7 @@ index 2234d079f0d9e7..82a9d220e139af 100644
  // Note: Can run these tests against the non-BoringCrypto
  // version of the code by using "CGO_ENABLED=0 go test".
 diff --git a/src/crypto/rsa/notboring.go b/src/crypto/rsa/notboring.go
-index 34c22c8fbba7da..933ac569e034a8 100644
+index 34c22c8fbba..933ac569e03 100644
 --- a/src/crypto/rsa/notboring.go
 +++ b/src/crypto/rsa/notboring.go
 @@ -2,7 +2,7 @@
@@ -567,7 +509,7 @@ index 34c22c8fbba7da..933ac569e034a8 100644
  package rsa
  
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 16101f043a770f..379fb06526ccc7 100644
+index 16101f043a7..379fb06526c 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -653,6 +653,9 @@ func TestDecryptOAEP(t *testing.T) {
@@ -581,7 +523,7 @@ index 16101f043a770f..379fb06526ccc7 100644
  
  	msg := []byte{0xed, 0x36, 0x90, 0x8d, 0xbe, 0xfc, 0x35, 0x40, 0x70, 0x4f, 0xf5, 0x9d, 0x6e, 0xc2, 0xeb, 0xf5, 0x27, 0xae, 0x65, 0xb0, 0x59, 0x29, 0x45, 0x25, 0x8c, 0xc1, 0x91, 0x22}
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 1827f764589b58..70baa62d63754a 100644
+index 1827f764589..70baa62d637 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -2,7 +2,7 @@
@@ -594,7 +536,7 @@ index 1827f764589b58..70baa62d63754a 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 59d4d2b2724ea3..ea23a0336bd575 100644
+index 59d4d2b2724..ea23a0336bd 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -607,7 +549,7 @@ index 59d4d2b2724ea3..ea23a0336bd575 100644
  package tls
  
 diff --git a/src/crypto/tls/fipsonly/fipsonly.go b/src/crypto/tls/fipsonly/fipsonly.go
-index e5e47835e2f48d..1a94656dfee6dd 100644
+index e5e47835e2f..1a94656dfee 100644
 --- a/src/crypto/tls/fipsonly/fipsonly.go
 +++ b/src/crypto/tls/fipsonly/fipsonly.go
 @@ -2,7 +2,7 @@
@@ -620,7 +562,7 @@ index e5e47835e2f48d..1a94656dfee6dd 100644
  // Package fipsonly restricts all TLS configuration to FIPS-approved settings.
  //
 diff --git a/src/crypto/tls/fipsonly/fipsonly_test.go b/src/crypto/tls/fipsonly/fipsonly_test.go
-index f8485dc3ca1c29..9c1d3d279c472f 100644
+index f8485dc3ca1..9c1d3d279c4 100644
 --- a/src/crypto/tls/fipsonly/fipsonly_test.go
 +++ b/src/crypto/tls/fipsonly/fipsonly_test.go
 @@ -2,7 +2,7 @@
@@ -633,7 +575,7 @@ index f8485dc3ca1c29..9c1d3d279c472f 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index 7d85b39c59319e..1aaabd5ef486aa 100644
+index 7d85b39c593..1aaabd5ef48 100644
 --- a/src/crypto/tls/notboring.go
 +++ b/src/crypto/tls/notboring.go
 @@ -2,7 +2,7 @@
@@ -646,7 +588,7 @@ index 7d85b39c59319e..1aaabd5ef486aa 100644
  package tls
  
 diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
-index 095b58c31590d4..9aec21dbcd3bff 100644
+index 095b58c3159..9aec21dbcd3 100644
 --- a/src/crypto/x509/boring.go
 +++ b/src/crypto/x509/boring.go
 @@ -2,7 +2,7 @@
@@ -659,7 +601,7 @@ index 095b58c31590d4..9aec21dbcd3bff 100644
  package x509
  
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index 33fd0ed52b1ff6..e8fce393d29b00 100644
+index 33fd0ed52b1..e8fce393d29 100644
 --- a/src/crypto/x509/boring_test.go
 +++ b/src/crypto/x509/boring_test.go
 @@ -2,7 +2,7 @@
@@ -672,7 +614,7 @@ index 33fd0ed52b1ff6..e8fce393d29b00 100644
  package x509
  
 diff --git a/src/crypto/x509/notboring.go b/src/crypto/x509/notboring.go
-index c83a7272c9f01f..a0548a7f9179c5 100644
+index c83a7272c9f..a0548a7f917 100644
 --- a/src/crypto/x509/notboring.go
 +++ b/src/crypto/x509/notboring.go
 @@ -2,7 +2,7 @@
@@ -685,32 +627,32 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 874b035dd2d574..583db20b19f2fd 100644
+index 2a1261f925a..ada45c9308b 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.20
  
  require (
-+	github.com/microsoft/go-crypto-openssl v0.2.2
++	github.com/microsoft/go-crypto-openssl v0.2.3
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10
  )
 diff --git a/src/go.sum b/src/go.sum
-index 3ff1619712fac4..4bc18da6466301 100644
+index ef6748d5968..799a91a2af7 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.2.2 h1:Et6hPiaoGW3UXZ4IdjGwN0j4ZoiT8Ffg+Han7+SiDgk=
-+github.com/microsoft/go-crypto-openssl v0.2.2/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-openssl v0.2.3 h1:bbY1FjnyjNcxZydzBcWp3FDruolP66P1gUGDlN5WGug=
++github.com/microsoft/go-crypto-openssl v0.2.3/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
  golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10 h1:Frnccbp+ok2GkUS2tC84yAq/U9Vg+0sIO7aRL3T4Xnc=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 640e3f425ede1c..0a905134394057 100644
+index 40f53b1ea43..afab09a9437 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -397,6 +397,8 @@ var depsRules = `
+@@ -398,6 +398,8 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -719,7 +661,7 @@ index 640e3f425ede1c..0a905134394057 100644
  	< crypto/internal/boring
  	< crypto/internal/backend
  	< crypto/boring;
-@@ -431,6 +433,7 @@ var depsRules = `
+@@ -432,6 +434,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -727,7 +669,7 @@ index 640e3f425ede1c..0a905134394057 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -672,7 +675,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -673,7 +676,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -736,7 +678,7 @@ index 640e3f425ede1c..0a905134394057 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -682,7 +685,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -683,7 +686,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}
@@ -747,7 +689,7 @@ index 640e3f425ede1c..0a905134394057 100644
  	fset := token.NewFileSet()
 diff --git a/src/internal/goexperiment/exp_opensslcrypto_off.go b/src/internal/goexperiment/exp_opensslcrypto_off.go
 new file mode 100644
-index 00000000000000..62033547c6143a
+index 00000000000..62033547c61
 --- /dev/null
 +++ b/src/internal/goexperiment/exp_opensslcrypto_off.go
 @@ -0,0 +1,9 @@
@@ -762,7 +704,7 @@ index 00000000000000..62033547c6143a
 +const OpenSSLCryptoInt = 0
 diff --git a/src/internal/goexperiment/exp_opensslcrypto_on.go b/src/internal/goexperiment/exp_opensslcrypto_on.go
 new file mode 100644
-index 00000000000000..a7f2712e9e1464
+index 00000000000..a7f2712e9e1
 --- /dev/null
 +++ b/src/internal/goexperiment/exp_opensslcrypto_on.go
 @@ -0,0 +1,9 @@
@@ -776,7 +718,7 @@ index 00000000000000..a7f2712e9e1464
 +const OpenSSLCrypto = true
 +const OpenSSLCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 02e744362c30d5..cffb78a7234546 100644
+index 02e744362c3..cffb78a7234 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,7 @@ type Flags struct {
@@ -788,7 +730,7 @@ index 02e744362c30d5..cffb78a7234546 100644
  	// Unified enables the compiler's unified IR construction
  	// experiment.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index edff9a201ef2e0..49752c0d1c1791 100644
+index edff9a201ef..49752c0d1c1 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
 @@ -14,6 +14,7 @@ import (

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -56,7 +56,7 @@ Subject: [PATCH] Add CNG crypto backend
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_on.go
 
 diff --git a/src/cmd/api/boring_test.go b/src/cmd/api/boring_test.go
-index 0e9aceeb832d3b..aecf81b09c8ad3 100644
+index 01765f01736..7598da96946 100644
 --- a/src/cmd/api/boring_test.go
 +++ b/src/cmd/api/boring_test.go
 @@ -2,7 +2,7 @@
@@ -69,7 +69,7 @@ index 0e9aceeb832d3b..aecf81b09c8ad3 100644
  package api
  
 diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
-index 5376227f74cfaa..492ccf79d66b45 100644
+index 5376227f74c..492ccf79d66 100644
 --- a/src/cmd/go/go_boring_test.go
 +++ b/src/cmd/go/go_boring_test.go
 @@ -2,7 +2,7 @@
@@ -82,7 +82,7 @@ index 5376227f74cfaa..492ccf79d66b45 100644
  package main_test
  
 diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
-index 7b04f14ebdd618..8bdafb72f2c51a 100644
+index 7b04f14ebdd..8bdafb72f2c 100644
 --- a/src/crypto/boring/boring.go
 +++ b/src/crypto/boring/boring.go
 @@ -2,7 +2,7 @@
@@ -95,7 +95,7 @@ index 7b04f14ebdd618..8bdafb72f2c51a 100644
  // Package boring exposes functions that are only available when building with
  // Go+BoringCrypto. This package is available on all targets as long as the
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
-index 602cb894e20d39..bf9e77e06599f0 100644
+index 602cb894e20..bf9e77e0659 100644
 --- a/src/crypto/ecdsa/boring.go
 +++ b/src/crypto/ecdsa/boring.go
 @@ -2,7 +2,7 @@
@@ -108,7 +108,7 @@ index 602cb894e20d39..bf9e77e06599f0 100644
  package ecdsa
  
 diff --git a/src/crypto/ecdsa/notboring.go b/src/crypto/ecdsa/notboring.go
-index 3cc16ecab567a0..dbbc6e3897e153 100644
+index 3cc16ecab56..dbbc6e3897e 100644
 --- a/src/crypto/ecdsa/notboring.go
 +++ b/src/crypto/ecdsa/notboring.go
 @@ -2,7 +2,7 @@
@@ -121,7 +121,7 @@ index 3cc16ecab567a0..dbbc6e3897e153 100644
  package ecdsa
  
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
-index c2c06d3bff8c74..837cff477e257e 100644
+index c2c06d3bff8..837cff477e2 100644
 --- a/src/crypto/internal/backend/backend_test.go
 +++ b/src/crypto/internal/backend/backend_test.go
 @@ -4,9 +4,7 @@
@@ -136,7 +136,7 @@ index c2c06d3bff8c74..837cff477e257e 100644
  // Test that Unreachable panics.
  func TestUnreachable(t *testing.T) {
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
-index 51bc3c68048d51..15f9833c9fcd20 100644
+index 51bc3c68048..15f9833c9fc 100644
 --- a/src/crypto/internal/backend/bbig/big.go
 +++ b/src/crypto/internal/backend/bbig/big.go
 @@ -2,7 +2,7 @@
@@ -150,7 +150,7 @@ index 51bc3c68048d51..15f9833c9fcd20 100644
  
 diff --git a/src/crypto/internal/backend/bbig/big_cng.go b/src/crypto/internal/backend/bbig/big_cng.go
 new file mode 100644
-index 00000000000000..92623031fd87d0
+index 00000000000..92623031fd8
 --- /dev/null
 +++ b/src/crypto/internal/backend/bbig/big_cng.go
 @@ -0,0 +1,12 @@
@@ -168,7 +168,7 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..9d1bbf010c0fb6
+index 00000000000..9d1bbf010c0
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,205 @@
@@ -378,7 +378,7 @@ index 00000000000000..9d1bbf010c0fb6
 +	return cng.NewPublicKeyECDH(curve, bytes)
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
-index 007d8070538247..114f72c3d10ee4 100644
+index 007d8070538..114f72c3d10 100644
 --- a/src/crypto/internal/backend/common.go
 +++ b/src/crypto/internal/backend/common.go
 @@ -5,16 +5,19 @@
@@ -446,7 +446,7 @@ index 007d8070538247..114f72c3d10ee4 100644
 +	return !goexperiment.CNGCrypto
 +}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-index fcdea7f8ab5a9d..503e49212f972c 100644
+index fcdea7f8ab5..503e49212f9 100644
 --- a/src/crypto/internal/backend/nobackend.go
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -2,7 +2,7 @@
@@ -459,7 +459,7 @@ index fcdea7f8ab5a9d..503e49212f972c 100644
  package backend
  
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
-index 1dc7116efdff2e..b4c321d1d2babb 100644
+index 1dc7116efdf..b4c321d1d2b 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
 +++ b/src/crypto/internal/boring/fipstls/stub.s
 @@ -2,7 +2,7 @@
@@ -472,7 +472,7 @@ index 1dc7116efdff2e..b4c321d1d2babb 100644
  // runtime_arg0 is declared in tls.go without a body.
  // It's provided by package runtime,
 diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
-index 4e629a4db8f7c7..a7cd24a0d15647 100644
+index 4e629a4db8f..a7cd24a0d15 100644
 --- a/src/crypto/internal/boring/fipstls/tls.go
 +++ b/src/crypto/internal/boring/fipstls/tls.go
 @@ -2,7 +2,7 @@
@@ -485,7 +485,7 @@ index 4e629a4db8f7c7..a7cd24a0d15647 100644
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
  // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
 diff --git a/src/crypto/rand/rand_windows.go b/src/crypto/rand/rand_windows.go
-index 6c0655c72b692a..755861fc5bc21d 100644
+index 6c0655c72b6..755861fc5bc 100644
 --- a/src/crypto/rand/rand_windows.go
 +++ b/src/crypto/rand/rand_windows.go
 @@ -8,10 +8,17 @@
@@ -508,7 +508,7 @@ index 6c0655c72b692a..755861fc5bc21d 100644
  type rngReader struct{}
  
 diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
-index 220f8c05c3d94b..dd20b4af2e0472 100644
+index 220f8c05c3d..dd20b4af2e0 100644
 --- a/src/crypto/rsa/boring.go
 +++ b/src/crypto/rsa/boring.go
 @@ -2,7 +2,7 @@
@@ -521,7 +521,7 @@ index 220f8c05c3d94b..dd20b4af2e0472 100644
  package rsa
  
 diff --git a/src/crypto/rsa/boring_test.go b/src/crypto/rsa/boring_test.go
-index 82a9d220e139af..c3860f8d698bc3 100644
+index 82a9d220e13..c3860f8d698 100644
 --- a/src/crypto/rsa/boring_test.go
 +++ b/src/crypto/rsa/boring_test.go
 @@ -2,7 +2,7 @@
@@ -534,7 +534,7 @@ index 82a9d220e139af..c3860f8d698bc3 100644
  // Note: Can run these tests against the non-BoringCrypto
  // version of the code by using "CGO_ENABLED=0 go test".
 diff --git a/src/crypto/rsa/notboring.go b/src/crypto/rsa/notboring.go
-index 933ac569e034a8..0f152b210fdd84 100644
+index 933ac569e03..0f152b210fd 100644
 --- a/src/crypto/rsa/notboring.go
 +++ b/src/crypto/rsa/notboring.go
 @@ -2,7 +2,7 @@
@@ -547,7 +547,7 @@ index 933ac569e034a8..0f152b210fdd84 100644
  package rsa
  
 diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
-index 577e9fca2201e7..438c7ce7f11449 100644
+index 577e9fca220..438c7ce7f11 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
 @@ -91,7 +91,9 @@ func DecryptPKCS1v15(random io.Reader, priv *PrivateKey, ciphertext []byte) ([]b
@@ -595,7 +595,7 @@ index 577e9fca2201e7..438c7ce7f11449 100644
  		if err != nil {
  			return err
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
-index f2f2a64ed35e23..645434caf9c6d5 100644
+index f2f2a64ed35..645434caf9c 100644
 --- a/src/crypto/rsa/pss.go
 +++ b/src/crypto/rsa/pss.go
 @@ -214,7 +214,9 @@ func signPSSWithSalt(priv *PrivateKey, hash crypto.Hash, hashed, salt []byte) ([
@@ -632,7 +632,7 @@ index f2f2a64ed35e23..645434caf9c6d5 100644
  		if err != nil {
  			return err
 diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
-index cf03e3cb7ed2cc..361eab5db6137d 100644
+index cf03e3cb7ed..361eab5db61 100644
 --- a/src/crypto/rsa/pss_test.go
 +++ b/src/crypto/rsa/pss_test.go
 @@ -283,7 +283,7 @@ func fromHex(hexStr string) []byte {
@@ -645,7 +645,7 @@ index cf03e3cb7ed2cc..361eab5db6137d 100644
  		t.Fatal(err)
  	}
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index 512e4a4d6616e5..284db01c221d93 100644
+index 512e4a4d661..284db01c221 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
 @@ -36,6 +36,7 @@ import (
@@ -692,7 +692,7 @@ index 512e4a4d6616e5..284db01c221d93 100644
  		if err != nil {
  			return nil, err
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 379fb06526ccc7..d844cc4b8d749e 100644
+index 379fb06526c..d844cc4b8d7 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -8,6 +8,7 @@ import (
@@ -733,7 +733,7 @@ index 379fb06526ccc7..d844cc4b8d749e 100644
  	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
  	if err == ErrMessageTooLong {
 diff --git a/src/crypto/sha1/boring.go b/src/crypto/sha1/boring.go
-index e82a21c44a57c8..500b641dca6a1b 100644
+index e82a21c44a5..500b641dca6 100644
 --- a/src/crypto/sha1/boring.go
 +++ b/src/crypto/sha1/boring.go
 @@ -6,8 +6,9 @@
@@ -749,7 +749,7 @@ index e82a21c44a57c8..500b641dca6a1b 100644
  package sha1
  
 diff --git a/src/crypto/sha1/notboring.go b/src/crypto/sha1/notboring.go
-index 42ef87937faa34..9de147350c5f59 100644
+index 42ef87937fa..9de147350c5 100644
 --- a/src/crypto/sha1/notboring.go
 +++ b/src/crypto/sha1/notboring.go
 @@ -2,8 +2,8 @@
@@ -764,7 +764,7 @@ index 42ef87937faa34..9de147350c5f59 100644
  package sha1
  
 diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
-index bc169888786321..e0d6f4c5040d91 100644
+index bc169888786..e0d6f4c5040 100644
 --- a/src/crypto/sha1/sha1_test.go
 +++ b/src/crypto/sha1/sha1_test.go
 @@ -13,6 +13,7 @@ import (
@@ -796,7 +796,7 @@ index bc169888786321..e0d6f4c5040d91 100644
  
  		h := New()
 diff --git a/src/crypto/sha256/sha256.go b/src/crypto/sha256/sha256.go
-index b6fd0c3aab5100..fa246e9ecf65ba 100644
+index b6fd0c3aab5..fa246e9ecf6 100644
 --- a/src/crypto/sha256/sha256.go
 +++ b/src/crypto/sha256/sha256.go
 @@ -158,7 +158,7 @@ func New() hash.Hash {
@@ -840,7 +840,7 @@ index b6fd0c3aab5100..fa246e9ecf65ba 100644
  	}
  	var d digest
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index 7437655badee23..95c8688904c088 100644
+index 7437655bade..95c8688904c 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -13,6 +13,7 @@ import (
@@ -882,7 +882,7 @@ index 7437655badee23..95c8688904c088 100644
  
  		h := New()
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index 2fef7ddae07480..979e4c69ab710c 100644
+index 2fef7ddae07..979e4c69ab7 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -14,6 +14,7 @@ import (
@@ -924,7 +924,7 @@ index 2fef7ddae07480..979e4c69ab710c 100644
  
  		h := New()
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 70baa62d63754a..ecd0f5a7b3e9ed 100644
+index 70baa62d637..ecd0f5a7b3e 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -2,7 +2,7 @@
@@ -937,7 +937,7 @@ index 70baa62d63754a..ecd0f5a7b3e9ed 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index ea23a0336bd575..b117e47ba3a2c1 100644
+index ea23a0336bd..b117e47ba3a 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -950,7 +950,7 @@ index ea23a0336bd575..b117e47ba3a2c1 100644
  package tls
  
 diff --git a/src/crypto/tls/fipsonly/fipsonly.go b/src/crypto/tls/fipsonly/fipsonly.go
-index 1a94656dfee6dd..d7d1441ed319be 100644
+index 1a94656dfee..d7d1441ed31 100644
 --- a/src/crypto/tls/fipsonly/fipsonly.go
 +++ b/src/crypto/tls/fipsonly/fipsonly.go
 @@ -2,7 +2,7 @@
@@ -963,7 +963,7 @@ index 1a94656dfee6dd..d7d1441ed319be 100644
  // Package fipsonly restricts all TLS configuration to FIPS-approved settings.
  //
 diff --git a/src/crypto/tls/fipsonly/fipsonly_test.go b/src/crypto/tls/fipsonly/fipsonly_test.go
-index 9c1d3d279c472f..0ca7a863b73690 100644
+index 9c1d3d279c4..0ca7a863b73 100644
 --- a/src/crypto/tls/fipsonly/fipsonly_test.go
 +++ b/src/crypto/tls/fipsonly/fipsonly_test.go
 @@ -2,7 +2,7 @@
@@ -976,7 +976,7 @@ index 9c1d3d279c472f..0ca7a863b73690 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index 80d4dce3c5d6ed..f4f85f2fb2038f 100644
+index 80d4dce3c5d..f4f85f2fb20 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
 @@ -13,6 +13,7 @@ import (
@@ -1004,7 +1004,7 @@ index 80d4dce3c5d6ed..f4f85f2fb2038f 100644
  	}
  	state, err := marshaler.MarshalBinary()
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index 1aaabd5ef486aa..5a133c9b2f94c7 100644
+index 1aaabd5ef48..5a133c9b2f9 100644
 --- a/src/crypto/tls/notboring.go
 +++ b/src/crypto/tls/notboring.go
 @@ -2,7 +2,7 @@
@@ -1017,7 +1017,7 @@ index 1aaabd5ef486aa..5a133c9b2f94c7 100644
  package tls
  
 diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
-index 9aec21dbcd3bff..05324f731bedc4 100644
+index 9aec21dbcd3..05324f731be 100644
 --- a/src/crypto/x509/boring.go
 +++ b/src/crypto/x509/boring.go
 @@ -2,7 +2,7 @@
@@ -1030,7 +1030,7 @@ index 9aec21dbcd3bff..05324f731bedc4 100644
  package x509
  
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index e8fce393d29b00..9818c9b7d6b6b8 100644
+index e8fce393d29..9818c9b7d6b 100644
 --- a/src/crypto/x509/boring_test.go
 +++ b/src/crypto/x509/boring_test.go
 @@ -2,7 +2,7 @@
@@ -1043,7 +1043,7 @@ index e8fce393d29b00..9818c9b7d6b6b8 100644
  package x509
  
 diff --git a/src/crypto/x509/notboring.go b/src/crypto/x509/notboring.go
-index a0548a7f9179c5..ae6117a1554b7f 100644
+index a0548a7f917..ae6117a1554 100644
 --- a/src/crypto/x509/notboring.go
 +++ b/src/crypto/x509/notboring.go
 @@ -2,7 +2,7 @@
@@ -1056,34 +1056,34 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 583db20b19f2fd..b567a544298e27 100644
+index ada45c9308b..9e62dfa1a24 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.20
  
  require (
- 	github.com/microsoft/go-crypto-openssl v0.2.2
+ 	github.com/microsoft/go-crypto-openssl v0.2.3
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10
  )
 diff --git a/src/go.sum b/src/go.sum
-index 4bc18da6466301..a5359c3bdc0886 100644
+index 799a91a2af7..e137340699e 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/microsoft/go-crypto-openssl v0.2.2 h1:Et6hPiaoGW3UXZ4IdjGwN0j4ZoiT8Ffg+Han7+SiDgk=
- github.com/microsoft/go-crypto-openssl v0.2.2/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
+ github.com/microsoft/go-crypto-openssl v0.2.3 h1:bbY1FjnyjNcxZydzBcWp3FDruolP66P1gUGDlN5WGug=
+ github.com/microsoft/go-crypto-openssl v0.2.3/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1 h1:KqlMKMf4t+yh6I2FbFvJpaMQTRH6MtWw06+ME10xxy0=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
  golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10 h1:Frnccbp+ok2GkUS2tC84yAq/U9Vg+0sIO7aRL3T4Xnc=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 0a905134394057..871bc6765dc79d 100644
+index afab09a9437..4fe37939cf4 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -397,6 +397,10 @@ var depsRules = `
+@@ -398,6 +398,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1094,7 +1094,7 @@ index 0a905134394057..871bc6765dc79d 100644
  	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
  	< github.com/microsoft/go-crypto-openssl/openssl
  	< crypto/internal/boring
-@@ -433,6 +437,7 @@ var depsRules = `
+@@ -434,6 +438,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -1103,7 +1103,7 @@ index 0a905134394057..871bc6765dc79d 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
 diff --git a/src/hash/example_test.go b/src/hash/example_test.go
-index f07b9aaa2c4898..2ff6c4827391c0 100644
+index f07b9aaa2c4..2ff6c482739 100644
 --- a/src/hash/example_test.go
 +++ b/src/hash/example_test.go
 @@ -2,6 +2,8 @@
@@ -1116,7 +1116,7 @@ index f07b9aaa2c4898..2ff6c4827391c0 100644
  
  import (
 diff --git a/src/hash/marshal_test.go b/src/hash/marshal_test.go
-index 3091f7a67acede..824be4a90fd4db 100644
+index 3091f7a67ac..824be4a90fd 100644
 --- a/src/hash/marshal_test.go
 +++ b/src/hash/marshal_test.go
 @@ -21,6 +21,7 @@ import (
@@ -1139,7 +1139,7 @@ index 3091f7a67acede..824be4a90fd4db 100644
  			enc, err := h2m.MarshalBinary()
 diff --git a/src/internal/goexperiment/exp_cngcrypto_off.go b/src/internal/goexperiment/exp_cngcrypto_off.go
 new file mode 100644
-index 00000000000000..831460053281e2
+index 00000000000..83146005328
 --- /dev/null
 +++ b/src/internal/goexperiment/exp_cngcrypto_off.go
 @@ -0,0 +1,9 @@
@@ -1154,7 +1154,7 @@ index 00000000000000..831460053281e2
 +const CNGCryptoInt = 0
 diff --git a/src/internal/goexperiment/exp_cngcrypto_on.go b/src/internal/goexperiment/exp_cngcrypto_on.go
 new file mode 100644
-index 00000000000000..99ee2542ca38a9
+index 00000000000..99ee2542ca3
 --- /dev/null
 +++ b/src/internal/goexperiment/exp_cngcrypto_on.go
 @@ -0,0 +1,9 @@
@@ -1168,7 +1168,7 @@ index 00000000000000..99ee2542ca38a9
 +const CNGCrypto = true
 +const CNGCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index cffb78a7234546..0a6d239a03dddd 100644
+index cffb78a7234..0a6d239a03d 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,7 @@ type Flags struct {

--- a/patches/0007-Vendor-crypto-backends.patch
+++ b/patches/0007-Vendor-crypto-backends.patch
@@ -9,14 +9,15 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/aes.go          | 472 ++++++++++++++
  .../go-crypto-openssl/openssl/bbig/big.go     |  38 ++
  .../go-crypto-openssl/openssl/big.go          |  13 +
+ .../go-crypto-openssl/openssl/ecdh.go         | 212 +++++++
  .../go-crypto-openssl/openssl/ecdsa.go        | 185 ++++++
  .../go-crypto-openssl/openssl/evpkey.go       | 313 ++++++++++
  .../go-crypto-openssl/openssl/goopenssl.c     | 153 +++++
  .../go-crypto-openssl/openssl/goopenssl.h     | 147 +++++
  .../go-crypto-openssl/openssl/hmac.go         | 251 ++++++++
  .../openssl/internal/subtle/aliasing.go       |  32 +
- .../go-crypto-openssl/openssl/openssl.go      | 295 +++++++++
- .../go-crypto-openssl/openssl/openssl_funcs.h | 279 +++++++++
+ .../go-crypto-openssl/openssl/openssl.go      | 302 +++++++++
+ .../go-crypto-openssl/openssl/openssl_funcs.h | 288 +++++++++
  .../openssl/openssl_lock_setup.c              |  53 ++
  .../go-crypto-openssl/openssl/rand.go         |  24 +
  .../go-crypto-openssl/openssl/rsa.go          | 336 ++++++++++
@@ -38,11 +39,12 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  12 +
- 33 files changed, 5548 insertions(+)
+ 34 files changed, 5927 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
@@ -74,7 +76,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
 
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE b/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
 new file mode 100644
-index 00000000000000..9e841e7a26e4eb
+index 00000000000..9e841e7a26e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
 @@ -0,0 +1,21 @@
@@ -101,7 +103,7 @@ index 00000000000000..9e841e7a26e4eb
 +    SOFTWARE
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
 new file mode 100644
-index 00000000000000..89268b471aa481
+index 00000000000..89268b471aa
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
 @@ -0,0 +1,472 @@
@@ -579,7 +581,7 @@ index 00000000000000..89268b471aa481
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
 new file mode 100644
-index 00000000000000..1214e1097ef56d
+index 00000000000..1214e1097ef
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
 @@ -0,0 +1,38 @@
@@ -623,7 +625,7 @@ index 00000000000000..1214e1097ef56d
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 new file mode 100644
-index 00000000000000..7207bde01c9d94
+index 00000000000..7207bde01c9
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 @@ -0,0 +1,13 @@
@@ -640,9 +642,227 @@ index 00000000000000..7207bde01c9d94
 +// This definition allows us to avoid importing math/big.
 +// Conversion between BigInt and *big.Int is in openssl/bbig.
 +type BigInt []uint
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
+new file mode 100644
+index 00000000000..a13c4116252
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
+@@ -0,0 +1,212 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build linux && !android
++// +build linux,!android
++
++package openssl
++
++// #include "goopenssl.h"
++import "C"
++import (
++	"errors"
++	"runtime"
++)
++
++type PublicKeyECDH struct {
++	curve string
++	key   C.GO_EC_POINT_PTR
++	bytes []byte
++}
++
++func (k *PublicKeyECDH) finalize() {
++	C.go_openssl_EC_POINT_free(k.key)
++}
++
++type PrivateKeyECDH struct {
++	curve string
++	key   C.GO_EC_KEY_PTR
++}
++
++func (k *PrivateKeyECDH) finalize() {
++	C.go_openssl_EC_KEY_free(k.key)
++}
++
++func NewPublicKeyECDH(curve string, bytes []byte) (*PublicKeyECDH, error) {
++	if len(bytes) < 1 {
++		return nil, errors.New("NewPublicKeyECDH: missing key")
++	}
++
++	nid, err := curveNID(curve)
++	if err != nil {
++		return nil, err
++	}
++
++	group := C.go_openssl_EC_GROUP_new_by_curve_name(nid)
++	if group == nil {
++		return nil, newOpenSSLError("EC_GROUP_new_by_curve_name")
++	}
++	defer C.go_openssl_EC_GROUP_free(group)
++	key := C.go_openssl_EC_POINT_new(group)
++	if key == nil {
++		return nil, newOpenSSLError("EC_POINT_new")
++	}
++	ok := C.go_openssl_EC_POINT_oct2point(group, key, base(bytes), C.size_t(len(bytes)), nil) != 0
++	if !ok {
++		C.go_openssl_EC_POINT_free(key)
++		return nil, errors.New("point not on curve")
++	}
++
++	k := &PublicKeyECDH{curve, key, append([]byte(nil), bytes...)}
++	runtime.SetFinalizer(k, (*PublicKeyECDH).finalize)
++	return k, nil
++}
++
++func (k *PublicKeyECDH) Bytes() []byte { return k.bytes }
++
++func NewPrivateKeyECDH(curve string, bytes []byte) (*PrivateKeyECDH, error) {
++	nid, err := curveNID(curve)
++	if err != nil {
++		return nil, err
++	}
++	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
++	if key == nil {
++		return nil, newOpenSSLError("EC_KEY_new_by_curve_name")
++	}
++	b := bytesToBN(bytes)
++	ok := b != nil && C.go_openssl_EC_KEY_set_private_key(key, b) != 0
++	if b != nil {
++		C.go_openssl_BN_free(b)
++	}
++	if !ok {
++		C.go_openssl_EC_KEY_free(key)
++		return nil, newOpenSSLError("EC_KEY_set_private_key")
++	}
++	k := &PrivateKeyECDH{curve, key}
++	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
++	return k, nil
++}
++
++func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
++	defer runtime.KeepAlive(k)
++
++	group := C.go_openssl_EC_KEY_get0_group(k.key)
++	if group == nil {
++		return nil, newOpenSSLError("EC_KEY_get0_group")
++	}
++	kbig := C.go_openssl_EC_KEY_get0_private_key(k.key)
++	if kbig == nil {
++		return nil, newOpenSSLError("EC_KEY_get0_private_key")
++	}
++	pt := C.go_openssl_EC_POINT_new(group)
++	if pt == nil {
++		return nil, newOpenSSLError("EC_POINT_new")
++	}
++	if C.go_openssl_EC_POINT_mul(group, pt, kbig, nil, nil, nil) == 0 {
++		C.go_openssl_EC_POINT_free(pt)
++		return nil, newOpenSSLError("EC_POINT_mul")
++	}
++	bytes, err := pointBytesECDH(k.curve, group, pt)
++	if err != nil {
++		C.go_openssl_EC_POINT_free(pt)
++		return nil, err
++	}
++	pub := &PublicKeyECDH{k.curve, pt, bytes}
++	// Note: Same as in NewPublicKeyECDH regarding finalizer and KeepAlive.
++	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
++	return pub, nil
++}
++
++func pointBytesECDH(curve string, group C.GO_EC_GROUP_PTR, pt C.GO_EC_POINT_PTR) ([]byte, error) {
++	out := make([]byte, 1+2*curveSize(curve))
++	n := C.go_openssl_EC_POINT_point2oct(group, pt, C.GO_POINT_CONVERSION_UNCOMPRESSED, base(out), C.size_t(len(out)), nil)
++	if int(n) != len(out) {
++		return nil, newOpenSSLError("EC_POINT_point2oct")
++	}
++	return out, nil
++}
++
++func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
++	group := C.go_openssl_EC_KEY_get0_group(priv.key)
++	if group == nil {
++		return nil, newOpenSSLError("EC_KEY_get0_group")
++	}
++	privBig := C.go_openssl_EC_KEY_get0_private_key(priv.key)
++	if privBig == nil {
++		return nil, newOpenSSLError("EC_KEY_get0_private_key")
++	}
++	pt := C.go_openssl_EC_POINT_new(group)
++	if pt == nil {
++		return nil, newOpenSSLError("EC_POINT_new")
++	}
++	defer C.go_openssl_EC_POINT_free(pt)
++	if C.go_openssl_EC_POINT_mul(group, pt, nil, pub.key, privBig, nil) == 0 {
++		return nil, newOpenSSLError("EC_POINT_mul")
++	}
++	out, err := xCoordBytesECDH(priv.curve, group, pt)
++	if err != nil {
++		return nil, err
++	}
++	return out, nil
++}
++
++func xCoordBytesECDH(curve string, group C.GO_EC_GROUP_PTR, pt C.GO_EC_POINT_PTR) ([]byte, error) {
++	big := C.go_openssl_BN_new()
++	defer C.go_openssl_BN_free(big)
++	if C.go_openssl_EC_POINT_get_affine_coordinates_GFp(group, pt, big, nil, nil) == 0 {
++		return nil, newOpenSSLError("EC_POINT_get_affine_coordinates_GFp")
++	}
++	return bigBytesECDH(curve, big)
++}
++
++func bigBytesECDH(curve string, big C.GO_BIGNUM_PTR) ([]byte, error) {
++	out := make([]byte, curveSize(curve))
++	if C.go_openssl_BN_bn2binpad(big, base(out), C.int(len(out))) == 0 {
++		return nil, newOpenSSLError("BN_bn2binpad")
++	}
++	return out, nil
++}
++
++func curveSize(curve string) int {
++	switch curve {
++	default:
++		panic("openssl: unknown curve " + curve)
++	case "P-256":
++		return 256 / 8
++	case "P-384":
++		return 384 / 8
++	case "P-521":
++		return (521 + 7) / 8
++	}
++}
++
++func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
++	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_EC, 0, curve)
++	if err != nil {
++		return nil, nil, err
++	}
++	defer C.go_openssl_EVP_PKEY_free(pkey)
++	key := C.go_openssl_EVP_PKEY_get1_EC_KEY(pkey)
++	if key == nil {
++		return nil, nil, newOpenSSLError("EVP_PKEY_get1_EC_KEY")
++	}
++	group := C.go_openssl_EC_KEY_get0_group(key)
++	if group == nil {
++		C.go_openssl_EC_KEY_free(key)
++		return nil, nil, newOpenSSLError("EC_KEY_get0_group")
++	}
++	b := C.go_openssl_EC_KEY_get0_private_key(key)
++	if b == nil {
++		C.go_openssl_EC_KEY_free(key)
++		return nil, nil, newOpenSSLError("EC_KEY_get0_private_key")
++	}
++	bytes, err := bigBytesECDH(curve, b)
++	if err != nil {
++		C.go_openssl_EC_KEY_free(key)
++		return nil, nil, err
++	}
++
++	k := &PrivateKeyECDH{curve, key}
++	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
++	return k, bytes, nil
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 new file mode 100644
-index 00000000000000..e5a3e03a390135
+index 00000000000..a9edf8d86cc
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 @@ -0,0 +1,185 @@
@@ -750,7 +970,7 @@ index 00000000000000..e5a3e03a390135
 +	bx = bigToBN(X)
 +	by = bigToBN(Y)
 +	if bx == nil || by == nil {
-+		return nil, newOpenSSLError("BN_bin2bn failed")
++		return nil, newOpenSSLError("BN_lebin2bn failed")
 +	}
 +	if key = C.go_openssl_EC_KEY_new_by_curve_name(nid); key == nil {
 +		return nil, newOpenSSLError("EC_KEY_new_by_curve_name failed")
@@ -761,7 +981,7 @@ index 00000000000000..e5a3e03a390135
 +	if D != nil {
 +		bd := bigToBN(D)
 +		if bd == nil {
-+			return nil, newOpenSSLError("BN_bin2bn failed")
++			return nil, newOpenSSLError("BN_lebin2bn failed")
 +		}
 +		defer C.go_openssl_BN_free(bd)
 +		if C.go_openssl_EC_KEY_set_private_key(key, bd) != 1 {
@@ -833,7 +1053,7 @@ index 00000000000000..e5a3e03a390135
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 new file mode 100644
-index 00000000000000..97e39c002e3052
+index 00000000000..97e39c002e3
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 @@ -0,0 +1,313 @@
@@ -1152,7 +1372,7 @@ index 00000000000000..97e39c002e3052
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
 new file mode 100644
-index 00000000000000..7bbf74185128dd
+index 00000000000..7bbf7418512
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
 @@ -0,0 +1,153 @@
@@ -1311,7 +1531,7 @@ index 00000000000000..7bbf74185128dd
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
 new file mode 100644
-index 00000000000000..03aed43e001d54
+index 00000000000..03aed43e001
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
 @@ -0,0 +1,147 @@
@@ -1465,7 +1685,7 @@ index 00000000000000..03aed43e001d54
 \ No newline at end of file
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
 new file mode 100644
-index 00000000000000..81918cde673cee
+index 00000000000..81918cde673
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
 @@ -0,0 +1,251 @@
@@ -1722,7 +1942,7 @@ index 00000000000000..81918cde673cee
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go
 new file mode 100644
-index 00000000000000..db09e4aae64f8c
+index 00000000000..db09e4aae64
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go
 @@ -0,0 +1,32 @@
@@ -1760,10 +1980,10 @@ index 00000000000000..db09e4aae64f8c
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
 new file mode 100644
-index 00000000000000..95f3e888bb4cc0
+index 00000000000..e3e13d793c4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
-@@ -0,0 +1,295 @@
+@@ -0,0 +1,302 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2017,6 +2237,13 @@ index 00000000000000..95f3e888bb4cc0
 +	return (*C.uchar)(unsafe.Pointer(&b[0]))
 +}
 +
++func bytesToBN(x []byte) C.GO_BIGNUM_PTR {
++	if len(x) == 0 {
++		return nil
++	}
++	return C.go_openssl_BN_bin2bn(base(x), C.int(len(x)), nil)
++}
++
 +func bigToBN(x BigInt) C.GO_BIGNUM_PTR {
 +	if len(x) == 0 {
 +		return nil
@@ -2061,10 +2288,10 @@ index 00000000000000..95f3e888bb4cc0
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 new file mode 100644
-index 00000000000000..d6fc72a5ef1fff
+index 00000000000..46f592c4340
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
-@@ -0,0 +1,279 @@
+@@ -0,0 +1,288 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2105,8 +2332,12 @@ index 00000000000000..d6fc72a5ef1fff
 +
 +// #include <openssl/ec.h>
 +enum {
-+    GO_EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID = 0x1001
++    GO_EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID = 0x1001,
 +};
++
++typedef enum {
++    GO_POINT_CONVERSION_UNCOMPRESSED = 4,
++} point_conversion_form_t;
 +
 +// #include <openssl/obj_mac.h>
 +enum {
@@ -2271,16 +2502,21 @@ index 00000000000000..d6fc72a5ef1fff
 +DEFINEFUNC(int, BN_num_bits, (const GO_BIGNUM_PTR arg0), (arg0)) \
 +DEFINEFUNC(GO_BIGNUM_PTR, BN_bin2bn, (const unsigned char *arg0, int arg1, GO_BIGNUM_PTR arg2), (arg0, arg1, arg2)) \
 +DEFINEFUNC(int, BN_bn2bin, (const GO_BIGNUM_PTR arg0, unsigned char *arg1), (arg0, arg1)) \
-+/* bn_lebin2bn and bn_bn2lebinpad are not exported in any OpenSSL 1.0.2, but they exist. */ \
++/* bn_lebin2bn, bn_bn2lebinpad and BN_bn2binpad are not exported in any OpenSSL 1.0.2, but they exist. */ \
 +/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(GO_BIGNUM_PTR, BN_lebin2bn, bn_lebin2bn, (const unsigned char *s, int len, GO_BIGNUM_PTR ret), (s, len, ret)) \
 +/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2lebinpad, bn_bn2lebinpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
++/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2binpad, bn_bn2binpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
 +DEFINEFUNC(void, EC_GROUP_free, (GO_EC_GROUP_PTR arg0), (arg0)) \
 +DEFINEFUNC(GO_EC_POINT_PTR, EC_POINT_new, (const GO_EC_GROUP_PTR arg0), (arg0)) \
 +DEFINEFUNC(void, EC_POINT_free, (GO_EC_POINT_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EC_POINT_get_affine_coordinates_GFp, (const GO_EC_GROUP_PTR arg0, const GO_EC_POINT_PTR arg1, GO_BIGNUM_PTR arg2, GO_BIGNUM_PTR arg3, GO_BN_CTX_PTR arg4), (arg0, arg1, arg2, arg3, arg4)) \
++DEFINEFUNC(size_t, EC_POINT_point2oct, (const GO_EC_GROUP_PTR group, const GO_EC_POINT_PTR p, point_conversion_form_t form, unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, form, buf, len, ctx)) \
++DEFINEFUNC(int, EC_POINT_oct2point, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR p, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, buf, len, ctx)) \
++DEFINEFUNC(int, EC_POINT_mul, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR r, const GO_BIGNUM_PTR n, const GO_EC_POINT_PTR q, const GO_BIGNUM_PTR m, GO_BN_CTX_PTR ctx), (group, r, n, q, m, ctx)) \
 +DEFINEFUNC(GO_EC_KEY_PTR, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
 +DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (GO_EC_KEY_PTR key, GO_BIGNUM_PTR x, GO_BIGNUM_PTR y), (key, x, y)) \
 +DEFINEFUNC(void, EC_KEY_free, (GO_EC_KEY_PTR arg0), (arg0)) \
++DEFINEFUNC(GO_EC_GROUP_PTR, EC_GROUP_new_by_curve_name, (int nid), (nid)) \
 +DEFINEFUNC(const GO_EC_GROUP_PTR, EC_KEY_get0_group, (const GO_EC_KEY_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EC_KEY_set_private_key, (GO_EC_KEY_PTR arg0, const GO_BIGNUM_PTR arg1), (arg0, arg1)) \
 +DEFINEFUNC(const GO_BIGNUM_PTR, EC_KEY_get0_private_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
@@ -2346,7 +2582,7 @@ index 00000000000000..d6fc72a5ef1fff
 +
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c
 new file mode 100644
-index 00000000000000..5cd7275f4075ed
+index 00000000000..5cd7275f407
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c
 @@ -0,0 +1,53 @@
@@ -2405,7 +2641,7 @@ index 00000000000000..5cd7275f4075ed
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go
 new file mode 100644
-index 00000000000000..17f64a52ae5255
+index 00000000000..17f64a52ae5
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go
 @@ -0,0 +1,24 @@
@@ -2435,7 +2671,7 @@ index 00000000000000..17f64a52ae5255
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 new file mode 100644
-index 00000000000000..cfc6e40fcf41e2
+index 00000000000..cfc6e40fcf4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 @@ -0,0 +1,336 @@
@@ -2777,7 +3013,7 @@ index 00000000000000..cfc6e40fcf41e2
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 new file mode 100644
-index 00000000000000..bb96a9bcaee7d4
+index 00000000000..bb96a9bcaee
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 @@ -0,0 +1,580 @@
@@ -3363,7 +3599,7 @@ index 00000000000000..bb96a9bcaee7d4
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/LICENSE b/src/vendor/github.com/microsoft/go-crypto-winnative/LICENSE
 new file mode 100644
-index 00000000000000..9e841e7a26e4eb
+index 00000000000..9e841e7a26e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/LICENSE
 @@ -0,0 +1,21 @@
@@ -3390,7 +3626,7 @@ index 00000000000000..9e841e7a26e4eb
 +    SOFTWARE
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
 new file mode 100644
-index 00000000000000..e3b865ab7823d1
+index 00000000000..e3b865ab782
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
 @@ -0,0 +1,359 @@
@@ -3755,7 +3991,7 @@ index 00000000000000..e3b865ab7823d1
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/bbig/big.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/bbig/big.go
 new file mode 100644
-index 00000000000000..584f2069b1cd0a
+index 00000000000..584f2069b1c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/bbig/big.go
 @@ -0,0 +1,31 @@
@@ -3792,7 +4028,7 @@ index 00000000000000..584f2069b1cd0a
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/big.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/big.go
 new file mode 100644
-index 00000000000000..36f0e0c6e278bc
+index 00000000000..36f0e0c6e27
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/big.go
 @@ -0,0 +1,30 @@
@@ -3828,7 +4064,7 @@ index 00000000000000..36f0e0c6e278bc
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go
 new file mode 100644
-index 00000000000000..844c087287cabe
+index 00000000000..844c087287c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go
 @@ -0,0 +1,130 @@
@@ -3964,7 +4200,7 @@ index 00000000000000..844c087287cabe
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go
 new file mode 100644
-index 00000000000000..c3fa6dd766e34e
+index 00000000000..c3fa6dd766e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go
 @@ -0,0 +1,252 @@
@@ -4222,7 +4458,7 @@ index 00000000000000..c3fa6dd766e34e
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
 new file mode 100644
-index 00000000000000..a77ff97bb8f521
+index 00000000000..a77ff97bb8f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
 @@ -0,0 +1,175 @@
@@ -4403,7 +4639,7 @@ index 00000000000000..a77ff97bb8f521
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
 new file mode 100644
-index 00000000000000..736472d5b4e700
+index 00000000000..736472d5b4e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
 @@ -0,0 +1,55 @@
@@ -4464,7 +4700,7 @@ index 00000000000000..736472d5b4e700
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
 new file mode 100644
-index 00000000000000..766768e9d46b41
+index 00000000000..766768e9d46
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
 @@ -0,0 +1,161 @@
@@ -4631,7 +4867,7 @@ index 00000000000000..766768e9d46b41
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go
 new file mode 100644
-index 00000000000000..cdd845ab5bea98
+index 00000000000..cdd845ab5be
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go
 @@ -0,0 +1,28 @@
@@ -4665,7 +4901,7 @@ index 00000000000000..cdd845ab5bea98
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
 new file mode 100644
-index 00000000000000..7e3f7abe3487cb
+index 00000000000..7e3f7abe348
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
 @@ -0,0 +1,374 @@
@@ -5045,7 +5281,7 @@ index 00000000000000..7e3f7abe3487cb
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go
 new file mode 100644
-index 00000000000000..0ab3c9e9ce06fb
+index 00000000000..0ab3c9e9ce0
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go
 @@ -0,0 +1,199 @@
@@ -5250,7 +5486,7 @@ index 00000000000000..0ab3c9e9ce06fb
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000000..f3100669d53d3f
+index 00000000000..f3100669d53
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 @@ -0,0 +1,221 @@
@@ -5477,7 +5713,7 @@ index 00000000000000..f3100669d53d3f
 +//sys   DestroySecret(hSecret SECRET_HANDLE) (s error) = bcrypt.BCryptDestroySecret
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go
 new file mode 100644
-index 00000000000000..09053bb5a4738b
+index 00000000000..09053bb5a47
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go
 @@ -0,0 +1,372 @@
@@ -5855,7 +6091,7 @@ index 00000000000000..09053bb5a4738b
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/subtle/aliasing.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/subtle/aliasing.go
 new file mode 100644
-index 00000000000000..db09e4aae64f8c
+index 00000000000..db09e4aae64
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/subtle/aliasing.go
 @@ -0,0 +1,32 @@
@@ -5893,7 +6129,7 @@ index 00000000000000..db09e4aae64f8c
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 new file mode 100644
-index 00000000000000..1722410e5af193
+index 00000000000..1722410e5af
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 @@ -0,0 +1,55 @@
@@ -5953,11 +6189,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 0854beacdd92eb..90869b5102d695 100644
+index 3e4bb5b90bc..b9a24040a44 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,15 @@
-+# github.com/microsoft/go-crypto-openssl v0.2.2
++# github.com/microsoft/go-crypto-openssl v0.2.3
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig


### PR DESCRIPTION
This PR implements ECDH support for the OpenSSL backend. CNG and Boring backends support ECDH since #804.