### PR TITLE
Add JSON file with same data as download table

### DIFF
--- a/eng/_core/supportdata/supportdata.go
+++ b/eng/_core/supportdata/supportdata.go
@@ -7,10 +7,13 @@ package supportdata
 type Branch struct {
 	// Version of the branch not including patch version, e.g. "1.20".
 	Version string `json:"version,omitempty"`
-	// Stable is true if this is the latest stable release.
+	// Stable is true if this is a stable release.
 	Stable bool `json:"stable,omitempty"`
-	// OldStable is true if this is the stable release just before the latest stable one.
-	OldStable bool `json:"oldStable,omitempty"`
+	// LatestStable is true if this is the most recent stable release.
+	LatestStable bool `json:"latestStable,omitempty"`
+	// PreviousStable is true if this is the stable release just before the
+	// latest stable one.
+	PreviousStable bool `json:"previousStable,omitempty"`
 	// Files is the list of "latest X" links for each artifact X.
 	Files []*LatestLink `json:"files,omitempty"`
 }

--- a/eng/_core/supportdata/supportdata.go
+++ b/eng/_core/supportdata/supportdata.go
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package supportdata
+
+type Branch struct {
+	// Version of the branch not including patch version, e.g. "1.20".
+	Version string `json:"version,omitempty"`
+	// Stable is true if this is the latest stable release.
+	Stable bool `json:"stable,omitempty"`
+	// OldStable is true if this is the stable release just before the latest stable one.
+	OldStable bool `json:"oldStable,omitempty"`
+	// Files is the list of "latest X" links for each artifact X.
+	Files []*LatestLink `json:"files,omitempty"`
+}
+
+type ArtifactKind string
+
+const (
+	Archive   ArtifactKind = "archive"
+	Installer ArtifactKind = "installer"
+	Source    ArtifactKind = "source"
+)
+
+type LatestLink struct {
+	Filename string       `json:"filename"`
+	OS       string       `json:"os"`
+	Arch     string       `json:"arch"`
+	Version  string       `json:"version"`
+	Kind     ArtifactKind `json:"kind"`
+	// URL is the aka.ms link that downloads the latest patch version of this
+	// artifact.
+	//
+	// Note that downloading URL then ChecksumURL may result in a race condition
+	// because the aka.ms URLs may be updated to point to a new build between
+	// the two downloads.
+	URL string `json:"url,omitempty"`
+	// ChecksumURL is the aks.ms link that downloads the latest checksum file
+	// associated with this artifact (if any).
+	ChecksumURL string `json:"checksumURL,omitempty"`
+	// SignatureURL is the aks.ms link that downloads the latest signature file
+	// associated with this artifact (if any).
+	SignatureURL string `json:"signatureURL,omitempty"`
+}

