### PR TITLE
Use SBOM template and build retention from Arcade

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -13,12 +13,20 @@ trigger:
       - dev/official/*
 pr: none
 
+# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
+parameters:
+  - name: releaseVersion
+    displayName: '[Release automation input] The version being built. Leave "nil" for non-release builds.'
+    type: string
+    default: nil
+
 stages:
   - template: stages/go-builder-matrix-stages.yml
     parameters:
       innerloop: true
       sign: true
       createSourceArchive: true
+      releaseVersion: ${{ parameters.releaseVersion }}
 
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/')) }}:
     - template: stages/pool.yml

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -12,6 +12,7 @@ parameters:
   sign: false
   # If true, generate source archive tarballs, and sign them if signing is enabled.
   createSourceArchive: false
+  releaseVersion: ''
 
 stages:
   - ${{ each builder in parameters.builders }}:
@@ -22,6 +23,7 @@ stages:
           parameters:
             builder: ${{ builder }}
             createSourceArchive: ${{ parameters.createSourceArchive }}
+            releaseVersion: ${{ parameters.releaseVersion }}
 
   - ${{ if eq(parameters.sign, true) }}:
     - template: pool.yml

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -10,6 +10,7 @@ parameters:
   outerloop: false
   sign: false
   createSourceArchive: false
+  releaseVersion: ''
 
 stages:
   - template: shorthand-builders-to-builders.yml
@@ -18,6 +19,7 @@ stages:
       jobsParameters:
         sign: ${{ parameters.sign }}
         createSourceArchive: ${{ parameters.createSourceArchive }}
+        releaseVersion: ${{ parameters.releaseVersion }}
       shorthandBuilders:
         - ${{ if eq(parameters.innerloop, true) }}:
           - { os: linux, arch: amd64, config: buildandpack }

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -8,6 +8,7 @@ parameters:
   # { id, os, arch, hostArch, config, distro?, experiment?, fips? }
   builder: {}
   createSourceArchive: false
+  releaseVersion: ''
 
 stages:
   - stage: ${{ parameters.builder.id }}
@@ -218,6 +219,19 @@ stages:
                 buildPlatform: ${{ parameters.builder.arch }}
                 buildConfiguration: ${{ parameters.builder.config }}
                 publishRunAttachments: true
+
+          - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
+            - template: ../../common/templates/steps/generate-sbom.yml
+              parameters:
+                PackageName: 'Go'
+                ${{ if eq(parameters.releaseVersion, 'nil') }}:
+                  PackageVersion: dev
+                ${{ else }}:
+                  PackageVersion: ${{ parameters.releaseVersion }}
+                BuildDropPath: $(Build.SourcesDirectory)/eng/artifacts
+
+            - ${{ if ne(parameters.releaseVersion, 'nil') }}:
+              - template: ../../common/templates/steps/retain-build.yml
 
           - ${{ if eq(parameters.builder.os, 'linux') }}:
             # Files may be owned by root because builds don't set user ID. If this build is running on a


### PR DESCRIPTION
* Always generate an SBOM. The SBOM is meant to contain the version, so this commit also adds a releaseVersion parameter.
* Retain the build forever when this build is a versioned release. This also relies on the new releaseVersion parameter.

A change in go-infra release automation will be required to pass in releaseVersion. (Only after I port this change to the release branches.)

Example build with this exact commit: https://dev.azure.com/dnceng/internal/_build/results?buildId=2158970&view=results

I reviewed this WIP build's SBOMs: https://dev.azure.com/dnceng/internal/_build/results?buildId=2157318&view=results. It overreports, but this is fine according to [the Arcade guidance](https://github.com/dotnet/arcade/blob/main/Documentation/SBOMGenerationGuidance.md). It captures the tar.gz and checksum outputs, the go.mod dependencies, and the product name is "Go " then the releaseVersion value I passed in.

* The runtime parameter doc link depends on https://github.com/microsoft/go-infra/pull/82
* For #442 
