### PR TITLE
Call fipstls.Force() when running in FIPS mode

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -167,13 +167,7 @@ This feature does not require any additional configuration, but it only works wi
 
 ### TLS with FIPS-approved settings
 
-The Go TLS stack will automatically use OpenSSL crypto primitives when running in FIPS mode. Yet, the FIPS 140-2 standard places additional restrictions on TLS communications, mainly on which cyphers and signers are allowed.
-
-A program can import the `crypto/tls/fipsonly` package to configure the Go TLS stack so it is compliant with these restrictions. The configuration is done by an `init()` function, so only importing it is necessary:
-
-```go
-  import _ "crypto/tls/fipsonly"
-```
+The Microsoft Go runtime will automatically enforce that `crypto/tls` and `crypto/x509` only use FIPS-approved settings when running in FIPS mode. These differs from upstream's BoringCrypto backend, in which to get these additional restrictions one has to import `crypto/tls/fipsonly`.
 
 Note that this can reduce compatibility with old devices that do not support modern cryptography techniques such as TLS 1.2.
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -167,7 +167,15 @@ This feature does not require any additional configuration, but it only works wi
 
 ### TLS with FIPS-approved settings
 
-The Microsoft Go runtime will automatically enforce that `crypto/tls` and `crypto/x509` only use FIPS-approved settings when running in FIPS mode. These differs from upstream's BoringCrypto backend, in which to get these additional restrictions one has to import `crypto/tls/fipsonly`.
+The Go TLS stack will automatically use OpenSSL crypto primitives. Yet, the FIPS 140-2 standard places additional restrictions on TLS communications, mainly on which cyphers and signers are allowed.
+
+Since Go 1.22, the Microsoft Go runtime will automatically enforce that `crypto/tls` and `crypto/x509` only use FIPS-approved settings when running in FIPS mode. These differs from upstream's BoringCrypto backend, in which to get these additional restrictions one has to import `crypto/tls/fipsonly`.
+
+Prior to Go 1.22, a program should import the `crypto/tls/fipsonly` package to configure the Go TLS stack so it is compliant with these restrictions. The configuration is done by an `init()` function, so only importing it is necessary:
+
+```go
+  import _ "crypto/tls/fipsonly"
+```
 
 Note that this can reduce compatibility with old devices that do not support modern cryptography techniques such as TLS 1.2.
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -169,9 +169,9 @@ This feature does not require any additional configuration, but it only works wi
 
 The Go TLS stack will automatically use OpenSSL crypto primitives. Yet, the FIPS 140-2 standard places additional restrictions on TLS communications, mainly on which cyphers and signers are allowed.
 
-Since Go 1.22, the Microsoft Go runtime will automatically enforce that `crypto/tls` and `crypto/x509` only use FIPS-approved settings when running in FIPS mode. These differs from upstream's BoringCrypto backend, in which to get these additional restrictions one has to import `crypto/tls/fipsonly`.
+Since Go 1.22, the Microsoft Go runtime automatically enforces that `crypto/tls` and `crypto/x509` only use FIPS-approved settings when running in FIPS mode. This differs from upstream's BoringCrypto backend, which requires you to import `crypto/tls/fipsonly` to apply the FIPS-mandated restrictions. The Microsoft Go crypto backends do this automatically to reduce the source code changes necessary to produce a FIPS-compliant Go application.
 
