### PR TITLE
Implement support for crypto/md5 using OpenSSL/CNG

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -395,10 +395,10 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..75eb22290bcc92
+index 00000000000000..275a6078f90514
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,143 @@
+@@ -0,0 +1,145 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -15,13 +15,14 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/ed25519/ed25519_test.go           |   2 +-
  src/crypto/hmac/hmac.go                      |   2 +-
  src/crypto/hmac/hmac_test.go                 |   2 +-
- src/crypto/internal/backend/backend_test.go  |  30 +++++
+ src/crypto/internal/backend/backend_test.go  |  30 ++++
  src/crypto/internal/backend/bbig/big.go      |  17 +++
  src/crypto/internal/backend/common.go        |  78 +++++++++++
  src/crypto/internal/backend/isrequirefips.go |   9 ++
- src/crypto/internal/backend/nobackend.go     | 135 +++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go     | 137 +++++++++++++++++++
  src/crypto/internal/backend/norequirefips.go |   9 ++
  src/crypto/internal/backend/stub.s           |  10 ++
+ src/crypto/md5/md5.go                        |   7 +
  src/crypto/rand/rand_unix.go                 |   2 +-
  src/crypto/rsa/boring.go                     |   4 +-
  src/crypto/rsa/notboring.go                  |   2 +-
