### PR TITLE
Upgrade go-crypto-winnative to latest in main

### DIFF
--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -56,7 +56,7 @@ Subject: [PATCH] Add CNG crypto backend
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_on.go
 
 diff --git a/src/cmd/api/boring_test.go b/src/cmd/api/boring_test.go
-index 01765f01736..7598da96946 100644
+index 01765f01736ccb..7598da96946b9f 100644
 --- a/src/cmd/api/boring_test.go
 +++ b/src/cmd/api/boring_test.go
 @@ -2,7 +2,7 @@
@@ -69,7 +69,7 @@ index 01765f01736..7598da96946 100644
  package api
  
 diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
-index 5376227f74c..492ccf79d66 100644
+index 5376227f74cfaa..492ccf79d66b45 100644
 --- a/src/cmd/go/go_boring_test.go
 +++ b/src/cmd/go/go_boring_test.go
 @@ -2,7 +2,7 @@
@@ -82,7 +82,7 @@ index 5376227f74c..492ccf79d66 100644
  package main_test
  
 diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
-index 7b04f14ebdd..8bdafb72f2c 100644
+index 7b04f14ebdd618..8bdafb72f2c51a 100644
 --- a/src/crypto/boring/boring.go
 +++ b/src/crypto/boring/boring.go
 @@ -2,7 +2,7 @@
@@ -95,7 +95,7 @@ index 7b04f14ebdd..8bdafb72f2c 100644
  // Package boring exposes functions that are only available when building with
  // Go+BoringCrypto. This package is available on all targets as long as the
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
-index 602cb894e20..bf9e77e0659 100644
+index 602cb894e20d39..bf9e77e06599f0 100644
 --- a/src/crypto/ecdsa/boring.go
 +++ b/src/crypto/ecdsa/boring.go
 @@ -2,7 +2,7 @@
@@ -108,7 +108,7 @@ index 602cb894e20..bf9e77e0659 100644
  package ecdsa
  
 diff --git a/src/crypto/ecdsa/notboring.go b/src/crypto/ecdsa/notboring.go
-index 3cc16ecab56..dbbc6e3897e 100644
+index 3cc16ecab567a0..dbbc6e3897e153 100644
 --- a/src/crypto/ecdsa/notboring.go
 +++ b/src/crypto/ecdsa/notboring.go
 @@ -2,7 +2,7 @@
@@ -121,7 +121,7 @@ index 3cc16ecab56..dbbc6e3897e 100644
  package ecdsa
  
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
-index c2c06d3bff8..837cff477e2 100644
+index c2c06d3bff8c74..837cff477e257e 100644
 --- a/src/crypto/internal/backend/backend_test.go
 +++ b/src/crypto/internal/backend/backend_test.go
 @@ -4,9 +4,7 @@
@@ -136,7 +136,7 @@ index c2c06d3bff8..837cff477e2 100644
  // Test that Unreachable panics.
  func TestUnreachable(t *testing.T) {
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
-index 51bc3c68048..15f9833c9fc 100644
+index 51bc3c68048d51..15f9833c9fcd20 100644
 --- a/src/crypto/internal/backend/bbig/big.go
 +++ b/src/crypto/internal/backend/bbig/big.go
 @@ -2,7 +2,7 @@
@@ -150,7 +150,7 @@ index 51bc3c68048..15f9833c9fc 100644
  
 diff --git a/src/crypto/internal/backend/bbig/big_cng.go b/src/crypto/internal/backend/bbig/big_cng.go
 new file mode 100644
-index 00000000000..92623031fd8
+index 00000000000000..92623031fd87d0
 --- /dev/null
 +++ b/src/crypto/internal/backend/bbig/big_cng.go
 @@ -0,0 +1,12 @@
@@ -168,7 +168,7 @@ index 00000000000..92623031fd8
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000..9d1bbf010c0
+index 00000000000000..9d1bbf010c0fb6
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,205 @@
@@ -378,7 +378,7 @@ index 00000000000..9d1bbf010c0
 +	return cng.NewPublicKeyECDH(curve, bytes)
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
-index 007d8070538..114f72c3d10 100644
+index 007d8070538247..114f72c3d10ee4 100644
 --- a/src/crypto/internal/backend/common.go
 +++ b/src/crypto/internal/backend/common.go
 @@ -5,16 +5,19 @@
@@ -446,7 +446,7 @@ index 007d8070538..114f72c3d10 100644
 +	return !goexperiment.CNGCrypto
 +}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-index fcdea7f8ab5..503e49212f9 100644
