### PR TITLE
Stop filtering syso files in runtime/race/internal

### DIFF
--- a/eng/_core/archive/archive.go
+++ b/eng/_core/archive/archive.go
@@ -194,14 +194,18 @@ func CreateFromBuild(source, output string) error {
 				targetPath = filepath.Join("bin", filepath.Base(relPath))
 			}
 
-			// Skip race detection syso file if it doesn't match the target runtime.
-			//
-			// Ignore error: the only possible error is one that says the pattern is invalid (see
-			// filepath.Match doc), which will never happen here because the pattern is a constant
-			// string. (Do be careful if you change it!)
-			isRaceSyso, _ := filepath.Match("race_*.syso", info.Name())
-			if isRaceSyso && info.Name() != targetRuntimeRaceSyso {
-				return nil
+			// Filter syso files in runtime/race. Note: intentionally leave all
+			// runtime/race/internal syso files in place.
+			if filepath.Dir(relPath) == filepath.Join("src", "runtime", "race") {
+				// Skip race detection syso file if it doesn't match the target runtime.
+				//
+				// Ignore error: the only possible error is one that says the pattern is invalid (see
+				// filepath.Match doc), which will never happen here because the pattern is a constant
+				// string. (Do be careful if you change it!)
+				isRaceSyso, _ := filepath.Match("race_*.syso", info.Name())
+				if isRaceSyso && info.Name() != targetRuntimeRaceSyso {
+					return nil
+				}
 			}
 		}
 


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/904

Expected content (upstream archives):

```
#> unzip -l go1.20.3.windows-amd64.zip | grep race.*syso$
   541464  03-29-2023 16:15   go/src/runtime/race/internal/amd64v1/race_darwin.syso
   712464  03-29-2023 16:15   go/src/runtime/race/internal/amd64v1/race_freebsd.syso
   563848  03-29-2023 16:15   go/src/runtime/race/internal/amd64v1/race_linux.syso
   714520  03-29-2023 16:15   go/src/runtime/race/internal/amd64v1/race_netbsd.syso
   688784  03-29-2023 16:15   go/src/runtime/race/internal/amd64v1/race_openbsd.syso
   461185  03-29-2023 16:15   go/src/runtime/race/internal/amd64v1/race_windows.syso
   563664  03-29-2023 16:15   go/src/runtime/race/internal/amd64v3/race_linux.syso
	  
#> tar -tf go1.20.3.linux-amd64.tar.gz  | grep race.*syso$
go/src/runtime/race/internal/amd64v1/race_darwin.syso
go/src/runtime/race/internal/amd64v1/race_freebsd.syso
go/src/runtime/race/internal/amd64v1/race_linux.syso
go/src/runtime/race/internal/amd64v1/race_netbsd.syso
go/src/runtime/race/internal/amd64v1/race_openbsd.syso
go/src/runtime/race/internal/amd64v1/race_windows.syso
go/src/runtime/race/internal/amd64v3/race_linux.syso

#> tar -tf go1.20.3.linux-arm64.tar.gz  | grep race.*syso$
go/src/runtime/race/internal/amd64v1/race_darwin.syso
go/src/runtime/race/internal/amd64v1/race_freebsd.syso
go/src/runtime/race/internal/amd64v1/race_linux.syso
go/src/runtime/race/internal/amd64v1/race_netbsd.syso
go/src/runtime/race/internal/amd64v1/race_openbsd.syso
go/src/runtime/race/internal/amd64v1/race_windows.syso
go/src/runtime/race/internal/amd64v3/race_linux.syso
go/src/runtime/race/race_linux_arm64.syso
```

It looks like all platforms have all `runtime/race/internal/**/*.syso` files, but only the current platform's `runtime/race/*.syso` file (if one exists for that platform).

But in our current microsoft/go archives:
* All `runtime/race/internal/**/*.syso` files are removed no matter what.
* So: we don't have any race `syso` files on windows/linux amd64 platforms.
* Our linux_arm64 build does have `runtime/race/race_linux_arm64.syso`, but *only* that one.

---

This PR fixes the filter. Diff of all content in a packed Linux amd64 build before vs. after this change:

```diff
...
 go/src/runtime/race/internal/amd64v1/doc.go
+go/src/runtime/race/internal/amd64v1/race_darwin.syso
+go/src/runtime/race/internal/amd64v1/race_freebsd.syso
+go/src/runtime/race/internal/amd64v1/race_linux.syso
+go/src/runtime/race/internal/amd64v1/race_netbsd.syso
+go/src/runtime/race/internal/amd64v1/race_openbsd.syso
+go/src/runtime/race/internal/amd64v1/race_windows.syso
 go/src/runtime/race/internal/amd64v3/
 go/src/runtime/race/internal/amd64v3/doc.go
+go/src/runtime/race/internal/amd64v3/race_linux.syso
 go/src/runtime/race/mkcgo.sh
...
```

This roughly matches this part of the upstream infra: https://github.com/golang/build/blob/208db0ba5f4e4fdfdc462e9c0af3f0e0999f6d45/internal/task/buildrelease.go#L163-L174

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2161813&view=results

I tried a local build's results in an isolated container, and it worked fine with `-race`.