-Prior to Go 1.22, a program should import the `crypto/tls/fipsonly` package to configure the Go TLS stack so it is compliant with these restrictions. The configuration is done by an `init()` function, so only importing it is necessary:
+Prior to Go 1.22, a program using the Go TLS stack must import the `crypto/tls/fipsonly` package to be compliant with these restrictions. The configuration is done by an `init()` function, so only importing it is necessary:
 
 ```go
   import _ "crypto/tls/fipsonly"

--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -1233,8 +1233,8 @@ Package tls partially implements TLS 1.2, as specified in RFC 5246, and TLS 1.3,
 
 Package tls will automatically use FIPS compliant primitives implemented in other crypto packages. 
 
-Since Go 1.22, the Microsoft Go runtime will automatically enforce that tls only use FIPS-approved settings when running in FIPS mode.
-Prior to Go 1.22, a program should import the `crypto/tls/fipsonly` package to configure tls so it is compliant with these restrictions.
+Since Go 1.22, the Microsoft Go runtime automatically enforces that tls only uses FIPS-approved settings when running in FIPS mode.
+Prior to Go 1.22, a program using tls must import the `crypto/tls/fipsonly` package to be compliant with these restrictions.
 
 When using TLS in FIPS-only mode the TLS handshake has the following restrictions:
 

--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -1231,6 +1231,11 @@ Does not contain crypto primitives, out of FIPS scope.
 
 Package tls partially implements TLS 1.2, as specified in RFC 5246, and TLS 1.3, as specified in RFC 8446.
 
+Package tls will automatically use FIPS compliant primitives implemented in other crypto packages. 
+
+Since Go 1.22, the Microsoft Go runtime will automatically enforce that tls only use FIPS-approved settings when running in FIPS mode.
+Prior to Go 1.22, a program should import the `crypto/tls/fipsonly` package to configure tls so it is compliant with these restrictions.
+
 When using TLS in FIPS-only mode the TLS handshake has the following restrictions:
 
 - TLS versions: `tls.VersionTLS12`

--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -53,12 +53,12 @@ The Go crypto documentation is available online at https://pkg.go.dev/crypto.
     - [crypto/sha512](#cryptosha512)
       - [func New](#func-new-3)
       - [func New384](#func-new384)
-      - [func New512_224](#func-new512_224)
-      - [func New512_256](#func-new512_256)
+      - [func New512\_224](#func-new512_224)
+      - [func New512\_256](#func-new512_256)
       - [func Sum384](#func-sum384)
       - [func Sum512](#func-sum512)
-      - [func Sum512_224](#func-sum512_224)
-      - [func Sum512_256](#func-sum512_256)
+      - [func Sum512\_224](#func-sum512_224)
+      - [func Sum512\_256](#func-sum512_256)
     - [crypto/rsa](#cryptorsa)
       - [func DecryptOAEP](#func-decryptoaep)
       - [func DecryptPKCS1v15](#func-decryptpkcs1v15)
@@ -1230,8 +1230,6 @@ Does not contain crypto primitives, out of FIPS scope.
 ### [crypto/tls](https://pkg.go.dev/crypto/tls)
 
 Package tls partially implements TLS 1.2, as specified in RFC 5246, and TLS 1.3, as specified in RFC 8446.
-
-Package tls will automatically use FIPS compliant primitives implemented in other crypto packages, but it will accept non-FIPS ciphers and signature algorithms unless `crypto/tls/fipsonly` is imported.
 
 When using TLS in FIPS-only mode the TLS handshake has the following restrictions:
 

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -35,10 +35,14 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/sha256/sha256_test.go            |   2 +-
  src/crypto/sha512/sha512.go                 |   2 +-
  src/crypto/sha512/sha512_test.go            |   2 +-
+ src/crypto/tls/boring_test.go               |   5 +
  src/crypto/tls/cipher_suites.go             |   2 +-
+ src/crypto/x509/boring_test.go              |   5 +
  src/go/build/deps_test.go                   |   2 +
+ src/net/http/client_test.go                 |   6 +-
+ src/net/smtp/smtp_test.go                   |  71 +++++++-----
  src/runtime/runtime_boring.go               |   5 +
- 34 files changed, 294 insertions(+), 29 deletions(-)
+ 38 files changed, 353 insertions(+), 57 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
@@ -669,6 +673,22 @@ index 921cdbb7bbd477..2fef7ddae07480 100644
  	"crypto/rand"
  	"encoding"
  	"encoding/hex"
+diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
+index ba68f355eb037c..6aa9fdd60fc4fa 100644
+--- a/src/crypto/tls/boring_test.go
++++ b/src/crypto/tls/boring_test.go
+@@ -25,6 +25,11 @@ import (
+ 	"time"
+ )
+ 
++func init() {
++	// crypto/tls expects fipstls.Required() to be false.
++	fipstls.Abandon()
++}
++
+ func TestBoringServerProtocolVersion(t *testing.T) {
+ 	test := func(name string, v uint16, msg string) {
+ 		t.Run(name, func(t *testing.T) {
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
 index 589e8b6fafbba3..0a6d665ee3096d 100644
 --- a/src/crypto/tls/cipher_suites.go
@@ -682,6 +702,22 @@ index 589e8b6fafbba3..0a6d665ee3096d 100644
  	"crypto/rc4"
  	"crypto/sha1"
  	"crypto/sha256"
+diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
+index 33fd0ed52b1ff6..b3eb1f89f2a716 100644
+--- a/src/crypto/x509/boring_test.go
++++ b/src/crypto/x509/boring_test.go
+@@ -26,6 +26,11 @@ const (
+ 	boringCertFIPSOK = 0x80
+ )
+ 
++func init() {
++	// crypto/x509 expects fipstls.Required() to be false.
++	fipstls.Abandon()
++}
++
+ func boringRSAKey(t *testing.T, size int) *rsa.PrivateKey {
+ 	k, err := rsa.GenerateKey(rand.Reader, size)
+ 	if err != nil {
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index be8ac30f9daf9f..3356154c7d1082 100644
 --- a/src/go/build/deps_test.go
@@ -702,6 +738,120 @@ index be8ac30f9daf9f..3356154c7d1082 100644
  	< crypto/rand
  	< crypto/ed25519
  	< encoding/asn1
+diff --git a/src/net/http/client_test.go b/src/net/http/client_test.go
+index 0fe555af38f08a..6e0681b974e39b 100644
+--- a/src/net/http/client_test.go
++++ b/src/net/http/client_test.go
+@@ -960,7 +960,9 @@ func testResponseSetsTLSConnectionState(t *testing.T, mode testMode) {
+ 
+ 	c := ts.Client()
+ 	tr := c.Transport.(*Transport)
+-	tr.TLSClientConfig.CipherSuites = []uint16{tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA}
++	// The cipher suite doesn't really matter, but we need a FIPS-compliant one
++	// in case fipstls.Required() is true.
++	tr.TLSClientConfig.CipherSuites = []uint16{tls.TLS_RSA_WITH_AES_256_GCM_SHA384}
+ 	tr.TLSClientConfig.MaxVersion = tls.VersionTLS12 // to get to pick the cipher suite
+ 	tr.Dial = func(netw, addr string) (net.Conn, error) {
+ 		return net.Dial(netw, ts.Listener.Addr().String())
+@@ -973,7 +975,7 @@ func testResponseSetsTLSConnectionState(t *testing.T, mode testMode) {
+ 	if res.TLS == nil {
+ 		t.Fatal("Response didn't set TLS Connection State.")
+ 	}
+-	if got, want := res.TLS.CipherSuite, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA; got != want {
++	if got, want := res.TLS.CipherSuite, tls.TLS_RSA_WITH_AES_256_GCM_SHA384; got != want {
+ 		t.Errorf("TLS Cipher Suite = %d; want %d", got, want)
+ 	}
+ }
+diff --git a/src/net/smtp/smtp_test.go b/src/net/smtp/smtp_test.go
+index 259b10b93d9e36..2ee46483954fcb 100644
+--- a/src/net/smtp/smtp_test.go
++++ b/src/net/smtp/smtp_test.go
+@@ -1105,40 +1105,59 @@ func sendMail(hostPort string) error {
+ 
+ // localhostCert is a PEM-encoded TLS cert generated from src/crypto/tls:
+ //
+-//	go run generate_cert.go --rsa-bits 1024 --host 127.0.0.1,::1,example.com \
++//	go run generate_cert.go --rsa-bits 2048 --host 127.0.0.1,::1,example.com \
+ //		--ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+ var localhostCert = []byte(`
+ -----BEGIN CERTIFICATE-----
+-MIICFDCCAX2gAwIBAgIRAK0xjnaPuNDSreeXb+z+0u4wDQYJKoZIhvcNAQELBQAw
+-EjEQMA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2
+-MDAwMFowEjEQMA4GA1UEChMHQWNtZSBDbzCBnzANBgkqhkiG9w0BAQEFAAOBjQAw
+-gYkCgYEA0nFbQQuOWsjbGtejcpWz153OlziZM4bVjJ9jYruNw5n2Ry6uYQAffhqa
+-JOInCmmcVe2siJglsyH9aRh6vKiobBbIUXXUU1ABd56ebAzlt0LobLlx7pZEMy30
+-LqIi9E6zmL3YvdGzpYlkFRnRrqwEtWYbGBf3znO250S56CCWH2UCAwEAAaNoMGYw
+-DgYDVR0PAQH/BAQDAgKkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1UdEwEB/wQF
+-MAMBAf8wLgYDVR0RBCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAAAAAAAAAA
+-AAAAAAEwDQYJKoZIhvcNAQELBQADgYEAbZtDS2dVuBYvb+MnolWnCNqvw1w5Gtgi
+-NmvQQPOMgM3m+oQSCPRTNGSg25e1Qbo7bgQDv8ZTnq8FgOJ/rbkyERw2JckkHpD4
+-n4qcK27WkEDBtQFlPihIM8hLIuzWoi/9wygiElTy/tVL3y7fGCvY2/k1KBthtZGF
+-tN8URjVmyEo=
++MIIDOTCCAiGgAwIBAgIQKhWw7zkzXjX78HaPlVbNrjANBgkqhkiG9w0BAQsFADAS
++MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
++MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
++MIIBCgKCAQEAy1EYLA8IFvZyUPY+uI7KToneaQPvIzQiOeWlDnFnoanw6h3KpoVc
+++yNbinK41WfXoSN/1kJ9gmGiFhJTPZ4rQ7DJsD7ethcpuz4uIimdWPohcBzwgbx4
++wjhUgfUsCO6m76fFqrhbkHMDiS2iUjg2gyMVQCrqi8EuBW16yFQdJqPU04p+2rYw
++eJ9lzdeSLR4yvx7p1JS8sS4DbSyrAUaJ9J1sH/gu0nSHNMo7WtIu9K8JmPeYR4X5
++5KLURBU9PmvoGW+5ss/xS6SnacHAD9FebNPQqGB/soBA9gdJIN+5KW0xcE38Zz5Q
++wAAUiU+VlWuZmge0sI8Ix8uIPIvGQSKN0wIDAQABo4GIMIGFMA4GA1UdDwEB/wQE
++AwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1Ud
++DgQWBBRNMP9Cr0yrXpMpsgEtDr8FPmUEazAuBgNVHREEJzAlggtleGFtcGxlLmNv
++bYcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAQEAF0/z
++KEnZrAsz4ov4fEvKY42EbKPm8s0pklPLmKVIh/iS7jTxxxvgDtOToiJ6IXY8Cfb3
++nG1i78YakoVPUL5Cfh5LKDefMoefk6575ur2+gSdzgNmKUnlVfOMfpflia/ugATZ
++5ORhpmKRKWzwXQ67S5XeVlZAehTsywQstsDu8WEVoSUnRSk1jZsCThOQfdlpox+K
++71rGPSTxB9yCHMzZsk4xyZlGLaC0vDSJ+Zb5gWvAcvkSnpREvmc3/9TaW/lbUed6
++uhO17lARcUhPCzkR5wAZCo/PihHMSXL8cqT4QdIux75OBxB/3EgLHL7KQw28A50g
++DogldK8zx1ZADmupUA==
+ -----END CERTIFICATE-----`)
+ 
+ // localhostKey is the private key for localhostCert.
+ var localhostKey = []byte(testingKey(`
+ -----BEGIN RSA TESTING KEY-----
+-MIICXgIBAAKBgQDScVtBC45ayNsa16NylbPXnc6XOJkzhtWMn2Niu43DmfZHLq5h
+-AB9+Gpok4icKaZxV7ayImCWzIf1pGHq8qKhsFshRddRTUAF3np5sDOW3QuhsuXHu
+-lkQzLfQuoiL0TrOYvdi90bOliWQVGdGurAS1ZhsYF/fOc7bnRLnoIJYfZQIDAQAB
+-AoGBAMst7OgpKyFV6c3JwyI/jWqxDySL3caU+RuTTBaodKAUx2ZEmNJIlx9eudLA
+-kucHvoxsM/eRxlxkhdFxdBcwU6J+zqooTnhu/FE3jhrT1lPrbhfGhyKnUrB0KKMM
+-VY3IQZyiehpxaeXAwoAou6TbWoTpl9t8ImAqAMY8hlULCUqlAkEA+9+Ry5FSYK/m
+-542LujIcCaIGoG1/Te6Sxr3hsPagKC2rH20rDLqXwEedSFOpSS0vpzlPAzy/6Rbb
+-PHTJUhNdwwJBANXkA+TkMdbJI5do9/mn//U0LfrCR9NkcoYohxfKz8JuhgRQxzF2
+-6jpo3q7CdTuuRixLWVfeJzcrAyNrVcBq87cCQFkTCtOMNC7fZnCTPUv+9q1tcJyB
+-vNjJu3yvoEZeIeuzouX9TJE21/33FaeDdsXbRhQEj23cqR38qFHsF1qAYNMCQQDP
+-QXLEiJoClkR2orAmqjPLVhR3t2oB3INcnEjLNSq8LHyQEfXyaFfu4U9l5+fRPL2i
+-jiC0k/9L5dHUsF0XZothAkEA23ddgRs+Id/HxtojqqUT27B8MT/IGNrYsp4DvS/c
+-qgkeluku4GjxRlDMBuXk94xOBEinUs+p/hwP1Alll80Tpg==
++MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDLURgsDwgW9nJQ
++9j64jspOid5pA+8jNCI55aUOcWehqfDqHcqmhVz7I1uKcrjVZ9ehI3/WQn2CYaIW
++ElM9nitDsMmwPt62Fym7Pi4iKZ1Y+iFwHPCBvHjCOFSB9SwI7qbvp8WquFuQcwOJ
++LaJSODaDIxVAKuqLwS4FbXrIVB0mo9TTin7atjB4n2XN15ItHjK/HunUlLyxLgNt
++LKsBRon0nWwf+C7SdIc0yjta0i70rwmY95hHhfnkotREFT0+a+gZb7myz/FLpKdp
++wcAP0V5s09CoYH+ygED2B0kg37kpbTFwTfxnPlDAABSJT5WVa5maB7SwjwjHy4g8
++i8ZBIo3TAgMBAAECggEAc7dv/oN/ozIY1iOQhxId6p1lTHfEv1CIulMNoi7BQK2s
++RFM4Z5Y32WfCTgYFVNCJVVkTBStKq85Npio/3i4Libcw03K05wY/5iX5s8/jkiSq
++q1iNOgm+4SuWTXDw4xSRRo1CX2wWERykwoqKfCkqPXDWQ3Mpkukb/FLXMvVMshRA
++9v9L6MyrCnsFHl8q2J6hcC+RQJ0pb5I4NF6KhMxABWxxxlDO0zYLA0wfhEn8nj/l
++J37QLHmsA7pzxo+NqDTPgpfBuuTbRVGMkC+fPCXYinbubBeURFO2j2yBlseK+Vbd
++sEffiAnPr4ocCz0k0tHAMMY7hKHup2HWuJGFu0IhAQKBgQDkKFEEcYWNx5Ybl1LV
++qr2qIYofpFL+Gu5MWSZxzZbE8u9v0tTsp8SRhXkgjeHY6qjBUBnLgklOKwSigQAm
++j9de44cXjnUIArzeAHsH3fzpYrLfsvBla6wQyr34D0chVCZ0cX/s/zXkSN4PcEkA
++GGfKAENrGskDyc4uq1sIactu8wKBgQDkIL/XT7ysvsaxA+SfIs2CHgb8GNKgtoI1
++QyR0+MfeJGCLwI9qcLbVzXda34qrzQw3YLIm2VHqhzJ4zb0gnyJ4adPZYwpLTgiU
++jVksBVIwBTfbxYvF2+07poCSobCFKLGQnAujhDDIGDAUKQXQmFcqUNWw0QHfQzkS
++xs36H27doQKBgQCjM8+YLRgKbc0LGXhwTHz1GJ6zuZiAGYWB6XddimEhqmDpjVcv
++nWY3bdFSHwuBXYGvHfwFncGP/6eGEl6oNtYpEvoMOKOwQj0VVCStYPZLf4VSDK52
++7ckcDdpLeao4xffn7VRDk97Z1+G4C2q8fbioPv36vCMz6YPp0DsCzqJtTwKBgCUN
++4LtDW10fu7xC6p6ik4jgAbhu+79ZBbtLBZ/uTOCbPgdVJrZeSoRd1FYxWx/etW5F
++SYqf3/tdLGiM2nxy/LFcVynHOYPTz/b5IpPQ5XGhV1peMv7XYyg+OkIW+0oVuwnH
++HujXbukBbMXJiAVCyV25NYx71ncCP0H6grhu5J4hAoGAUaketZWHD/ks9JCoPtfy
++pNnXqrIvTp1cSGJpVUQT/DUqAjevyZ5Q8PFPf09BZ6uYlXtCqsp7pA/fqNdlJRPR
++tHRjpZ5XauBiFdpRNH4tJBTiWWhyuWhkWn369Az7HP3CIlJLeq2FlKCvMClcO4op
++Qc9LHT7jqtcy+LqAVBpsJ/o=
+ -----END RSA TESTING KEY-----`))
+ 
+ func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "PRIVATE KEY") }
 diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
 index 5a98b20253181c..9042f2c2795e19 100644
 --- a/src/runtime/runtime_boring.go

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -13,8 +13,8 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/boring.go                    |   2 +-
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
- .../internal/backend/bbig/big_openssl.go      |  12 ++
- src/crypto/internal/backend/openssl_linux.go  | 203 ++++++++++++++++++
+ .../internal/backend/bbig/big_openssl.go      |  12 +
+ src/crypto/internal/backend/openssl_linux.go  | 210 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -36,7 +36,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 32 files changed, 284 insertions(+), 23 deletions(-)
+ 32 files changed, 291 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -189,10 +189,10 @@ index 00000000000000..61ef3fdd90b607
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..68ea43ea892e1d
+index 00000000000000..46a3f5cd83d364
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,203 @@
+@@ -0,0 +1,210 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -207,6 +207,7 @@ index 00000000000000..68ea43ea892e1d
 +import (
 +	"crypto"
 +	"crypto/cipher"
++	"crypto/internal/boring/fipstls"
 +	"crypto/internal/boring/sig"
 +	"hash"
 +	"syscall"
@@ -245,6 +246,12 @@ index 00000000000000..68ea43ea892e1d
 +				panic("opensslcrypto: can't enable FIPS mode: " + err.Error())
 +			}
 +		}
++	}
++	if openssl.FIPS() {
++		// FIPS mode is enabled,
++		// so force FIPS mode for crypto/tls and crypto/x509.
++		fipstls.Force()
++		sig.FIPSOnly()
 +	}
 +	sig.BoringCrypto()
 +}

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -31,12 +31,12 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/x509/notboring.go                  |   2 +-
  src/go.mod                                    |   1 +
  src/go.sum                                    |   2 +
- src/go/build/deps_test.go                     |   7 +-
+ src/go/build/deps_test.go                     |   8 +-
  .../goexperiment/exp_opensslcrypto_off.go     |   9 +
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 32 files changed, 291 insertions(+), 23 deletions(-)
+ 32 files changed, 292 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -609,19 +609,21 @@ index 93d34efbe889f7..a9a97eef7d763d 100644
  golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
  golang.org/x/net v0.11.1-0.20230613203745-f5464ddb689c h1:icjsA5jFPWsTcuIb/yIeU6mgXRHPQBfo0Lzd1GQmKZI=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 3356154c7d1082..ef79bb8b7b24ca 100644
+index 3356154c7d1082..1131b9988d4128 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -425,6 +425,8 @@ var depsRules = `
+@@ -425,7 +425,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
 +	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
 +	< github.com/microsoft/go-crypto-openssl/openssl
  	< crypto/internal/boring
