### PR TITLE
Add systemcrypto experiment alias

### DIFF
--- a/patches/0006-Add-systemcrypto-experiment-alias.patch
+++ b/patches/0006-Add-systemcrypto-experiment-alias.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 31 May 2023 16:54:31 -0500
+Subject: [PATCH] Add systemcrypto experiment alias
+
+---
+ src/internal/buildcfg/exp.go       | 27 +++++++++++++++++++++++++++
+ src/internal/goexperiment/flags.go |  3 +++
+ 2 files changed, 30 insertions(+)
+
+diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
+index 513070c8af7b57..47bc7144763f02 100644
+--- a/src/internal/buildcfg/exp.go
++++ b/src/internal/buildcfg/exp.go
+@@ -101,6 +101,29 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+ 			flags.RegabiArgs = v
+ 		}
+ 
++		// "systemcrypto" is an alias to make Go use the crypto library
++		// typically provided by the target system (GOOS). If systemcrypto is
++		// specified but the GOOS is not supported, returns an error.
++		//
++		// "nosystemcrypto" likewise turns off the experiment matching the GOOS.
++		// This means if the baseline flags include system crypto by default, it
++		// can be intuitively disabled.
++		var platformCryptoErr error
++		names["systemcrypto"] = func(v bool) {
++			switch goos {
++			case "linux":
++				flags.OpenSSLCrypto = v
++			case "windows":
++				flags.CNGCrypto = v
++			default:
++				// If the user wants system crypto and we can't provide it, fail.
++				// If the user wants no system crypto and it wasn't there anyway, ignore it.
++				if v {
++					platformCryptoErr = fmt.Errorf("the systemcrypto feature provided by the Microsoft build of Go does not support GOOS %q; for more information, see https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips", goos)
++				}
++			}
++		}
++
+ 		// Parse names.
+ 		for _, f := range strings.Split(goexp, ",") {
+ 			if f == "" {
+@@ -123,6 +146,10 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+ 			}
+ 			set(val)
+ 		}
++
++		if platformCryptoErr != nil {
++			return nil, platformCryptoErr
++		}
+ 	}
+ 
+ 	if regabiAlwaysOn {
+diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
+index 34af42fb857a8c..25fe720111f888 100644
+--- a/src/internal/goexperiment/flags.go
++++ b/src/internal/goexperiment/flags.go
+@@ -62,6 +62,9 @@ type Flags struct {
+ 	OpenSSLCrypto     bool
+ 	CNGCrypto         bool
+ 
++	// The "systemcrypto" GOEXPERIMENT is an alias for the crypto experiment
++	// that matches the target system (OS).
++
+ 	// Regabi is split into several sub-experiments that can be
+ 	// enabled individually. Not all combinations work.
+ 	// The "regabi" GOEXPERIMENT is an alias for all "working"


### PR DESCRIPTION
`GOEXPERIMENT=systemcrypto` enables the CNG or OpenSSL backend (or fails the build) depending on `GOOS`. On a Linux host, here are the results for a simple test app:

```
$ GOOS=linux GOEXPERIMENT=systemcrypto go build . ; go version exp
exp: devel go1.21-a37c2efaa4 Wed May 31 16:54:31 2023 -0500 X:opensslcrypto
$ GOOS=windows GOEXPERIMENT=systemcrypto go build . ; go version exp.exe
exp.exe: devel go1.21-a37c2efaa4 Wed May 31 16:54:31 2023 -0500 X:cngcrypto
$ GOOS=freebsd GOEXPERIMENT=systemcrypto go build .
go: the systemcrypto feature provided by the Microsoft build of Go does not support GOOS "freebsd"; for more information, see https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
```

I noticed this `ParseGOEXPERIMENT` function is also where we could potentially enable this behavior by default in the future, so I checked that if we did that, `nosystemcrypto` would already work to disable it. (`GOOS=linux GOEXPERIMENT=opensslcrypto;nosystemcrypto` also disables the openssl backend. The experiment values are processed in order.)

The error message is a little lengthy, but I wanted to make it super clear that it's our repo that's doing this and where to find more info about it.

This should make it easier for everyone to integrate into their builds. For anything system-agnostic (e.g. building on the same machine it runs on--no knowledge of GOOS) this might be particularly useful.