### PR TITLE
Add requirefips tag

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -17,11 +17,9 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/hmac/hmac_test.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go  |  30 +++++
  src/crypto/internal/backend/bbig/big.go      |  17 +++
- src/crypto/internal/backend/common.go        |  81 +++++++++++++
- src/crypto/internal/backend/iscgo.go         |  10 ++
+ src/crypto/internal/backend/common.go        |  78 +++++++++++++
  src/crypto/internal/backend/isrequirefips.go |   9 ++
  src/crypto/internal/backend/nobackend.go     | 116 +++++++++++++++++++
- src/crypto/internal/backend/nocgo.go         |  10 ++
  src/crypto/internal/backend/norequirefips.go |   9 ++
  src/crypto/internal/backend/stub.s           |  10 ++
  src/crypto/rand/rand_unix.go                 |   2 +-
@@ -40,14 +38,12 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 36 files changed, 328 insertions(+), 29 deletions(-)
+ 34 files changed, 305 insertions(+), 29 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
- create mode 100644 src/crypto/internal/backend/iscgo.go
  create mode 100644 src/crypto/internal/backend/isrequirefips.go
  create mode 100644 src/crypto/internal/backend/nobackend.go
- create mode 100644 src/crypto/internal/backend/nocgo.go
  create mode 100644 src/crypto/internal/backend/norequirefips.go
  create mode 100644 src/crypto/internal/backend/stub.s
 
@@ -260,10 +256,10 @@ index 00000000000000..85bd3ed083f5b2
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..c69ee3b8b53c9e
+index 00000000000000..efdd080a1b7708
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,78 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -278,13 +274,10 @@ index 00000000000000..c69ee3b8b53c9e
 +
 +func init() {
 +	if v, r, ok := envGoFIPS(); ok && v == "1" {
-+		if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
-+			panic("FIPS mode requested (" + r + ") but not supported on " + runtime.GOOS)
-+		}
-+		if runtime.GOOS == "linux" && !iscgo {
-+			panic("FIPS mode requested (" + r + ") but not supported with cgo disabled")
-+		}
 +		if !Enabled {
++			if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
++				panic("FIPS mode requested (" + r + ") but no crypto backend is supported on " + runtime.GOOS)
++			}
 +			panic("FIPS mode requested (" + r + ") but no supported crypto backend is enabled")
 +		}
 +	}
@@ -345,22 +338,6 @@ index 00000000000000..c69ee3b8b53c9e
 +		}
 +	}
 +}
-diff --git a/src/crypto/internal/backend/iscgo.go b/src/crypto/internal/backend/iscgo.go
-new file mode 100644
-index 00000000000000..1e0d3cf8c18b55
---- /dev/null
-+++ b/src/crypto/internal/backend/iscgo.go
-@@ -0,0 +1,10 @@
-+// Copyright 2022 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build cgo
-+// +build cgo
-+
-+package backend
-+
-+const iscgo = true
 diff --git a/src/crypto/internal/backend/isrequirefips.go b/src/crypto/internal/backend/isrequirefips.go
 new file mode 100644
 index 00000000000000..e5d7570d6d4363
@@ -498,22 +475,6 @@ index 00000000000000..ad6081552af15d
 +func NewPublicKeyECDH(string, []byte) (*PublicKeyECDH, error) { panic("cryptobackend: not available") }
 +func (*PublicKeyECDH) Bytes() []byte                          { panic("cryptobackend: not available") }
 +func (*PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error)    { panic("cryptobackend: not available") }
-diff --git a/src/crypto/internal/backend/nocgo.go b/src/crypto/internal/backend/nocgo.go
-new file mode 100644
-index 00000000000000..63c13fc4b01cba
---- /dev/null
-+++ b/src/crypto/internal/backend/nocgo.go
-@@ -0,0 +1,10 @@
-+// Copyright 2022 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build !cgo
-+// +build !cgo
-+
-+package backend
-+
-+const iscgo = false
 diff --git a/src/crypto/internal/backend/norequirefips.go b/src/crypto/internal/backend/norequirefips.go
 new file mode 100644
 index 00000000000000..26bfb5f6a643f3

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -4,47 +4,51 @@ Date: Thu, 30 Jun 2022 10:03:03 +0200
 Subject: [PATCH] Add crypto backend foundation
 
 ---
