### PR TITLE
Update SDL script's path-unifying regex

### DIFF
--- a/eng/compliance/Guardian/execute-go-sdl-tools.ps1
+++ b/eng/compliance/Guardian/execute-go-sdl-tools.ps1
@@ -14,13 +14,13 @@ $downloadedArtifactsDirectory = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "a
 foreach ($item in Get-ChildItem -Directory $downloadedArtifactsDirectory)
 {
   # Handle e.g.
-  # C:\artifacts\go1.22-cd589c8-20230809.2.linux-arm64.tar.gz.extracted\
-  # C:\artifacts\go1.22.3-20230809.2.windows-amd64.zip.extracted\
-  # C:\artifacts\go1.22.0-20230813.14.src.tar.gz.extracted\
+  # C:\artifacts\go1.22-cd589c8-20230809.2.linux-arm64.tar.gz.extracted
+  # C:\artifacts\go1.22.3-20230809.2.windows-amd64.zip.extracted
+  # C:\artifacts\go1.22.0-20230813.14.src.tar.gz.extracted
   if ($item.Name.StartsWith("go") -and $item.Name.EndsWith(".extracted"))
   {
     $oldName = $item.FullName
-    $newName = $item.FullName -replace '\\go.+\.([\w-]+)\.(tar\.gz|zip)\.extracted\\', '\go.$1.$2.extracted\'
+    $newName = $item.FullName -replace '\\go.+\.([\w-]+)\.(tar\.gz|zip)\.extracted', '\go.$1.$2.extracted'
     if ($oldName -ne $newName)
     {
       Write-Host "Renaming '$oldName' to '$newName'"

--- a/eng/compliance/Guardian/execute-go-sdl-tools.ps1
+++ b/eng/compliance/Guardian/execute-go-sdl-tools.ps1
@@ -13,10 +13,11 @@ $downloadedArtifactsDirectory = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "a
 # Remove verison number from the artifact path to make path-based issue suppression more reliable.
 foreach ($item in Get-ChildItem -Directory $downloadedArtifactsDirectory)
 {
-  if ($item.Name.StartsWith("go.") -and $item.Name.EndsWith(".extracted"))
+  # Handle e.g. "go1.22-cd589c8-20230809.2.linux-arm64.tar.gz"
+  if ($item.Name.StartsWith("go") -and $item.Name.EndsWith(".extracted"))
   {
     $oldName = $item.FullName
-    $newName = $item.FullName -replace '\\go\.[0-9]+\.[0-9]+\.', '\go.'
+    $newName = $item.FullName -replace '\\go[0-9]+\.[-a-f0-9]+\.[0-9]+\.', '\go.'
     if ($oldName -ne $newName)
     {
       Write-Host "Renaming '$oldName' to '$newName'"

--- a/eng/compliance/Guardian/execute-go-sdl-tools.ps1
+++ b/eng/compliance/Guardian/execute-go-sdl-tools.ps1
@@ -13,11 +13,14 @@ $downloadedArtifactsDirectory = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "a
 # Remove verison number from the artifact path to make path-based issue suppression more reliable.
 foreach ($item in Get-ChildItem -Directory $downloadedArtifactsDirectory)
 {
-  # Handle e.g. "go1.22-cd589c8-20230809.2.linux-arm64.tar.gz"
+  # Handle e.g.
+  # C:\artifacts\go1.22-cd589c8-20230809.2.linux-arm64.tar.gz.extracted\
+  # C:\artifacts\go1.22.3-20230809.2.windows-amd64.zip.extracted\
+  # C:\artifacts\go1.22.0-20230813.14.src.tar.gz.extracted\
   if ($item.Name.StartsWith("go") -and $item.Name.EndsWith(".extracted"))
   {
     $oldName = $item.FullName
-    $newName = $item.FullName -replace '\\go[0-9]+\.[-a-f0-9]+\.[0-9]+\.', '\go.'
+    $newName = $item.FullName -replace '\\go.+\.([\w-]+)\.(tar\.gz|zip)\.extracted\\', '\go.$1.$2.extracted\'
     if ($oldName -ne $newName)
     {
       Write-Host "Renaming '$oldName' to '$newName'"

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -73,4 +73,3 @@ stages:
             -TsaRepositoryName "$(TsaRepositoryName)"
             -TsaCodebaseName "$(TsaCodebaseName)"
             -TsaPublish $true
-            -BreakOnFailure $true


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go/issues/1016

Tested it out in https://dev.azure.com/dnceng/internal/_build/results?buildId=2241148&view=results:

```
Renaming 'D:\a\_work\1\a\artifacts\go1.22-cd589c8-20230810.3.linux-amd64.tar.gz.extracted' to 'D:\a\_work\1\a\artifacts\go.linux-amd64.tar.gz.extracted'
Renaming 'D:\a\_work\1\a\artifacts\go1.22-cd589c8-20230810.3.linux-arm.tar.gz.extracted' to 'D:\a\_work\1\a\artifacts\go.linux-arm.tar.gz.extracted'
Renaming 'D:\a\_work\1\a\artifacts\go1.22-cd589c8-20230810.3.linux-arm64.tar.gz.extracted' to 'D:\a\_work\1\a\artifacts\go.linux-arm64.tar.gz.extracted'
Renaming 'D:\a\_work\1\a\artifacts\go1.22-cd589c8-20230810.3.src.tar.gz.extracted' to 'D:\a\_work\1\a\artifacts\go.src.tar.gz.extracted'
Renaming 'D:\a\_work\1\a\artifacts\go1.22-cd589c8-20230810.3.windows-amd64.zip.extracted' to 'D:\a\_work\1\a\artifacts\go.windows-amd64.zip.extracted'
```

Also removes `-BreakOnFailure $true`. Every pipeline run fails: the tool detects the same set of test secrets and reports them to the TSA service. The pipeline doesn't know whether or not the issues will be suppressed. Removing the constant source of failure means that more important failures (infra breaks) will show up. We can rely on TSA to show us new/important reported failures.