### PR TITLE
Implement support for crypto/des using OpenSSL/CNG

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -7,6 +7,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/aes/cipher.go                     |   2 +-
  src/crypto/aes/cipher_asm.go                 |   2 +-
  src/crypto/boring/boring.go                  |   2 +-
+ src/crypto/des/cipher.go                     |   7 +
  src/crypto/ecdh/ecdh.go                      |   2 +-
  src/crypto/ecdh/nist.go                      |   2 +-
  src/crypto/ecdsa/boring.go                   |   4 +-
@@ -15,11 +16,11 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/ed25519/ed25519_test.go           |   2 +-
  src/crypto/hmac/hmac.go                      |   2 +-
  src/crypto/hmac/hmac_test.go                 |   2 +-
- src/crypto/internal/backend/backend_test.go  |  30 +++++
+ src/crypto/internal/backend/backend_test.go  |  30 ++++
  src/crypto/internal/backend/bbig/big.go      |  17 +++
- src/crypto/internal/backend/common.go        |  78 +++++++++++
+ src/crypto/internal/backend/common.go        |  78 ++++++++++
  src/crypto/internal/backend/isrequirefips.go |   9 ++
- src/crypto/internal/backend/nobackend.go     | 135 +++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go     | 143 +++++++++++++++++++
  src/crypto/internal/backend/norequirefips.go |   9 ++
  src/crypto/internal/backend/stub.s           |  10 ++
  src/crypto/rand/rand_unix.go                 |   2 +-
@@ -39,11 +40,11 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/handshake_client.go           |  25 +++-
  src/crypto/tls/handshake_server.go           |  25 +++-
  src/crypto/tls/key_schedule.go               |  18 ++-
- src/crypto/tls/prf.go                        |  77 +++++++----
+ src/crypto/tls/prf.go                        |  77 +++++++---
  src/crypto/tls/prf_test.go                   |  12 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 39 files changed, 445 insertions(+), 65 deletions(-)
