### PR TITLE
default to GOTOOLCHAIN=local

### DIFF
--- a/eng/_core/archive/archive.go
+++ b/eng/_core/archive/archive.go
@@ -89,7 +89,7 @@ func CreateFromBuild(source, output string) error {
 
 	// Root-level directory entry names to include in the archive.
 	includeNames := []string{
-		"AUTHORS", "CONTRIBUTORS", "LICENSE", "PATENTS", "VERSION",
+		"AUTHORS", "CONTRIBUTORS", "go.env", "LICENSE", "PATENTS", "VERSION",
 		"api", "bin", "doc", "lib", "misc", "pkg", "src", "test",
 	}
 

--- a/patches/0007-Update-default-go.env.patch
+++ b/patches/0007-Update-default-go.env.patch
@@ -5,9 +5,7 @@ Subject: [PATCH] Update default go.env
 
 ---
  go.env                                           | 6 ++++--
- src/cmd/go/script_test.go                        | 1 +
- src/cmd/go/testdata/script/gotoolchain_local.txt | 8 +-------
- 3 files changed, 6 insertions(+), 9 deletions(-)
+ 1 files changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/go.env b/go.env
 index 6ff2b921d464bc..4aca2ff2c63dbc 100644
@@ -36,23 +34,4 @@ index a2c1087bd81d3e..7c8948a94b63a1 100644
  		"newline=\n",
  	}
  
-diff --git a/src/cmd/go/testdata/script/gotoolchain_local.txt b/src/cmd/go/testdata/script/gotoolchain_local.txt
-index 313c5415015764..0e08207f451714 100644
---- a/src/cmd/go/testdata/script/gotoolchain_local.txt
-+++ b/src/cmd/go/testdata/script/gotoolchain_local.txt
-@@ -5,14 +5,8 @@
- env TESTGO_VERSION=go1.500
- env TESTGO_VERSION_SWITCH=switch
- 
--# Default setting should be auto
--env GOTOOLCHAIN=
--go env GOTOOLCHAIN
--stdout auto
--go env
--stdout GOTOOLCHAIN=.?auto.?  # maybe quoted
--
- # GOTOOLCHAIN=auto runs default toolchain without a go.mod or go.work
-+env GOTOOLCHAIN=auto
- go version
- stdout go1.500
  

--- a/patches/0007-Update-default-go.env.patch
+++ b/patches/0007-Update-default-go.env.patch
@@ -4,9 +4,10 @@ Date: Thu, 8 Jun 2023 14:17:13 +0200
 Subject: [PATCH] Update default go.env
 
 ---
- go.env                    | 6 ++++--
- src/cmd/go/script_test.go | 1 +
- 2 files changed, 5 insertions(+), 2 deletions(-)
+ go.env                                           | 6 ++++--
+ src/cmd/go/script_test.go                        | 1 +
+ src/cmd/go/testdata/script/gotoolchain_local.txt | 8 +-------
+ 3 files changed, 6 insertions(+), 9 deletions(-)
 
 diff --git a/go.env b/go.env
 index 6ff2b921d464bc..4aca2ff2c63dbc 100644
@@ -34,4 +35,24 @@ index a2c1087bd81d3e..7c8948a94b63a1 100644
 +		"GOTOOLCHAIN=auto", // Temporary workaround for #60685.
  		"newline=\n",
  	}
+ 
+diff --git a/src/cmd/go/testdata/script/gotoolchain_local.txt b/src/cmd/go/testdata/script/gotoolchain_local.txt
+index 313c5415015764..0e08207f451714 100644
+--- a/src/cmd/go/testdata/script/gotoolchain_local.txt
++++ b/src/cmd/go/testdata/script/gotoolchain_local.txt
+@@ -5,14 +5,8 @@
+ env TESTGO_VERSION=go1.500
+ env TESTGO_VERSION_SWITCH=switch
+ 
+-# Default setting should be auto
+-env GOTOOLCHAIN=
+-go env GOTOOLCHAIN
+-stdout auto
+-go env
+-stdout GOTOOLCHAIN=.?auto.?  # maybe quoted
+-
+ # GOTOOLCHAIN=auto runs default toolchain without a go.mod or go.work
++env GOTOOLCHAIN=auto
+ go version
+ stdout go1.500
  

--- a/patches/0007-Update-default-go.env.patch
+++ b/patches/0007-Update-default-go.env.patch
@@ -22,16 +22,3 @@ index 6ff2b921d464bc..4aca2ff2c63dbc 100644
  # See https://go.dev/doc/toolchain for details.
 -GOTOOLCHAIN=auto
 +GOTOOLCHAIN=local
