### PR TITLE
[microsoft/release-branch.go1.21] Update 1.21 branch

### DIFF
--- a/eng/_core/buildutil/buildutil.go
+++ b/eng/_core/buildutil/buildutil.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // Retry runs f until it succeeds or the attempt limit is reached.
@@ -91,6 +92,15 @@ func GetEnvOrDefault(varName, defaultValue string) (string, error) {
 // AppendExperimentEnv sets the GOEXPERIMENT env var to the given value, or if GOEXPERIMENT is
 // already set, appends a comma separator and then the given value.
 func AppendExperimentEnv(experiment string) {
+	// If the experiment enables a crypto backend, allow fallback to Go crypto. Go turns off cgo
+	// and/or cross-builds in various situations during the build/tests, so we need to allow for it.
+	if strings.Contains(experiment, "opensslcrypto") ||
+		strings.Contains(experiment, "cngcrypto") ||
+		strings.Contains(experiment, "boringcrypto") ||
+		strings.Contains(experiment, "systemcrypto") {
+
+		experiment += ",allowcryptofallback"
+	}
 	if v, ok := os.LookupEnv("GOEXPERIMENT"); ok {
 		experiment = v + "," + experiment
 	}

--- a/eng/_core/cmd/build/build.go
+++ b/eng/_core/cmd/build/build.go
@@ -133,6 +133,10 @@ func build(o *options) error {
 		return err
 	}
 
+	if o.Experiment != "" {
+		buildutil.AppendExperimentEnv(o.Experiment)
+	}
+
 	if !o.SkipBuild {
 		// If we have a stage 0 copy of Go in an env variable (as set by run.ps1), use it in the
 		// build command by setting GOROOT_BOOTSTRAP. The upstream build script "make.bash" uses
@@ -224,17 +228,6 @@ func build(o *options) error {
 			// The stderr output isn't used to determine whether the tests succeeded or not. (The
 			// redirect doesn't cause an issue where tests succeed that should have failed.)
 			testCmd.Stderr = os.Stdout
-
-			if o.Experiment != "" {
-				buildutil.AppendExperimentEnv(o.Experiment)
-				// We aren't able to rebuild Go standard library packages under a crypto experiment,
-				// but "cmd/dist/test.go" will normally do this for local test runs to make sure the
-				// build is clean. The problem is that the build doesn't include cgo, which is
-				// required for some crypto backends. Set this variable specific to Microsoft Go to
-				// indicate that our build is fresh because it's running within our scripts and
-				// doesn't need a rebuild. A patch in the test runner detects this.
-				os.Setenv("GO_MSFT_SCRIPTED_BUILD", "1")
-			}
 
 			return runCmd(testCmd)
 		}

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -189,7 +189,7 @@ index 00000000000000..61ef3fdd90b607
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..34c2b8a90c9526
+index 00000000000000..2c36a07866fd6a
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,203 @@
@@ -580,7 +580,7 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 5ef63d4e3bf7d9..23b1e7323ec50d 100644
+index 25829e17f2dd9e..eb380c5a589cdf 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -588,21 +588,21 @@ index 5ef63d4e3bf7d9..23b1e7323ec50d 100644
  
  require (
 +	github.com/microsoft/go-crypto-openssl v0.2.7
- 	golang.org/x/crypto v0.10.0
- 	golang.org/x/net v0.11.1-0.20230613203745-f5464ddb689c
+ 	golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d
+ 	golang.org/x/net v0.12.1-0.20230712162946-57553cbff163
  )
 diff --git a/src/go.sum b/src/go.sum
-index 93d34efbe889f7..a9a97eef7d763d 100644
+index e474b8be318c84..921f8a4a9923cd 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
 +github.com/microsoft/go-crypto-openssl v0.2.7 h1:NKugDhOzj/ck0xRcATCL2L16B6IqZ/2AaG7b+KFa5aE=
 +github.com/microsoft/go-crypto-openssl v0.2.7/go.mod h1:xOSmQnWz4xvNB2+KQN2g2UUwMG9vqDHBk9nk/NdmyRw=
- golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
- golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
- golang.org/x/net v0.11.1-0.20230613203745-f5464ddb689c h1:icjsA5jFPWsTcuIb/yIeU6mgXRHPQBfo0Lzd1GQmKZI=
+ golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d h1:LiA25/KWKuXfIq5pMIBq1s5hz3HQxhJJSu/SUGlD+SM=
+ golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
+ golang.org/x/net v0.12.1-0.20230712162946-57553cbff163 h1:1EDKNuaCsog7zGLEml1qRuO4gt23jORUQX2f0IKZ860=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 3356154c7d1082..ef79bb8b7b24ca 100644
+index 4e4c0fa9f11f5b..7d32c7c63795d6 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -425,6 +425,8 @@ var depsRules = `
@@ -683,7 +683,7 @@ index de79140b2d4780..8c3cd998d0e7e1 100644
  	// SystemCrypto enables the OpenSSL or CNG crypto experiment depending on
  	// which one is appropriate on the target GOOS.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index 67cd446f420e8a..3015409ccb0f09 100644
+index 473f92ba8e43a1..b4df61a7b95c7a 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
 @@ -14,6 +14,7 @@ import (

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -48,7 +48,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 44 files changed, 403 insertions(+), 46 deletions(-)
+ 44 files changed, 402 insertions(+), 44 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -167,7 +167,7 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..bea98e0f838b41
+index 00000000000000..1e39e1fb5c8da1
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,207 @@
@@ -379,7 +379,7 @@ index 00000000000000..bea98e0f838b41
 +	return cng.NewPublicKeyECDH(curve, bytes)
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
-index 19f6fc47e4daa3..7df07e9a8379fa 100644
+index efdd080a1b7708..9d7f7b849d6485 100644
 --- a/src/crypto/internal/backend/common.go
 +++ b/src/crypto/internal/backend/common.go
 @@ -5,7 +5,9 @@
@@ -392,7 +392,7 @@ index 19f6fc47e4daa3..7df07e9a8379fa 100644
  	"runtime"
  	"syscall"
  )
-@@ -70,7 +72,11 @@ func hasSuffix(s, t string) bool {
+@@ -67,7 +69,11 @@ func hasSuffix(s, t string) bool {
  // UnreachableExceptTests marks code that should be unreachable
  // when backend is in use. It panics.
  func UnreachableExceptTests() {
@@ -405,7 +405,7 @@ index 19f6fc47e4daa3..7df07e9a8379fa 100644
  		name := runtime_arg0()
  		// If ran on Windows we'd need to allow _test.exe and .test.exe as well.
  		if !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
-@@ -79,3 +85,28 @@ func UnreachableExceptTests() {
+@@ -76,3 +82,28 @@ func UnreachableExceptTests() {
  		}
  	}
  }
@@ -1024,7 +1024,7 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 23b1e7323ec50d..69c746f405d27c 100644
+index eb380c5a589cdf..0453795f7d6119 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.21
@@ -1032,11 +1032,11 @@ index 23b1e7323ec50d..69c746f405d27c 100644
  require (
  	github.com/microsoft/go-crypto-openssl v0.2.7
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20230502061212-6eb98854418e
- 	golang.org/x/crypto v0.10.0
- 	golang.org/x/net v0.11.1-0.20230613203745-f5464ddb689c
+ 	golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d
+ 	golang.org/x/net v0.12.1-0.20230712162946-57553cbff163
  )
 diff --git a/src/go.sum b/src/go.sum
-index a9a97eef7d763d..7dbe6f682268ef 100644
+index 921f8a4a9923cd..eb34153bfc5cb8 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
@@ -1044,11 +1044,11 @@ index a9a97eef7d763d..7dbe6f682268ef 100644
  github.com/microsoft/go-crypto-openssl v0.2.7/go.mod h1:xOSmQnWz4xvNB2+KQN2g2UUwMG9vqDHBk9nk/NdmyRw=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20230502061212-6eb98854418e h1:BB2UybwbUjtxG2OFs6KnKi8AOlk9rjH7ekjkbW+vHA0=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20230502061212-6eb98854418e/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
- golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
- golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
- golang.org/x/net v0.11.1-0.20230613203745-f5464ddb689c h1:icjsA5jFPWsTcuIb/yIeU6mgXRHPQBfo0Lzd1GQmKZI=
+ golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d h1:LiA25/KWKuXfIq5pMIBq1s5hz3HQxhJJSu/SUGlD+SM=
+ golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
+ golang.org/x/net v0.12.1-0.20230712162946-57553cbff163 h1:1EDKNuaCsog7zGLEml1qRuO4gt23jORUQX2f0IKZ860=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index ef79bb8b7b24ca..65706944d6bdf5 100644
+index 7d32c7c63795d6..6146e20c7b027e 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -425,6 +425,10 @@ var depsRules = `

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -6268,7 +6268,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 438c2f447be441..6f2e303cc5f53c 100644
+index 2b5f965f8f890b..6310039510be28 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,15 @@
@@ -6284,6 +6284,6 @@ index 438c2f447be441..6f2e303cc5f53c 100644
 +github.com/microsoft/go-crypto-winnative/internal/bcrypt
 +github.com/microsoft/go-crypto-winnative/internal/subtle
 +github.com/microsoft/go-crypto-winnative/internal/sysdll
- # golang.org/x/crypto v0.10.0
+ # golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d
  ## explicit; go 1.17
  golang.org/x/crypto/chacha20

--- a/patches/0007-Add-backend-code-gen.patch
+++ b/patches/0007-Add-backend-code-gen.patch
@@ -25,28 +25,25 @@ harder to update the generators and to deal with conflicts.
 Use "go/bin/go generate crypto/internal/backend" after recently building
 the repository to run the generators.
 ---
- src/cmd/dist/build.go                         |   2 +-
- src/cmd/dist/test.go                          |   9 +-
- src/cmd/internal/obj/x86/pcrelative_test.go   |   4 +
- src/cmd/internal/testdir/testdir_test.go      |   4 +
- src/cmd/link/internal/ld/stackcheck_test.go   |   2 +-
- src/cmd/link/link_test.go                     |   4 +-
- src/cmd/vet/vet_test.go                       |   2 +-
  src/crypto/internal/backend/backendgen.go     |  20 ++
- .../internal/backend/backendgen_test.go       | 279 ++++++++++++++++++
+ .../internal/backend/backendgen_test.go       | 284 ++++++++++++++++++
  src/crypto/internal/backend/nobackend.go      |   2 +-
+ .../exp_allowcryptofallback_off.go            |   9 +
+ .../exp_allowcryptofallback_on.go             |   9 +
+ src/internal/goexperiment/flags.go            |   8 +
  .../backenderr_gen_conflict_boring_cng.go     |  17 ++
  .../backenderr_gen_conflict_boring_openssl.go |  17 ++
  .../backenderr_gen_conflict_cng_openssl.go    |  17 ++
- .../backenderr_gen_nofallback_boring.go       |  19 ++
- src/runtime/backenderr_gen_nofallback_cng.go  |  19 ++
- .../backenderr_gen_nofallback_openssl.go      |  19 ++
+ .../backenderr_gen_nofallback_boring.go       |  24 ++
+ src/runtime/backenderr_gen_nofallback_cng.go  |  24 ++
+ .../backenderr_gen_nofallback_openssl.go      |  24 ++
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 ++
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
- src/syscall/exec_linux_test.go                |   2 +-
- 19 files changed, 463 insertions(+), 8 deletions(-)
+ 14 files changed, 487 insertions(+), 1 deletion(-)
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
+ create mode 100644 src/internal/goexperiment/exp_allowcryptofallback_off.go
+ create mode 100644 src/internal/goexperiment/exp_allowcryptofallback_on.go
  create mode 100644 src/runtime/backenderr_gen_conflict_boring_cng.go
  create mode 100644 src/runtime/backenderr_gen_conflict_boring_openssl.go
  create mode 100644 src/runtime/backenderr_gen_conflict_cng_openssl.go
@@ -56,131 +53,6 @@ the repository to run the generators.
  create mode 100644 src/runtime/backenderr_gen_requirefips_nosystemcrypto.go
  create mode 100644 src/runtime/backenderr_gen_systemcrypto_nobackend.go
 
-diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 8973a871682816..61a2f52a462f4c 100644
---- a/src/cmd/dist/build.go
-+++ b/src/cmd/dist/build.go
-@@ -1472,7 +1472,7 @@ func cmdbootstrap() {
- 	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
- 	os.Setenv("GOEXPERIMENT", goexperiment)
- 	// No need to enable PGO for toolchain2.
--	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
-+	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off", "-tags=allow_missing_crypto_backend_fallback"}, toolchain...)...)
- 	if debug {
- 		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
- 		copyfile(pathf("%s/compile2", tooldir), pathf("%s/compile", tooldir), writeExec)
-diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index a0525bf42e3c18..d123e25725eea2 100644
---- a/src/cmd/dist/test.go
-+++ b/src/cmd/dist/test.go
-@@ -153,7 +153,7 @@ func (t *tester) run() {
- 	}
- 
- 	if !t.listMode {
--		if builder := os.Getenv("GO_BUILDER_NAME"); builder == "" {
-+		if builder, scripted := os.Getenv("GO_BUILDER_NAME"), os.Getenv("GO_MSFT_SCRIPTED_BUILD"); builder == "" && scripted != "1" {
- 			// Ensure that installed commands are up to date, even with -no-rebuild,
- 			// so that tests that run commands end up testing what's actually on disk.
- 			// If everything is up-to-date, this is a no-op.
-@@ -166,6 +166,12 @@ func (t *tester) run() {
- 			// and virtualization we usually start with a clean GOCACHE, so we would
- 			// end up rebuilding large parts of the standard library that aren't
- 			// otherwise relevant to the actual set of packages under test.
-+			//
-+			// Also skip this step if GO_MSFT_SCRIPTED_BUILD is 1. This is
-+			// similar to running in a builder, but it works locally. However,
-+			// the skip isn't for performance reasons: rebuilding the toolchain
-+			// may not work. For example, testing the OpenSSLCrypto GOEXPERIMENT
-+			// requires cgo, but cgo is disabled by toolenv().
- 			goInstall(toolenv(), gorootBinGo, toolchain...)
- 			goInstall(toolenv(), gorootBinGo, toolchain...)
- 			goInstall(toolenv(), gorootBinGo, "cmd")
-@@ -761,6 +767,7 @@ func (t *tester) registerTests() {
- 				ldflags:   "-linkmode=internal",
- 				env:       []string{"CGO_ENABLED=0"},
- 				pkg:       "reflect",
-+				tags:      []string{"allow_missing_crypto_backend_fallback"},
- 			})
- 		// Also test a cgo package.
- 		if t.cgoEnabled && t.internalLink() && !disablePIE {
-diff --git a/src/cmd/internal/obj/x86/pcrelative_test.go b/src/cmd/internal/obj/x86/pcrelative_test.go
-index 3827100123f26d..92344e8a681114 100644
---- a/src/cmd/internal/obj/x86/pcrelative_test.go
-+++ b/src/cmd/internal/obj/x86/pcrelative_test.go
-@@ -63,6 +63,10 @@ func objdumpOutput(t *testing.T, mname, source string) []byte {
- 		testenv.GoToolPath(t), "build", "-o",
- 		filepath.Join(tmpdir, "output"))
- 
-+	// Crypto backends are not available on all platforms (CNG is not available
-+	// on Linux), but it's ok to fall back to pure Go for this test.
-+	cmd.Args = append(cmd.Args, "-tags=allow_missing_crypto_backend_fallback")
-+
- 	cmd.Env = append(os.Environ(),
- 		"GOARCH=amd64", "GOOS=linux", "GOPATH="+filepath.Join(tmpdir, "_gopath"))
- 	cmd.Dir = tmpdir
-diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index bd7785900c637a..0657ee09dc04ca 100644
---- a/src/cmd/internal/testdir/testdir_test.go
-+++ b/src/cmd/internal/testdir/testdir_test.go
-@@ -694,6 +694,10 @@ func (t test) run() error {
- 			// -S=2 forces outermost line numbers when disassembling inlined code.
- 			cmdline := []string{"build", "-gcflags", "-S=2"}
- 
-+			// Crypto backends are not available on all platforms (386), but
-+			// it's ok to fall back to pure Go for this test.
-+			cmdline = append(cmdline, "-tags=allow_missing_crypto_backend_fallback")
-+
- 			// Append flags, but don't override -gcflags=-S=2; add to it instead.
- 			for i := 0; i < len(flags); i++ {
- 				flag := flags[i]
-diff --git a/src/cmd/link/internal/ld/stackcheck_test.go b/src/cmd/link/internal/ld/stackcheck_test.go
-index dd7e20528f0959..6b0d28d14f4935 100644
---- a/src/cmd/link/internal/ld/stackcheck_test.go
-+++ b/src/cmd/link/internal/ld/stackcheck_test.go
-@@ -19,7 +19,7 @@ func TestStackCheckOutput(t *testing.T) {
- 	testenv.MustHaveGoBuild(t)
- 	t.Parallel()
- 
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-o", os.DevNull, "./testdata/stackcheck")
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-tags=allow_missing_crypto_backend_fallback", "-o", os.DevNull, "./testdata/stackcheck")
- 	// The rules for computing frame sizes on all of the
- 	// architectures are complicated, so just do this on amd64.
- 	cmd.Env = append(os.Environ(), "GOARCH=amd64", "GOOS=linux")
-diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
-index c37d6e57bc0920..a4fd751dcd7c3b 100644
---- a/src/cmd/link/link_test.go
-+++ b/src/cmd/link/link_test.go
-@@ -162,7 +162,7 @@ TEXT ·x(SB),0,$0
-         MOVD ·zero(SB), AX
-         RET
- `)
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "build")
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-tags=allow_missing_crypto_backend_fallback")
- 	cmd.Dir = tmpdir
- 	cmd.Env = append(os.Environ(),
- 		"GOARCH=amd64", "GOOS=linux", "GOPATH="+filepath.Join(tmpdir, "_gopath"))
-@@ -362,7 +362,7 @@ func TestMachOBuildVersion(t *testing.T) {
- 	}
- 
- 	exe := filepath.Join(tmpdir, "main")
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal", "-o", exe, src)
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal", "-tags=allow_missing_crypto_backend_fallback", "-o", exe, src)
- 	cmd.Env = append(os.Environ(),
- 		"CGO_ENABLED=0",
- 		"GOOS=darwin",
-diff --git a/src/cmd/vet/vet_test.go b/src/cmd/vet/vet_test.go
-index 8b29907e818c9d..f29a76796de71f 100644
---- a/src/cmd/vet/vet_test.go
-+++ b/src/cmd/vet/vet_test.go
-@@ -54,7 +54,7 @@ var (
- )
- 
- func vetCmd(t *testing.T, arg, pkg string) *exec.Cmd {
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "vet", "-vettool="+vetPath(t), arg, path.Join("cmd/vet/testdata", pkg))
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "vet", "-tags=allow_missing_crypto_backend_fallback", "-vettool="+vetPath(t), arg, path.Join("cmd/vet/testdata", pkg))
- 	cmd.Env = os.Environ()
- 	return cmd
- }
 diff --git a/src/crypto/internal/backend/backendgen.go b/src/crypto/internal/backend/backendgen.go
 new file mode 100644
 index 00000000000000..acf0113bbefb6c
@@ -209,10 +81,10 @@ index 00000000000000..acf0113bbefb6c
 +//go:generate go test -run TestGenerated -fix
 diff --git a/src/crypto/internal/backend/backendgen_test.go b/src/crypto/internal/backend/backendgen_test.go
 new file mode 100644
-index 00000000000000..1cc4952e7ca9c2
+index 00000000000000..1ba948c8f207e5
 --- /dev/null
 +++ b/src/crypto/internal/backend/backendgen_test.go
-@@ -0,0 +1,279 @@
+@@ -0,0 +1,284 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -377,7 +249,7 @@ index 00000000000000..1cc4952e7ca9c2
 +
 +func testPreventUnintendedFallback(t *testing.T, backend *backend) string {
 +	expTag := &constraint.TagExpr{Tag: "goexperiment." + backend.name + "crypto"}
-+	optOutTag := &constraint.TagExpr{Tag: "allow_missing_crypto_backend_fallback"}
++	optOutTag := &constraint.TagExpr{Tag: "goexperiment.allowcryptofallback"}
 +	c := constraint.AndExpr{
 +		X: &constraint.AndExpr{
 +			X: expTag,
@@ -392,7 +264,12 @@ index 00000000000000..1cc4952e7ca9c2
 +		"The "+expTag.String()+" tag is specified, but other tags required to enable that backend were not met.",
 +		"Required build tags:",
 +		"  "+backend.constraint.String(),
-+		"Please check your build environment and build command for a reason one or more of these tags weren't specified.")
++		"Please check your build environment and build command for a reason one or more of these tags weren't specified.",
++		"",
++		"If you only performed a Go toolset upgrade and didn't expect this error, your code was likely depending on fallback to Go standard library crypto.",
++		"As of Go 1.21, Go crypto fallback is a build error. This helps prevent accidental fallback.",
++		"Removing "+backend.name+"crypto will restore pre-1.21 behavior by intentionally using Go standard library crypto.",
++		"")
 +}
 +
 +// testUnsatisfied checks/generates a file that fails if systemcrypto is enabled
@@ -493,7 +370,7 @@ index 00000000000000..1cc4952e7ca9c2
 +	return bs
 +}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-index ad6081552af15d..64d2330186e795 100644
+index ad6081552af15d..d5948dbc5f8a2a 100644
 --- a/src/crypto/internal/backend/nobackend.go
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -4,7 +4,7 @@
@@ -505,6 +382,55 @@ index ad6081552af15d..64d2330186e795 100644
  
  package backend
  
+diff --git a/src/internal/goexperiment/exp_allowcryptofallback_off.go b/src/internal/goexperiment/exp_allowcryptofallback_off.go
+new file mode 100644
+index 00000000000000..dfce36d834c46e
+--- /dev/null
++++ b/src/internal/goexperiment/exp_allowcryptofallback_off.go
+@@ -0,0 +1,9 @@
++// Code generated by mkconsts.go. DO NOT EDIT.
++
++//go:build !goexperiment.allowcryptofallback
++// +build !goexperiment.allowcryptofallback
++
++package goexperiment
++
++const AllowCryptoFallback = false
++const AllowCryptoFallbackInt = 0
+diff --git a/src/internal/goexperiment/exp_allowcryptofallback_on.go b/src/internal/goexperiment/exp_allowcryptofallback_on.go
+new file mode 100644
+index 00000000000000..8d0c3fde9ab5e8
+--- /dev/null
++++ b/src/internal/goexperiment/exp_allowcryptofallback_on.go
+@@ -0,0 +1,9 @@
++// Code generated by mkconsts.go. DO NOT EDIT.
++
++//go:build goexperiment.allowcryptofallback
++// +build goexperiment.allowcryptofallback
++
++package goexperiment
++
++const AllowCryptoFallback = true
++const AllowCryptoFallbackInt = 1
+diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
+index c2f69930e2240e..c8e10ebc1696c4 100644
+--- a/src/internal/goexperiment/flags.go
++++ b/src/internal/goexperiment/flags.go
+@@ -77,6 +77,14 @@ type Flags struct {
+ 	// being used to build the Go program.
+ 	SystemCrypto bool
+ 
++	// AllowCryptoFallback allows the use of pure Go crypto if a crypto backend
++	// experiment is enabled but the backend's requirements are not met. This is
++	// used during the Go build itself to allow running the test suite with a
++	// backend experiment enabled. Some parts of the Go build (bootstrapping)
++	// and parts of the test suite run without cgo, so
++	// GOEXPERIMENT=opensslcrypto,allowcryptofallback must be used to succeed.
++	AllowCryptoFallback bool
++
+ 	// Regabi is split into several sub-experiments that can be
+ 	// enabled individually. Not all combinations work.
+ 	// The "regabi" GOEXPERIMENT is an alias for all "working"
 diff --git a/src/runtime/backenderr_gen_conflict_boring_cng.go b/src/runtime/backenderr_gen_conflict_boring_cng.go
 new file mode 100644
 index 00000000000000..361db2a962d60f
@@ -576,17 +502,17 @@ index 00000000000000..bf44084570bbbc
 +}
 diff --git a/src/runtime/backenderr_gen_nofallback_boring.go b/src/runtime/backenderr_gen_nofallback_boring.go
 new file mode 100644
-index 00000000000000..764172d1159e17
+index 00000000000000..6db0ed6dc09639
 --- /dev/null
 +++ b/src/runtime/backenderr_gen_nofallback_boring.go
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,24 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
 +
-+//go:build goexperiment.boringcrypto && !(goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan) && !allow_missing_crypto_backend_fallback
++//go:build goexperiment.boringcrypto && !(goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan) && !goexperiment.allowcryptofallback
 +
 +package runtime
 +
@@ -596,22 +522,27 @@ index 00000000000000..764172d1159e17
 +	Required build tags:
 +	  goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan
 +	Please check your build environment and build command for a reason one or more of these tags weren't specified.
++	
++	If you only performed a Go toolset upgrade and didn't expect this error, your code was likely depending on fallback to Go standard library crypto.
++	As of Go 1.21, Go crypto fallback is a build error. This helps prevent accidental fallback.
++	Removing boringcrypto will restore pre-1.21 behavior by intentionally using Go standard library crypto.
++	
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`
 +}
 diff --git a/src/runtime/backenderr_gen_nofallback_cng.go b/src/runtime/backenderr_gen_nofallback_cng.go
 new file mode 100644
-index 00000000000000..3187f794dd49a4
+index 00000000000000..ae7f798ea41225
 --- /dev/null
 +++ b/src/runtime/backenderr_gen_nofallback_cng.go
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,24 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
 +
-+//go:build goexperiment.cngcrypto && !(goexperiment.cngcrypto && windows) && !allow_missing_crypto_backend_fallback
++//go:build goexperiment.cngcrypto && !(goexperiment.cngcrypto && windows) && !goexperiment.allowcryptofallback
 +
 +package runtime
 +
@@ -621,22 +552,27 @@ index 00000000000000..3187f794dd49a4
 +	Required build tags:
 +	  goexperiment.cngcrypto && windows
 +	Please check your build environment and build command for a reason one or more of these tags weren't specified.
++	
++	If you only performed a Go toolset upgrade and didn't expect this error, your code was likely depending on fallback to Go standard library crypto.
++	As of Go 1.21, Go crypto fallback is a build error. This helps prevent accidental fallback.
++	Removing cngcrypto will restore pre-1.21 behavior by intentionally using Go standard library crypto.
++	
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`
 +}
 diff --git a/src/runtime/backenderr_gen_nofallback_openssl.go b/src/runtime/backenderr_gen_nofallback_openssl.go
 new file mode 100644
-index 00000000000000..36ea1ea1884d8c
+index 00000000000000..351be70262084b
 --- /dev/null
 +++ b/src/runtime/backenderr_gen_nofallback_openssl.go
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,24 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
 +
-+//go:build goexperiment.opensslcrypto && !(goexperiment.opensslcrypto && linux && cgo && !android) && !allow_missing_crypto_backend_fallback
++//go:build goexperiment.opensslcrypto && !(goexperiment.opensslcrypto && linux && cgo && !android) && !goexperiment.allowcryptofallback
 +
 +package runtime
 +
@@ -646,6 +582,11 @@ index 00000000000000..36ea1ea1884d8c
 +	Required build tags:
 +	  goexperiment.opensslcrypto && linux && cgo && !android
 +	Please check your build environment and build command for a reason one or more of these tags weren't specified.
++	
++	If you only performed a Go toolset upgrade and didn't expect this error, your code was likely depending on fallback to Go standard library crypto.
++	As of Go 1.21, Go crypto fallback is a build error. This helps prevent accidental fallback.
++	Removing opensslcrypto will restore pre-1.21 behavior by intentionally using Go standard library crypto.
++	
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`
 +}
@@ -694,16 +635,3 @@ index 00000000000000..97ba7da6260b50
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`
 +}
-diff --git a/src/syscall/exec_linux_test.go b/src/syscall/exec_linux_test.go
-index f4ff7bf81b358b..b4504afac961c0 100644
---- a/src/syscall/exec_linux_test.go
-+++ b/src/syscall/exec_linux_test.go
-@@ -277,7 +277,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
- 		}
- 	})
- 
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "-tags=allow_missing_crypto_backend_fallback", "syscall")
- 	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
- 	if o, err := cmd.CombinedOutput(); err != nil {
- 		t.Fatalf("Build of syscall in chroot failed, output %v, err %v", o, err)


### PR DESCRIPTION
Update the submodule to the current 1.21 commit and fix patches. The usual trivial conflicts in go.mod/go.sum and vendoring.

I mentioned in Go sync that I saw this branch and remembered that upstream typically branches for the first `rc` release. This has been the case before, but as far as I can tell from https://github.com/golang/go/commits/release-branch.go1.21, the branch was just created today. (I don't know a reasonable way to tell when a branch was actually created on GitHub, but what is easy to see is that today is when the first branch-specific commit was pushed.)