### PR TITLE
Use openssl/cng to implement HKDF in crypto/tls

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -17,9 +17,9 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/hmac/hmac_test.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go  |  30 +++++
  src/crypto/internal/backend/bbig/big.go      |  17 +++
- src/crypto/internal/backend/common.go        |  78 +++++++++++++
+ src/crypto/internal/backend/common.go        |  78 ++++++++++++
  src/crypto/internal/backend/isrequirefips.go |   9 ++
- src/crypto/internal/backend/nobackend.go     | 116 +++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go     | 125 +++++++++++++++++++
  src/crypto/internal/backend/norequirefips.go |   9 ++
  src/crypto/internal/backend/stub.s           |  10 ++
  src/crypto/rand/rand_unix.go                 |   2 +-
@@ -38,7 +38,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 34 files changed, 305 insertions(+), 29 deletions(-)
+ 34 files changed, 314 insertions(+), 29 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
@@ -355,10 +355,10 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..ad6081552af15d
+index 00000000000000..3698bbac41e5c8
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,125 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -373,6 +373,7 @@ index 00000000000000..ad6081552af15d
 +	"crypto"
 +	"crypto/cipher"
 +	"hash"
++	"io"
 +)
 +
 +const Enabled = false
@@ -475,6 +476,14 @@ index 00000000000000..ad6081552af15d
 +func NewPublicKeyECDH(string, []byte) (*PublicKeyECDH, error) { panic("cryptobackend: not available") }
 +func (*PublicKeyECDH) Bytes() []byte                          { panic("cryptobackend: not available") }
 +func (*PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error)    { panic("cryptobackend: not available") }
++
++func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
++	panic("cryptobackend: not available")
++}
++
++func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
 diff --git a/src/crypto/internal/backend/norequirefips.go b/src/crypto/internal/backend/norequirefips.go
 new file mode 100644
 index 00000000000000..26bfb5f6a643f3
@@ -694,7 +703,7 @@ index 589e8b6fafbba3..0a6d665ee3096d 100644
  	"crypto/sha1"
  	"crypto/sha256"
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index bdb09737b03954..184447eb7992a0 100644
+index ff03691eb90397..1a8530d999b0c9 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -428,6 +428,7 @@ var depsRules = `

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 ++
- src/crypto/internal/backend/boring_linux.go   | 135 ++++++++++++++++++
- 2 files changed, 147 insertions(+)
+ src/crypto/internal/backend/boring_linux.go   | 144 ++++++++++++++++++
+ 2 files changed, 156 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..3b5504b6afc5c6
+index 00000000000000..5c9d6daa8db782
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,135 @@
+@@ -0,0 +1,144 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -50,6 +50,7 @@ index 00000000000000..3b5504b6afc5c6
 +	"crypto/cipher"
 +	"crypto/internal/boring"
 +	"hash"
++	"io"
 +)
 +
 +const Enabled = true
@@ -168,4 +169,12 @@ index 00000000000000..3b5504b6afc5c6
 +
 +func NewPublicKeyECDH(curve string, bytes []byte) (*boring.PublicKeyECDH, error) {
 +	return boring.NewPublicKeyECDH(curve, bytes)
++}
++
++func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
++	panic("cryptobackend: not available")
++}
++
++func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
++	panic("cryptobackend: not available")
 +}

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 226 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 235 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -25,6 +25,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/tls/boring_test.go                 |   2 +-
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
  src/crypto/tls/fipsonly/fipsonly_test.go      |   2 +-
+ src/crypto/tls/key_schedule.go                |  20 +-
  src/crypto/tls/notboring.go                   |   2 +-
  src/crypto/x509/boring.go                     |   2 +-
  src/crypto/x509/boring_test.go                |   2 +-
@@ -36,14 +37,14 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 32 files changed, 307 insertions(+), 23 deletions(-)
+ 33 files changed, 335 insertions(+), 24 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_on.go
 
 diff --git a/src/cmd/api/boring_test.go b/src/cmd/api/boring_test.go
-index a9ec6e6bfefb76..01765f01736ccb 100644
+index f0e3575637c62a..0e9aceeb832d3b 100644
 --- a/src/cmd/api/boring_test.go
 +++ b/src/cmd/api/boring_test.go
 @@ -2,7 +2,7 @@
@@ -56,10 +57,10 @@ index a9ec6e6bfefb76..01765f01736ccb 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index f148fb97b5f62d..a0525bf42e3c18 100644
+index 5e57c0c427bf71..439f8198e4121e 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1178,12 +1178,11 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1206,12 +1206,11 @@ func (t *tester) registerCgoTests(heading string) {
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
@@ -106,10 +107,10 @@ index 4aaf46b5d0f0dc..6fe798cf4a94e9 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index 91e2d5149ce4da..3e16cdabed263a 100644
+index a6f7173706f5f9..fecbab119f716a 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
-@@ -1146,6 +1146,7 @@ var hostobj []Hostobj
+@@ -1152,6 +1152,7 @@ var hostobj []Hostobj
  // These packages can use internal linking mode.
  // Others trigger external mode.
  var internalpkg = []string{
@@ -189,10 +190,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..835e7ed2a53fa9
+index 00000000000000..9995444d1f1e9f
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,226 @@
+@@ -0,0 +1,235 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -209,6 +210,7 @@ index 00000000000000..835e7ed2a53fa9
 +	"crypto/cipher"
 +	"crypto/internal/boring/sig"
 +	"hash"
++	"io"
 +	"syscall"
 +
 +	"github.com/golang-fips/openssl/v2"
@@ -419,6 +421,14 @@ index 00000000000000..835e7ed2a53fa9
 +func NewPublicKeyECDH(curve string, bytes []byte) (*openssl.PublicKeyECDH, error) {
 +	return openssl.NewPublicKeyECDH(curve, bytes)
 +}
++
++func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
++	return openssl.ExpandHKDF(h, pseudorandomKey, info)
++}
++
++func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
++	return openssl.ExtractHKDF(h, secret, salt)
++}
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
 index f2e5a503eaacb6..1dc7116efdff2e 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
@@ -550,6 +560,54 @@ index f8485dc3ca1c29..9c1d3d279c472f 100644
  
  package fipsonly
  
+diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
+index d7f082c9ee1e04..ee9d4650e3523b 100644
+--- a/src/crypto/tls/key_schedule.go
++++ b/src/crypto/tls/key_schedule.go
+@@ -7,9 +7,11 @@ package tls
+ import (
+ 	"crypto/ecdh"
+ 	"crypto/hmac"
++	boring "crypto/internal/backend"
+ 	"errors"
+ 	"fmt"
+ 	"hash"
++	"internal/goexperiment"
+ 	"io"
+ 
+ 	"golang.org/x/crypto/cryptobyte"
+@@ -59,7 +61,16 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
+ 		panic(fmt.Errorf("failed to construct HKDF label: %s", err))
+ 	}
+ 	out := make([]byte, length)
+-	n, err := hkdf.Expand(c.hash.New, secret, hkdfLabelBytes).Read(out)
++	var r io.Reader
++	if goexperiment.OpenSSLCrypto {
++		r, err = boring.ExpandHKDF(c.hash.New, secret, hkdfLabelBytes)
++		if err != nil {
++			panic(fmt.Errorf("tls: HKDF-Expand-Label invocation failed unexpectedly: %s", err))
++		}
++	} else {
++		r = hkdf.Expand(c.hash.New, secret, hkdfLabelBytes)
++	}
++	n, err := r.Read(out)
+ 	if err != nil || n != length {
+ 		panic("tls: HKDF-Expand-Label invocation failed unexpectedly")
+ 	}
+@@ -79,6 +90,13 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
+ 	if newSecret == nil {
+ 		newSecret = make([]byte, c.hash.Size())
+ 	}
++	if goexperiment.OpenSSLCrypto {
++		v, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
++		if err != nil {
++			panic(fmt.Errorf("tls: HKDF-Extract invocation failed unexpectedly: %s", err))
++		}
++		return v
++	}
+ 	return hkdf.Extract(c.hash.New, newSecret, currentSecret)
+ }
+ 
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
 index 7d85b39c59319e..1aaabd5ef486aa 100644
 --- a/src/crypto/tls/notboring.go
@@ -603,7 +661,7 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 5ef63d4e3bf7d9..e52d56ea42e0a0 100644
+index beb4d13d8bdc6f..3de2b296d0fecb 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -615,7 +673,7 @@ index 5ef63d4e3bf7d9..e52d56ea42e0a0 100644
  	golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9
  )
 diff --git a/src/go.sum b/src/go.sum
-index 93d34efbe889f7..0b6e1010f5679c 100644
+index 81b83159f77a36..ff87d3883113cd 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
@@ -625,10 +683,10 @@ index 93d34efbe889f7..0b6e1010f5679c 100644
  golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
  golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9 h1:eQR0jFW5dN2q8lFzSF7rjkRCOOnBf0llczNvITm6ICs=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 4e4c0fa9f11f5b..b584ed4fee1373 100644
+index 1a8530d999b0c9..a31878487bc285 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -425,6 +425,8 @@ var depsRules = `
+@@ -427,6 +427,8 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -637,7 +695,7 @@ index 4e4c0fa9f11f5b..b584ed4fee1373 100644
  	< crypto/internal/boring
  	< crypto/internal/backend
  	< crypto/boring;