+ 40 files changed, 460 insertions(+), 65 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
@@ -91,6 +92,38 @@ index 097c37e343fdb8..1cf43edba40359 100644
  
  // Enabled reports whether BoringCrypto handles supported crypto operations.
  func Enabled() bool {
+diff --git a/src/crypto/des/cipher.go b/src/crypto/des/cipher.go
+index 699e5177aef5d5..7e9c2a74adf74b 100644
+--- a/src/crypto/des/cipher.go
++++ b/src/crypto/des/cipher.go
+@@ -7,6 +7,7 @@ package des
+ import (
+ 	"crypto/cipher"
+ 	"crypto/internal/alias"
++	boring "crypto/internal/backend"
+ 	"encoding/binary"
+ 	"strconv"
+ )
+@@ -30,6 +31,9 @@ func NewCipher(key []byte) (cipher.Block, error) {
+ 	if len(key) != 8 {
+ 		return nil, KeySizeError(len(key))
+ 	}
++	if boring.Enabled && boring.SupportsDESCipher() {
++		return boring.NewDESCipher(key)
++	}
+ 
+ 	c := new(desCipher)
+ 	c.generateSubkeys(key)
+@@ -74,6 +78,9 @@ func NewTripleDESCipher(key []byte) (cipher.Block, error) {
+ 	if len(key) != 24 {
+ 		return nil, KeySizeError(len(key))
+ 	}
++	if boring.Enabled && boring.SupportsTripleDESCipher() {
++		return boring.NewTripleDESCipher(key)
++	}
+ 
+ 	c := new(tripleDESCipher)
+ 	c.cipher1.generateSubkeys(key[:8])
 diff --git a/src/crypto/ecdh/ecdh.go b/src/crypto/ecdh/ecdh.go
 index b86f5217878251..a48043a044f309 100644
 --- a/src/crypto/ecdh/ecdh.go
@@ -360,10 +393,10 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..e3e9817a7c5c40
+index 00000000000000..75eb22290bcc92
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,135 @@
+@@ -0,0 +1,143 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -499,6 +532,14 @@ index 00000000000000..e3e9817a7c5c40
 +func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 +	panic("cryptobackend: not available")
 +}
++
++func SupportsDESCipher() bool { panic("cryptobackend: not available") }
++
++func SupportsTripleDESCipher() bool { panic("cryptobackend: not available") }
++
++func NewDESCipher(key []byte) (cipher.Block, error) { panic("cryptobackend: not available") }
++
++func NewTripleDESCipher(key []byte) (cipher.Block, error) { panic("cryptobackend: not available") }
 diff --git a/src/crypto/internal/backend/norequirefips.go b/src/crypto/internal/backend/norequirefips.go
 new file mode 100644
 index 00000000000000..26bfb5f6a643f3
@@ -1088,7 +1129,7 @@ index 8233985a62bd22..f46d4636557714 100644
  		serverMACString := hex.EncodeToString(serverMAC)
  		clientKeyString := hex.EncodeToString(clientKey)
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index ca0c4089a2e505..4a6d42b18c46bc 100644
+index 187dff74cfcb54..0fc11c2fb3ae7b 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -428,6 +428,7 @@ var depsRules = `

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 ++
- src/crypto/internal/backend/boring_linux.go   | 161 ++++++++++++++++++
- 2 files changed, 173 insertions(+)
+ src/crypto/internal/backend/boring_linux.go   | 173 ++++++++++++++++++
+ 2 files changed, 185 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..35e1d00d29980d
+index 00000000000000..ea2ec3c2527dcc
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,161 @@
+@@ -0,0 +1,173 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -193,5 +193,17 @@ index 00000000000000..35e1d00d29980d
 +func SupportsTLS1PRF() bool { return false }
 +
 +func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
++	panic("cryptobackend: not available")
++}
++
++func SupportsDESCipher() bool { return false }
++
++func SupportsTripleDESCipher() bool { return false }
++
++func NewDESCipher(key []byte) (cipher.Block, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 +	panic("cryptobackend: not available")
 +}

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 261 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 277 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -37,7 +37,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 33 files changed, 343 insertions(+), 23 deletions(-)
+ 33 files changed, 359 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -190,10 +190,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..1da89e6645069f
+index 00000000000000..bc10293bb719ff
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,261 @@
+@@ -0,0 +1,277 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -455,6 +455,22 @@ index 00000000000000..1da89e6645069f
 +func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 +	return openssl.TLS1PRF(result, secret, label, seed, h)
 +}
++
++func SupportsDESCipher() bool {
++	return openssl.SupportsDESCipher()
++}
++
++func SupportsTripleDESCipher() bool {
++	return openssl.SupportsTripleDESCipher()
++}
++
++func NewDESCipher(key []byte) (cipher.Block, error) {
++	return openssl.NewDESCipher(key)
++}
++
++func NewTripleDESCipher(key []byte) (cipher.Block, error) {
++	return openssl.NewTripleDESCipher(key)
++}
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
 index f2e5a503eaacb6..1dc7116efdff2e 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
@@ -548,7 +564,7 @@ index 1827f764589b58..70baa62d63754a 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index ba68f355eb037c..929111d8679cc2 100644
+index 085ff5713ec52f..7b7de66cb7e8c4 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -651,7 +667,7 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index beb4d13d8bdc6f..8bc13536fc98c0 100644
+index 021d00b3f6f519..5fe135982d20ee 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -663,7 +679,7 @@ index beb4d13d8bdc6f..8bc13536fc98c0 100644
  	golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9
  )
 diff --git a/src/go.sum b/src/go.sum
-index 81b83159f77a36..fca63cfe4a8d1d 100644
+index cae131c06ee904..daaf12048cf9f7 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
@@ -673,7 +689,7 @@ index 81b83159f77a36..fca63cfe4a8d1d 100644
  golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
  golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9 h1:eQR0jFW5dN2q8lFzSF7rjkRCOOnBf0llczNvITm6ICs=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 4a6d42b18c46bc..0a6be3cc0231fc 100644
+index 0fc11c2fb3ae7b..07bc42530a2cca 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -427,6 +427,8 @@ var depsRules = `
@@ -742,7 +758,7 @@ index 00000000000000..a7f2712e9e1464
 +const OpenSSLCrypto = true
 +const OpenSSLCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 5d0f5b678b4f9d..416b5002944529 100644
+index 50a1e8ed557a4b..47391d37269b9e 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,7 @@ type Flags struct {

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 232 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 248 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -46,7 +46,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 42 files changed, 422 insertions(+), 40 deletions(-)
+ 42 files changed, 438 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -165,10 +165,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..27a0480c8ceb75
+index 00000000000000..8a1b5618989d06
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,232 @@
+@@ -0,0 +1,248 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -400,6 +400,22 @@ index 00000000000000..27a0480c8ceb75
 +
 +func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 +	return cng.TLS1PRF(result, secret, label, seed, h)
++}
++
++func SupportsDESCipher() bool {
++	return true
++}
++
++func SupportsTripleDESCipher() bool {
++	return true
++}
++
++func NewDESCipher(key []byte) (cipher.Block, error) {
++	return cng.NewDESCipher(key)
++}
++
++func NewTripleDESCipher(key []byte) (cipher.Block, error) {
++	return cng.NewTripleDESCipher(key)
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 index efdd080a1b7708..9d7f7b849d6485 100644
@@ -897,7 +913,7 @@ index 70baa62d63754a..ecd0f5a7b3e9ed 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 929111d8679cc2..3e63ba6a053c42 100644
+index 7b7de66cb7e8c4..86595e588cf604 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -1016,7 +1032,7 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 8bc13536fc98c0..da1926b3982c3a 100644
+index 5fe135982d20ee..8e312e40abd195 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
@@ -1028,7 +1044,7 @@ index 8bc13536fc98c0..da1926b3982c3a 100644
  	golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9
  )
 diff --git a/src/go.sum b/src/go.sum
-index fca63cfe4a8d1d..0c5126e6ced297 100644
+index daaf12048cf9f7..0323d2b19d2f8f 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
@@ -1040,7 +1056,7 @@ index fca63cfe4a8d1d..0c5126e6ced297 100644
  golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
  golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9 h1:eQR0jFW5dN2q8lFzSF7rjkRCOOnBf0llczNvITm6ICs=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 0a6be3cc0231fc..d9cf7f503b107b 100644
+index 07bc42530a2cca..416f0c1b83c720 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -427,6 +427,10 @@ var depsRules = `
@@ -1128,7 +1144,7 @@ index 00000000000000..99ee2542ca38a9
 +const CNGCrypto = true
 +const CNGCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 416b5002944529..9bb027e3c70fe7 100644
+index 47391d37269b9e..88df36e379eece 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,7 @@ type Flags struct {

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1032,26 +1032,26 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 5fe135982d20ee..8e312e40abd195 100644
+index 5fe135982d20ee..c4f71d4914022b 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
  	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20230919193409-4899d534a7ff
++	github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7
  	golang.org/x/crypto v0.12.0
  	golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9
  )
 diff --git a/src/go.sum b/src/go.sum
-index daaf12048cf9f7..0323d2b19d2f8f 100644
+index daaf12048cf9f7..cc117b5822c93d 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6 h1:htngJbDceHA29WbezaO55msU/iITDkdto1p1iHHmjC0=
  github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20230919193409-4899d534a7ff h1:m0Cr4tuDOCmNoHtQV7RRTTH54d5Q9yV2g0AC2SO/7uI=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20230919193409-4899d534a7ff/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7 h1:FDuMHAVeFPpxVCdoMkwOjzuLWlvyxOQQPbOBjsJCC2E=
++github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
  golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
  golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9 h1:eQR0jFW5dN2q8lFzSF7rjkRCOOnBf0llczNvITm6ICs=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -41,7 +41,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../microsoft/go-crypto-winnative/cng/big.go  |  30 +
  .../go-crypto-winnative/cng/cipher.go         |  56 ++
  .../microsoft/go-crypto-winnative/cng/cng.go  | 130 +++
- .../microsoft/go-crypto-winnative/cng/des.go  | 106 +++
+ .../microsoft/go-crypto-winnative/cng/des.go  | 107 +++
  .../microsoft/go-crypto-winnative/cng/ecdh.go | 260 ++++++
  .../go-crypto-winnative/cng/ecdsa.go          | 175 ++++
  .../microsoft/go-crypto-winnative/cng/hash.go | 298 +++++++
@@ -57,7 +57,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 52 files changed, 8368 insertions(+)
+ 52 files changed, 8369 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -5530,7 +5530,7 @@ index 00000000000000..9e841e7a26e4eb
 +    SOFTWARE
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
 new file mode 100644
-index 00000000000000..1722fa341daff9
+index 00000000000000..bf68ece6a306e1
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
 @@ -0,0 +1,331 @@
@@ -5669,7 +5669,7 @@ index 00000000000000..1722fa341daff9
 +	switch alg {
 +	case bcrypt.AES_ALGORITHM:
 +		blockSize = aesBlockSize
-+	case bcrypt.DES_ALGORITHM:
++	case bcrypt.DES_ALGORITHM, bcrypt.DES3_ALGORITHM:
 +		blockSize = desBlockSize
 +	default:
 +		panic("invalid algorithm: " + alg)
@@ -6138,10 +6138,10 @@ index 00000000000000..844c087287cabe
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/des.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/des.go
 new file mode 100644
-index 00000000000000..78b4d0a54a3689
+index 00000000000000..2172f03e860418
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/des.go
-@@ -0,0 +1,106 @@
+@@ -0,0 +1,107 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -6162,6 +6162,7 @@ index 00000000000000..78b4d0a54a3689
 +
 +type desCipher struct {
 +	kh  bcrypt.KEY_HANDLE
++	alg string
 +	key []byte
 +}
 +
@@ -6170,7 +6171,7 @@ index 00000000000000..78b4d0a54a3689
 +	if err != nil {
 +		return nil, err
 +	}
-+	c := &desCipher{kh: kh, key: make([]byte, len(key))}
++	c := &desCipher{kh: kh, alg: bcrypt.DES_ALGORITHM, key: make([]byte, len(key))}
 +	copy(c.key, key)
 +	runtime.SetFinalizer(c, (*desCipher).finalize)
 +	return c, nil
@@ -6181,7 +6182,7 @@ index 00000000000000..78b4d0a54a3689
 +	if err != nil {
 +		return nil, err
 +	}
-+	c := &desCipher{kh: kh, key: make([]byte, len(key))}
++	c := &desCipher{kh: kh, alg: bcrypt.DES3_ALGORITHM, key: make([]byte, len(key))}
 +	copy(c.key, key)
 +	runtime.SetFinalizer(c, (*desCipher).finalize)
 +	return c, nil
@@ -6242,11 +6243,11 @@ index 00000000000000..78b4d0a54a3689
 +}
 +
 +func (c *desCipher) NewCBCEncrypter(iv []byte) cipher.BlockMode {
-+	return newCBC(true, bcrypt.DES_ALGORITHM, c.key, iv)
++	return newCBC(true, c.alg, c.key, iv)
 +}
 +
 +func (c *desCipher) NewCBCDecrypter(iv []byte) cipher.BlockMode {
-+	return newCBC(false, bcrypt.DES_ALGORITHM, c.key, iv)
++	return newCBC(false, c.alg, c.key, iv)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go
 new file mode 100644
@@ -8776,7 +8777,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index abd3f0b5193381..929469ecc4d448 100644
+index 34d406c99bed1d..b4e4501c464cac 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
@@ -8784,7 +8785,7 @@ index abd3f0b5193381..929469ecc4d448 100644
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20230919193409-4899d534a7ff
++# github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
This PR patches `crypto/des` so it is implemented using the OpenSSL and CNG backends.