+index fcdea7f8ab5a9d..503e49212f972c 100644
 --- a/src/crypto/internal/backend/nobackend.go
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -2,7 +2,7 @@
@@ -459,7 +459,7 @@ index fcdea7f8ab5..503e49212f9 100644
  package backend
  
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
-index 1dc7116efdf..b4c321d1d2b 100644
+index 1dc7116efdff2e..b4c321d1d2babb 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
 +++ b/src/crypto/internal/boring/fipstls/stub.s
 @@ -2,7 +2,7 @@
@@ -472,7 +472,7 @@ index 1dc7116efdf..b4c321d1d2b 100644
  // runtime_arg0 is declared in tls.go without a body.
  // It's provided by package runtime,
 diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
-index 4e629a4db8f..a7cd24a0d15 100644
+index 4e629a4db8f7c7..a7cd24a0d15647 100644
 --- a/src/crypto/internal/boring/fipstls/tls.go
 +++ b/src/crypto/internal/boring/fipstls/tls.go
 @@ -2,7 +2,7 @@
@@ -485,7 +485,7 @@ index 4e629a4db8f..a7cd24a0d15 100644
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
  // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
 diff --git a/src/crypto/rand/rand_windows.go b/src/crypto/rand/rand_windows.go
-index 6c0655c72b6..755861fc5bc 100644
+index 6c0655c72b692a..755861fc5bc21d 100644
 --- a/src/crypto/rand/rand_windows.go
 +++ b/src/crypto/rand/rand_windows.go
 @@ -8,10 +8,17 @@
@@ -508,7 +508,7 @@ index 6c0655c72b6..755861fc5bc 100644
  type rngReader struct{}
  
 diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
-index 220f8c05c3d..dd20b4af2e0 100644
+index 220f8c05c3d94b..dd20b4af2e0472 100644
 --- a/src/crypto/rsa/boring.go
 +++ b/src/crypto/rsa/boring.go
 @@ -2,7 +2,7 @@
@@ -521,7 +521,7 @@ index 220f8c05c3d..dd20b4af2e0 100644
  package rsa
  
 diff --git a/src/crypto/rsa/boring_test.go b/src/crypto/rsa/boring_test.go
-index 82a9d220e13..c3860f8d698 100644
+index 82a9d220e139af..c3860f8d698bc3 100644
 --- a/src/crypto/rsa/boring_test.go
 +++ b/src/crypto/rsa/boring_test.go
 @@ -2,7 +2,7 @@
@@ -534,7 +534,7 @@ index 82a9d220e13..c3860f8d698 100644
  // Note: Can run these tests against the non-BoringCrypto
  // version of the code by using "CGO_ENABLED=0 go test".
 diff --git a/src/crypto/rsa/notboring.go b/src/crypto/rsa/notboring.go
-index 933ac569e03..0f152b210fd 100644
+index 933ac569e034a8..0f152b210fdd84 100644
 --- a/src/crypto/rsa/notboring.go
 +++ b/src/crypto/rsa/notboring.go
 @@ -2,7 +2,7 @@
@@ -547,7 +547,7 @@ index 933ac569e03..0f152b210fd 100644
  package rsa
  
 diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
