### PR TITLE
hkdf: use boring.SupportsHKDF instead of hardcoding backends

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -19,7 +19,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/internal/backend/bbig/big.go      |  17 +++
  src/crypto/internal/backend/common.go        |  78 ++++++++++++
  src/crypto/internal/backend/isrequirefips.go |   9 ++
- src/crypto/internal/backend/nobackend.go     | 125 +++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go     | 127 +++++++++++++++++++
  src/crypto/internal/backend/norequirefips.go |   9 ++
  src/crypto/internal/backend/stub.s           |  10 ++
  src/crypto/rand/rand_unix.go                 |   2 +-
@@ -36,9 +36,10 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/sha512/sha512.go                  |   2 +-
  src/crypto/sha512/sha512_test.go             |   2 +-
  src/crypto/tls/cipher_suites.go              |   2 +-
+ src/crypto/tls/key_schedule.go               |  18 ++-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 34 files changed, 314 insertions(+), 29 deletions(-)
+ 35 files changed, 333 insertions(+), 30 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
@@ -355,10 +356,10 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..3698bbac41e5c8
+index 00000000000000..2be7b5a47926bb
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,127 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -476,6 +477,8 @@ index 00000000000000..3698bbac41e5c8
 +func NewPublicKeyECDH(string, []byte) (*PublicKeyECDH, error) { panic("cryptobackend: not available") }
 +func (*PublicKeyECDH) Bytes() []byte                          { panic("cryptobackend: not available") }
 +func (*PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error)    { panic("cryptobackend: not available") }
++
++func SupportsHKDF() bool { panic("cryptobackend: not available") }
 +
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
 +	panic("cryptobackend: not available")
@@ -702,6 +705,42 @@ index 589e8b6fafbba3..0a6d665ee3096d 100644
  	"crypto/rc4"
  	"crypto/sha1"
  	"crypto/sha256"
+diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
+index d7f082c9ee1e04..14a85fbf1bd465 100644
+--- a/src/crypto/tls/key_schedule.go
++++ b/src/crypto/tls/key_schedule.go
+@@ -59,7 +59,16 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
+ 		panic(fmt.Errorf("failed to construct HKDF label: %s", err))
+ 	}
+ 	out := make([]byte, length)
+-	n, err := hkdf.Expand(c.hash.New, secret, hkdfLabelBytes).Read(out)
++	var r io.Reader
++	if boring.Enabled && boring.SupportsHKDF() {
++		r, err = boring.ExpandHKDF(c.hash.New, secret, hkdfLabelBytes)
++		if err != nil {
++			panic(fmt.Errorf("tls: HKDF-Expand-Label invocation failed unexpectedly: %s", err))
++		}
++	} else {
++		r = hkdf.Expand(c.hash.New, secret, hkdfLabelBytes)
++	}
++	n, err := r.Read(out)
+ 	if err != nil || n != length {
+ 		panic("tls: HKDF-Expand-Label invocation failed unexpectedly")
+ 	}
+@@ -79,6 +88,13 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
+ 	if newSecret == nil {
+ 		newSecret = make([]byte, c.hash.Size())
+ 	}
++	if boring.Enabled && boring.SupportsHKDF() {
++		prk, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
++		if err != nil {
++			panic(fmt.Errorf("tls: HKDF-Extract invocation failed unexpectedly: %s", err))
++		}
++		return prk
++	}
+ 	return hkdf.Extract(c.hash.New, newSecret, currentSecret)
+ }
+ 
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index ff03691eb90397..1a8530d999b0c9 100644
 --- a/src/go/build/deps_test.go

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 ++
- src/crypto/internal/backend/boring_linux.go   | 144 ++++++++++++++++++
- 2 files changed, 156 insertions(+)
+ src/crypto/internal/backend/boring_linux.go   | 146 ++++++++++++++++++
+ 2 files changed, 158 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..5c9d6daa8db782
+index 00000000000000..4f3057b92627c3
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,146 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -170,6 +170,8 @@ index 00000000000000..5c9d6daa8db782
 +func NewPublicKeyECDH(curve string, bytes []byte) (*boring.PublicKeyECDH, error) {
 +	return boring.NewPublicKeyECDH(curve, bytes)
 +}
++
++func SupportsHKDF() bool { return false }
 +
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
 +	panic("cryptobackend: not available")

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 235 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 239 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -25,7 +25,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/tls/boring_test.go                 |   2 +-
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
  src/crypto/tls/fipsonly/fipsonly_test.go      |   2 +-
- src/crypto/tls/key_schedule.go                |  20 +-
+ src/crypto/tls/key_schedule.go                |   1 +
  src/crypto/tls/notboring.go                   |   2 +-
  src/crypto/x509/boring.go                     |   2 +-
  src/crypto/x509/boring_test.go                |   2 +-
@@ -37,7 +37,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 33 files changed, 335 insertions(+), 24 deletions(-)
+ 33 files changed, 321 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -190,10 +190,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..9995444d1f1e9f
+index 00000000000000..401ac5ce6101d9
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,235 @@
+@@ -0,0 +1,239 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -422,6 +422,10 @@ index 00000000000000..9995444d1f1e9f
 +	return openssl.NewPublicKeyECDH(curve, bytes)
 +}
 +
++func SupportsHKDF() bool {
++	return openssl.SupportsHKDF()
++}
++
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
 +	return openssl.ExpandHKDF(h, pseudorandomKey, info)
 +}