-@@ -459,6 +461,7 @@ var depsRules = `
+@@ -461,6 +463,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -645,7 +703,7 @@ index 4e4c0fa9f11f5b..b584ed4fee1373 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -707,7 +710,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -709,7 +712,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -654,7 +712,7 @@ index 4e4c0fa9f11f5b..b584ed4fee1373 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -717,7 +720,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -719,7 +722,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}
@@ -694,7 +752,7 @@ index 00000000000000..a7f2712e9e1464
 +const OpenSSLCrypto = true
 +const OpenSSLCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index de79140b2d4780..8c3cd998d0e7e1 100644
+index 5d0f5b678b4f9d..416b5002944529 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,7 @@ type Flags struct {

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -599,11 +599,11 @@ index d7f082c9ee1e04..ee9d4650e3523b 100644
  		newSecret = make([]byte, c.hash.Size())
  	}
 +	if goexperiment.OpenSSLCrypto {
-+		v, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
++		prk, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
 +		if err != nil {
 +			panic(fmt.Errorf("tls: HKDF-Extract invocation failed unexpectedly: %s", err))
 +		}
-+		return v
++		return prk
 +	}
  	return hkdf.Extract(c.hash.New, newSecret, currentSecret)
  }

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 207 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 216 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -34,6 +34,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
  src/crypto/tls/fipsonly/fipsonly_test.go      |   2 +-
  src/crypto/tls/handshake_server_tls13.go      |  10 +
+ src/crypto/tls/key_schedule.go                |   4 +-
  src/crypto/tls/notboring.go                   |   2 +-
  src/crypto/x509/boring.go                     |   2 +-
  src/crypto/x509/boring_test.go                |   2 +-
@@ -46,14 +47,14 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 42 files changed, 398 insertions(+), 40 deletions(-)
+ 43 files changed, 408 insertions(+), 42 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_on.go
 
 diff --git a/src/cmd/api/boring_test.go b/src/cmd/api/boring_test.go
-index 01765f01736ccb..7598da96946b9f 100644
+index 0e9aceeb832d3b..aecf81b09c8ad3 100644
 --- a/src/cmd/api/boring_test.go
 +++ b/src/cmd/api/boring_test.go
 @@ -2,7 +2,7 @@
@@ -165,10 +166,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..1e39e1fb5c8da1
+index 00000000000000..6841062f39dfbb
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,207 @@
+@@ -0,0 +1,216 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -185,6 +186,7 @@ index 00000000000000..1e39e1fb5c8da1
 +	"crypto/cipher"
 +	"crypto/internal/boring/sig"
 +	"hash"
++	"io"
 +	_ "unsafe"
 +
 +	"github.com/microsoft/go-crypto-winnative/cng"
@@ -375,6 +377,14 @@ index 00000000000000..1e39e1fb5c8da1
 +
 +func NewPublicKeyECDH(curve string, bytes []byte) (*cng.PublicKeyECDH, error) {
 +	return cng.NewPublicKeyECDH(curve, bytes)
++}
++
++func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
++	return cng.ExpandHKDF(h, pseudorandomKey, info)
++}
++
++func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
++	return cng.ExtractHKDF(h, secret, salt)
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 index efdd080a1b7708..9d7f7b849d6485 100644
@@ -938,6 +948,28 @@ index 07b1a3851e0714..6fae2b4ba22540 100644
  		return nil
  	}
  	state, err := marshaler.MarshalBinary()
+diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
+index ee9d4650e3523b..4d792561cabe04 100644
+--- a/src/crypto/tls/key_schedule.go
++++ b/src/crypto/tls/key_schedule.go
+@@ -62,7 +62,7 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
+ 	}
+ 	out := make([]byte, length)
+ 	var r io.Reader
+-	if goexperiment.OpenSSLCrypto {
++	if goexperiment.OpenSSLCrypto || goexperiment.CNGCrypto {
+ 		r, err = boring.ExpandHKDF(c.hash.New, secret, hkdfLabelBytes)
+ 		if err != nil {
+ 			panic(fmt.Errorf("tls: HKDF-Expand-Label invocation failed unexpectedly: %s", err))
+@@ -90,7 +90,7 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
+ 	if newSecret == nil {
+ 		newSecret = make([]byte, c.hash.Size())
+ 	}
+-	if goexperiment.OpenSSLCrypto {
++	if goexperiment.OpenSSLCrypto || goexperiment.CNGCrypto {
+ 		v, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
+ 		if err != nil {
+ 			panic(fmt.Errorf("tls: HKDF-Extract invocation failed unexpectedly: %s", err))
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
 index 1aaabd5ef486aa..5a133c9b2f94c7 100644
 --- a/src/crypto/tls/notboring.go
@@ -991,34 +1023,34 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index e52d56ea42e0a0..fc903b34f227f3 100644
+index 3de2b296d0fecb..e441e40d1227b0 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
  	github.com/golang-fips/openssl/v2 v2.0.0-rc.2
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20230502061212-6eb98854418e
++	github.com/microsoft/go-crypto-winnative v0.0.0-20230822062938-306d53ca6072
  	golang.org/x/crypto v0.12.0
  	golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9
  )
 diff --git a/src/go.sum b/src/go.sum
-index 0b6e1010f5679c..2f7b86d1166c41 100644
+index ff87d3883113cd..497d219d18acd9 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/golang-fips/openssl/v2 v2.0.0-rc.2 h1:0RFGh/pnzSAe5LlriE416hQUYxYNFZD9y/53d0ld7K0=
  github.com/golang-fips/openssl/v2 v2.0.0-rc.2/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20230502061212-6eb98854418e h1:BB2UybwbUjtxG2OFs6KnKi8AOlk9rjH7ekjkbW+vHA0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20230502061212-6eb98854418e/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20230822062938-306d53ca6072 h1:FyW57WKhBHQm/ebpbvQ7+eMiKBRQuLEA6iq228Py1fI=
++github.com/microsoft/go-crypto-winnative v0.0.0-20230822062938-306d53ca6072/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
  golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
  golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9 h1:eQR0jFW5dN2q8lFzSF7rjkRCOOnBf0llczNvITm6ICs=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index b584ed4fee1373..db054c5b2230f1 100644
+index a31878487bc285..0a7ef1f77b040a 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -425,6 +425,10 @@ var depsRules = `
+@@ -427,6 +427,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1029,7 +1061,7 @@ index b584ed4fee1373..db054c5b2230f1 100644
  	< github.com/golang-fips/openssl/v2/internal/subtle
  	< github.com/golang-fips/openssl/v2
  	< crypto/internal/boring