-diff --git a/src/cmd/go/script_test.go b/src/cmd/go/script_test.go
-index a2c1087bd81d3e..7c8948a94b63a1 100644
---- a/src/cmd/go/script_test.go
-+++ b/src/cmd/go/script_test.go
-@@ -246,6 +246,7 @@ func scriptEnv(srv *vcstest.Server, srvCertFile string) ([]string, error) {
- 		"goversion=" + version,
- 		"CMDGO_TEST_RUN_MAIN=true",
- 		"HGRCPATH=",
-+		"GOTOOLCHAIN=auto", // Temporary workaround for #60685.
- 		"newline=\n",
- 	}
- 
- 

--- a/patches/0007-Update-default-go.env.patch
+++ b/patches/0007-Update-default-go.env.patch
@@ -16,7 +16,7 @@ index 9bab8ffd73dd71..4aca2ff2c63dbc 100644
  GOSUMDB=sum.golang.org
  
 -# Automatically download newer toolchains as directed by go.mod files.
--# See https://go.dev/s/gotoolchain for details.
+-# See https://go.dev/doc/toolchain for details.
 -GOTOOLCHAIN=auto
 +# Use the locally installed Go toolchain, never downloading a different one.
 +# Upstream uses `GOTOOLCHAIN=auto` instead, but `auto` can download and switch

--- a/patches/0007-Update-default-go.env.patch
+++ b/patches/0007-Update-default-go.env.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: qmuntal <qmuntaldiaz@microsoft.com>
+Date: Thu, 8 Jun 2023 14:17:13 +0200
+Subject: [PATCH] Update default go.env
+
+---
+ go.env | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/go.env b/go.env
+index 9bab8ffd73dd71..4aca2ff2c63dbc 100644
+--- a/go.env
++++ b/go.env
+@@ -7,6 +7,8 @@
+ GOPROXY=https://proxy.golang.org,direct
+ GOSUMDB=sum.golang.org
+ 
+-# Automatically download newer toolchains as directed by go.mod files.
+-# See https://go.dev/s/gotoolchain for details.
+-GOTOOLCHAIN=auto
++# Use the locally installed Go toolchain, never downloading a different one.
++# Upstream uses `GOTOOLCHAIN=auto` instead, but `auto` can download and switch
++# to a non-MSFT Go toolchain, and we want to avoid that.
++# See https://go.dev/doc/toolchain for details.
++GOTOOLCHAIN=local

--- a/patches/0007-Update-default-go.env.patch
+++ b/patches/0007-Update-default-go.env.patch
@@ -4,11 +4,12 @@ Date: Thu, 8 Jun 2023 14:17:13 +0200
 Subject: [PATCH] Update default go.env
 
 ---
- go.env | 8 +++++---
- 1 file changed, 5 insertions(+), 3 deletions(-)
+ go.env                    | 6 ++++--
+ src/cmd/go/script_test.go | 1 +
+ 2 files changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/go.env b/go.env
-index 9bab8ffd73dd71..4aca2ff2c63dbc 100644
+index 6ff2b921d464bc..4aca2ff2c63dbc 100644
 --- a/go.env
 +++ b/go.env
 @@ -7,6 +7,8 @@
@@ -16,10 +17,21 @@ index 9bab8ffd73dd71..4aca2ff2c63dbc 100644
  GOSUMDB=sum.golang.org
  
 -# Automatically download newer toolchains as directed by go.mod files.
--# See https://go.dev/doc/toolchain for details.
--GOTOOLCHAIN=auto
 +# Use the locally installed Go toolchain, never downloading a different one.
 +# Upstream uses `GOTOOLCHAIN=auto` instead, but `auto` can download and switch
 +# to a non-MSFT Go toolchain, and we want to avoid that.
-+# See https://go.dev/doc/toolchain for details.
+ # See https://go.dev/doc/toolchain for details.
+-GOTOOLCHAIN=auto
 +GOTOOLCHAIN=local
+diff --git a/src/cmd/go/script_test.go b/src/cmd/go/script_test.go
+index a2c1087bd81d3e..7c8948a94b63a1 100644
+--- a/src/cmd/go/script_test.go
++++ b/src/cmd/go/script_test.go
+@@ -246,6 +246,7 @@ func scriptEnv(srv *vcstest.Server, srvCertFile string) ([]string, error) {
+ 		"goversion=" + version,
+ 		"CMDGO_TEST_RUN_MAIN=true",
+ 		"HGRCPATH=",
++		"GOTOOLCHAIN=auto", // Temporary workaround for #60685.
+ 		"newline=\n",
+ 	}
+ 


### PR DESCRIPTION
This PR does two things:
- Include `go.env` when creating toolchain archives so downstream users installing MSFT Go from those archives have sane default env variables set.
- Patch upstream's `go.env` so `GOTOOLCHAIN` defaults to `local` instead of `auto`. With this we make sure that the MSFT Go toolchain won't silently download and use non-MSFT Go toolchains when compiling applications that require a Go version other than the one being used. See https://github.com/microsoft/go/issues/912#issuecomment-1582255155 for more context.