- src/crypto/aes/cipher.go                    |   2 +-
- src/crypto/aes/cipher_asm.go                |   2 +-
- src/crypto/boring/boring.go                 |   2 +-
- src/crypto/ecdh/ecdh.go                     |   2 +-
- src/crypto/ecdh/nist.go                     |   2 +-
- src/crypto/ecdsa/boring.go                  |   4 +-
- src/crypto/ecdsa/ecdsa.go                   |   4 +-
- src/crypto/ecdsa/notboring.go               |   2 +-
- src/crypto/ed25519/ed25519_test.go          |   2 +-
- src/crypto/hmac/hmac.go                     |   2 +-
- src/crypto/hmac/hmac_test.go                |   2 +-
- src/crypto/internal/backend/backend_test.go |  30 +++++
- src/crypto/internal/backend/bbig/big.go     |  17 +++
- src/crypto/internal/backend/common.go       |  65 +++++++++++
- src/crypto/internal/backend/iscgo.go        |  10 ++
- src/crypto/internal/backend/nobackend.go    | 116 ++++++++++++++++++++
- src/crypto/internal/backend/nocgo.go        |  10 ++
- src/crypto/internal/backend/stub.s          |  10 ++
- src/crypto/rand/rand_unix.go                |   2 +-
- src/crypto/rsa/boring.go                    |   4 +-
- src/crypto/rsa/notboring.go                 |   2 +-
- src/crypto/rsa/pkcs1v15.go                  |   2 +-
- src/crypto/rsa/pss.go                       |   2 +-
- src/crypto/rsa/rsa.go                       |   4 +-
- src/crypto/rsa/rsa_test.go                  |   2 +-
- src/crypto/sha1/boring.go                   |   2 +-
- src/crypto/sha1/sha1_test.go                |   2 +-
- src/crypto/sha256/sha256.go                 |   2 +-
- src/crypto/sha256/sha256_test.go            |   2 +-
- src/crypto/sha512/sha512.go                 |   2 +-
- src/crypto/sha512/sha512_test.go            |   2 +-
- src/crypto/tls/cipher_suites.go             |   2 +-
- src/go/build/deps_test.go                   |   2 +
- src/runtime/runtime_boring.go               |   5 +
- 34 files changed, 294 insertions(+), 29 deletions(-)
+ src/crypto/aes/cipher.go                     |   2 +-
+ src/crypto/aes/cipher_asm.go                 |   2 +-
+ src/crypto/boring/boring.go                  |   2 +-
+ src/crypto/ecdh/ecdh.go                      |   2 +-
+ src/crypto/ecdh/nist.go                      |   2 +-
+ src/crypto/ecdsa/boring.go                   |   4 +-
+ src/crypto/ecdsa/ecdsa.go                    |   4 +-
+ src/crypto/ecdsa/notboring.go                |   2 +-
+ src/crypto/ed25519/ed25519_test.go           |   2 +-
+ src/crypto/hmac/hmac.go                      |   2 +-
+ src/crypto/hmac/hmac_test.go                 |   2 +-
+ src/crypto/internal/backend/backend_test.go  |  30 +++++
+ src/crypto/internal/backend/bbig/big.go      |  17 +++
+ src/crypto/internal/backend/common.go        |  81 +++++++++++++
+ src/crypto/internal/backend/iscgo.go         |  10 ++
+ src/crypto/internal/backend/isrequirefips.go |   9 ++
+ src/crypto/internal/backend/nobackend.go     | 116 +++++++++++++++++++
+ src/crypto/internal/backend/nocgo.go         |  10 ++
+ src/crypto/internal/backend/norequirefips.go |   9 ++
+ src/crypto/internal/backend/stub.s           |  10 ++
+ src/crypto/rand/rand_unix.go                 |   2 +-
+ src/crypto/rsa/boring.go                     |   4 +-
+ src/crypto/rsa/notboring.go                  |   2 +-
+ src/crypto/rsa/pkcs1v15.go                   |   2 +-
+ src/crypto/rsa/pss.go                        |   2 +-
+ src/crypto/rsa/rsa.go                        |   4 +-
+ src/crypto/rsa/rsa_test.go                   |   2 +-
+ src/crypto/sha1/boring.go                    |   2 +-
+ src/crypto/sha1/sha1_test.go                 |   2 +-
+ src/crypto/sha256/sha256.go                  |   2 +-
+ src/crypto/sha256/sha256_test.go             |   2 +-
+ src/crypto/sha512/sha512.go                  |   2 +-
+ src/crypto/sha512/sha512_test.go             |   2 +-
+ src/crypto/tls/cipher_suites.go              |   2 +-
+ src/go/build/deps_test.go                    |   2 +
+ src/runtime/runtime_boring.go                |   5 +
+ 36 files changed, 328 insertions(+), 29 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
  create mode 100644 src/crypto/internal/backend/iscgo.go