++	< crypto/internal/boring/fipstls
  	< crypto/internal/backend
  	< crypto/boring;
-@@ -459,6 +461,7 @@ var depsRules = `
+ 
+@@ -459,6 +462,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -629,7 +631,7 @@ index 3356154c7d1082..ef79bb8b7b24ca 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -707,7 +710,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -707,7 +711,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -638,7 +640,7 @@ index 3356154c7d1082..ef79bb8b7b24ca 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -717,7 +720,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -717,7 +721,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -609,20 +609,26 @@ index 93d34efbe889f7..a9a97eef7d763d 100644
  golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
  golang.org/x/net v0.11.1-0.20230613203745-f5464ddb689c h1:icjsA5jFPWsTcuIb/yIeU6mgXRHPQBfo0Lzd1GQmKZI=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 3356154c7d1082..1131b9988d4128 100644
+index 3356154c7d1082..3551408289a4b6 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -425,7 +425,10 @@ var depsRules = `
+@@ -414,6 +414,7 @@ var depsRules = `
+ 	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
+ 	# Unfortunately, stuck with reflect via encoding/binary.
+ 	crypto/internal/boring/sig,
++	crypto/internal/boring/fipstls,
+ 	crypto/internal/boring/syso,
+ 	encoding/binary,
+ 	golang.org/x/sys/cpu,
+@@ -425,6 +426,8 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
 +	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
 +	< github.com/microsoft/go-crypto-openssl/openssl
  	< crypto/internal/boring
-+	< crypto/internal/boring/fipstls
  	< crypto/internal/backend
  	< crypto/boring;
- 
 @@ -459,6 +462,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -167,7 +167,7 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..369887f7ff6020
+index 00000000000000..726945c65e6cef
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,212 @@
@@ -206,7 +206,7 @@ index 00000000000000..369887f7ff6020
 +			panic("cngcrypto: not in FIPS mode")
 +		}
 +	}
-+	if cng.FIPS() {
++	if enabled, _ := cng.FIPS(); enabled {
 +		// FIPS mode is enabled,
 +		// so force FIPS mode for crypto/tls and crypto/x509.
 +		fipstls.Force()

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 205 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 213 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  38 +++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -48,7 +48,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 44 files changed, 404 insertions(+), 46 deletions(-)
+ 44 files changed, 412 insertions(+), 46 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -167,10 +167,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..9d1bbf010c0fb6
+index 00000000000000..9f99bf65311427
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,205 @@
+@@ -0,0 +1,213 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -185,10 +185,12 @@ index 00000000000000..9d1bbf010c0fb6
 +import (
 +	"crypto"
 +	"crypto/cipher"
++	"crypto/internal/boring/fipstls"
 +	"crypto/internal/boring/sig"
 +	"hash"
 +	_ "unsafe"
 +
++	"github.com/microsoft/go-crypto-openssl/openssl"
 +	"github.com/microsoft/go-crypto-winnative/cng"
 +)
 +
@@ -204,6 +206,12 @@ index 00000000000000..9d1bbf010c0fb6
 +		if !enabled {
 +			panic("cngcrypto: not in FIPS mode")
 +		}
++	}
++	if openssl.FIPS() {
++		// FIPS mode is enabled,
++		// so force FIPS mode for crypto/tls and crypto/x509.
++		fipstls.Force()
++		sig.FIPSOnly()
 +	}
 +	sig.BoringCrypto()
 +}

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 213 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 212 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  38 +++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -48,7 +48,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 44 files changed, 412 insertions(+), 46 deletions(-)
+ 44 files changed, 411 insertions(+), 46 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -167,10 +167,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..9f99bf65311427
+index 00000000000000..369887f7ff6020
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,213 @@
+@@ -0,0 +1,212 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -190,7 +190,6 @@ index 00000000000000..9f99bf65311427
 +	"hash"
 +	_ "unsafe"
 +
-+	"github.com/microsoft/go-crypto-openssl/openssl"
 +	"github.com/microsoft/go-crypto-winnative/cng"
 +)
 +
@@ -207,7 +206,7 @@ index 00000000000000..9f99bf65311427
 +			panic("cngcrypto: not in FIPS mode")
 +		}
 +	}
-+	if openssl.FIPS() {
++	if cng.FIPS() {
 +		// FIPS mode is enabled,
 +		// so force FIPS mode for crypto/tls and crypto/x509.
 +		fipstls.Force()
@@ -1066,10 +1065,10 @@ index a9a97eef7d763d..7dbe6f682268ef 100644
  golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
  golang.org/x/net v0.11.1-0.20230613203745-f5464ddb689c h1:icjsA5jFPWsTcuIb/yIeU6mgXRHPQBfo0Lzd1GQmKZI=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index ef79bb8b7b24ca..65706944d6bdf5 100644
+index 3551408289a4b6..c2e0ac0c3d240c 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -425,6 +425,10 @@ var depsRules = `
+@@ -426,6 +426,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1080,7 +1079,7 @@ index ef79bb8b7b24ca..65706944d6bdf5 100644
  	< github.com/microsoft/go-crypto-openssl/openssl/internal/subtle
  	< github.com/microsoft/go-crypto-openssl/openssl
  	< crypto/internal/boring
-@@ -461,6 +465,7 @@ var depsRules = `
+@@ -462,6 +466,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big


### PR DESCRIPTION
Given the new crypto policy, downstream users who need to run in FIPS mode would always want to restrict the TLS stack settings to be FIPS-compliant. It's easier for everyone, less downstream changes  if we just enforce it at runtime when we detect that the underlying crypto is running in FIPS mode.