-index 577e9fca220..438c7ce7f11 100644
+index 577e9fca2201e7..438c7ce7f11449 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
 @@ -91,7 +91,9 @@ func DecryptPKCS1v15(random io.Reader, priv *PrivateKey, ciphertext []byte) ([]b
@@ -595,7 +595,7 @@ index 577e9fca220..438c7ce7f11 100644
  		if err != nil {
  			return err
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
-index f2f2a64ed35..645434caf9c 100644
+index f2f2a64ed35e23..645434caf9c6d5 100644
 --- a/src/crypto/rsa/pss.go
 +++ b/src/crypto/rsa/pss.go
 @@ -214,7 +214,9 @@ func signPSSWithSalt(priv *PrivateKey, hash crypto.Hash, hashed, salt []byte) ([
@@ -632,7 +632,7 @@ index f2f2a64ed35..645434caf9c 100644
  		if err != nil {
  			return err
 diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
-index cf03e3cb7ed..361eab5db61 100644
+index cf03e3cb7ed2cc..361eab5db6137d 100644
 --- a/src/crypto/rsa/pss_test.go
 +++ b/src/crypto/rsa/pss_test.go
 @@ -283,7 +283,7 @@ func fromHex(hexStr string) []byte {
@@ -645,7 +645,7 @@ index cf03e3cb7ed..361eab5db61 100644
  		t.Fatal(err)
  	}
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index 512e4a4d661..284db01c221 100644
+index 512e4a4d6616e5..284db01c221d93 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
 @@ -36,6 +36,7 @@ import (
@@ -692,7 +692,7 @@ index 512e4a4d661..284db01c221 100644
  		if err != nil {
  			return nil, err
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 379fb06526c..d844cc4b8d7 100644
+index 379fb06526ccc7..d844cc4b8d749e 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -8,6 +8,7 @@ import (
@@ -733,7 +733,7 @@ index 379fb06526c..d844cc4b8d7 100644
  	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
  	if err == ErrMessageTooLong {
 diff --git a/src/crypto/sha1/boring.go b/src/crypto/sha1/boring.go
-index e82a21c44a5..500b641dca6 100644
+index e82a21c44a57c8..500b641dca6a1b 100644
 --- a/src/crypto/sha1/boring.go
 +++ b/src/crypto/sha1/boring.go
 @@ -6,8 +6,9 @@
@@ -749,7 +749,7 @@ index e82a21c44a5..500b641dca6 100644
  package sha1
  
 diff --git a/src/crypto/sha1/notboring.go b/src/crypto/sha1/notboring.go
-index 42ef87937fa..9de147350c5 100644
+index 42ef87937faa34..9de147350c5f59 100644
 --- a/src/crypto/sha1/notboring.go
 +++ b/src/crypto/sha1/notboring.go
 @@ -2,8 +2,8 @@
@@ -764,7 +764,7 @@ index 42ef87937fa..9de147350c5 100644
  package sha1
  
 diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
-index bc169888786..e0d6f4c5040 100644
+index bc169888786321..e0d6f4c5040d91 100644
 --- a/src/crypto/sha1/sha1_test.go
 +++ b/src/crypto/sha1/sha1_test.go
 @@ -13,6 +13,7 @@ import (
@@ -796,7 +796,7 @@ index bc169888786..e0d6f4c5040 100644
  
  		h := New()
 diff --git a/src/crypto/sha256/sha256.go b/src/crypto/sha256/sha256.go
-index b6fd0c3aab5..fa246e9ecf6 100644
+index b6fd0c3aab5100..fa246e9ecf65ba 100644
 --- a/src/crypto/sha256/sha256.go
 +++ b/src/crypto/sha256/sha256.go
 @@ -158,7 +158,7 @@ func New() hash.Hash {
@@ -840,7 +840,7 @@ index b6fd0c3aab5..fa246e9ecf6 100644
  	}
  	var d digest
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index 7437655bade..95c8688904c 100644
+index 7437655badee23..95c8688904c088 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -13,6 +13,7 @@ import (
@@ -882,7 +882,7 @@ index 7437655bade..95c8688904c 100644
  
  		h := New()
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index 2fef7ddae07..979e4c69ab7 100644
+index 2fef7ddae07480..979e4c69ab710c 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -14,6 +14,7 @@ import (
@@ -924,7 +924,7 @@ index 2fef7ddae07..979e4c69ab7 100644
  
  		h := New()
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 70baa62d637..ecd0f5a7b3e 100644
+index 70baa62d63754a..ecd0f5a7b3e9ed 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -2,7 +2,7 @@
@@ -937,7 +937,7 @@ index 70baa62d637..ecd0f5a7b3e 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index ea23a0336bd..b117e47ba3a 100644
+index ea23a0336bd575..b117e47ba3a2c1 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -950,7 +950,7 @@ index ea23a0336bd..b117e47ba3a 100644
  package tls
  
 diff --git a/src/crypto/tls/fipsonly/fipsonly.go b/src/crypto/tls/fipsonly/fipsonly.go
-index 1a94656dfee..d7d1441ed31 100644
+index 1a94656dfee6dd..d7d1441ed319be 100644
 --- a/src/crypto/tls/fipsonly/fipsonly.go
 +++ b/src/crypto/tls/fipsonly/fipsonly.go
 @@ -2,7 +2,7 @@
@@ -963,7 +963,7 @@ index 1a94656dfee..d7d1441ed31 100644
  // Package fipsonly restricts all TLS configuration to FIPS-approved settings.
  //
 diff --git a/src/crypto/tls/fipsonly/fipsonly_test.go b/src/crypto/tls/fipsonly/fipsonly_test.go
-index 9c1d3d279c4..0ca7a863b73 100644
+index 9c1d3d279c472f..0ca7a863b73690 100644
 --- a/src/crypto/tls/fipsonly/fipsonly_test.go
 +++ b/src/crypto/tls/fipsonly/fipsonly_test.go
 @@ -2,7 +2,7 @@
@@ -976,7 +976,7 @@ index 9c1d3d279c4..0ca7a863b73 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index 80d4dce3c5d..f4f85f2fb20 100644
+index 80d4dce3c5d6ed..f4f85f2fb2038f 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
 @@ -13,6 +13,7 @@ import (
@@ -1004,7 +1004,7 @@ index 80d4dce3c5d..f4f85f2fb20 100644
  	}
  	state, err := marshaler.MarshalBinary()
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index 1aaabd5ef48..5a133c9b2f9 100644
+index 1aaabd5ef486aa..5a133c9b2f94c7 100644
 --- a/src/crypto/tls/notboring.go
 +++ b/src/crypto/tls/notboring.go
 @@ -2,7 +2,7 @@
@@ -1017,7 +1017,7 @@ index 1aaabd5ef48..5a133c9b2f9 100644
  package tls
  
 diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
-index 9aec21dbcd3..05324f731be 100644
+index 9aec21dbcd3bff..05324f731bedc4 100644
 --- a/src/crypto/x509/boring.go
 +++ b/src/crypto/x509/boring.go
 @@ -2,7 +2,7 @@
@@ -1030,7 +1030,7 @@ index 9aec21dbcd3..05324f731be 100644
  package x509
  
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index e8fce393d29..9818c9b7d6b 100644
+index e8fce393d29b00..9818c9b7d6b6b8 100644
 --- a/src/crypto/x509/boring_test.go
 +++ b/src/crypto/x509/boring_test.go
 @@ -2,7 +2,7 @@
@@ -1043,7 +1043,7 @@ index e8fce393d29..9818c9b7d6b 100644
  package x509
  
 diff --git a/src/crypto/x509/notboring.go b/src/crypto/x509/notboring.go
-index a0548a7f917..ae6117a1554 100644
+index a0548a7f9179c5..ae6117a1554b7f 100644
 --- a/src/crypto/x509/notboring.go
 +++ b/src/crypto/x509/notboring.go
 @@ -2,7 +2,7 @@
@@ -1056,31 +1056,31 @@ index a0548a7f917..ae6117a1554 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index ada45c9308b..9e62dfa1a24 100644
+index eccb90ae2d36ac..7fd7320e0a0e91 100644
 --- a/src/go.mod
 +++ b/src/go.mod
-@@ -4,6 +4,7 @@ go 1.20
+@@ -4,6 +4,7 @@ go 1.21
  
  require (
  	github.com/microsoft/go-crypto-openssl v0.2.3
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1
++	github.com/microsoft/go-crypto-winnative v0.0.0-20230125071228-ef6c7cb780c6
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10
  )
 diff --git a/src/go.sum b/src/go.sum
-index 799a91a2af7..e137340699e 100644
+index 799a91a2af7f4d..ce5ddcdf80951f 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/microsoft/go-crypto-openssl v0.2.3 h1:bbY1FjnyjNcxZydzBcWp3FDruolP66P1gUGDlN5WGug=
  github.com/microsoft/go-crypto-openssl v0.2.3/go.mod h1:rC+rtBU3m60UCQifBmpWII0VETfu78w6YGZQvVc0rd4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1 h1:KqlMKMf4t+yh6I2FbFvJpaMQTRH6MtWw06+ME10xxy0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20230125071228-ef6c7cb780c6 h1:6DT0+Xkuu2MOaGrK41ATNUB4AhqUVq1/wWcOsCTAkck=
++github.com/microsoft/go-crypto-winnative v0.0.0-20230125071228-ef6c7cb780c6/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
  golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10 h1:Frnccbp+ok2GkUS2tC84yAq/U9Vg+0sIO7aRL3T4Xnc=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index afab09a9437..4fe37939cf4 100644
+index 7b6ccd1f189f7f..f6796dbc1ff029 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -398,6 +398,10 @@ var depsRules = `
@@ -1103,7 +1103,7 @@ index afab09a9437..4fe37939cf4 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
 diff --git a/src/hash/example_test.go b/src/hash/example_test.go
-index f07b9aaa2c4..2ff6c482739 100644
+index f07b9aaa2c4898..2ff6c4827391c0 100644
 --- a/src/hash/example_test.go
 +++ b/src/hash/example_test.go
 @@ -2,6 +2,8 @@
@@ -1116,7 +1116,7 @@ index f07b9aaa2c4..2ff6c482739 100644
  
  import (
 diff --git a/src/hash/marshal_test.go b/src/hash/marshal_test.go
-index 3091f7a67ac..824be4a90fd 100644
+index 3091f7a67acede..824be4a90fd4db 100644
 --- a/src/hash/marshal_test.go
 +++ b/src/hash/marshal_test.go
 @@ -21,6 +21,7 @@ import (
@@ -1139,7 +1139,7 @@ index 3091f7a67ac..824be4a90fd 100644
  			enc, err := h2m.MarshalBinary()
 diff --git a/src/internal/goexperiment/exp_cngcrypto_off.go b/src/internal/goexperiment/exp_cngcrypto_off.go
 new file mode 100644
-index 00000000000..83146005328
+index 00000000000000..831460053281e2
 --- /dev/null
 +++ b/src/internal/goexperiment/exp_cngcrypto_off.go
 @@ -0,0 +1,9 @@
@@ -1154,7 +1154,7 @@ index 00000000000..83146005328
 +const CNGCryptoInt = 0
 diff --git a/src/internal/goexperiment/exp_cngcrypto_on.go b/src/internal/goexperiment/exp_cngcrypto_on.go
 new file mode 100644
-index 00000000000..99ee2542ca3
+index 00000000000000..99ee2542ca38a9
 --- /dev/null
 +++ b/src/internal/goexperiment/exp_cngcrypto_on.go
 @@ -0,0 +1,9 @@
@@ -1168,7 +1168,7 @@ index 00000000000..99ee2542ca3
 +const CNGCrypto = true
 +const CNGCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index cffb78a7234..0a6d239a03d 100644
+index cffb78a7234546..0a6d239a03dddd 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,7 @@ type Flags struct {

--- a/patches/0007-Vendor-crypto-backends.patch
+++ b/patches/0007-Vendor-crypto-backends.patch
@@ -27,7 +27,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../go-crypto-winnative/cng/bbig/big.go       |  31 +
  .../microsoft/go-crypto-winnative/cng/big.go  |  30 +
  .../microsoft/go-crypto-winnative/cng/cng.go  | 130 ++++
- .../microsoft/go-crypto-winnative/cng/ecdh.go | 252 ++++++++
+ .../microsoft/go-crypto-winnative/cng/ecdh.go | 260 ++++++++
  .../go-crypto-winnative/cng/ecdsa.go          | 175 ++++++
  .../microsoft/go-crypto-winnative/cng/hmac.go |  55 ++
  .../microsoft/go-crypto-winnative/cng/keys.go | 161 +++++
@@ -39,7 +39,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  12 +
- 34 files changed, 5927 insertions(+)
+ 34 files changed, 5935 insertions(+)
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
@@ -76,7 +76,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
 
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE b/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
 new file mode 100644
-index 00000000000..9e841e7a26e
+index 00000000000000..9e841e7a26e4eb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/LICENSE
 @@ -0,0 +1,21 @@
@@ -103,7 +103,7 @@ index 00000000000..9e841e7a26e
 +    SOFTWARE
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
 new file mode 100644
-index 00000000000..89268b471aa
+index 00000000000000..89268b471aa481
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
 @@ -0,0 +1,472 @@
@@ -581,7 +581,7 @@ index 00000000000..89268b471aa
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
 new file mode 100644
-index 00000000000..1214e1097ef
+index 00000000000000..1214e1097ef56d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/bbig/big.go
 @@ -0,0 +1,38 @@
@@ -625,7 +625,7 @@ index 00000000000..1214e1097ef
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 new file mode 100644
-index 00000000000..7207bde01c9
+index 00000000000000..7207bde01c9d94
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/big.go
 @@ -0,0 +1,13 @@
@@ -644,7 +644,7 @@ index 00000000000..7207bde01c9
 +type BigInt []uint
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
 new file mode 100644
-index 00000000000..a13c4116252
+index 00000000000000..a13c4116252a83
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
 @@ -0,0 +1,212 @@
@@ -862,7 +862,7 @@ index 00000000000..a13c4116252
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 new file mode 100644
-index 00000000000..a9edf8d86cc
+index 00000000000000..a9edf8d86cc97f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 @@ -0,0 +1,185 @@
@@ -1053,7 +1053,7 @@ index 00000000000..a9edf8d86cc
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 new file mode 100644
-index 00000000000..97e39c002e3
+index 00000000000000..97e39c002e3052
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evpkey.go
 @@ -0,0 +1,313 @@
@@ -1372,7 +1372,7 @@ index 00000000000..97e39c002e3
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
 new file mode 100644
-index 00000000000..7bbf7418512
+index 00000000000000..7bbf74185128dd
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.c
 @@ -0,0 +1,153 @@
@@ -1531,7 +1531,7 @@ index 00000000000..7bbf7418512
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
 new file mode 100644
-index 00000000000..03aed43e001
+index 00000000000000..03aed43e001d54
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/goopenssl.h
 @@ -0,0 +1,147 @@
@@ -1685,7 +1685,7 @@ index 00000000000..03aed43e001
 \ No newline at end of file
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
 new file mode 100644
-index 00000000000..81918cde673
+index 00000000000000..81918cde673cee
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
 @@ -0,0 +1,251 @@
@@ -1942,7 +1942,7 @@ index 00000000000..81918cde673
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go
 new file mode 100644
-index 00000000000..db09e4aae64
+index 00000000000000..db09e4aae64f8c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/internal/subtle/aliasing.go
 @@ -0,0 +1,32 @@
@@ -1980,7 +1980,7 @@ index 00000000000..db09e4aae64
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
 new file mode 100644
-index 00000000000..e3e13d793c4
+index 00000000000000..e3e13d793c4d8b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
 @@ -0,0 +1,302 @@
@@ -2288,7 +2288,7 @@ index 00000000000..e3e13d793c4
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 new file mode 100644
-index 00000000000..46f592c4340
+index 00000000000000..46f592c4340a26
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_funcs.h
 @@ -0,0 +1,288 @@
@@ -2582,7 +2582,7 @@ index 00000000000..46f592c4340
 +
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c
 new file mode 100644
-index 00000000000..5cd7275f407
+index 00000000000000..5cd7275f4075ed
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl_lock_setup.c
 @@ -0,0 +1,53 @@
@@ -2641,7 +2641,7 @@ index 00000000000..5cd7275f407
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go
 new file mode 100644
-index 00000000000..17f64a52ae5
+index 00000000000000..17f64a52ae5255
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rand.go
 @@ -0,0 +1,24 @@
@@ -2671,7 +2671,7 @@ index 00000000000..17f64a52ae5
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 new file mode 100644
-index 00000000000..cfc6e40fcf4
+index 00000000000000..cfc6e40fcf41e2
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 @@ -0,0 +1,336 @@
@@ -3013,7 +3013,7 @@ index 00000000000..cfc6e40fcf4
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 new file mode 100644
-index 00000000000..bb96a9bcaee
+index 00000000000000..bb96a9bcaee7d4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/sha.go
 @@ -0,0 +1,580 @@
@@ -3599,7 +3599,7 @@ index 00000000000..bb96a9bcaee
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/LICENSE b/src/vendor/github.com/microsoft/go-crypto-winnative/LICENSE
 new file mode 100644
-index 00000000000..9e841e7a26e
+index 00000000000000..9e841e7a26e4eb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/LICENSE
 @@ -0,0 +1,21 @@
@@ -3626,7 +3626,7 @@ index 00000000000..9e841e7a26e
 +    SOFTWARE
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
 new file mode 100644
-index 00000000000..e3b865ab782
+index 00000000000000..e3b865ab7823d1
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
 @@ -0,0 +1,359 @@
@@ -3991,7 +3991,7 @@ index 00000000000..e3b865ab782
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/bbig/big.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/bbig/big.go
 new file mode 100644
-index 00000000000..584f2069b1c
+index 00000000000000..584f2069b1cd0a
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/bbig/big.go
 @@ -0,0 +1,31 @@
@@ -4028,7 +4028,7 @@ index 00000000000..584f2069b1c
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/big.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/big.go
 new file mode 100644
-index 00000000000..36f0e0c6e27
+index 00000000000000..36f0e0c6e278bc
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/big.go
 @@ -0,0 +1,30 @@
@@ -4064,7 +4064,7 @@ index 00000000000..36f0e0c6e27
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go
 new file mode 100644
-index 00000000000..844c087287c
+index 00000000000000..844c087287cabe
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go
 @@ -0,0 +1,130 @@
@@ -4200,10 +4200,10 @@ index 00000000000..844c087287c
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go
 new file mode 100644
-index 00000000000..c3fa6dd766e
+index 00000000000000..cd6e9a98f6f967
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go
-@@ -0,0 +1,252 @@
+@@ -0,0 +1,260 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -4261,10 +4261,18 @@ index 00000000000..c3fa6dd766e
 +type PublicKeyECDH struct {
 +	hkey  bcrypt.KEY_HANDLE
 +	bytes []byte
++
++	// priv is only set when PublicKeyECDH is derived from a private key,
++	// in which case priv's finalizer is responsible for freeing hkey.
++	// This ensures priv is not finalized while the public key is alive,
++	// which could cause use-after-free and double-free behavior.
++	priv *PrivateKeyECDH
 +}
 +
 +func (k *PublicKeyECDH) finalize() {
-+	bcrypt.DestroyKey(k.hkey)
++	if k.priv == nil {
++		bcrypt.DestroyKey(k.hkey)
++	}
 +}
 +
 +type PrivateKeyECDH struct {
@@ -4375,7 +4383,7 @@ index 00000000000..c3fa6dd766e
 +	if err != nil {
 +		return nil, err
 +	}
-+	k := &PublicKeyECDH{hkey, append([]byte(nil), bytes...)}
++	k := &PublicKeyECDH{hkey, append([]byte(nil), bytes...), nil}
 +	runtime.SetFinalizer(k, (*PublicKeyECDH).finalize)
 +	return k, nil
 +}
@@ -4423,7 +4431,7 @@ index 00000000000..c3fa6dd766e
 +		// Only include X.
 +		bytes = data[:hdr.KeySize]
 +	}
-+	pub := &PublicKeyECDH{k.hkey, bytes}
++	pub := &PublicKeyECDH{k.hkey, bytes, k}
 +	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
 +	return pub, nil
 +}
@@ -4458,7 +4466,7 @@ index 00000000000..c3fa6dd766e
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
 new file mode 100644
-index 00000000000..a77ff97bb8f
+index 00000000000000..a77ff97bb8f521
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
 @@ -0,0 +1,175 @@
@@ -4639,7 +4647,7 @@ index 00000000000..a77ff97bb8f
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
 new file mode 100644
-index 00000000000..736472d5b4e
+index 00000000000000..736472d5b4e700
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
 @@ -0,0 +1,55 @@
@@ -4700,7 +4708,7 @@ index 00000000000..736472d5b4e
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
 new file mode 100644
-index 00000000000..766768e9d46
+index 00000000000000..766768e9d46b41
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
 @@ -0,0 +1,161 @@
@@ -4867,7 +4875,7 @@ index 00000000000..766768e9d46
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go
 new file mode 100644
-index 00000000000..cdd845ab5be
+index 00000000000000..cdd845ab5bea98
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go
 @@ -0,0 +1,28 @@
@@ -4901,7 +4909,7 @@ index 00000000000..cdd845ab5be
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
 new file mode 100644
-index 00000000000..7e3f7abe348
+index 00000000000000..7e3f7abe3487cb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
 @@ -0,0 +1,374 @@
@@ -5281,7 +5289,7 @@ index 00000000000..7e3f7abe348
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go
 new file mode 100644
-index 00000000000..0ab3c9e9ce0
+index 00000000000000..0ab3c9e9ce06fb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go
 @@ -0,0 +1,199 @@
@@ -5486,7 +5494,7 @@ index 00000000000..0ab3c9e9ce0
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000..f3100669d53
+index 00000000000000..f3100669d53d3f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 @@ -0,0 +1,221 @@
@@ -5713,7 +5721,7 @@ index 00000000000..f3100669d53
 +//sys   DestroySecret(hSecret SECRET_HANDLE) (s error) = bcrypt.BCryptDestroySecret
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go
 new file mode 100644
-index 00000000000..09053bb5a47
+index 00000000000000..09053bb5a4738b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go
 @@ -0,0 +1,372 @@
@@ -6091,7 +6099,7 @@ index 00000000000..09053bb5a47
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/subtle/aliasing.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/subtle/aliasing.go
 new file mode 100644
-index 00000000000..db09e4aae64
+index 00000000000000..db09e4aae64f8c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/subtle/aliasing.go
 @@ -0,0 +1,32 @@
@@ -6129,7 +6137,7 @@ index 00000000000..db09e4aae64
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 new file mode 100644
-index 00000000000..1722410e5af
+index 00000000000000..1722410e5af193
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 @@ -0,0 +1,55 @@
@@ -6189,7 +6197,7 @@ index 00000000000..1722410e5af
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 3e4bb5b90bc..b9a24040a44 100644
+index 3e4bb5b90bc672..e9962f98172436 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,15 @@
@@ -6198,7 +6206,7 @@ index 3e4bb5b90bc..b9a24040a44 100644
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/openssl/bbig
 +github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20221118163944-7649d98424c1
++# github.com/microsoft/go-crypto-winnative v0.0.0-20230125071228-ef6c7cb780c6
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
* This upgrades to the same version we're using in the 1.20 branch: https://github.com/microsoft/go/pull/858 

This should help with CI flakiness.