--- a/eng/_util/cmd/updatelinktable/updatelinktable.go
+++ b/eng/_util/cmd/updatelinktable/updatelinktable.go
@@ -23,8 +23,8 @@ This command updates the table in ` + docPath + ` and data in ` + jsonPath + `.
 
 var supported = []version{
 	{
-		Number: "1.20",
-		Stable: true,
+		Number:       "1.20",
+		LatestStable: true,
 		Platforms: map[string]struct{}{
 			"linux-amd64":   {},
 			"linux-arm64":   {},
@@ -34,8 +34,8 @@ var supported = []version{
 		},
 	},
 	{
-		Number:    "1.19",
-		OldStable: true,
+		Number:         "1.19",
+		PreviousStable: true,
 		Platforms: map[string]struct{}{
 			"linux-amd64":   {},
 			"linux-arm64":   {},
@@ -51,10 +51,10 @@ var platformPrettyNames = map[string]string{
 }
 
 type version struct {
-	Number    string
-	Stable    bool
-	OldStable bool
-	Platforms map[string]struct{}
+	Number         string
+	LatestStable   bool
+	PreviousStable bool
+	Platforms      map[string]struct{}
 }
 
 var linuxFiles = []goFileType{
@@ -198,9 +198,10 @@ func data() (string, []supportdata.Branch) {
 		b.WriteString(v.Number)
 		b.WriteString(" |")
 		branches = append(branches, supportdata.Branch{
-			Version:   "go" + v.Number,
-			Stable:    v.Stable,
-			OldStable: v.OldStable,
+			Version:        "go" + v.Number,
+			Stable:         true,
+			LatestStable:   v.LatestStable,
+			PreviousStable: v.PreviousStable,
 		})
 	}
 	b.WriteString("\n| --- |")

--- a/eng/_util/cmd/updatelinktable/updatelinktable.go
+++ b/eng/_util/cmd/updatelinktable/updatelinktable.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -12,16 +13,19 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/microsoft/go/_core/supportdata"
 )
 
 var description = `
-This command updates the table in ` + docPath + `.
+This command updates the table in ` + docPath + ` and data in ` + jsonPath + `.
 `
 
 var supported = []version{
 	{
-		"1.20",
-		map[string]struct{}{
+		Number: "1.20",
+		Stable: true,
+		Platforms: map[string]struct{}{
 			"linux-amd64":   {},
 			"linux-arm64":   {},
 			"linux-armv6l":  {},
@@ -30,8 +34,9 @@ var supported = []version{
 		},
 	},
 	{
-		"1.19",
-		map[string]struct{}{
+		Number:    "1.19",
+		OldStable: true,
+		Platforms: map[string]struct{}{
 			"linux-amd64":   {},
 			"linux-arm64":   {},
 			"linux-armv6l":  {},
@@ -47,30 +52,79 @@ var platformPrettyNames = map[string]string{
 
 type version struct {
 	Number    string
+	Stable    bool
+	OldStable bool
 	Platforms map[string]struct{}
 }
 
 var linuxFiles = []goFileType{
-	{"Binaries (tar.gz)", ".tar.gz"},
-	{"Checksum (SHA256)", ".tar.gz.sha256"},
-	{"Signature<sup>1</sup>", ".tar.gz.sig"},
+	{
+		Kind:      supportdata.Archive,
+		Name:      "Binaries (tar.gz)",
+		Ext:       ".tar.gz",
+		Checksum:  true,
+		Signature: true,
+	},
 }
+
 var windowsFiles = []goFileType{
-	{"Binaries (zip)", ".zip"},
-	{"Checksum (SHA256)", ".zip.sha256"},
+	{
+		Kind:     supportdata.Archive,
+		Name:     "Binaries (zip)",
+		Ext:      ".zip",
+		Checksum: true,
+	},
 }
+
 var sourceFiles = []goFileType{
-	{"Source (tar.gz)", ".tar.gz"},
-	{"Checksum (SHA256)", ".tar.gz.sha256"},
-	{"Signature<sup>1</sup>", ".tar.gz.sig"},
+	{
+		Kind:      supportdata.Source,
+		Name:      "Source (tar.gz)",
+		Ext:       ".tar.gz",
+		Checksum:  true,
+		Signature: true,
+	},
 }
 
 type goFileType struct {
-	Name string
-	Ext  string
+	Kind      supportdata.ArtifactKind
+	Name      string
+	Ext       string
+	Checksum  bool
+	Signature bool
 }
 
+func (t *goFileType) ArtifactLink(version, platform, os, arch string) *supportdata.LatestLink {
+	l := supportdata.LatestLink{
+		Filename: filename(version, platform, t.Ext),
+		OS:       os,
+		Arch:     arch,
+		Version:  "go" + version,
+		Kind:     t.Kind,
+		URL:      baseURL + filename(version, platform, t.Ext),
+	}
+	if t.Checksum {
+		l.ChecksumURL = baseURL + filename(version, platform, t.Ext+checksumSuffix)
+	}
+	if t.Signature {
+		l.SignatureURL = baseURL + filename(version, platform, t.Ext+signatureSuffix)
+	}
+	return &l
+}
+
+func filename(version, platform, ext string) string {
+	return "go" + version + "." + platform + ext
+}
+
+const checksumSuffix = ".sha256"
+const checksumMsg = "Checksum (SHA256)"
+const signatureSuffix = ".sig"
+const signatureMsg = "Signature<sup>1</sup>"
+
+const baseURL = "https://aka.ms/golang/release/latest/"
+
 var docPath = filepath.Join("eng", "doc", "Downloads.md")
+var jsonPath = filepath.Join("eng", "doc", "release-branch-links.json")
 
 const beginMark = "<!-- BEGIN TABLES -->"
 const endMark = "<!-- END TABLES -->"
@@ -90,12 +144,12 @@ func main() {
 		return
 	}
 
-	if err := writeTables(); err != nil {
+	if err := write(); err != nil {
 		log.Fatalln(err)
 	}
 }
 
-func writeTables() error {
+func write() error {
 	bytes, err := os.ReadFile(docPath)
 	if err != nil {
 		return err
@@ -113,18 +167,41 @@ func writeTables() error {
 		return fmt.Errorf("marker %#q not found after start mark in %#q", endMark, docPath)
 	}
 
-	content := s[:start] + "\n\n" + tables() + "\n\n" + s[end:]
-	return os.WriteFile(docPath, []byte(content), 0666)
+	table, branches := data()
+	content := s[:start] + "\n\n" + table + "\n\n" + s[end:]
+	if err := os.WriteFile(docPath, []byte(content), 0o666); err != nil {
+		return err
+	}
+
+	branchJSON, err := json.MarshalIndent(branches, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(jsonPath, append(branchJSON, '\n'), 0o666)
 }
 
-func tables() string {
+func data() (string, []supportdata.Branch) {
 	var b strings.Builder
+	branches := make([]supportdata.Branch, 0, len(supported))
+
+	writeURL := func(name, url string) {
+		b.WriteString("- [")
+		b.WriteString(name)
+		b.WriteString("](")
+		b.WriteString(url)
+		b.WriteString(")<br/>")
+	}
 
 	b.WriteString("|   |")
 	for _, v := range supported {
 		b.WriteString(" ")
 		b.WriteString(v.Number)
 		b.WriteString(" |")
+		branches = append(branches, supportdata.Branch{
+			Version:   "go" + v.Number,
+			Stable:    v.Stable,
+			OldStable: v.OldStable,
+		})
 	}
 	b.WriteString("\n| --- |")
 	for range supported {
@@ -132,24 +209,30 @@ func tables() string {
 	}
 	b.WriteString("\n|")
 	for _, p := range platforms() {
+		os, arch, _ := strings.Cut(p, "-")
+		if p == "src" {
+			os = ""
+		}
 		b.WriteString(" ")
 		b.WriteString(platformPrettyName(p))
 		b.WriteString(" |")
-		for _, v := range supported {
+		for vi, v := range supported {
+			branch := &branches[vi]
 			b.WriteString(" ")
 			types := fileTypes(p)
 			if _, ok := v.Platforms[p]; !ok {
 				types = fileTypes("")
 			}
 			for _, f := range types {
-				b.WriteString("- [")
-				b.WriteString(f.Name)
-				b.WriteString("](https://aka.ms/golang/release/latest/go")
-				b.WriteString(v.Number)
-				b.WriteString(".")
-				b.WriteString(p)
-				b.WriteString(f.Ext)
-				b.WriteString(")<br/>")
+				artifact := f.ArtifactLink(v.Number, p, os, arch)
+				writeURL(f.Name, artifact.URL)
+				branch.Files = append(branch.Files, artifact)
+				if artifact.ChecksumURL != "" {
+					writeURL(checksumMsg, artifact.ChecksumURL)
+				}
+				if artifact.SignatureURL != "" {
+					writeURL(signatureMsg, artifact.SignatureURL)
+				}
 			}
 			if len(types) == 0 {
 				b.WriteString("N/A")
@@ -159,7 +242,7 @@ func tables() string {
 		b.WriteString("\n")
 	}
 
-	return b.String()
+	return b.String(), branches
 }
 
 func platforms() []string {

--- a/eng/doc/README.md
+++ b/eng/doc/README.md
@@ -3,3 +3,6 @@ infrastructure used to build Go, in particular any designs that are not obvious
 by reading the infrastructure code itself.
 
 For dev scenario documentation, see [eng/README.md](/eng/README.md).
+
+The [Downloads.md](Downloads.md) doc contains a table of links to the latest assets for each supported Go release branch.
+The [release-branch-links.json](release-branch-links.json) file contains the same data in JSON format suitable for parsing.

--- a/eng/doc/release-branch-links.json
+++ b/eng/doc/release-branch-links.json
@@ -1,0 +1,112 @@
+[
+  {
+    "version": "go1.20",
+    "stable": true,
+    "files": [
+      {
+        "filename": "go1.20.src.tar.gz",
+        "os": "",
+        "arch": "",
+        "version": "go1.20",
+        "kind": "source",
+        "url": "https://aka.ms/golang/release/latest/go1.20.src.tar.gz",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.20.src.tar.gz.sha256",
+        "signatureURL": "https://aka.ms/golang/release/latest/go1.20.src.tar.gz.sig"
+      },
+      {
+        "filename": "go1.20.linux-amd64.tar.gz",
+        "os": "linux",
+        "arch": "amd64",
+        "version": "go1.20",
+        "kind": "archive",
+        "url": "https://aka.ms/golang/release/latest/go1.20.linux-amd64.tar.gz",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.20.linux-amd64.tar.gz.sha256",
+        "signatureURL": "https://aka.ms/golang/release/latest/go1.20.linux-amd64.tar.gz.sig"
+      },
+      {
+        "filename": "go1.20.linux-arm64.tar.gz",
+        "os": "linux",
+        "arch": "arm64",
+        "version": "go1.20",
+        "kind": "archive",
+        "url": "https://aka.ms/golang/release/latest/go1.20.linux-arm64.tar.gz",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.20.linux-arm64.tar.gz.sha256",
+        "signatureURL": "https://aka.ms/golang/release/latest/go1.20.linux-arm64.tar.gz.sig"
+      },
+      {
+        "filename": "go1.20.linux-armv6l.tar.gz",
+        "os": "linux",
+        "arch": "armv6l",
+        "version": "go1.20",
+        "kind": "archive",
+        "url": "https://aka.ms/golang/release/latest/go1.20.linux-armv6l.tar.gz",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.20.linux-armv6l.tar.gz.sha256",
+        "signatureURL": "https://aka.ms/golang/release/latest/go1.20.linux-armv6l.tar.gz.sig"
+      },
+      {
+        "filename": "go1.20.windows-amd64.zip",
+        "os": "windows",
+        "arch": "amd64",
+        "version": "go1.20",
+        "kind": "archive",
+        "url": "https://aka.ms/golang/release/latest/go1.20.windows-amd64.zip",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.20.windows-amd64.zip.sha256"
+      }
+    ]
+  },
+  {
+    "version": "go1.19",
+    "oldStable": true,
+    "files": [
+      {
+        "filename": "go1.19.src.tar.gz",
+        "os": "",
+        "arch": "",
+        "version": "go1.19",
+        "kind": "source",
+        "url": "https://aka.ms/golang/release/latest/go1.19.src.tar.gz",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.19.src.tar.gz.sha256",
+        "signatureURL": "https://aka.ms/golang/release/latest/go1.19.src.tar.gz.sig"
+      },
+      {
+        "filename": "go1.19.linux-amd64.tar.gz",
+        "os": "linux",
+        "arch": "amd64",
+        "version": "go1.19",
+        "kind": "archive",
+        "url": "https://aka.ms/golang/release/latest/go1.19.linux-amd64.tar.gz",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.19.linux-amd64.tar.gz.sha256",
+        "signatureURL": "https://aka.ms/golang/release/latest/go1.19.linux-amd64.tar.gz.sig"
+      },
+      {
+        "filename": "go1.19.linux-arm64.tar.gz",
+        "os": "linux",
+        "arch": "arm64",
+        "version": "go1.19",
+        "kind": "archive",
+        "url": "https://aka.ms/golang/release/latest/go1.19.linux-arm64.tar.gz",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.19.linux-arm64.tar.gz.sha256",
+        "signatureURL": "https://aka.ms/golang/release/latest/go1.19.linux-arm64.tar.gz.sig"
+      },
+      {
+        "filename": "go1.19.linux-armv6l.tar.gz",
+        "os": "linux",
+        "arch": "armv6l",
+        "version": "go1.19",
+        "kind": "archive",
+        "url": "https://aka.ms/golang/release/latest/go1.19.linux-armv6l.tar.gz",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.19.linux-armv6l.tar.gz.sha256",
+        "signatureURL": "https://aka.ms/golang/release/latest/go1.19.linux-armv6l.tar.gz.sig"
+      },
+      {
+        "filename": "go1.19.windows-amd64.zip",
+        "os": "windows",
+        "arch": "amd64",
+        "version": "go1.19",
+        "kind": "archive",
+        "url": "https://aka.ms/golang/release/latest/go1.19.windows-amd64.zip",
+        "checksumURL": "https://aka.ms/golang/release/latest/go1.19.windows-amd64.zip.sha256"
+      }
+    ]
+  }
+]

--- a/eng/doc/release-branch-links.json
+++ b/eng/doc/release-branch-links.json
@@ -2,6 +2,7 @@
   {
     "version": "go1.20",
     "stable": true,
+    "latestStable": true,
     "files": [
       {
         "filename": "go1.20.src.tar.gz",
@@ -56,7 +57,8 @@
   },
   {
     "version": "go1.19",
-    "oldStable": true,
+    "stable": true,
+    "previousStable": true,
     "files": [
       {
         "filename": "go1.19.src.tar.gz",


### PR DESCRIPTION
Modify the `updatelinktable` tool that generates the downloads table to also generate a JSON file with basically the same data. This file can be parsed to easily figure out what major versions are supported/released and download them.

The format is essentially https://go.dev/dl/?mode=json, but adjusted to make sense when it only provides links to the latest patch of each Go version.

* Fixes https://github.com/microsoft/go/issues/939

We should consider publishing this file to our own blob storage with an aka.ms link so Go installation tools don't end up relying on e.g. https://raw.githubusercontent.com/microsoft/go/da62c0bec9417596b1ded94c01ca612e502b374a/eng/doc/release-branch-links.json in the long term. This could go along with publishing the assets.json files: https://github.com/microsoft/go/issues/945.