### PR TITLE
[microsoft/release-branch.go1.19] Port infrastructure improvements

### DIFF
--- a/eng/compliance/Guardian/BinSkimConfig.xml
+++ b/eng/compliance/Guardian/BinSkimConfig.xml
@@ -23,4 +23,8 @@
   <Properties Key="BA3010.EnableReadOnlyRelocations.Options" Type="PropertiesDictionary">
     <Property Key="RuleEnabled" Value="Disabled" Type="Driver.RuleEnabledState" />
   </Properties>
+  <!-- Go doesn't enable BIND_NOW by default: https://github.com/microsoft/go/issues/851 -->
+  <Properties Key="BA3011.EnableBindNow.Options" Type="PropertiesDictionary">
+    <Property Key="RuleEnabled" Value="Disabled" Type="Driver.RuleEnabledState" />
+  </Properties>
 </Properties>


### PR DESCRIPTION
Clean cherry-pick of a cmdscan flakiness fix and a BinSkim exception for a newly added category that we are tracking and can't directly address.