+ create mode 100644 src/crypto/internal/backend/isrequirefips.go
  create mode 100644 src/crypto/internal/backend/nobackend.go
  create mode 100644 src/crypto/internal/backend/nocgo.go
+ create mode 100644 src/crypto/internal/backend/norequirefips.go
  create mode 100644 src/crypto/internal/backend/stub.s
 
 diff --git a/src/crypto/aes/cipher.go b/src/crypto/aes/cipher.go
@@ -256,10 +260,10 @@ index 00000000000000..85bd3ed083f5b2
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..007d8070538247
+index 00000000000000..c69ee3b8b53c9e
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,81 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -273,25 +277,41 @@ index 00000000000000..007d8070538247
 +)
 +
 +func init() {
-+	if v, _ := envGoFIPS(); v == "1" {
-+		if runtime.GOOS != "linux" {
-+			panic("FIPS mode requested (GOFIPS=1) but not supported on " + runtime.GOOS)
-+		} else if !iscgo {
-+			panic("FIPS mode requested (GOFIPS=1) but not supported with cgo disabled")
++	if v, r, ok := envGoFIPS(); ok && v == "1" {
++		if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
++			panic("FIPS mode requested (" + r + ") but not supported on " + runtime.GOOS)
++		}
++		if runtime.GOOS == "linux" && !iscgo {
++			panic("FIPS mode requested (" + r + ") but not supported with cgo disabled")
++		}
++		if !Enabled {
++			panic("FIPS mode requested (" + r + ") but no supported crypto backend is enabled")
 +		}
 +	}
 +}
 +
-+func envGoFIPS() (string, bool) {
-+	if v, ok := syscall.Getenv("GOFIPS"); ok {
-+		return v, true
-+	}
++func envGoFIPS() (value string, reason string, ok bool) {
 +	// TODO: Decide which environment variable to use.
 +	// See https://github.com/microsoft/go/issues/397.
-+	if v, ok := syscall.Getenv("GOLANG_FIPS"); ok {
-+		return v, true
++	var varName string
++	if value, ok = syscall.Getenv("GOFIPS"); ok {
++		varName = "GOFIPS"
++	} else if value, ok = syscall.Getenv("GOLANG_FIPS"); ok {
++		varName = "GOLANG_FIPS"
 +	}
-+	return "", false
++	if isRequireFIPS {
++		if ok && value != "1" {
++			panic("the 'requirefips' build tag is enabled, but it conflicts " +
++				"with the detected env variable " +
++				varName + "=" + value +
++				" which would disable FIPS mode")
++		}
++		return "1", "requirefips tag set", true
++	}
++	if ok {
++		return value, "environment variable " + varName + "=1", true
++	}
++	return "", "", false
 +}
 +
 +// Unreachable marks code that should be unreachable
@@ -341,6 +361,21 @@ index 00000000000000..1e0d3cf8c18b55
 +package backend
 +
 +const iscgo = true
+diff --git a/src/crypto/internal/backend/isrequirefips.go b/src/crypto/internal/backend/isrequirefips.go
+new file mode 100644
+index 00000000000000..e5d7570d6d4363
+--- /dev/null
++++ b/src/crypto/internal/backend/isrequirefips.go
+@@ -0,0 +1,9 @@
++// Copyright 2022 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build requirefips
++
++package backend
++
++const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
 index 00000000000000..ad6081552af15d
@@ -479,6 +514,21 @@ index 00000000000000..63c13fc4b01cba
 +package backend
 +
 +const iscgo = false
+diff --git a/src/crypto/internal/backend/norequirefips.go b/src/crypto/internal/backend/norequirefips.go
+new file mode 100644
+index 00000000000000..26bfb5f6a643f3
+--- /dev/null
++++ b/src/crypto/internal/backend/norequirefips.go
+@@ -0,0 +1,9 @@
++// Copyright 2022 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !requirefips
++
++package backend
++
++const isRequireFIPS = false
 diff --git a/src/crypto/internal/backend/stub.s b/src/crypto/internal/backend/stub.s
 new file mode 100644
 index 00000000000000..5e4b436554d44d

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -189,7 +189,7 @@ index 00000000000000..61ef3fdd90b607
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..68ea43ea892e1d
+index 00000000000000..34c2b8a90c9526
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,203 @@
@@ -226,7 +226,7 @@ index 00000000000000..68ea43ea892e1d
 +	// 1: FIPS required: abort the process if it is not enabled and can't be enabled.
 +	// other values: do not override OpenSSL configured FIPS mode.
 +	var fips string
-+	if v, ok := envGoFIPS(); ok {
++	if v, _, ok := envGoFIPS(); ok {
 +		fips = v
 +	} else if systemFIPSMode() {
 +		// System configuration can only force FIPS mode.

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,8 +12,8 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 205 ++++++++++++++++++
- src/crypto/internal/backend/common.go         |  38 +++-
+ src/crypto/internal/backend/cng_windows.go    | 207 ++++++++++++++++++
+ src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rand/rand_windows.go               |   9 +-
@@ -48,7 +48,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 44 files changed, 404 insertions(+), 46 deletions(-)
+ 44 files changed, 403 insertions(+), 44 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -167,10 +167,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..9d1bbf010c0fb6
+index 00000000000000..bea98e0f838b41
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,205 @@
+@@ -0,0 +1,207 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -196,7 +196,9 @@ index 00000000000000..9d1bbf010c0fb6
 +const Enabled = true
 +
 +func init() {
-+	if v, ok := envGoFIPS(); ok && v == "1" {
++	// 1: FIPS required: abort the process if the system is not in FIPS mode.
++	// other values: continue regardless of system-configured FIPS mode.
++	if v, _, ok := envGoFIPS(); ok && v == "1" {
 +		enabled, err := cng.FIPS()
 +		if err != nil {
 +			panic("cngcrypto: unknown FIPS mode: " + err.Error())
@@ -377,10 +379,10 @@ index 00000000000000..9d1bbf010c0fb6
 +	return cng.NewPublicKeyECDH(curve, bytes)
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
-index 007d8070538247..114f72c3d10ee4 100644
+index 19f6fc47e4daa3..7df07e9a8379fa 100644
 --- a/src/crypto/internal/backend/common.go
 +++ b/src/crypto/internal/backend/common.go
-@@ -5,16 +5,19 @@
+@@ -5,7 +5,9 @@
  package backend
  
  import (
@@ -390,19 +392,7 @@ index 007d8070538247..114f72c3d10ee4 100644
  	"runtime"
  	"syscall"
  )
- 
- func init() {
- 	if v, _ := envGoFIPS(); v == "1" {
--		if runtime.GOOS != "linux" {
-+		if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
- 			panic("FIPS mode requested (GOFIPS=1) but not supported on " + runtime.GOOS)
--		} else if !iscgo {
-+		}
-+		if runtime.GOOS == "linux" && !iscgo {
- 			panic("FIPS mode requested (GOFIPS=1) but not supported with cgo disabled")
- 		}
- 	}
-@@ -54,7 +57,11 @@ func hasSuffix(s, t string) bool {
+@@ -70,7 +72,11 @@ func hasSuffix(s, t string) bool {
  // UnreachableExceptTests marks code that should be unreachable
  // when backend is in use. It panics.
  func UnreachableExceptTests() {
@@ -415,7 +405,7 @@ index 007d8070538247..114f72c3d10ee4 100644
  		name := runtime_arg0()
  		// If ran on Windows we'd need to allow _test.exe and .test.exe as well.
  		if !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
-@@ -63,3 +70,28 @@ func UnreachableExceptTests() {
+@@ -79,3 +85,28 @@ func UnreachableExceptTests() {
  		}
  	}
  }

--- a/patches/0007-Add-backend-code-gen.patch
+++ b/patches/0007-Add-backend-code-gen.patch
@@ -33,7 +33,7 @@ the repository to run the generators.
  src/cmd/link/link_test.go                     |   4 +-
  src/cmd/vet/vet_test.go                       |   2 +-
  src/crypto/internal/backend/backendgen.go     |  20 ++
- .../internal/backend/backendgen_test.go       | 273 ++++++++++++++++++
+ .../internal/backend/backendgen_test.go       | 279 ++++++++++++++++++
  src/crypto/internal/backend/nobackend.go      |   2 +-
  .../backenderr_gen_conflict_boring_cng.go     |  17 ++
  .../backenderr_gen_conflict_boring_openssl.go |  17 ++
@@ -41,9 +41,10 @@ the repository to run the generators.
  .../backenderr_gen_nofallback_boring.go       |  19 ++
  src/runtime/backenderr_gen_nofallback_cng.go  |  19 ++
  .../backenderr_gen_nofallback_openssl.go      |  19 ++
+ ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 ++
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/syscall/exec_linux_test.go                |   2 +-
- 18 files changed, 440 insertions(+), 8 deletions(-)
+ 19 files changed, 463 insertions(+), 8 deletions(-)
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
  create mode 100644 src/runtime/backenderr_gen_conflict_boring_cng.go
@@ -52,6 +53,7 @@ the repository to run the generators.
  create mode 100644 src/runtime/backenderr_gen_nofallback_boring.go
  create mode 100644 src/runtime/backenderr_gen_nofallback_cng.go
  create mode 100644 src/runtime/backenderr_gen_nofallback_openssl.go
+ create mode 100644 src/runtime/backenderr_gen_requirefips_nosystemcrypto.go
  create mode 100644 src/runtime/backenderr_gen_systemcrypto_nobackend.go
 
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
@@ -207,10 +209,10 @@ index 00000000000000..acf0113bbefb6c
 +//go:generate go test -run TestGenerated -fix
 diff --git a/src/crypto/internal/backend/backendgen_test.go b/src/crypto/internal/backend/backendgen_test.go
 new file mode 100644
-index 00000000000000..0013ffec084722
+index 00000000000000..1cc4952e7ca9c2
 --- /dev/null
 +++ b/src/crypto/internal/backend/backendgen_test.go
-@@ -0,0 +1,273 @@
+@@ -0,0 +1,279 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -345,6 +347,8 @@ index 00000000000000..0013ffec084722
 +	}
 +	f := testUnsatisfied(t, backends)
 +	delete(existingFiles, f)
++	f = testRequireFIPSWithoutBackend(t)
++	delete(existingFiles, f)
 +
 +	for f := range existingFiles {
 +		if *fix {
@@ -363,14 +367,12 @@ index 00000000000000..0013ffec084722
 +// testConflict checks/generates a file that fails if two backends are enabled
 +// at the same time.
 +func testConflict(t *testing.T, a, b string) string {
-+	f := filepath.Join(runtimePackageDir, backendErrPrefix+"conflict_"+a+"_"+b+".go")
-+	testErrorFile(
++	return testErrorFile(
 +		t,
-+		f,
++		filepath.Join(runtimePackageDir, backendErrPrefix+"conflict_"+a+"_"+b+".go"),
 +		"//go:build goexperiment."+a+"crypto && goexperiment."+b+"crypto",
 +		"The "+a+" and "+b+" backends are both enabled, but they are mutually exclusive.",
 +		"Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.")
-+	return f
 +}
 +
 +func testPreventUnintendedFallback(t *testing.T, backend *backend) string {
@@ -383,16 +385,14 @@ index 00000000000000..0013ffec084722
 +		},
 +		Y: &constraint.NotExpr{X: optOutTag},
 +	}
-+	f := filepath.Join(runtimePackageDir, backendErrPrefix+"nofallback_"+backend.name+".go")
-+	testErrorFile(
++	return testErrorFile(
 +		t,
-+		f,
++		filepath.Join(runtimePackageDir, backendErrPrefix+"nofallback_"+backend.name+".go"),
 +		"//go:build "+c.String(),
 +		"The "+expTag.String()+" tag is specified, but other tags required to enable that backend were not met.",
 +		"Required build tags:",
 +		"  "+backend.constraint.String(),
 +		"Please check your build environment and build command for a reason one or more of these tags weren't specified.")
-+	return f
 +}
 +
 +// testUnsatisfied checks/generates a file that fails if systemcrypto is enabled
@@ -402,19 +402,26 @@ index 00000000000000..0013ffec084722
 +	for _, b := range backends {
 +		constraint += ` && !goexperiment.` + b.name + "crypto"
 +	}
-+	f := filepath.Join(runtimePackageDir, backendErrPrefix+"systemcrypto_nobackend.go")
-+	testErrorFile(
++	return testErrorFile(
 +		t,
-+		f,
++		filepath.Join(runtimePackageDir, backendErrPrefix+"systemcrypto_nobackend.go"),
 +		constraint,
 +		"The systemcrypto feature is enabled, but it was unable to enable an appropriate crypto backend for the target GOOS.")
-+	return f
++}
++
++func testRequireFIPSWithoutBackend(t *testing.T) string {
++	return testErrorFile(
++		t,
++		filepath.Join(runtimePackageDir, backendErrPrefix+"requirefips_nosystemcrypto.go"),
++		"//go:build requirefips && !goexperiment.systemcrypto",
++		"The requirefips tag is enabled, but no crypto backend is enabled.",
++		"A crypto backend is required to enable FIPS mode.")
 +}
 +
 +// testErrorFile checks/generates a Go file with a given build constraint that
 +// fails to compile. The file uses an unused string to convey an error message
 +// to the dev on the "go build" command line.
-+func testErrorFile(t *testing.T, file, constraint string, message ...string) {
++func testErrorFile(t *testing.T, file, constraint string, message ...string) string {
 +	const header = `// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -441,6 +448,7 @@ index 00000000000000..0013ffec084722
 +			t.Log("would generate:", c)
 +		}
 +	}
++	return file
 +}
 +
 +type backend struct {
@@ -638,6 +646,29 @@ index 00000000000000..d90c0cafebd623
 +	Required build tags:
 +	  goexperiment.opensslcrypto && linux && cgo && !android && !cmd_go_bootstrap && !msan
 +	Please check your build environment and build command for a reason one or more of these tags weren't specified.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/runtime/backenderr_gen_requirefips_nosystemcrypto.go b/src/runtime/backenderr_gen_requirefips_nosystemcrypto.go
+new file mode 100644
+index 00000000000000..1c015dd2b08972
+--- /dev/null
++++ b/src/runtime/backenderr_gen_requirefips_nosystemcrypto.go
+@@ -0,0 +1,17 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
++
++//go:build requirefips && !goexperiment.systemcrypto
++
++package runtime
++
++func init() {
++	`
++	The requirefips tag is enabled, but no crypto backend is enabled.
++	A crypto backend is required to enable FIPS mode.
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`
 +}


### PR DESCRIPTION
* Resolves https://github.com/microsoft/go/issues/928
* Doc PR: https://github.com/microsoft/go/pull/970

This change makes `GOEXPERIMENT=systemcrypto go build -tags=requirefips . && ./exp` use `GOFIPS=1` behavior, and panics if `GOFIPS=0` or `GOLANG_FIPS=0`:

```
$ GOEXPERIMENT=systemcrypto go build -tags=requirefips . && GOFIPS=0 ./exp
panic: the 'requirefips' build tag is enabled, but it conflicts with the detected env variable GOFIPS=0 which would disable FIPS mode

goroutine 1 [running]:
crypto/internal/backend.envGoFIPS()
        /work/go/src/crypto/internal/backend/common.go:40 +0xf4
crypto/internal/backend.init.0()
        /work/go/src/crypto/internal/backend/common.go:16 +0xf
```

I tested on a Windows VM, and it behaves as expected there, failing if `HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy` isn't configured. Behavior on Mariner is enabling FIPS mode (I added a println to the backend to make sure) and on my dev Fedora machine (without FIPS OpenSSL) it results in an OpenSSL error as expected.

---

Updates the `crypto/internal/backend/common.go` logic to more generally catch when no backend is enabled and FIPS mode is requested. Now, you get this on Windows:

```
$ $env:GOFIPS='1'
$ go build . && .\exp                                           
panic: FIPS mode requested (environment variable GOFIPS=1) but no supported crypto backend is enabled
```

This follows the theme of some of the recent changes: it technically reduces our toolset's compatibility, but simplifies respecting the *intent* of the app's user and the chance of mistakes in less clear-cut situations.

It will also help if someone intended to add FIPS support to their build, but their change to the build process didn't work as they intended. E.g. tags specified in an env var are overridden if the `-tags` flag is set:

```
$ $env:GOFIPS='1'
$ $env:GOFLAGS='-tags=goexperiment.systemcrypto,requirefips'
$ go build -tags 'fun' . && .\exp
panic: FIPS mode requested (environment variable GOFIPS=1) but no supported crypto backend is enabled
```

It's hard to get into this state in other ways. The added build error does this:

```
$ $env:GOFIPS=''
$ go build -tags='requirefips' .
# runtime
..\go\go\src\runtime\backenderr_gen_requirefips_nosystemcrypto.go:12:2: `
        The requirefips tag is enabled, but no crypto backend is enabled.
        A crypto backend is required to enable FIPS mode.
        For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
        ` (untyped string constant "\n\tThe requirefips tag is enabled, but no crypto backend is enabled...) is not used
```

Generally speaking, though, I think failing at runtime if `GOFIPS=1` and `!backend.Enabled` is a reasonable backstop if there's anything we missed when coding the compile errors or updating build tags.

(This PR also moves the logic entirely into the backend foundation patch rather than part of it being in the CNG patch. It was inconsistent: the CNG part was implemented in the CNG patch, but the OpenSSL part was implemented in the foundation patch.)

---

The reason to panic on `GOFIPS=0` rather than just ignoring it is to make sure nobody's intent is being silently ignored--the binary's author or its user.

Say someone is building a system that uses a handful of prebuilt Go binaries. Some are compiled with `requirefips` and some aren't. The user needs the system to communicate with a legacy server using crypto that the FIPS standard doesn't allow. The user sees failures related to FIPS TLS restrictions and sets `GOFIPS=0`. If this were silently ignored, parts of the system without `requirefips` would function and parts with `requirefips` would keep failing, and there's no surface-level way to tell why. (If you dig, `go version -m` on a binary has enough information to see `requirefips`, but you'd have to know a lot about this system to get this far and recognize the tag.)

Having the affected binaries panic, instead, gives them a way forward. They could either compile the binaries themselves, or (particularly in an internal or Docker scenario) look or ask for a non-FIPS version of the binaries from whoever provided the ones they were originally using.

---

I'll submit another PR to update the FIPS docs to describe this change and also `systemcrypto`.