@@ -561,10 +565,10 @@ index f8485dc3ca1c29..9c1d3d279c472f 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
-index d7f082c9ee1e04..ee9d4650e3523b 100644
+index 14a85fbf1bd465..5caa181eec51a5 100644
 --- a/src/crypto/tls/key_schedule.go
 +++ b/src/crypto/tls/key_schedule.go
-@@ -7,9 +7,11 @@ package tls
+@@ -7,6 +7,7 @@ package tls
  import (
  	"crypto/ecdh"
  	"crypto/hmac"
@@ -572,42 +576,6 @@ index d7f082c9ee1e04..ee9d4650e3523b 100644
  	"errors"
  	"fmt"
  	"hash"
-+	"internal/goexperiment"
- 	"io"
- 
- 	"golang.org/x/crypto/cryptobyte"
-@@ -59,7 +61,16 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
- 		panic(fmt.Errorf("failed to construct HKDF label: %s", err))
- 	}
- 	out := make([]byte, length)
--	n, err := hkdf.Expand(c.hash.New, secret, hkdfLabelBytes).Read(out)
-+	var r io.Reader
-+	if goexperiment.OpenSSLCrypto {
-+		r, err = boring.ExpandHKDF(c.hash.New, secret, hkdfLabelBytes)
-+		if err != nil {
-+			panic(fmt.Errorf("tls: HKDF-Expand-Label invocation failed unexpectedly: %s", err))
-+		}
-+	} else {
-+		r = hkdf.Expand(c.hash.New, secret, hkdfLabelBytes)
-+	}
-+	n, err := r.Read(out)
- 	if err != nil || n != length {
- 		panic("tls: HKDF-Expand-Label invocation failed unexpectedly")
- 	}
-@@ -79,6 +90,13 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
- 	if newSecret == nil {
- 		newSecret = make([]byte, c.hash.Size())
- 	}
-+	if goexperiment.OpenSSLCrypto {
-+		prk, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
-+		if err != nil {
-+			panic(fmt.Errorf("tls: HKDF-Extract invocation failed unexpectedly: %s", err))
-+		}
-+		return prk
-+	}
- 	return hkdf.Extract(c.hash.New, newSecret, currentSecret)
- }
- 
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
 index 7d85b39c59319e..1aaabd5ef486aa 100644
 --- a/src/crypto/tls/notboring.go

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 216 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 220 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -34,7 +34,6 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
  src/crypto/tls/fipsonly/fipsonly_test.go      |   2 +-
  src/crypto/tls/handshake_server_tls13.go      |  10 +
- src/crypto/tls/key_schedule.go                |   4 +-
  src/crypto/tls/notboring.go                   |   2 +-
  src/crypto/x509/boring.go                     |   2 +-
  src/crypto/x509/boring_test.go                |   2 +-
@@ -47,7 +46,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 43 files changed, 408 insertions(+), 42 deletions(-)
+ 42 files changed, 410 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -166,10 +165,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..6841062f39dfbb
+index 00000000000000..a6127c1fa36403
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,216 @@
+@@ -0,0 +1,220 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -377,6 +376,10 @@ index 00000000000000..6841062f39dfbb
 +
 +func NewPublicKeyECDH(curve string, bytes []byte) (*cng.PublicKeyECDH, error) {
 +	return cng.NewPublicKeyECDH(curve, bytes)
++}
++
++func SupportsHKDF() bool {
++	return cng.SupportsHKDF()
 +}
 +
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
@@ -948,28 +951,6 @@ index 07b1a3851e0714..6fae2b4ba22540 100644
  		return nil
  	}
  	state, err := marshaler.MarshalBinary()
-diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
-index ee9d4650e3523b..4d792561cabe04 100644
---- a/src/crypto/tls/key_schedule.go
-+++ b/src/crypto/tls/key_schedule.go
-@@ -62,7 +62,7 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
- 	}
- 	out := make([]byte, length)
- 	var r io.Reader
--	if goexperiment.OpenSSLCrypto {
-+	if goexperiment.OpenSSLCrypto || goexperiment.CNGCrypto {
- 		r, err = boring.ExpandHKDF(c.hash.New, secret, hkdfLabelBytes)
- 		if err != nil {
- 			panic(fmt.Errorf("tls: HKDF-Expand-Label invocation failed unexpectedly: %s", err))
-@@ -90,7 +90,7 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
- 	if newSecret == nil {
- 		newSecret = make([]byte, c.hash.Size())
- 	}
--	if goexperiment.OpenSSLCrypto {
-+	if goexperiment.OpenSSLCrypto || goexperiment.CNGCrypto {
- 		prk, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
- 		if err != nil {
- 			panic(fmt.Errorf("tls: HKDF-Extract invocation failed unexpectedly: %s", err))
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
 index 1aaabd5ef486aa..5a133c9b2f94c7 100644
 --- a/src/crypto/tls/notboring.go


### PR DESCRIPTION
While working on #1036 I realized that  the `goexperiment.OpenSSLCrypto || goexperiment.CNGCrypto` check done before calling HKDF functions could be generalized to `backend.Enabled && backend.SupportsHKDF()`.

This PR also fixes a potential bug: we should be checking if OpenSSL/CNG support HKDF before calling HKDF-related functions, else those functions will fail. We haven't seen this issue yet because HKDF is well-supported in recent Windows and OpenSSL versions.