### PR TITLE
Change "arm" to "armv6l" during tar.gz prep

### DIFF
--- a/eng/_core/cmd/build/build.go
+++ b/eng/_core/cmd/build/build.go
@@ -282,9 +282,16 @@ func build(o *options) error {
 		// patches but build the same submodule commit multiple times.
 		buildID := getBuildID()
 		if o.PackBuild {
+			// distpack calls GOARCH=arm "arm" in its tar.gz filename, but the upstream release
+			// process changes it to "armv6l" on https://go.dev/dl/ to match the historical name.
+			// Do the same here.
+			brandingTargetArch := targetArch
+			if brandingTargetArch == "arm" {
+				brandingTargetArch = "armv6l"
+			}
 			packs = append(packs, packCopy{
 				src: filepath.Join(distPackDir, version+"."+targetOS+"-"+targetArch+archiveExtension),
-				dst: filepath.Join(artifactsBinDir, version+"-"+buildID+"."+targetOS+"-"+targetArch+archiveExtension),
+				dst: filepath.Join(artifactsBinDir, version+"-"+buildID+"."+targetOS+"-"+brandingTargetArch+archiveExtension),
 			})
 		}
 		if o.PackSource {


### PR DESCRIPTION
distpack produces files like `go1.21.0.linux-arm.tar.gz`, but upstream published it as `go1.21.0.linux-armv6l.tar.gz`. This matches the historical name. I _believe_ this line is responsible for upstream's rename: https://github.com/golang/build/blob/a929908712e90b6259357273fafcfc08f7215193/internal/relui/workflows.go#L1455

Unfortunately for us, since upstream seems to rename the file in `x/build` rather than distpack, we have to reimplement the name swap in our own code.

I noticed this because some SDL issue suppressions were no longer applying due to the filename change, but it actually would have broken the aka.ms links at https://github.com/microsoft/go/blob/microsoft/main/eng/doc/Downloads.md. Luckily we aren't using distpack yet in 1.21, so the 1.21.0 release's aka.ms links are fine and we have time to fix this up for 1.22.