### PR TITLE
Upgrade go-crypto-openssl to v0.2.5

### DIFF
--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -627,24 +627,24 @@ index c83a7272c9f..a0548a7f917 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 2a1261f925a..ada45c9308b 100644
+index 2a1261f925a..efb49244051 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.20
  
  require (
-+	github.com/microsoft/go-crypto-openssl v0.2.3
++	github.com/microsoft/go-crypto-openssl v0.2.5
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10
  )
 diff --git a/src/go.sum b/src/go.sum
-index ef6748d5968..799a91a2af7 100644
+index ef6748d5968..3e5bef0deac 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/microsoft/go-crypto-openssl v0.2.3 h1:bbY1FjnyjNcxZydzBcWp3FDruolP66P1gUGDlN5WGug=
-+github.com/microsoft/go-crypto-openssl v0.2.3/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
++github.com/microsoft/go-crypto-openssl v0.2.5 h1:GtC8zLixUmBKArLGmLLIe/VIC/c/9Z02nhDzg5Uxgdk=
++github.com/microsoft/go-crypto-openssl v0.2.5/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
  golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10 h1:Frnccbp+ok2GkUS2tC84yAq/U9Vg+0sIO7aRL3T4Xnc=
@@ -730,7 +730,7 @@ index 02e744362c3..cffb78a7234 100644
  	// Unified enables the compiler's unified IR construction
  	// experiment.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index edff9a201ef..49752c0d1c1 100644