-@@ -461,6 +465,7 @@ var depsRules = `
+@@ -463,6 +467,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -1103,7 +1135,7 @@ index 00000000000000..99ee2542ca38a9
 +const CNGCrypto = true
 +const CNGCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 8c3cd998d0e7e1..c2f69930e2240e 100644
+index 416b5002944529..9bb027e3c70fe7 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,7 @@ type Flags struct {

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -967,7 +967,7 @@ index ee9d4650e3523b..4d792561cabe04 100644
  	}
 -	if goexperiment.OpenSSLCrypto {
 +	if goexperiment.OpenSSLCrypto || goexperiment.CNGCrypto {
- 		v, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
+ 		prk, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
  		if err != nil {
  			panic(fmt.Errorf("tls: HKDF-Extract invocation failed unexpectedly: %s", err))
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -34,17 +34,19 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../microsoft/go-crypto-winnative/cng/cng.go  | 130 ++++
  .../microsoft/go-crypto-winnative/cng/ecdh.go | 260 +++++++
  .../go-crypto-winnative/cng/ecdsa.go          | 175 +++++
+ .../microsoft/go-crypto-winnative/cng/hash.go | 298 ++++++++
+ .../microsoft/go-crypto-winnative/cng/hkdf.go | 150 ++++
  .../microsoft/go-crypto-winnative/cng/hmac.go |  55 ++
- .../microsoft/go-crypto-winnative/cng/keys.go | 161 ++++
+ .../microsoft/go-crypto-winnative/cng/keys.go | 178 +++++
+ .../go-crypto-winnative/cng/pbkdf2.go         |  71 ++
  .../microsoft/go-crypto-winnative/cng/rand.go |  28 +
  .../microsoft/go-crypto-winnative/cng/rsa.go  | 374 ++++++++++
- .../microsoft/go-crypto-winnative/cng/sha.go  | 219 ++++++
- .../internal/bcrypt/bcrypt_windows.go         | 222 ++++++
- .../internal/bcrypt/zsyscall_windows.go       | 380 ++++++++++
+ .../internal/bcrypt/bcrypt_windows.go         | 276 +++++++
+ .../internal/bcrypt/zsyscall_windows.go       | 389 ++++++++++
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 39 files changed, 7051 insertions(+)
+ 41 files changed, 7431 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -74,11 +76,13 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/cng.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
- create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/subtle/aliasing.go
@@ -5773,9 +5777,469 @@ index 00000000000000..a77ff97bb8f521
 +	sig = append(sig, s...)
 +	return keyVerify(pub.hkey, nil, hash, sig, bcrypt.PAD_UNDEFINED) == nil
 +}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
+new file mode 100644
+index 00000000000000..d894c07822fa8c
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
+@@ -0,0 +1,298 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build windows
++// +build windows
++
++package cng
++
++import (
++	"crypto"
++	"hash"
++	"runtime"
++	"unsafe"
++
++	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
++)
++
++// SupportsHash returns true if a hash.Hash implementation is supported for h.
++func SupportsHash(h crypto.Hash) bool {
++	switch h {
++	case crypto.MD4, crypto.MD5, crypto.SHA1, crypto.SHA256, crypto.SHA384, crypto.SHA512:
++		return true
++	case crypto.SHA3_256:
++		_, err := loadHash(bcrypt.SHA3_256_ALGORITHM, bcrypt.ALG_NONE_FLAG)
++		return err == nil
++	case crypto.SHA3_384:
++		_, err := loadHash(bcrypt.SHA3_384_ALGORITHM, bcrypt.ALG_NONE_FLAG)
++		return err == nil
++	case crypto.SHA3_512:
++		_, err := loadHash(bcrypt.SHA3_512_ALGORITHM, bcrypt.ALG_NONE_FLAG)
++		return err == nil
++	}
++	return false
++}
++
++func hashOneShot(id string, p, sum []byte) error {
++	h, err := loadHash(id, 0)
++	if err != nil {
++		return err
++	}
++	return bcrypt.Hash(h.handle, nil, p, sum)
++}
++
++func MD4(p []byte) (sum [16]byte) {
++	if err := hashOneShot(bcrypt.MD4_ALGORITHM, p, sum[:]); err != nil {
++		panic("bcrypt: MD4 failed")
++	}
++	return
++}
++
++func MD5(p []byte) (sum [16]byte) {
++	if err := hashOneShot(bcrypt.MD5_ALGORITHM, p, sum[:]); err != nil {
++		panic("bcrypt: MD5 failed")
++	}
++	return
++}
++
++func SHA1(p []byte) (sum [20]byte) {
++	if err := hashOneShot(bcrypt.SHA1_ALGORITHM, p, sum[:]); err != nil {
++		panic("bcrypt: SHA1 failed")
++	}
++	return
++}
++
++func SHA256(p []byte) (sum [32]byte) {
++	if err := hashOneShot(bcrypt.SHA256_ALGORITHM, p, sum[:]); err != nil {
++		panic("bcrypt: SHA256 failed")
++	}
++	return
++}
++
++func SHA384(p []byte) (sum [48]byte) {
++	if err := hashOneShot(bcrypt.SHA384_ALGORITHM, p, sum[:]); err != nil {
++		panic("bcrypt: SHA384 failed")
++	}
++	return
++}
++
++func SHA512(p []byte) (sum [64]byte) {
++	if err := hashOneShot(bcrypt.SHA512_ALGORITHM, p, sum[:]); err != nil {
++		panic("bcrypt: SHA512 failed")
++	}
++	return
++}
++
++func SHA3_256(p []byte) (sum [32]byte) {
++	if err := hashOneShot(bcrypt.SHA3_256_ALGORITHM, p, sum[:]); err != nil {
++		panic("bcrypt: SHA3_256 failed")
++	}
++	return
++}
++
++func SHA3_384(p []byte) (sum [48]byte) {
++	if err := hashOneShot(bcrypt.SHA3_384_ALGORITHM, p, sum[:]); err != nil {
++		panic("bcrypt: SHA3_384 failed")
++	}
++	return
++}
++
++func SHA3_512(p []byte) (sum [64]byte) {
++	if err := hashOneShot(bcrypt.SHA3_512_ALGORITHM, p, sum[:]); err != nil {
++		panic("bcrypt: SHA3_512 failed")
++	}
++	return
++}
++
++// NewMD4 returns a new MD4 hash.
++func NewMD4() hash.Hash {
++	return newHashX(bcrypt.MD4_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
++}
++
++// NewMD5 returns a new MD5 hash.
++func NewMD5() hash.Hash {
++	return newHashX(bcrypt.MD5_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
++}
++
++// NewSHA1 returns a new SHA1 hash.
++func NewSHA1() hash.Hash {
++	return newHashX(bcrypt.SHA1_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
++}
++
++// NewSHA256 returns a new SHA256 hash.
++func NewSHA256() hash.Hash {
++	return newHashX(bcrypt.SHA256_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
++}
++
++// NewSHA384 returns a new SHA384 hash.
++func NewSHA384() hash.Hash {
++	return newHashX(bcrypt.SHA384_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
++}
++
++// NewSHA512 returns a new SHA512 hash.
++func NewSHA512() hash.Hash {
++	return newHashX(bcrypt.SHA512_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
++}
++
++// NewSHA3_256 returns a new SHA256 hash.
++func NewSHA3_256() hash.Hash {
++	return newHashX(bcrypt.SHA3_256_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
++}
++
++// NewSHA3_384 returns a new SHA384 hash.
++func NewSHA3_384() hash.Hash {
++	return newHashX(bcrypt.SHA3_384_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
++}
++
++// NewSHA3_512 returns a new SHA512 hash.
++func NewSHA3_512() hash.Hash {
++	return newHashX(bcrypt.SHA3_512_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
++}
++
++type hashAlgorithm struct {
++	handle    bcrypt.ALG_HANDLE
++	size      uint32
++	blockSize uint32
++}
++
++func loadHash(id string, flags bcrypt.AlgorithmProviderFlags) (hashAlgorithm, error) {
++	v, err := loadOrStoreAlg(id, flags, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
++		size, err := getUint32(bcrypt.HANDLE(h), bcrypt.HASH_LENGTH)
++		if err != nil {
++			return nil, err
++		}
++		blockSize, err := getUint32(bcrypt.HANDLE(h), bcrypt.HASH_BLOCK_LENGTH)
++		if err != nil {
++			return nil, err
++		}
++		return hashAlgorithm{h, size, blockSize}, nil
++	})
++	if err != nil {
++		return hashAlgorithm{}, err
++	}
++	return v.(hashAlgorithm), nil
++}
++
++type hashX struct {
++	h         bcrypt.ALG_HANDLE
++	ctx       bcrypt.HASH_HANDLE
++	size      int
++	blockSize int
++	buf       []byte
++	key       []byte
++}
++
++func newHashX(id string, flag bcrypt.AlgorithmProviderFlags, key []byte) *hashX {
++	h, err := loadHash(id, flag)
++	if err != nil {
++		panic(err)
++	}
++	hx := new(hashX)
++	hx.h = h.handle
++	hx.size = int(h.size)
++	hx.blockSize = int(h.blockSize)
++	hx.buf = make([]byte, hx.size)
++	if len(key) > 0 {
++		hx.key = make([]byte, len(key))
++		copy(hx.key, key)
++	}
++	hx.Reset()
++	runtime.SetFinalizer(hx, (*hashX).finalize)
++	return hx
++}
++
++func (h *hashX) finalize() {
++	if h.ctx != 0 {
++		bcrypt.DestroyHash(h.ctx)
++	}
++}
++
++func (h *hashX) Clone() (hash.Hash, error) {
++	h2 := &hashX{
++		h:         h.h,
++		size:      h.size,
++		blockSize: h.blockSize,
++		buf:       make([]byte, len(h.buf)),
++		key:       make([]byte, len(h.key)),
++	}
++	copy(h2.key, h.key)
++	err := bcrypt.DuplicateHash(h.ctx, &h2.ctx, nil, 0)
++	if err != nil {
++		return nil, err
++	}
++	runtime.SetFinalizer(h2, (*hashX).finalize)
++	runtime.KeepAlive(h)
++	return h2, nil
++}
++
++func (h *hashX) Reset() {
++	if h.ctx != 0 {
++		bcrypt.DestroyHash(h.ctx)
++		h.ctx = 0
++	}
++	err := bcrypt.CreateHash(h.h, &h.ctx, nil, h.key, 0)
++	if err != nil {
++		panic(err)
++	}
++	runtime.KeepAlive(h)
++}
++
++func (h *hashX) Write(p []byte) (n int, err error) {
++	for n < len(p) && err == nil {
++		nn := len32(p[n:])
++		err = bcrypt.HashData(h.ctx, p[n:n+nn], 0)
++		n += nn
++	}
++	if err != nil {
++		// hash.Hash interface mandates Write should never return an error.
++		panic(err)
++	}
++	runtime.KeepAlive(h)
++	return len(p), nil
++}
++
++func (h *hashX) WriteString(s string) (int, error) {
++	// TODO: use unsafe.StringData once we drop support
++	// for go1.19 and earlier.
++	hdr := (*struct {
++		Data *byte
++		Len  int
++	})(unsafe.Pointer(&s))
++	return h.Write(unsafe.Slice(hdr.Data, len(s)))
++}
++
++func (h *hashX) WriteByte(c byte) error {
++	if err := bcrypt.HashDataRaw(h.ctx, &c, 1, 0); err != nil {
++		// hash.Hash interface mandates Write should never return an error.
++		panic(err)
++	}
++	runtime.KeepAlive(h)
++	return nil
++}
++
++func (h *hashX) Size() int {
++	return h.size
++}
++
++func (h *hashX) BlockSize() int {
++	return h.blockSize
++}
++
++func (h *hashX) Sum(in []byte) []byte {
++	h.sum(h.buf)
++	return append(in, h.buf...)
++}
++
++func (h *hashX) sum(out []byte) {
++	var ctx2 bcrypt.HASH_HANDLE
++	err := bcrypt.DuplicateHash(h.ctx, &ctx2, nil, 0)
++	if err != nil {
++		panic(err)
++	}
++	defer bcrypt.DestroyHash(ctx2)
++	err = bcrypt.FinishHash(ctx2, out, 0)
++	if err != nil {
++		panic(err)
++	}
++	runtime.KeepAlive(h)
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
+new file mode 100644
+index 00000000000000..725fa5c1b45784
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
+@@ -0,0 +1,150 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build windows
++// +build windows
++
++package cng
++
++import (
++	"encoding/binary"
++	"errors"
++	"hash"
++	"io"
++	"runtime"
++	"unsafe"
++
++	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
++)
++
++func SupportsHKDF() bool {
++	_, err := loadHKDF()
++	return err == nil
++}
++
++func loadHKDF() (bcrypt.ALG_HANDLE, error) {
++	h, err := loadOrStoreAlg(bcrypt.HKDF_ALGORITHM, 0, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
++		return h, nil
++	})
++	if err != nil {
++		return 0, err
++	}
++	return h.(bcrypt.ALG_HANDLE), nil
++}
++
++type hkdf struct {
++	hkey bcrypt.KEY_HANDLE
++	info []byte
++
++	hashLen int
++	buf     []byte
++}
++
++func (c *hkdf) finalize() {
++	bcrypt.DestroyKey(c.hkey)
++}
++
++func (c *hkdf) Read(p []byte) (int, error) {
++	var params *bcrypt.BufferDesc
++	if len(c.info) > 0 {
++		params = &bcrypt.BufferDesc{
++			Count: 1,
++			Buffers: &bcrypt.Buffer{
++				Length: uint32(len(c.info)),
++				Type:   bcrypt.KDF_HKDF_INFO,
++				Data:   uintptr(unsafe.Pointer(&c.info[0])),
++			},
++		}
++	}
++	// KeyDerivation doesn't support incremental output, each call
++	// derives the key from scratch and returns the requested bytes.
++	// To implement io.Reader, we need to ask for len(c.buf) + len(p)
++	// bytes and copy the last derived len(p) bytes to p.
++	// We use c.buf to know how many bytes we've already derived and
++	// to avoid allocating the whole output buffer on each call.
++	prevLen := len(c.buf)
++	needLen := len(p)
++	remains := 255*c.hashLen - prevLen
++	// Check whether enough data can be generated.
++	if remains < needLen {
++		return 0, errors.New("hkdf: entropy limit reached")
++	}
++	c.buf = append(c.buf, make([]byte, needLen)...)
++	var size uint32
++	if err := bcrypt.KeyDerivation(c.hkey, params, c.buf, &size, 0); err != nil {
++		return 0, err
++	}
++	runtime.KeepAlive(params)
++	n := copy(p, c.buf[prevLen:size])
++	return n, nil
++}
++
++func newHKDF(h func() hash.Hash, secret, salt []byte, info []byte) (*hkdf, error) {
++	ch := h()
++	hashID := hashToID(ch)
++	if hashID == "" {
++		return nil, errors.New("cng: unsupported hash function")
++	}
++	alg, err := loadHKDF()
++	if err != nil {
++		return nil, err
++	}
++	var kh bcrypt.KEY_HANDLE
++	if err := bcrypt.GenerateSymmetricKey(alg, &kh, nil, secret, 0); err != nil {
++		return nil, err
++	}
++	if err := setString(bcrypt.HANDLE(kh), bcrypt.HKDF_HASH_ALGORITHM, hashID); err != nil {
++		bcrypt.DestroyKey(kh)
++		return nil, err
++	}
++	if salt != nil {
++		// Used for Extract.
++		err = bcrypt.SetProperty(bcrypt.HANDLE(kh), utf16PtrFromString(bcrypt.HKDF_SALT_AND_FINALIZE), salt, 0)
++	} else {
++		// Used for Expand.
++		err = bcrypt.SetProperty(bcrypt.HANDLE(kh), utf16PtrFromString(bcrypt.HKDF_PRK_AND_FINALIZE), nil, 0)
++	}
++	if err != nil {
++		bcrypt.DestroyKey(kh)
++		return nil, err
++	}
++	k := &hkdf{kh, info, ch.Size(), nil}
++	runtime.SetFinalizer(k, (*hkdf).finalize)
++	return k, nil
++}
++
++func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
++	if salt == nil {
++		// Replicate x/crypto/hkdf behavior.
++		salt = make([]byte, h().Size())
++	}
++	kh, err := newHKDF(h, secret, salt, nil)
++	if err != nil {
++		return nil, err
++	}
++	hdr, blob, err := exportKeyData(kh.hkey)
++	if err != nil {
++		return nil, err
++	}
++	runtime.KeepAlive(kh)
++	if hdr.Version != bcrypt.KEY_DATA_BLOB_VERSION1 {
++		return nil, errors.New("cng: unknown key data blob version")
++	}
++	// KEY_DATA_BLOB_VERSION1 format is:
++	// cbHash uint32 // Big-endian
++	// hashName [cbHash]byte
++	// key []byte // Rest of the blob
++	if len(blob) < 4 {
++		return nil, errors.New("cng: exported key is corrupted")
++	}
++	hashLength := binary.BigEndian.Uint32(blob[:])
++	return blob[4+hashLength:], nil
++}
++
++func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
++	kh, err := newHKDF(h, pseudorandomKey, nil, info)
++	if err != nil {
++		return nil, err
++	}
++	return kh, nil
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
 new file mode 100644
-index 00000000000000..736472d5b4e700
+index 00000000000000..76a80ce8c3bc56
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
 @@ -0,0 +1,55 @@
@@ -5796,7 +6260,7 @@ index 00000000000000..736472d5b4e700
 +// hashToID converts a hash.Hash implementation from this package
 +// to a CNG hash ID
 +func hashToID(h hash.Hash) string {
-+	if _, ok := h.(*shaXHash); !ok {
++	if _, ok := h.(*hashX); !ok {
 +		return ""
 +	}
 +	var id string
@@ -5832,14 +6296,14 @@ index 00000000000000..736472d5b4e700
 +		ch.Write(key)
 +		key = ch.Sum(nil)
 +	}
-+	return newSHAX(id, bcrypt.ALG_HANDLE_HMAC_FLAG, key)
++	return newHashX(id, bcrypt.ALG_HANDLE_HMAC_FLAG, key)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
 new file mode 100644
-index 00000000000000..766768e9d46b41
+index 00000000000000..95c3bcdc5e788d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
-@@ -0,0 +1,161 @@
+@@ -0,0 +1,178 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -5856,8 +6320,9 @@ index 00000000000000..766768e9d46b41
 +)
 +
 +const (
-+	sizeOfECCBlobHeader = uint32(unsafe.Sizeof(bcrypt.ECCKEY_BLOB{}))
-+	sizeOfRSABlobHeader = uint32(unsafe.Sizeof(bcrypt.RSAKEY_BLOB{}))
++	sizeOfECCBlobHeader     = uint32(unsafe.Sizeof(bcrypt.ECCKEY_BLOB{}))
++	sizeOfRSABlobHeader     = uint32(unsafe.Sizeof(bcrypt.RSAKEY_BLOB{}))
++	sizeOfKeyDataBlobHeader = uint32(unsafe.Sizeof(bcrypt.KEY_DATA_BLOB_HEADER{}))
 +)
 +
 +// exportRSAKey exports hkey into a bcrypt.ECCKEY_BLOB header and data.
@@ -5896,6 +6361,22 @@ index 00000000000000..766768e9d46b41
 +	}
 +	hdr := (*(*bcrypt.RSAKEY_BLOB)(unsafe.Pointer(&blob[0])))
 +	return hdr, blob[sizeOfRSABlobHeader:], nil
++}
++
++// exportKeyData exports hkey into a bcrypt.KEY_DATA_BLOB_HEADER header and data.
++func exportKeyData(hkey bcrypt.KEY_HANDLE) (bcrypt.KEY_DATA_BLOB_HEADER, []byte, error) {
++	blob, err := exportKey(hkey, bcrypt.KEY_DATA_BLOB)
++	if err != nil {
++		return bcrypt.KEY_DATA_BLOB_HEADER{}, nil, err
++	}
++	if len(blob) < int(sizeOfKeyDataBlobHeader) {
++		return bcrypt.KEY_DATA_BLOB_HEADER{}, nil, errors.New("cng: exported key is corrupted")
++	}
++	hdr := (*(*bcrypt.KEY_DATA_BLOB_HEADER)(unsafe.Pointer(&blob[0])))
++	if hdr.Magic != bcrypt.KEY_DATA_BLOB_MAGIC {
++		return bcrypt.KEY_DATA_BLOB_HEADER{}, nil, errors.New("cng: unknown key format")
++	}
++	return hdr, blob[sizeOfKeyDataBlobHeader : sizeOfKeyDataBlobHeader+hdr.Length], nil
 +}
 +
 +// exportKey exports hkey to a memory blob.
@@ -6000,6 +6481,83 @@ index 00000000000000..766768e9d46b41
 +		data = data[v.size:]
 +	}
 +	return nil
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
+new file mode 100644
+index 00000000000000..078a358887f620
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
+@@ -0,0 +1,71 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build windows
++// +build windows
++
++package cng
++
++import (
++	"errors"
++	"hash"
++	"unsafe"
++
++	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
++)
++
++func loadPBKDF2() (bcrypt.ALG_HANDLE, error) {
++	h, err := loadOrStoreAlg(bcrypt.PBKDF2_ALGORITHM, 0, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
++		return h, nil
++	})
++	if err != nil {
++		return 0, err
++	}
++	return h.(bcrypt.ALG_HANDLE), nil
++}
++
++func PBKDF2(password, salt []byte, iter, keyLen int, h func() hash.Hash) ([]byte, error) {
++	ch := h()
++	hashID := hashToID(ch)
++	if hashID == "" {
++		return nil, errors.New("cng: unsupported hash function")
++	}
++	alg, err := loadPBKDF2()
++	if err != nil {
++		return nil, err
++	}
++	var kh bcrypt.KEY_HANDLE
++	if err := bcrypt.GenerateSymmetricKey(alg, &kh, nil, password, 0); err != nil {
++		return nil, err
++	}
++	defer bcrypt.DestroyKey(kh)
++	u16HashID := utf16FromString(hashID)
++	buffers := [...]bcrypt.Buffer{
++		{
++			Type:   bcrypt.KDF_ITERATION_COUNT,
++			Data:   uintptr(unsafe.Pointer(&iter)),
++			Length: 8,
++		},
++		{
++			Type:   bcrypt.KDF_SALT,
++			Data:   uintptr(unsafe.Pointer(&salt[0])),
++			Length: uint32(len(salt)),
++		},
++		{
++			Type:   bcrypt.KDF_HASH_ALGORITHM,
++			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
++			Length: uint32(len(u16HashID) * 2),
++		},
++	}
++	params := &bcrypt.BufferDesc{
++		Count:   uint32(len(buffers)),
++		Buffers: &buffers[0],
++	}
++	out := make([]byte, keyLen)
++	var size uint32
++	err = bcrypt.KeyDerivation(kh, params, out, &size, 0)
++	if err != nil {
++		return nil, err
++	}
++	return out[:size], nil
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go
 new file mode 100644
@@ -6415,237 +6973,12 @@ index 00000000000000..7e3f7abe3487cb
 +	}
 +	return ""
 +}
-diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go
-new file mode 100644
-index 00000000000000..1f5356c9387fc6
---- /dev/null
-+++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha.go
-@@ -0,0 +1,219 @@
-+// Copyright (c) Microsoft Corporation.
-+// Licensed under the MIT License.
-+
-+//go:build windows
-+// +build windows
-+
-+package cng
-+
-+import (
-+	"hash"
-+	"runtime"
-+	"unsafe"
-+
-+	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
-+)
-+
-+func shaOneShot(id string, p, sum []byte) error {
-+	h, err := loadSha(id, 0)
-+	if err != nil {
-+		return err
-+	}
-+	return bcrypt.Hash(h.handle, nil, p, sum)
-+}
-+
-+func SHA1(p []byte) (sum [20]byte) {
-+	if err := shaOneShot(bcrypt.SHA1_ALGORITHM, p, sum[:]); err != nil {
-+		panic("bcrypt: SHA1 failed")
-+	}
-+	return
-+}
-+
-+func SHA256(p []byte) (sum [32]byte) {
-+	if err := shaOneShot(bcrypt.SHA256_ALGORITHM, p, sum[:]); err != nil {
-+		panic("bcrypt: SHA256 failed")
-+	}
-+	return
-+}
-+
-+func SHA384(p []byte) (sum [48]byte) {
-+	if err := shaOneShot(bcrypt.SHA384_ALGORITHM, p, sum[:]); err != nil {
-+		panic("bcrypt: SHA384 failed")
-+	}
-+	return
-+}
-+
-+func SHA512(p []byte) (sum [64]byte) {
-+	if err := shaOneShot(bcrypt.SHA512_ALGORITHM, p, sum[:]); err != nil {
-+		panic("bcrypt: SHA512 failed")
-+	}
-+	return
-+}
-+
-+// NewSHA1 returns a new SHA1 hash.
-+func NewSHA1() hash.Hash {
-+	return newSHAX(bcrypt.SHA1_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
-+}
-+
-+// NewSHA256 returns a new SHA256 hash.
-+func NewSHA256() hash.Hash {
-+	return newSHAX(bcrypt.SHA256_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
-+}
-+
-+// NewSHA384 returns a new SHA384 hash.
-+func NewSHA384() hash.Hash {
-+	return newSHAX(bcrypt.SHA384_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
-+}
-+
-+// NewSHA512 returns a new SHA512 hash.
-+func NewSHA512() hash.Hash {
-+	return newSHAX(bcrypt.SHA512_ALGORITHM, bcrypt.ALG_NONE_FLAG, nil)
-+}
-+
-+type shaAlgorithm struct {
-+	handle    bcrypt.ALG_HANDLE
-+	size      uint32
-+	blockSize uint32
-+}
-+
-+func loadSha(id string, flags bcrypt.AlgorithmProviderFlags) (shaAlgorithm, error) {
-+	v, err := loadOrStoreAlg(id, flags, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
-+		size, err := getUint32(bcrypt.HANDLE(h), bcrypt.HASH_LENGTH)
-+		if err != nil {
-+			return nil, err
-+		}
-+		blockSize, err := getUint32(bcrypt.HANDLE(h), bcrypt.HASH_BLOCK_LENGTH)
-+		if err != nil {
-+			return nil, err
-+		}
-+		return shaAlgorithm{h, size, blockSize}, nil
-+	})
-+	if err != nil {
-+		return shaAlgorithm{}, err
-+	}
-+	return v.(shaAlgorithm), nil
-+}
-+
-+type shaXHash struct {
-+	h         bcrypt.ALG_HANDLE
-+	ctx       bcrypt.HASH_HANDLE
-+	size      int
-+	blockSize int
-+	buf       []byte
-+	key       []byte
-+}
-+
-+func newSHAX(id string, flag bcrypt.AlgorithmProviderFlags, key []byte) *shaXHash {
-+	h, err := loadSha(id, flag)
-+	if err != nil {
-+		panic(err)
-+	}
-+	sha := new(shaXHash)
-+	sha.h = h.handle
-+	sha.size = int(h.size)
-+	sha.blockSize = int(h.blockSize)
-+	sha.buf = make([]byte, sha.size)
-+	if len(key) > 0 {
-+		sha.key = make([]byte, len(key))
-+		copy(sha.key, key)
-+	}
-+	sha.Reset()
-+	runtime.SetFinalizer(sha, (*shaXHash).finalize)
-+	return sha
-+}
-+
-+func (h *shaXHash) finalize() {
-+	if h.ctx != 0 {
-+		bcrypt.DestroyHash(h.ctx)
-+	}
-+}
-+
-+func (h *shaXHash) Clone() (hash.Hash, error) {
-+	h2 := &shaXHash{
-+		h:         h.h,
-+		size:      h.size,
-+		blockSize: h.blockSize,
-+		buf:       make([]byte, len(h.buf)),
-+		key:       make([]byte, len(h.key)),
-+	}
-+	copy(h2.key, h.key)
-+	err := bcrypt.DuplicateHash(h.ctx, &h2.ctx, nil, 0)
-+	if err != nil {
-+		return nil, err
-+	}
-+	runtime.SetFinalizer(h2, (*shaXHash).finalize)
-+	runtime.KeepAlive(h)
-+	return h2, nil
-+}
-+
-+func (h *shaXHash) Reset() {
-+	if h.ctx != 0 {
-+		bcrypt.DestroyHash(h.ctx)
-+		h.ctx = 0
-+	}
-+	err := bcrypt.CreateHash(h.h, &h.ctx, nil, h.key, 0)
-+	if err != nil {
-+		panic(err)
-+	}
-+	runtime.KeepAlive(h)
-+}
-+
-+func (h *shaXHash) Write(p []byte) (n int, err error) {
-+	for n < len(p) && err == nil {
-+		nn := len32(p[n:])
-+		err = bcrypt.HashData(h.ctx, p[n:n+nn], 0)
-+		n += nn
-+	}
-+	if err != nil {
-+		// hash.Hash interface mandates Write should never return an error.
-+		panic(err)
-+	}
-+	runtime.KeepAlive(h)
-+	return len(p), nil
-+}
-+
-+func (h *shaXHash) WriteString(s string) (int, error) {
-+	// TODO: use unsafe.StringData once we drop support
-+	// for go1.19 and earlier.
-+	hdr := (*struct {
-+		Data *byte
-+		Len  int
-+	})(unsafe.Pointer(&s))
-+	return h.Write(unsafe.Slice(hdr.Data, len(s)))
-+}
-+
-+func (h *shaXHash) WriteByte(c byte) error {
-+	if err := bcrypt.HashDataRaw(h.ctx, &c, 1, 0); err != nil {
-+		// hash.Hash interface mandates Write should never return an error.
-+		panic(err)
-+	}
-+	runtime.KeepAlive(h)
-+	return nil
-+}
-+
-+func (h *shaXHash) Size() int {
-+	return h.size
-+}
-+
-+func (h *shaXHash) BlockSize() int {
-+	return h.blockSize
-+}
-+
-+func (h *shaXHash) Sum(in []byte) []byte {
-+	h.sum(h.buf)
-+	return append(in, h.buf...)
-+}
-+
-+func (h *shaXHash) sum(out []byte) {
-+	var ctx2 bcrypt.HASH_HANDLE
-+	err := bcrypt.DuplicateHash(h.ctx, &ctx2, nil, 0)
-+	if err != nil {
-+		panic(err)
-+	}
-+	defer bcrypt.DestroyHash(ctx2)
-+	err = bcrypt.FinishHash(ctx2, out, 0)
-+	if err != nil {
-+		panic(err)
-+	}
-+	runtime.KeepAlive(h)
-+}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000000..d5f6c99a444b85
+index 00000000000000..69ce980e93d0df
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
-@@ -0,0 +1,222 @@
+@@ -0,0 +1,276 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -6659,15 +6992,21 @@ index 00000000000000..d5f6c99a444b85
 +)
 +
 +const (
-+	SHA1_ALGORITHM   = "SHA1"
-+	SHA256_ALGORITHM = "SHA256"
-+	SHA384_ALGORITHM = "SHA384"
-+	SHA512_ALGORITHM = "SHA512"
-+	AES_ALGORITHM    = "AES"
-+	RSA_ALGORITHM    = "RSA"
-+	MD5_ALGORITHM    = "MD5"
-+	ECDSA_ALGORITHM  = "ECDSA"
-+	ECDH_ALGORITHM   = "ECDH"
++	SHA1_ALGORITHM     = "SHA1"
++	SHA256_ALGORITHM   = "SHA256"
++	SHA384_ALGORITHM   = "SHA384"
++	SHA512_ALGORITHM   = "SHA512"
++	SHA3_256_ALGORITHM = "SHA3-256"
++	SHA3_384_ALGORITHM = "SHA3-384"
++	SHA3_512_ALGORITHM = "SHA3-512"
++	AES_ALGORITHM      = "AES"
++	RSA_ALGORITHM      = "RSA"
++	MD4_ALGORITHM      = "MD4"
++	MD5_ALGORITHM      = "MD5"
++	ECDSA_ALGORITHM    = "ECDSA"
++	ECDH_ALGORITHM     = "ECDH"
++	HKDF_ALGORITHM     = "HKDF"
++	PBKDF2_ALGORITHM   = "PBKDF2"
 +)
 +
 +const (
@@ -6697,6 +7036,43 @@ index 00000000000000..d5f6c99a444b85
 +	ECCPUBLIC_BLOB      = "ECCPUBLICBLOB"
 +	ECCPRIVATE_BLOB     = "ECCPRIVATEBLOB"
 +)
++
++const (
++	KDF_HKDF_INFO          = 0x14
++	HKDF_HASH_ALGORITHM    = "HkdfHashAlgorithm"
++	HKDF_SALT_AND_FINALIZE = "HkdfSaltAndFinalize"
++	HKDF_PRK_AND_FINALIZE  = "HkdfPrkAndFinalize"
++)
++
++const (
++	KDF_HASH_ALGORITHM  = 0x0
++	KDF_ITERATION_COUNT = 0x10
++	KDF_SALT            = 0xF
++)
++
++const (
++	KEY_DATA_BLOB          = "KeyDataBlob"
++	KEY_DATA_BLOB_MAGIC    = 0x4d42444b
++	KEY_DATA_BLOB_VERSION1 = 1
++)
++
++type KEY_DATA_BLOB_HEADER struct {
++	Magic   uint32
++	Version uint32
++	Length  uint32
++}
++
++type Buffer struct {
++	Length uint32
++	Type   uint32
++	Data   uintptr
++}
++
++type BufferDesc struct {
++	Version uint32
++	Count   uint32 // number of buffers
++	Buffers *Buffer
++}
 +
 +const (
 +	USE_SYSTEM_PREFERRED_RNG = 0x00000002
@@ -6855,7 +7231,7 @@ index 00000000000000..d5f6c99a444b85
 +
 +// Keys
 +
-+//sys   GenerateSymmetricKey(hAlgorithm ALG_HANDLE, phKey *KEY_HANDLE, pbKeyObject []byte, pbSecret []byte, dwFlags uint32) (s error) = bcrypt.BCryptGenerateSymmetricKey
++//sys   generateSymmetricKey(hAlgorithm ALG_HANDLE, phKey *KEY_HANDLE, pbKeyObject []byte, pbSecret *byte, cbSecret uint32, dwFlags uint32) (s error) = bcrypt.BCryptGenerateSymmetricKey
 +//sys   GenerateKeyPair(hAlgorithm ALG_HANDLE, phKey *KEY_HANDLE, dwLength uint32, dwFlags uint32) (s error) = bcrypt.BCryptGenerateKeyPair
 +//sys   FinalizeKeyPair(hKey KEY_HANDLE, dwFlags uint32) (s error) = bcrypt.BCryptFinalizeKeyPair
 +//sys   ImportKeyPair (hAlgorithm ALG_HANDLE, hImportKey KEY_HANDLE, pszBlobType *uint16, phKey *KEY_HANDLE, pbInput []byte, dwFlags uint32) (s error) = bcrypt.BCryptImportKeyPair
@@ -6866,14 +7242,25 @@ index 00000000000000..d5f6c99a444b85
 +//sys   SignHash (hKey KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbInput []byte, pbOutput []byte, pcbResult *uint32, dwFlags PadMode) (s error) = bcrypt.BCryptSignHash
 +//sys   VerifySignature(hKey KEY_HANDLE, pPaddingInfo unsafe.Pointer, pbHash []byte, pbSignature []byte, dwFlags PadMode) (s error) = bcrypt.BCryptVerifySignature
 +//sys   SecretAgreement(hPrivKey KEY_HANDLE, hPubKey KEY_HANDLE, phAgreedSecret *SECRET_HANDLE, dwFlags uint32) (s error) = bcrypt.BCryptSecretAgreement
-+//sys   DeriveKey(hSharedSecret SECRET_HANDLE, pwszKDF *uint16, pParameterList *byte, pbDerivedKey []byte, pcbResult *uint32, dwFlags uint32) (s error) = bcrypt.BCryptDeriveKey
++//sys   DeriveKey(hSharedSecret SECRET_HANDLE, pwszKDF *uint16, pParameterList *BufferDesc, pbDerivedKey []byte, pcbResult *uint32, dwFlags uint32) (s error) = bcrypt.BCryptDeriveKey
++//sys   KeyDerivation(hKey KEY_HANDLE, pParameterList *BufferDesc, pbDerivedKey []byte, pcbResult *uint32, dwFlags uint32) (s error) = bcrypt.BCryptKeyDerivation
 +//sys   DestroySecret(hSecret SECRET_HANDLE) (s error) = bcrypt.BCryptDestroySecret
++
++func GenerateSymmetricKey(hAlgorithm ALG_HANDLE, phKey *KEY_HANDLE, pbKeyObject []byte, pbSecret []byte, dwFlags uint32) error {
++	cbLen := uint32(len(pbSecret))
++	if cbLen == 0 {
++		// BCryptGenerateSymmetricKey does not support nil pbSecret,
++		// stack-allocate a zero byte here just to make CNG happy.
++		pbSecret = make([]byte, 1)
++	}
++	return generateSymmetricKey(hAlgorithm, phKey, pbKeyObject, &pbSecret[0], cbLen, dwFlags)
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go
 new file mode 100644
-index 00000000000000..53552169d7b980
+index 00000000000000..3c6a5764eb92ec
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go
-@@ -0,0 +1,380 @@
+@@ -0,0 +1,389 @@
 +// Code generated by 'go generate'; DO NOT EDIT.
 +
 +package bcrypt
@@ -6935,6 +7322,7 @@ index 00000000000000..53552169d7b980
 +	procBCryptHash                   = modbcrypt.NewProc("BCryptHash")
 +	procBCryptHashData               = modbcrypt.NewProc("BCryptHashData")
 +	procBCryptImportKeyPair          = modbcrypt.NewProc("BCryptImportKeyPair")
++	procBCryptKeyDerivation          = modbcrypt.NewProc("BCryptKeyDerivation")
 +	procBCryptOpenAlgorithmProvider  = modbcrypt.NewProc("BCryptOpenAlgorithmProvider")
 +	procBCryptSecretAgreement        = modbcrypt.NewProc("BCryptSecretAgreement")
 +	procBCryptSetProperty            = modbcrypt.NewProc("BCryptSetProperty")
@@ -6986,7 +7374,7 @@ index 00000000000000..53552169d7b980
 +	return
 +}
 +
-+func DeriveKey(hSharedSecret SECRET_HANDLE, pwszKDF *uint16, pParameterList *byte, pbDerivedKey []byte, pcbResult *uint32, dwFlags uint32) (s error) {
++func DeriveKey(hSharedSecret SECRET_HANDLE, pwszKDF *uint16, pParameterList *BufferDesc, pbDerivedKey []byte, pcbResult *uint32, dwFlags uint32) (s error) {
 +	var _p0 *byte
 +	if len(pbDerivedKey) > 0 {
 +		_p0 = &pbDerivedKey[0]
@@ -7102,16 +7490,12 @@ index 00000000000000..53552169d7b980
 +	return
 +}
 +
-+func GenerateSymmetricKey(hAlgorithm ALG_HANDLE, phKey *KEY_HANDLE, pbKeyObject []byte, pbSecret []byte, dwFlags uint32) (s error) {
++func generateSymmetricKey(hAlgorithm ALG_HANDLE, phKey *KEY_HANDLE, pbKeyObject []byte, pbSecret *byte, cbSecret uint32, dwFlags uint32) (s error) {
 +	var _p0 *byte
 +	if len(pbKeyObject) > 0 {
 +		_p0 = &pbKeyObject[0]
 +	}
-+	var _p1 *byte
-+	if len(pbSecret) > 0 {
-+		_p1 = &pbSecret[0]
-+	}
-+	r0, _, _ := syscall.Syscall9(procBCryptGenerateSymmetricKey.Addr(), 7, uintptr(hAlgorithm), uintptr(unsafe.Pointer(phKey)), uintptr(unsafe.Pointer(_p0)), uintptr(len(pbKeyObject)), uintptr(unsafe.Pointer(_p1)), uintptr(len(pbSecret)), uintptr(dwFlags), 0, 0)
++	r0, _, _ := syscall.Syscall9(procBCryptGenerateSymmetricKey.Addr(), 7, uintptr(hAlgorithm), uintptr(unsafe.Pointer(phKey)), uintptr(unsafe.Pointer(_p0)), uintptr(len(pbKeyObject)), uintptr(unsafe.Pointer(pbSecret)), uintptr(cbSecret), uintptr(dwFlags), 0, 0)
 +	if r0 != 0 {
 +		s = syscall.Errno(r0)
 +	}
@@ -7189,6 +7573,18 @@ index 00000000000000..53552169d7b980
 +		_p0 = &pbInput[0]
 +	}
 +	r0, _, _ := syscall.Syscall9(procBCryptImportKeyPair.Addr(), 7, uintptr(hAlgorithm), uintptr(hImportKey), uintptr(unsafe.Pointer(pszBlobType)), uintptr(unsafe.Pointer(phKey)), uintptr(unsafe.Pointer(_p0)), uintptr(len(pbInput)), uintptr(dwFlags), 0, 0)
++	if r0 != 0 {
++		s = syscall.Errno(r0)
++	}
++	return
++}
++
++func KeyDerivation(hKey KEY_HANDLE, pParameterList *BufferDesc, pbDerivedKey []byte, pcbResult *uint32, dwFlags uint32) (s error) {
++	var _p0 *byte
++	if len(pbDerivedKey) > 0 {
++		_p0 = &pbDerivedKey[0]
++	}
++	r0, _, _ := syscall.Syscall6(procBCryptKeyDerivation.Addr(), 6, uintptr(hKey), uintptr(unsafe.Pointer(pParameterList)), uintptr(unsafe.Pointer(_p0)), uintptr(len(pbDerivedKey)), uintptr(unsafe.Pointer(pcbResult)), uintptr(dwFlags))
 +	if r0 != 0 {
 +		s = syscall.Errno(r0)
 +	}
@@ -7354,7 +7750,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 88d2554c046451..b293f962411ffa 100644
+index abd3f0b5193381..0e35ad96e33c2c 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
@@ -7362,7 +7758,7 @@ index 88d2554c046451..b293f962411ffa 100644
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20230502061212-6eb98854418e
++# github.com/microsoft/go-crypto-winnative v0.0.0-20230822062938-306d53ca6072
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
This PR updates `crypto/tls` to use the HKDF implementations provided by the CNG/OpenSSL backends instead of the one in `x/crypto/hkdf`. The Boring backend doesn't implement HKDF, so it will fallback to `x/crypto/hkdf`.

I've upgraded the CNG backend to latest, the previous version didn't support HKDF.