@@ -43,7 +44,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/prf_test.go                   |  12 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 39 files changed, 445 insertions(+), 65 deletions(-)
+ 40 files changed, 454 insertions(+), 65 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
@@ -92,7 +93,7 @@ index 097c37e343fdb8..1cf43edba40359 100644
  // Enabled reports whether BoringCrypto handles supported crypto operations.
  func Enabled() bool {
 diff --git a/src/crypto/ecdh/ecdh.go b/src/crypto/ecdh/ecdh.go
-index b86f5217878251..a48043a044f309 100644
+index b21b5697d0e37f..5e373cd27b350f 100644
 --- a/src/crypto/ecdh/ecdh.go
 +++ b/src/crypto/ecdh/ecdh.go
 @@ -8,7 +8,7 @@ package ecdh
@@ -360,10 +361,10 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..e3e9817a7c5c40
+index 00000000000000..8720e85ba2bebf
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,135 @@
+@@ -0,0 +1,137 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -393,12 +394,14 @@ index 00000000000000..e3e9817a7c5c40
 +
 +func SupportsHash(h crypto.Hash) bool { panic("cryptobackend: not available") }
 +
++func NewMD5() hash.Hash    { panic("cryptobackend: not available") }
 +func NewSHA1() hash.Hash   { panic("cryptobackend: not available") }
 +func NewSHA224() hash.Hash { panic("cryptobackend: not available") }
 +func NewSHA256() hash.Hash { panic("cryptobackend: not available") }
 +func NewSHA384() hash.Hash { panic("cryptobackend: not available") }
 +func NewSHA512() hash.Hash { panic("cryptobackend: not available") }
 +
++func MD5(p []byte) (sum [16]byte)    { panic("cryptobackend: not available") }
 +func SHA1(p []byte) (sum [20]byte)   { panic("cryptobackend: not available") }
 +func SHA224(p []byte) (sum [28]byte) { panic("cryptobackend: not available") }
 +func SHA256(p []byte) (sum [32]byte) { panic("cryptobackend: not available") }
@@ -530,6 +533,38 @@ index 00000000000000..5e4b436554d44d
 +// Having this assembly file keeps the go command
 +// from complaining about the missing body
 +// (because the implementation might be here).
+diff --git a/src/crypto/md5/md5.go b/src/crypto/md5/md5.go
+index ccee4ea3a9914f..206249f5bf261e 100644
+--- a/src/crypto/md5/md5.go
++++ b/src/crypto/md5/md5.go
+@@ -12,6 +12,7 @@ package md5
+ 
+ import (
+ 	"crypto"
++	boring "crypto/internal/backend"
+ 	"encoding/binary"
+ 	"errors"
+ 	"hash"
+@@ -99,6 +100,9 @@ func consumeUint32(b []byte) ([]byte, uint32) {
+ // implements encoding.BinaryMarshaler and encoding.BinaryUnmarshaler to
+ // marshal and unmarshal the internal state of the hash.
+ func New() hash.Hash {
++	if boring.Enabled && boring.SupportsHash(crypto.MD5) {
++		return boring.NewMD5()
++	}
+ 	d := new(digest)
+ 	d.Reset()
+ 	return d
+@@ -176,6 +180,9 @@ func (d *digest) checkSum() [Size]byte {
+ 
+ // Sum returns the MD5 checksum of the data.
+ func Sum(data []byte) [Size]byte {
++	if boring.Enabled && boring.SupportsHash(crypto.MD5) {
++		return boring.MD5(data)
++	}
+ 	var d digest
+ 	d.Reset()
+ 	d.Write(data)
 diff --git a/src/crypto/rand/rand_unix.go b/src/crypto/rand/rand_unix.go
 index 40fce36314adfa..1d6231ae91d5ae 100644
 --- a/src/crypto/rand/rand_unix.go
@@ -1088,7 +1123,7 @@ index 8233985a62bd22..f46d4636557714 100644
  		serverMACString := hex.EncodeToString(serverMAC)
  		clientKeyString := hex.EncodeToString(clientKey)
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index ca0c4089a2e505..4a6d42b18c46bc 100644
+index 187dff74cfcb54..0fc11c2fb3ae7b 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -428,6 +428,7 @@ var depsRules = `

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -23,6 +23,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/internal/backend/norequirefips.go |   9 ++
  src/crypto/internal/backend/stub.s           |  10 ++
  src/crypto/md5/md5.go                        |   7 +
+ src/crypto/md5/md5_test.go                   |   4 +
  src/crypto/rand/rand_unix.go                 |   2 +-
  src/crypto/rsa/boring.go                     |   4 +-
  src/crypto/rsa/notboring.go                  |   2 +-
@@ -44,7 +45,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/prf_test.go                   |  12 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 40 files changed, 454 insertions(+), 65 deletions(-)
+ 41 files changed, 458 insertions(+), 65 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
@@ -565,6 +566,28 @@ index ccee4ea3a9914f..206249f5bf261e 100644
  	var d digest
  	d.Reset()
  	d.Write(data)
+diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
+index 851e7fb10d42f5..f9d1037c9b82b9 100644
+--- a/src/crypto/md5/md5_test.go
++++ b/src/crypto/md5/md5_test.go
+@@ -6,6 +6,7 @@ package md5
+ 
+ import (
+ 	"bytes"
++	boring "crypto/internal/backend"
+ 	"crypto/rand"
+ 	"encoding"
+ 	"fmt"
+@@ -144,6 +145,9 @@ func TestLarge(t *testing.T) {
+ 
+ // Tests that blockGeneric (pure Go) and block (in assembly for amd64, 386, arm) match.
+ func TestBlockGeneric(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("digest is not used when boring.Enabled is set")
++	}
+ 	gen, asm := New().(*digest), New().(*digest)
+ 	buf := make([]byte, BlockSize*20) // arbitrary factor
+ 	rand.Read(buf)
 diff --git a/src/crypto/rand/rand_unix.go b/src/crypto/rand/rand_unix.go
 index 40fce36314adfa..1d6231ae91d5ae 100644
 --- a/src/crypto/rand/rand_unix.go

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 ++
- src/crypto/internal/backend/boring_linux.go   | 173 ++++++++++++++++++
- 2 files changed, 185 insertions(+)
+ src/crypto/internal/backend/boring_linux.go   | 175 ++++++++++++++++++
+ 2 files changed, 187 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..ea2ec3c2527dcc
+index 00000000000000..bc5c54b02acf2f
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,173 @@
+@@ -0,0 +1,175 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 ++
- src/crypto/internal/backend/boring_linux.go   | 161 ++++++++++++++++++
- 2 files changed, 173 insertions(+)
+ src/crypto/internal/backend/boring_linux.go   | 163 ++++++++++++++++++
+ 2 files changed, 175 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..35e1d00d29980d
+index 00000000000000..4d9bffc4b97aa1
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,161 @@
+@@ -0,0 +1,163 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -66,12 +66,14 @@ index 00000000000000..35e1d00d29980d
 +	}
 +}
 +
++func NewMD5() hash.Hash    { panic("cryptobackend: not available") }
 +func NewSHA1() hash.Hash   { return boring.NewSHA1() }
 +func NewSHA224() hash.Hash { return boring.NewSHA224() }
 +func NewSHA256() hash.Hash { return boring.NewSHA256() }
 +func NewSHA384() hash.Hash { return boring.NewSHA384() }
 +func NewSHA512() hash.Hash { return boring.NewSHA512() }
 +
++func MD5(p []byte) (sum [16]byte)    { panic("cryptobackend: not available") }
 +func SHA1(p []byte) (sum [20]byte)   { return boring.SHA1(p) }
 +func SHA224(p []byte) (sum [28]byte) { return boring.SHA224(p) }
 +func SHA256(p []byte) (sum [32]byte) { return boring.SHA256(p) }

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 277 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 279 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -37,7 +37,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 33 files changed, 359 insertions(+), 23 deletions(-)
+ 33 files changed, 361 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -190,10 +190,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..bc10293bb719ff
+index 00000000000000..d342e4b0f11e23
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,277 @@
+@@ -0,0 +1,279 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 261 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 263 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -37,7 +37,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 33 files changed, 343 insertions(+), 23 deletions(-)
+ 33 files changed, 345 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -190,10 +190,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..1da89e6645069f
+index 00000000000000..d7142e2d5301e4
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,261 @@
+@@ -0,0 +1,263 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -322,12 +322,14 @@ index 00000000000000..1da89e6645069f
 +	return openssl.SupportsHash(h)
 +}
 +
++func NewMD5() hash.Hash   { return openssl.NewMD5() }
 +func NewSHA1() hash.Hash   { return openssl.NewSHA1() }
 +func NewSHA224() hash.Hash { return openssl.NewSHA224() }
 +func NewSHA256() hash.Hash { return openssl.NewSHA256() }
 +func NewSHA384() hash.Hash { return openssl.NewSHA384() }
 +func NewSHA512() hash.Hash { return openssl.NewSHA512() }
 +
++func MD5(p []byte) (sum [16]byte)   { return openssl.MD5(p) }
 +func SHA1(p []byte) (sum [20]byte)   { return openssl.SHA1(p) }
 +func SHA224(p []byte) (sum [28]byte) { return openssl.SHA224(p) }
 +func SHA256(p []byte) (sum [32]byte) { return openssl.SHA256(p) }
@@ -548,7 +550,7 @@ index 1827f764589b58..70baa62d63754a 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index ba68f355eb037c..929111d8679cc2 100644
+index 085ff5713ec52f..7b7de66cb7e8c4 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -651,7 +653,7 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index beb4d13d8bdc6f..8bc13536fc98c0 100644
+index 021d00b3f6f519..5fe135982d20ee 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -663,7 +665,7 @@ index beb4d13d8bdc6f..8bc13536fc98c0 100644
  	golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9
  )
 diff --git a/src/go.sum b/src/go.sum
-index 81b83159f77a36..fca63cfe4a8d1d 100644
+index cae131c06ee904..daaf12048cf9f7 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
@@ -673,7 +675,7 @@ index 81b83159f77a36..fca63cfe4a8d1d 100644
  golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
  golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9 h1:eQR0jFW5dN2q8lFzSF7rjkRCOOnBf0llczNvITm6ICs=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 4a6d42b18c46bc..0a6be3cc0231fc 100644
+index 0fc11c2fb3ae7b..07bc42530a2cca 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -427,6 +427,8 @@ var depsRules = `
@@ -742,7 +744,7 @@ index 00000000000000..a7f2712e9e1464
 +const OpenSSLCrypto = true
 +const OpenSSLCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 5d0f5b678b4f9d..416b5002944529 100644
+index 50a1e8ed557a4b..47391d37269b9e 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,7 @@ type Flags struct {

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -57,10 +57,10 @@ index f0e3575637c62a..0e9aceeb832d3b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 5e57c0c427bf71..439f8198e4121e 100644
+index 9635c4fb616ecf..ba12fbee276416 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1206,12 +1206,11 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1211,12 +1211,11 @@ func (t *tester) registerCgoTests(heading string) {
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
@@ -669,7 +669,7 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 021d00b3f6f519..5fe135982d20ee 100644
+index 8f7dd5c0b69932..b5222cd4fb66b3 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -677,21 +677,21 @@ index 021d00b3f6f519..5fe135982d20ee 100644
  
  require (
 +	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6
- 	golang.org/x/crypto v0.12.0
- 	golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9
+ 	golang.org/x/crypto v0.14.0
+ 	golang.org/x/net v0.17.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index cae131c06ee904..daaf12048cf9f7 100644
+index 22511da608a07b..2e071695221e13 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
 +github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6 h1:htngJbDceHA29WbezaO55msU/iITDkdto1p1iHHmjC0=
 +github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
- golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
- golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
- golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9 h1:eQR0jFW5dN2q8lFzSF7rjkRCOOnBf0llczNvITm6ICs=
+ golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
+ golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+ golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 0fc11c2fb3ae7b..07bc42530a2cca 100644
+index f10ecff5168acc..79d02564926b37 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -427,6 +427,8 @@ var depsRules = `
@@ -711,7 +711,7 @@ index 0fc11c2fb3ae7b..07bc42530a2cca 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -709,7 +712,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -712,7 +715,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -720,7 +720,7 @@ index 0fc11c2fb3ae7b..07bc42530a2cca 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -719,7 +722,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -722,7 +725,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -16,7 +16,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
- src/crypto/md5/md5_test.go                    |   4 +
+ src/crypto/md5/md5_test.go                    |   7 +
  src/crypto/rand/rand_windows.go               |   9 +-
  src/crypto/rsa/boring.go                      |   2 +-
  src/crypto/rsa/boring_test.go                 |   2 +-
@@ -47,7 +47,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 43 files changed, 404 insertions(+), 40 deletions(-)
+ 43 files changed, 407 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -463,10 +463,10 @@ index 4e629a4db8f7c7..a7cd24a0d15647 100644
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
  // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
 diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
-index 851e7fb10d42f5..9d52abe2856e14 100644
+index f9d1037c9b82b9..6b91d4388b73fe 100644
 --- a/src/crypto/md5/md5_test.go
 +++ b/src/crypto/md5/md5_test.go
-@@ -10,6 +10,7 @@ import (
+@@ -11,6 +11,7 @@ import (
  	"encoding"
  	"fmt"
  	"hash"
@@ -474,7 +474,7 @@ index 851e7fb10d42f5..9d52abe2856e14 100644
  	"io"
  	"testing"
  	"unsafe"
-@@ -87,6 +88,9 @@ func TestGolden(t *testing.T) {
+@@ -88,6 +89,9 @@ func TestGolden(t *testing.T) {
  }
  
  func TestGoldenMarshal(t *testing.T) {
@@ -484,6 +484,16 @@ index 851e7fb10d42f5..9d52abe2856e14 100644
  	for _, g := range golden {
  		h := New()
  		h2 := New()
+@@ -195,6 +199,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+ }
+ 
+ func TestLargeHashes(t *testing.T) {
++	if goexperiment.CNGCrypto {
++		t.Skip("CNGCrypto does not support hash marshalling")
++	}
+ 	for i, test := range largeUnmarshalTests {
+ 
+ 		h := New()
 diff --git a/src/crypto/rand/rand_windows.go b/src/crypto/rand/rand_windows.go
 index 6c0655c72b692a..755861fc5bc21d 100644
 --- a/src/crypto/rand/rand_windows.go

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 248 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 226 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -47,7 +47,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 42 files changed, 438 insertions(+), 40 deletions(-)
+ 44 files changed, 423 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -169,7 +169,7 @@ new file mode 100644
 index 00000000000000..8a1b5618989d06
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,248 @@
+@@ -0,0 +1,226 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -16,6 +16,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
+ src/crypto/md5/md5_test.go                    |   4 +
  src/crypto/rand/rand_windows.go               |   9 +-
  src/crypto/rsa/boring.go                      |   2 +-
  src/crypto/rsa/boring_test.go                 |   2 +-
@@ -46,7 +47,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 42 files changed, 400 insertions(+), 40 deletions(-)
+ 43 files changed, 404 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -461,6 +462,28 @@ index 4e629a4db8f7c7..a7cd24a0d15647 100644
  
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
  // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
+diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
+index 851e7fb10d42f5..9d52abe2856e14 100644
+--- a/src/crypto/md5/md5_test.go
++++ b/src/crypto/md5/md5_test.go
+@@ -10,6 +10,7 @@ import (
+ 	"encoding"
+ 	"fmt"
+ 	"hash"
++	"internal/goexperiment"
+ 	"io"
+ 	"testing"
+ 	"unsafe"
+@@ -87,6 +88,9 @@ func TestGolden(t *testing.T) {
+ }
+ 
+ func TestGoldenMarshal(t *testing.T) {
++	if goexperiment.CNGCrypto {
++		t.Skip("CNGCrypto does not support hash marshalling")
++	}
+ 	for _, g := range golden {
+ 		h := New()
+ 		h2 := New()
 diff --git a/src/crypto/rand/rand_windows.go b/src/crypto/rand/rand_windows.go
 index 6c0655c72b692a..755861fc5bc21d 100644
 --- a/src/crypto/rand/rand_windows.go

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 232 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 210 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -46,7 +46,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 42 files changed, 422 insertions(+), 40 deletions(-)
+ 42 files changed, 400 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -165,10 +165,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..27a0480c8ceb75
+index 00000000000000..c17b08e6454a0f
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,232 @@
+@@ -0,0 +1,210 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -215,41 +215,19 @@ index 00000000000000..27a0480c8ceb75
 +	return cng.SupportsHash(h)
 +}
 +
-+func NewSHA1() hash.Hash {
-+	return cng.NewSHA1()
-+}
-+
++func NewMD5() hash.Hash    { return cng.NewMD5() }
++func NewSHA1() hash.Hash   { return cng.NewSHA1() }
 +func NewSHA224() hash.Hash { panic("cngcrypto: not available") }
++func NewSHA256() hash.Hash { return cng.NewSHA256() }
++func NewSHA384() hash.Hash { return cng.NewSHA384() }
++func NewSHA512() hash.Hash { return cng.NewSHA512() }
 +
-+func NewSHA256() hash.Hash {
-+	return cng.NewSHA256()
-+}
-+
-+func NewSHA384() hash.Hash {
-+	return cng.NewSHA384()
-+}
-+
-+func NewSHA512() hash.Hash {
-+	return cng.NewSHA512()
-+}
-+
-+func SHA1(p []byte) (sum [20]byte) {
-+	return cng.SHA1(p)
-+}
-+
++func MD5(p []byte) (sum [16]byte)    { return cng.MD5(p) }
++func SHA1(p []byte) (sum [20]byte)   { return cng.SHA1(p) }
 +func SHA224(p []byte) (sum [28]byte) { panic("cngcrypto: not available") }
-+
-+func SHA256(p []byte) (sum [32]byte) {
-+	return cng.SHA256(p)
-+}
-+
-+func SHA384(p []byte) (sum [48]byte) {
-+	return cng.SHA384(p)
-+}
-+
-+func SHA512(p []byte) (sum [64]byte) {
-+	return cng.SHA512(p)
-+}
++func SHA256(p []byte) (sum [32]byte) { return cng.SHA256(p) }
++func SHA384(p []byte) (sum [48]byte) { return cng.SHA384(p) }
++func SHA512(p []byte) (sum [64]byte) { return cng.SHA512(p) }
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 +	return cng.NewHMAC(h, key)
@@ -897,7 +875,7 @@ index 70baa62d63754a..ecd0f5a7b3e9ed 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 929111d8679cc2..3e63ba6a053c42 100644
+index 7b7de66cb7e8c4..86595e588cf604 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -1016,7 +994,7 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 8bc13536fc98c0..da1926b3982c3a 100644
+index 5fe135982d20ee..8e312e40abd195 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
@@ -1028,7 +1006,7 @@ index 8bc13536fc98c0..da1926b3982c3a 100644
  	golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9
  )
 diff --git a/src/go.sum b/src/go.sum
-index fca63cfe4a8d1d..0c5126e6ced297 100644
+index daaf12048cf9f7..0323d2b19d2f8f 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
@@ -1040,7 +1018,7 @@ index fca63cfe4a8d1d..0c5126e6ced297 100644
  golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
  golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9 h1:eQR0jFW5dN2q8lFzSF7rjkRCOOnBf0llczNvITm6ICs=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 0a6be3cc0231fc..d9cf7f503b107b 100644
+index 07bc42530a2cca..416f0c1b83c720 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -427,6 +427,10 @@ var depsRules = `
@@ -1128,7 +1106,7 @@ index 00000000000000..99ee2542ca38a9
 +const CNGCrypto = true
 +const CNGCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 416b5002944529..9bb027e3c70fe7 100644
+index 47391d37269b9e..88df36e379eece 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,7 @@ type Flags struct {

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -47,7 +47,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 44 files changed, 423 insertions(+), 40 deletions(-)
+ 43 files changed, 423 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -166,7 +166,7 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..8a1b5618989d06
+index 00000000000000..fc6aa711558fe5
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,226 @@
@@ -1043,7 +1043,7 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 5fe135982d20ee..c4f71d4914022b 100644
+index b5222cd4fb66b3..7f8a27aa51d405 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
@@ -1051,11 +1051,11 @@ index 5fe135982d20ee..c4f71d4914022b 100644
  require (
  	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7
- 	golang.org/x/crypto v0.12.0
- 	golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9
+ 	golang.org/x/crypto v0.14.0
+ 	golang.org/x/net v0.17.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index daaf12048cf9f7..cc117b5822c93d 100644
+index 2e071695221e13..459b367e045642 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
@@ -1063,11 +1063,11 @@ index daaf12048cf9f7..cc117b5822c93d 100644
  github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7 h1:FDuMHAVeFPpxVCdoMkwOjzuLWlvyxOQQPbOBjsJCC2E=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
- golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
- golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
- golang.org/x/net v0.14.1-0.20230809150940-1e23797619c9 h1:eQR0jFW5dN2q8lFzSF7rjkRCOOnBf0llczNvITm6ICs=
+ golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
+ golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+ golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 07bc42530a2cca..416f0c1b83c720 100644
+index 79d02564926b37..f66f834ca76528 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -427,6 +427,10 @@ var depsRules = `

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -8777,7 +8777,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 34d406c99bed1d..b4e4501c464cac 100644
+index bc4eb872eb8495..1cafbc7fb60d2e 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
@@ -8792,6 +8792,6 @@ index 34d406c99bed1d..b4e4501c464cac 100644
 +github.com/microsoft/go-crypto-winnative/internal/bcrypt
 +github.com/microsoft/go-crypto-winnative/internal/subtle
 +github.com/microsoft/go-crypto-winnative/internal/sysdll
- # golang.org/x/crypto v0.12.0
+ # golang.org/x/crypto v0.14.0
  ## explicit; go 1.17
  golang.org/x/crypto/chacha20

--- a/patches/0009-Skip-failing-tests-on-Windows.patch
+++ b/patches/0009-Skip-failing-tests-on-Windows.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: qmuntal <qmuntaldiaz@microsoft.com>
+Date: Wed, 11 Oct 2023 10:44:22 +0200
+Subject: [PATCH] Skip failing tests on Windows
+
+---
+ src/cmd/cgo/internal/test/test.go | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/cmd/cgo/internal/test/test.go b/src/cmd/cgo/internal/test/test.go
+index 9a6c6d82cefa1a..b0b6795f6920f6 100644
+--- a/src/cmd/cgo/internal/test/test.go
++++ b/src/cmd/cgo/internal/test/test.go
+@@ -1074,6 +1074,9 @@ func testErrno(t *testing.T) {
+ }
+ 
+ func testMultipleAssign(t *testing.T) {
++	if runtime.GOOS == "windows" {
++		t.Skip("fails with internal linking: https://github.com/microsoft/go/issues/1059")
++	}
+ 	p := C.CString("234")
+ 	n, m := C.strtol(p, nil, 345), C.strtol(p, nil, 10)
+ 	if runtime.GOOS == "openbsd" {


### PR DESCRIPTION
This PR patches crypto/md5 so it is implemented using the OpenSSL and CNG backends.