+index 67e2d256b45..0052c720518 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
 @@ -14,6 +14,7 @@ import (

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -1056,24 +1056,24 @@ index a0548a7f917..ae6117a1554 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index ada45c9308b..9e62dfa1a24 100644
+index efb49244051..018e9581f14 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.20
  
  require (
- 	github.com/microsoft/go-crypto-openssl v0.2.3
+ 	github.com/microsoft/go-crypto-openssl v0.2.5
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10
  )
 diff --git a/src/go.sum b/src/go.sum
-index 799a91a2af7..e137340699e 100644
+index 3e5bef0deac..11cb1f42277 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/microsoft/go-crypto-openssl v0.2.3 h1:bbY1FjnyjNcxZydzBcWp3FDruolP66P1gUGDlN5WGug=
- github.com/microsoft/go-crypto-openssl v0.2.3/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
+ github.com/microsoft/go-crypto-openssl v0.2.5 h1:GtC8zLixUmBKArLGmLLIe/VIC/c/9Z02nhDzg5Uxgdk=
+ github.com/microsoft/go-crypto-openssl v0.2.5/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1 h1:KqlMKMf4t+yh6I2FbFvJpaMQTRH6MtWw06+ME10xxy0=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=

--- a/patches/0007-Vendor-crypto-backends.patch
+++ b/patches/0007-Vendor-crypto-backends.patch
@@ -9,18 +9,18 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-openssl/openssl/aes.go          | 472 ++++++++++++++
  .../go-crypto-openssl/openssl/bbig/big.go     |  38 ++
  .../go-crypto-openssl/openssl/big.go          |  13 +
- .../go-crypto-openssl/openssl/ecdh.go         | 212 +++++++
- .../go-crypto-openssl/openssl/ecdsa.go        | 185 ++++++
- .../go-crypto-openssl/openssl/evpkey.go       | 313 ++++++++++
+ .../go-crypto-openssl/openssl/ecdh.go         | 223 +++++++
+ .../go-crypto-openssl/openssl/ecdsa.go        | 174 ++++++
+ .../go-crypto-openssl/openssl/evpkey.go       | 325 ++++++++++
  .../go-crypto-openssl/openssl/goopenssl.c     | 153 +++++
  .../go-crypto-openssl/openssl/goopenssl.h     | 147 +++++
  .../go-crypto-openssl/openssl/hmac.go         | 251 ++++++++
  .../openssl/internal/subtle/aliasing.go       |  32 +
  .../go-crypto-openssl/openssl/openssl.go      | 302 +++++++++
- .../go-crypto-openssl/openssl/openssl_funcs.h | 288 +++++++++
+ .../go-crypto-openssl/openssl/openssl_funcs.h | 293 +++++++++
  .../openssl/openssl_lock_setup.c              |  53 ++
  .../go-crypto-openssl/openssl/rand.go         |  24 +
- .../go-crypto-openssl/openssl/rsa.go          | 336 ++++++++++
+ .../go-crypto-openssl/openssl/rsa.go          | 337 ++++++++++
  .../go-crypto-openssl/openssl/sha.go          | 580 ++++++++++++++++++
  .../microsoft/go-crypto-winnative/LICENSE     |  21 +
  .../microsoft/go-crypto-winnative/cng/aes.go  | 359 +++++++++++
@@ -39,7 +39,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  12 +
- 34 files changed, 5927 insertions(+)
+ 34 files changed, 5945 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
@@ -644,10 +644,10 @@ index 00000000000..7207bde01c9
 +type BigInt []uint
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
 new file mode 100644
-index 00000000000..a13c4116252
+index 00000000000..fba3704531e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
-@@ -0,0 +1,212 @@
+@@ -0,0 +1,223 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -664,50 +664,77 @@ index 00000000000..a13c4116252
 +)
 +
 +type PublicKeyECDH struct {
-+	curve string
-+	key   C.GO_EC_POINT_PTR
++	_pkey C.GO_EVP_PKEY_PTR
 +	bytes []byte
++
++	// priv is only set when PublicKeyECDH is derived from a private key,
++	// in which case priv's finalizer is responsible for freeing _pkey.
++	// This ensures priv is not finalized while the public key is alive,
++	// which could cause use-after-free and double-free behavior.
++	//
++	// We could avoid this altogether if using EVP_PKEY_up_ref
++	// when instantiating a derived public key, unfortunately
++	// it is not available on OpenSSL 1.0.2.
++	priv *PrivateKeyECDH
 +}
 +
 +func (k *PublicKeyECDH) finalize() {
-+	C.go_openssl_EC_POINT_free(k.key)
++	if k.priv == nil {
++		C.go_openssl_EVP_PKEY_free(k._pkey)
++	}
 +}
 +
 +type PrivateKeyECDH struct {
-+	curve string
-+	key   C.GO_EC_KEY_PTR
++	_pkey C.GO_EVP_PKEY_PTR
 +}
 +
 +func (k *PrivateKeyECDH) finalize() {
-+	C.go_openssl_EC_KEY_free(k.key)
++	C.go_openssl_EVP_PKEY_free(k._pkey)
 +}
 +
 +func NewPublicKeyECDH(curve string, bytes []byte) (*PublicKeyECDH, error) {
 +	if len(bytes) < 1 {
 +		return nil, errors.New("NewPublicKeyECDH: missing key")
 +	}
-+
 +	nid, err := curveNID(curve)
 +	if err != nil {
 +		return nil, err
 +	}
-+
-+	group := C.go_openssl_EC_GROUP_new_by_curve_name(nid)
-+	if group == nil {
-+		return nil, newOpenSSLError("EC_GROUP_new_by_curve_name")
-+	}
-+	defer C.go_openssl_EC_GROUP_free(group)
-+	key := C.go_openssl_EC_POINT_new(group)
++	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
 +	if key == nil {
-+		return nil, newOpenSSLError("EC_POINT_new")
++		return nil, newOpenSSLError("EC_KEY_new_by_curve_name")
 +	}
-+	ok := C.go_openssl_EC_POINT_oct2point(group, key, base(bytes), C.size_t(len(bytes)), nil) != 0
-+	if !ok {
-+		C.go_openssl_EC_POINT_free(key)
-+		return nil, errors.New("point not on curve")
++	var k *PublicKeyECDH
++	defer func() {
++		if k == nil {
++			C.go_openssl_EC_KEY_free(key)
++		}
++	}()
++	if vMajor == 1 && vMinor == 0 {
++		// EC_KEY_oct2key does not exist on OpenSSL 1.0.2,
++		// we have to simulate it.
++		group := C.go_openssl_EC_KEY_get0_group(key)
++		pt := C.go_openssl_EC_POINT_new(group)
++		if pt == nil {
++			return nil, newOpenSSLError("EC_POINT_new")
++		}
++		defer C.go_openssl_EC_POINT_free(pt)
++		if C.go_openssl_EC_POINT_oct2point(group, pt, base(bytes), C.size_t(len(bytes)), nil) != 1 {
++			return nil, errors.New("point not on curve")
++		}
++		if C.go_openssl_EC_KEY_set_public_key(key, pt) != 1 {
++			return nil, newOpenSSLError("EC_KEY_set_public_key")
++		}
++	} else {
++		if C.go_openssl_EC_KEY_oct2key(key, base(bytes), C.size_t(len(bytes)), nil) != 1 {
++			return nil, newOpenSSLError("EC_KEY_oct2key")
++		}
 +	}
-+
-+	k := &PublicKeyECDH{curve, key, append([]byte(nil), bytes...)}
++	pkey, err := newEVPPKEY(key)
++	if err != nil {
++		return nil, err
++	}
++	k = &PublicKeyECDH{pkey, append([]byte(nil), bytes...), nil}
 +	runtime.SetFinalizer(k, (*PublicKeyECDH).finalize)
 +	return k, nil
 +}
@@ -719,115 +746,100 @@ index 00000000000..a13c4116252
 +	if err != nil {
 +		return nil, err
 +	}
++	b := bytesToBN(bytes)
++	if b == nil {
++		return nil, newOpenSSLError("BN_bin2bn")
++	}
++	defer C.go_openssl_BN_free(b)
 +	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
 +	if key == nil {
 +		return nil, newOpenSSLError("EC_KEY_new_by_curve_name")
 +	}
-+	b := bytesToBN(bytes)
-+	ok := b != nil && C.go_openssl_EC_KEY_set_private_key(key, b) != 0
-+	if b != nil {
-+		C.go_openssl_BN_free(b)
-+	}
-+	if !ok {
-+		C.go_openssl_EC_KEY_free(key)
++	var pkey C.GO_EVP_PKEY_PTR
++	defer func() {
++		if pkey == nil {
++			C.go_openssl_EC_KEY_free(key)
++		}
++	}()
++	if C.go_openssl_EC_KEY_set_private_key(key, b) != 1 {
 +		return nil, newOpenSSLError("EC_KEY_set_private_key")
 +	}
-+	k := &PrivateKeyECDH{curve, key}
++	pkey, err = newEVPPKEY(key)
++	if err != nil {
++		return nil, err
++	}
++	k := &PrivateKeyECDH{pkey}
 +	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
 +	return k, nil
 +}
 +
 +func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 +	defer runtime.KeepAlive(k)
-+
-+	group := C.go_openssl_EC_KEY_get0_group(k.key)
++	key := C.go_openssl_EVP_PKEY_get1_EC_KEY(k._pkey)
++	if key == nil {
++		return nil, newOpenSSLError("EVP_PKEY_get1_EC_KEY")
++	}
++	defer C.go_openssl_EC_KEY_free(key)
++	group := C.go_openssl_EC_KEY_get0_group(key)
 +	if group == nil {
 +		return nil, newOpenSSLError("EC_KEY_get0_group")
 +	}
-+	kbig := C.go_openssl_EC_KEY_get0_private_key(k.key)
-+	if kbig == nil {
-+		return nil, newOpenSSLError("EC_KEY_get0_private_key")
-+	}
-+	pt := C.go_openssl_EC_POINT_new(group)
++	pt := C.go_openssl_EC_KEY_get0_public_key(key)
 +	if pt == nil {
-+		return nil, newOpenSSLError("EC_POINT_new")
++		// The public key will be nil if k has been generated using
++		// NewPrivateKeyECDH instead of GenerateKeyECDH.
++		//
++		// OpenSSL does not expose any method to generate the public
++		// key from the private key [1], so we have to calculate it here
++		// https://github.com/openssl/openssl/issues/18437#issuecomment-1144717206
++		pt = C.go_openssl_EC_POINT_new(group)
++		if pt == nil {
++			return nil, newOpenSSLError("EC_POINT_new")
++		}
++		defer C.go_openssl_EC_POINT_free(pt)
++		kbig := C.go_openssl_EC_KEY_get0_private_key(key)
++		if C.go_openssl_EC_POINT_mul(group, pt, kbig, nil, nil, nil) == 0 {
++			return nil, newOpenSSLError("EC_POINT_mul")
++		}
 +	}
-+	if C.go_openssl_EC_POINT_mul(group, pt, kbig, nil, nil, nil) == 0 {
-+		C.go_openssl_EC_POINT_free(pt)
-+		return nil, newOpenSSLError("EC_POINT_mul")
++	n := C.go_openssl_EC_POINT_point2oct(group, pt, C.GO_POINT_CONVERSION_UNCOMPRESSED, nil, 0, nil)
++	if n == 0 {
++		return nil, newOpenSSLError("EC_POINT_point2oct")
 +	}
-+	bytes, err := pointBytesECDH(k.curve, group, pt)
-+	if err != nil {
-+		C.go_openssl_EC_POINT_free(pt)
-+		return nil, err
++	bytes := make([]byte, n)
++	n = C.go_openssl_EC_POINT_point2oct(group, pt, C.GO_POINT_CONVERSION_UNCOMPRESSED, base(bytes), C.size_t(len(bytes)), nil)
++	if int(n) != len(bytes) {
++		return nil, newOpenSSLError("EC_POINT_point2oct")
 +	}
-+	pub := &PublicKeyECDH{k.curve, pt, bytes}
++	pub := &PublicKeyECDH{k._pkey, bytes, k}
 +	// Note: Same as in NewPublicKeyECDH regarding finalizer and KeepAlive.
 +	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
 +	return pub, nil
 +}
 +
-+func pointBytesECDH(curve string, group C.GO_EC_GROUP_PTR, pt C.GO_EC_POINT_PTR) ([]byte, error) {
-+	out := make([]byte, 1+2*curveSize(curve))
-+	n := C.go_openssl_EC_POINT_point2oct(group, pt, C.GO_POINT_CONVERSION_UNCOMPRESSED, base(out), C.size_t(len(out)), nil)
-+	if int(n) != len(out) {
-+		return nil, newOpenSSLError("EC_POINT_point2oct")
-+	}
-+	return out, nil
-+}
-+
 +func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
-+	group := C.go_openssl_EC_KEY_get0_group(priv.key)
-+	if group == nil {
-+		return nil, newOpenSSLError("EC_KEY_get0_group")
++	defer runtime.KeepAlive(priv)
++	defer runtime.KeepAlive(pub)
++	ctx := C.go_openssl_EVP_PKEY_CTX_new(priv._pkey, nil)
++	if ctx == nil {
++		return nil, newOpenSSLError("EVP_PKEY_CTX_new")
 +	}
-+	privBig := C.go_openssl_EC_KEY_get0_private_key(priv.key)
-+	if privBig == nil {
-+		return nil, newOpenSSLError("EC_KEY_get0_private_key")
++	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
++	if C.go_openssl_EVP_PKEY_derive_init(ctx) != 1 {
++		return nil, newOpenSSLError("EVP_PKEY_derive_init")
 +	}
-+	pt := C.go_openssl_EC_POINT_new(group)
-+	if pt == nil {
-+		return nil, newOpenSSLError("EC_POINT_new")
++	if C.go_openssl_EVP_PKEY_derive_set_peer(ctx, pub._pkey) != 1 {
++		return nil, newOpenSSLError("EVP_PKEY_derive_set_peer")
 +	}
-+	defer C.go_openssl_EC_POINT_free(pt)
-+	if C.go_openssl_EC_POINT_mul(group, pt, nil, pub.key, privBig, nil) == 0 {
-+		return nil, newOpenSSLError("EC_POINT_mul")
++	var outLen C.size_t
++	if C.go_openssl_EVP_PKEY_derive(ctx, nil, &outLen) != 1 {
++		return nil, newOpenSSLError("EVP_PKEY_derive_init")
 +	}
-+	out, err := xCoordBytesECDH(priv.curve, group, pt)
-+	if err != nil {
-+		return nil, err
-+	}
-+	return out, nil
-+}
-+
-+func xCoordBytesECDH(curve string, group C.GO_EC_GROUP_PTR, pt C.GO_EC_POINT_PTR) ([]byte, error) {
-+	big := C.go_openssl_BN_new()
-+	defer C.go_openssl_BN_free(big)
-+	if C.go_openssl_EC_POINT_get_affine_coordinates_GFp(group, pt, big, nil, nil) == 0 {
-+		return nil, newOpenSSLError("EC_POINT_get_affine_coordinates_GFp")
-+	}
-+	return bigBytesECDH(curve, big)
-+}
-+
-+func bigBytesECDH(curve string, big C.GO_BIGNUM_PTR) ([]byte, error) {
-+	out := make([]byte, curveSize(curve))
-+	if C.go_openssl_BN_bn2binpad(big, base(out), C.int(len(out))) == 0 {
-+		return nil, newOpenSSLError("BN_bn2binpad")
++	out := make([]byte, outLen)
++	if C.go_openssl_EVP_PKEY_derive(ctx, base(out), &outLen) != 1 {
++		return nil, newOpenSSLError("EVP_PKEY_derive_init")
 +	}
 +	return out, nil
-+}
-+
-+func curveSize(curve string) int {
-+	switch curve {
-+	default:
-+		panic("openssl: unknown curve " + curve)
-+	case "P-256":
-+		return 256 / 8
-+	case "P-384":
-+		return 384 / 8
-+	case "P-521":
-+		return (521 + 7) / 8
-+	}
 +}
 +
 +func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
@@ -835,37 +847,36 @@ index 00000000000..a13c4116252
 +	if err != nil {
 +		return nil, nil, err
 +	}
-+	defer C.go_openssl_EVP_PKEY_free(pkey)
++	var k *PrivateKeyECDH
++	defer func() {
++		if k == nil {
++			C.go_openssl_EVP_PKEY_free(pkey)
++		}
++	}()
 +	key := C.go_openssl_EVP_PKEY_get1_EC_KEY(pkey)
 +	if key == nil {
 +		return nil, nil, newOpenSSLError("EVP_PKEY_get1_EC_KEY")
 +	}
-+	group := C.go_openssl_EC_KEY_get0_group(key)
-+	if group == nil {
-+		C.go_openssl_EC_KEY_free(key)
-+		return nil, nil, newOpenSSLError("EC_KEY_get0_group")
-+	}
++	defer C.go_openssl_EC_KEY_free(key)
 +	b := C.go_openssl_EC_KEY_get0_private_key(key)
 +	if b == nil {
-+		C.go_openssl_EC_KEY_free(key)
 +		return nil, nil, newOpenSSLError("EC_KEY_get0_private_key")
 +	}
-+	bytes, err := bigBytesECDH(curve, b)
-+	if err != nil {
-+		C.go_openssl_EC_KEY_free(key)
-+		return nil, nil, err
++	bits := C.go_openssl_EVP_PKEY_get_bits(pkey)
++	out := make([]byte, (bits+7)/8)
++	if C.go_openssl_BN_bn2binpad(b, base(out), C.int(len(out))) == 0 {
++		return nil, nil, newOpenSSLError("BN_bn2binpad")
 +	}
-+
-+	k := &PrivateKeyECDH{curve, key}
++	k = &PrivateKeyECDH{pkey}
 +	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
-+	return k, bytes, nil
++	return k, out, nil
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 new file mode 100644
-index 00000000000..a9edf8d86cc
+index 00000000000..de4aa0ecfcb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
-@@ -0,0 +1,185 @@
+@@ -0,0 +1,174 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -879,7 +890,6 @@ index 00000000000..a9edf8d86cc
 +import (
 +	"errors"
 +	"runtime"
-+	"unsafe"
 +)
 +
 +type PrivateKeyECDSA struct {
@@ -941,13 +951,12 @@ index 00000000000..a9edf8d86cc
 +	return k, nil
 +}
 +
-+func newECKey(curve string, X, Y, D BigInt) (pkey C.GO_EVP_PKEY_PTR, err error) {
-+	var nid C.int
-+	if nid, err = curveNID(curve); err != nil {
++func newECKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
++	nid, err := curveNID(curve)
++	if err != nil {
 +		return nil, err
 +	}
-+	var bx, by C.GO_BIGNUM_PTR
-+	var key C.GO_EC_KEY_PTR
++	var bx, by, bd C.GO_BIGNUM_PTR
 +	defer func() {
 +		if bx != nil {
 +			C.go_openssl_BN_free(bx)
@@ -955,44 +964,35 @@ index 00000000000..a9edf8d86cc
 +		if by != nil {
 +			C.go_openssl_BN_free(by)
 +		}
-+		if err != nil {
-+			if key != nil {
-+				C.go_openssl_EC_KEY_free(key)
-+			}
-+			if pkey != nil {
-+				C.go_openssl_EVP_PKEY_free(pkey)
-+				// pkey is a named return, so in case of error
-+				// it have to be cleared before returing.
-+				pkey = nil
-+			}
++		if bd != nil {
++			C.go_openssl_BN_free(bd)
 +		}
 +	}()
 +	bx = bigToBN(X)
 +	by = bigToBN(Y)
-+	if bx == nil || by == nil {
++	bd = bigToBN(D)
++	if bx == nil || by == nil || (D != nil && bd == nil) {
 +		return nil, newOpenSSLError("BN_lebin2bn failed")
 +	}
-+	if key = C.go_openssl_EC_KEY_new_by_curve_name(nid); key == nil {
++	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
++	if key == nil {
 +		return nil, newOpenSSLError("EC_KEY_new_by_curve_name failed")
 +	}
++	var pkey C.GO_EVP_PKEY_PTR
++	defer func() {
++		if pkey == nil {
++			defer C.go_openssl_EC_KEY_free(key)
++		}
++	}()
 +	if C.go_openssl_EC_KEY_set_public_key_affine_coordinates(key, bx, by) != 1 {
 +		return nil, newOpenSSLError("EC_KEY_set_public_key_affine_coordinates failed")
 +	}
-+	if D != nil {
-+		bd := bigToBN(D)
-+		if bd == nil {
-+			return nil, newOpenSSLError("BN_lebin2bn failed")
-+		}
-+		defer C.go_openssl_BN_free(bd)
-+		if C.go_openssl_EC_KEY_set_private_key(key, bd) != 1 {
-+			return nil, newOpenSSLError("EC_KEY_set_private_key failed")
-+		}
++	if D != nil && C.go_openssl_EC_KEY_set_private_key(key, bd) != 1 {
++		return nil, newOpenSSLError("EC_KEY_set_private_key failed")
 +	}
-+	if pkey = C.go_openssl_EVP_PKEY_new(); pkey == nil {
-+		return nil, newOpenSSLError("EVP_PKEY_new failed")
-+	}
-+	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_EC, (unsafe.Pointer)(key)) != 1 {
-+		return nil, newOpenSSLError("EVP_PKEY_assign failed")
++	pkey, err = newEVPPKEY(key)
++	if err != nil {
++		return nil, err
 +	}
 +	return pkey, nil
 +}
@@ -1053,10 +1053,10 @@ index 00000000000..a9edf8d86cc
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 new file mode 100644
-index 00000000000..97e39c002e3
+index 00000000000..2965d017dda
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
-@@ -0,0 +1,313 @@
+@@ -0,0 +1,325 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -1369,6 +1369,18 @@ index 00000000000..97e39c002e3
 +		return nil
 +	}
 +	return verifyEVP(withKey, padding, nil, nil, saltLen, h, verifyInit, verify, sig, hashed)
++}
++
++func newEVPPKEY(key C.GO_EC_KEY_PTR) (C.GO_EVP_PKEY_PTR, error) {
++	pkey := C.go_openssl_EVP_PKEY_new()
++	if pkey == nil {
++		return nil, newOpenSSLError("EVP_PKEY_new failed")
++	}
++	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_EC, (unsafe.Pointer)(key)) != 1 {
++		C.go_openssl_EVP_PKEY_free(pkey)
++		return nil, newOpenSSLError("EVP_PKEY_assign failed")
++	}
++	return pkey, nil
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
 new file mode 100644
@@ -2288,10 +2300,10 @@ index 00000000000..e3e13d793c4
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 new file mode 100644
-index 00000000000..46f592c4340
+index 00000000000..fe72f90e9c7
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
-@@ -0,0 +1,288 @@
+@@ -0,0 +1,293 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2511,14 +2523,15 @@ index 00000000000..46f592c4340
 +DEFINEFUNC(void, EC_POINT_free, (GO_EC_POINT_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EC_POINT_get_affine_coordinates_GFp, (const GO_EC_GROUP_PTR arg0, const GO_EC_POINT_PTR arg1, GO_BIGNUM_PTR arg2, GO_BIGNUM_PTR arg3, GO_BN_CTX_PTR arg4), (arg0, arg1, arg2, arg3, arg4)) \
 +DEFINEFUNC(size_t, EC_POINT_point2oct, (const GO_EC_GROUP_PTR group, const GO_EC_POINT_PTR p, point_conversion_form_t form, unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, form, buf, len, ctx)) \
-+DEFINEFUNC(int, EC_POINT_oct2point, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR p, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, buf, len, ctx)) \
++DEFINEFUNC_LEGACY_1_0(int, EC_POINT_oct2point, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR p, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, buf, len, ctx)) \
 +DEFINEFUNC(int, EC_POINT_mul, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR r, const GO_BIGNUM_PTR n, const GO_EC_POINT_PTR q, const GO_BIGNUM_PTR m, GO_BN_CTX_PTR ctx), (group, r, n, q, m, ctx)) \
 +DEFINEFUNC(GO_EC_KEY_PTR, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
 +DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (GO_EC_KEY_PTR key, GO_BIGNUM_PTR x, GO_BIGNUM_PTR y), (key, x, y)) \
++DEFINEFUNC_LEGACY_1_0(int, EC_KEY_set_public_key, (GO_EC_KEY_PTR key, const GO_EC_POINT_PTR pub), (key, pub)) \
 +DEFINEFUNC(void, EC_KEY_free, (GO_EC_KEY_PTR arg0), (arg0)) \
-+DEFINEFUNC(GO_EC_GROUP_PTR, EC_GROUP_new_by_curve_name, (int nid), (nid)) \
 +DEFINEFUNC(const GO_EC_GROUP_PTR, EC_KEY_get0_group, (const GO_EC_KEY_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EC_KEY_set_private_key, (GO_EC_KEY_PTR arg0, const GO_BIGNUM_PTR arg1), (arg0, arg1)) \
++DEFINEFUNC_1_1(int, EC_KEY_oct2key, (GO_EC_KEY_PTR eckey, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (eckey, buf, len, ctx)) \
 +DEFINEFUNC(const GO_BIGNUM_PTR, EC_KEY_get0_private_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
 +DEFINEFUNC(const GO_EC_POINT_PTR, EC_KEY_get0_public_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
 +DEFINEFUNC(GO_RSA_PTR, RSA_new, (void), ()) \
@@ -2549,9 +2562,10 @@ index 00000000000..46f592c4340
 +DEFINEFUNC(void, EVP_CIPHER_CTX_free, (GO_EVP_CIPHER_CTX_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EVP_CIPHER_CTX_ctrl, (GO_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr), (ctx, type, arg, ptr)) \
 +DEFINEFUNC(GO_EVP_PKEY_PTR, EVP_PKEY_new, (void), ()) \
-+/* EVP_PKEY_size pkey parameter is const since OpenSSL 1.1.1. */ \
++/* EVP_PKEY_size and EVP_PKEY_get_bits pkey parameter is const since OpenSSL 1.1.1. */ \
 +/* Exclude it from headercheck tool when using previous OpenSSL versions. */ \
 +/*check:from=1.1.1*/ DEFINEFUNC_RENAMED_3_0(int, EVP_PKEY_get_size, EVP_PKEY_size, (const GO_EVP_PKEY_PTR pkey), (pkey)) \
++/*check:from=1.1.1*/ DEFINEFUNC_RENAMED_3_0(int, EVP_PKEY_get_bits, EVP_PKEY_bits, (const GO_EVP_PKEY_PTR pkey), (pkey)) \
 +DEFINEFUNC(void, EVP_PKEY_free, (GO_EVP_PKEY_PTR arg0), (arg0)) \
 +DEFINEFUNC(GO_EC_KEY_PTR, EVP_PKEY_get1_EC_KEY, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 +DEFINEFUNC(GO_RSA_PTR, EVP_PKEY_get1_RSA, (GO_EVP_PKEY_PTR pkey), (pkey)) \
@@ -2570,6 +2584,9 @@ index 00000000000..46f592c4340
 +DEFINEFUNC(int, EVP_PKEY_sign_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EVP_PKEY_verify_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4)) \
++DEFINEFUNC(int, EVP_PKEY_derive_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
++DEFINEFUNC(int, EVP_PKEY_derive_set_peer, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR peer), (ctx, peer)) \
++DEFINEFUNC(int, EVP_PKEY_derive, (GO_EVP_PKEY_CTX_PTR ctx, unsigned char *key, size_t *keylen), (ctx, key, keylen)) \
 +DEFINEFUNC_3_0(GO_EVP_MAC_PTR, EVP_MAC_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 +DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_new, (GO_EVP_MAC_PTR arg0), (arg0)) \
 +DEFINEFUNC_3_0(void, EVP_MAC_CTX_free, (GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
@@ -2671,10 +2688,10 @@ index 00000000000..17f64a52ae5
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 new file mode 100644
-index 00000000000..cfc6e40fcf4
+index 00000000000..b717ea932cd
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
-@@ -0,0 +1,336 @@
+@@ -0,0 +1,337 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2707,6 +2724,7 @@ index 00000000000..cfc6e40fcf4
 +	if key == nil {
 +		return bad(newOpenSSLError("EVP_PKEY_get1_RSA failed"))
 +	}
++	defer C.go_openssl_RSA_free(key)
 +	N, E, D = rsaGetKey(key)
 +	P, Q = rsaGetFactors(key)
 +	Dp, Dq, Qinv = rsaGetCRTParams(key)
@@ -6189,11 +6207,11 @@ index 00000000000..1722410e5af
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 3e4bb5b90bc..b9a24040a44 100644
+index 3e4bb5b90bc..3f4bc8565fa 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,15 @@
-+# github.com/microsoft/go-crypto-openssl v0.2.3
++# github.com/microsoft/go-crypto-openssl v0.2.5
 +## explicit; go 1.16
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig


### PR DESCRIPTION
Release notes:
- https://github.com/microsoft/go-crypto-openssl/releases/tag/v0.2.4
- https://github.com/microsoft/go-crypto-openssl/releases/tag/v0.2.5