### PR TITLE
Update FIPS docs post 1.18 EOL

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -111,7 +111,7 @@ Versions not listed above are not supported at all.
 
 Dynamic linking (as opposed to static linking) is a requirement for an app to be considered FIPS compliant in Microsoft. The approach the modified Go runtime takes meets that requirement.
 
-For OpenSSL, Go uses using [dlopen] when initializing. Therefore, dlopen's shared library search conventions also apply here. Sometimes this is called *dynamic loading* and not considered part of the *dynamic linking* category (https://stackoverflow.com/a/45959845), but it satisfies requirements for the same reasons as dynamic linking: the OpenSSL library provided by the OS/environment is used, and the app doesn't necessarily have to be rebuilt to take an update.
+For OpenSSL, Go uses [dlopen] when initializing. Sometimes this is called *dynamic loading* and not considered part of the *dynamic linking* category (https://stackoverflow.com/a/45959845), but it satisfies requirements for the same reasons as dynamic linking: the OpenSSL library provided by the OS/environment is used, and the app doesn't necessarily have to be rebuilt to take an update.
 
 For CNG, Go uses Windows syscalls to call the CNG APIs. This can also not be considered *dynamic linking*, but like *dynamic loading*, syscalls also mean the app is using OS-provided crypto functionality.
 


### PR DESCRIPTION
Reading this doc again in connection to some internal policy discussions, I thought it was time to get some changes done. I started with 1.18 removal, but found some more things I wanted to do: 😄

* Now that 1.18 is EOL, remove most mentions. Include a link back in time in case it's necessary for some reason.
* Include CNG more consistently in the doc.
* Add more detail to the dynamic linking section.
* Update the OpenSSL supported versions, and make the notes about the degree of support a bit more specific.
* Some misc doc ease-of-use/ease-of-reading changes.

Rendered: https://github.com/microsoft/go/blob/dev/dagood/fips-docs/eng/doc/fips/README.md