### PR TITLE
Update Windows pool to 2022 for new GCC version required after upstream change

### DIFF
--- a/eng/pipeline/stages/pool-core.yml
+++ b/eng/pipeline/stages/pool-core.yml
@@ -34,9 +34,9 @@ stages:
         # Pick images. https://helix.dot.net/#1esPools
         demands:
           ${{ if parameters.public }}:
-            windows: ImageOverride -equals 1es-windows-2019-open
+            windows: ImageOverride -equals 1es-windows-2022-open
           ${{ else }}:
-            windows: ImageOverride -equals 1es-windows-2019
+            windows: ImageOverride -equals 1es-windows-2022
 
           ${{ if parameters.public }}:
             linux: ImageOverride -equals 1es-ubuntu-2004-open

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -193,6 +193,11 @@ stages:
                   $env:PATH = (
                     $env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\Git\usr\bin' }
                   ) -join ';'
+
+                  Write-Host "Removing Chocolatey shim for SWIG to avoid running misc SWIG tests that would fail."
+                  # The Chocolatey shims are located in a single folder in PATH, so we can't change PATH to exclude it.
+                  # Upstream Windows builders don't have SWIG installed, so this makes coverage even.
+                  Remove-Item (Get-Command swig).Source
                 }
 
                 eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -- `

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -58,11 +58,11 @@ index a9ec6e6bfefb76..01765f01736ccb 100644
  package api
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 8b98b85960ccff..a7a059d35604f6 100644
+index 365b57aa42a0af..552eb67d2a000c 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1319,15 +1319,18 @@ func (t *tester) registerCgoTests() {
- 					return false
+@@ -1326,15 +1326,18 @@ func (t *tester) registerCgoTests() {
+ 					}
  				}
  			}
 -
@@ -116,10 +116,10 @@ index 4aaf46b5d0f0dc..e2ac54f96db1e8 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index c0730179db4acc..6cff17f652ba0c 100644
+index d364e090e86365..b17bb59314f1d2 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
-@@ -1102,6 +1102,7 @@ var hostobj []Hostobj
+@@ -1100,6 +1100,7 @@ var hostobj []Hostobj
  // These packages can use internal linking mode.
  // Others trigger external mode.
  var internalpkg = []string{
@@ -718,7 +718,7 @@ index 00000000000000..a7f2712e9e1464
 +const OpenSSLCrypto = true
 +const OpenSSLCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 02e744362c30d5..cffb78a7234546 100644
+index 8292f97b719314..20b4965e39b75d 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,7 @@ type Flags struct {
@@ -727,8 +727,8 @@ index 02e744362c30d5..cffb78a7234546 100644
  	BoringCrypto      bool
 +	OpenSSLCrypto     bool
  
- 	// Unified enables the compiler's unified IR construction
- 	// experiment.
+ 	// Regabi is split into several sub-experiments that can be
+ 	// enabled individually. Not all combinations work.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
 index 67e2d256b45027..0052c72051862f 100644
 --- a/src/os/exec/exec_test.go

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -1168,7 +1168,7 @@ index 00000000000000..99ee2542ca38a9
 +const CNGCrypto = true
 +const CNGCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index cffb78a7234546..0a6d239a03dddd 100644
+index 20b4965e39b75d..d9aacc5a5aa5e6 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,7 @@ type Flags struct {
@@ -1177,5 +1177,5 @@ index cffb78a7234546..0a6d239a03dddd 100644
  	OpenSSLCrypto     bool
 +	CNGCrypto         bool
  
- 	// Unified enables the compiler's unified IR construction
- 	// experiment.
+ 	// Regabi is split into several sub-experiments that can be
+ 	// enabled individually. Not all combinations work.


### PR DESCRIPTION
* https://github.com/microsoft/go/pull/856 is broken because a newer version of GCC is now needed to build with the race checker.
* Upstream change that requires newer GCC due to dependency on `libsynchronization.a`:  
  420197: runtime/race: update race_windows_amd64.syso | https://go-review.googlesource.com/c/go/+/420197
* Upstream Windows builder change to move from GCC 5.3.0 to 11.2.0 (or some system-provided one?):  
  414475: cmd/racebuild: tweak compilers used for windows syso build | https://go-review.googlesource.com/c/build/+/414475

We get GCC from MinGW-w64 in the `1es-windows-2019` image, which is based on https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md. That doc lists 8.1.0 as the version.

It looks like https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md has 11.2.0 so the first thing to try is changing to 1es-windows-2022.

Note: those docs seem to show GCC versions, not MinGW-w64 versions. The current latest version is 10.0.0. https://www.mingw-w64.org/downloads/

1ES images names are at https://helix.dot.net/#1esPools