### PR TITLE
Implement support for crypto/rc4 using OpenSSL/CNG

### DIFF
--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -817,6 +817,11 @@ func rc4.NewCipher() rc4.Cipher
 
 NewCipher creates and returns a new Cipher. The key argument should be the RC4 key, at least 1 byte and at most 256 bytes.
 
+**Requirements**
+
+Some OpenSSL distributions don't implement RC4, e.g., OpenSSL 1.x compiled with `-DOPENSSL_NO_RC4` and OpenSSL 3.x that can't load the legacy provider.
+In those cases, `rc4.NewCipher()` will fall back to standard Go crypto.
+
 **Implementation**
 
 <details><summary>OpenSSL (click for details)</summary>

--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -837,7 +837,7 @@ The rc4.Cipher methods are implemented as follows:
 
 <details><summary>CNG (click for details)</summary>
 
-The cipher is generated using [GenerateSymmetricKey] using the `BCRYPT_RC4_ALGORITHM` mode.
+The cipher is generated using [BCryptGenerateSymmetricKey] using the `BCRYPT_RC4_ALGORITHM` mode.
 
 The rc4.Cipher methods are implemented as follows:
 

--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -48,6 +48,7 @@ The Go crypto documentation is available online at https://pkg.go.dev/crypto.
       - [func Prime](#func-prime)
       - [func Read](#func-read)
     - [crypto/rc4](#cryptorc4)
+      - [func NewCipher](#func-newcipher-1)
     - [crypto/sha1](#cryptosha1)
       - [func New](#func-new-1)
       - [func Sum](#func-sum)
@@ -806,7 +807,39 @@ Read is a helper function that calls rand.Reader.Read using io.ReadFull.
 
 ### [crypto/rc4](https://pkg.go.dev/crypto/rc4)
 
-Not implemented by any backend.
+Package rc4 implements RC4 encryption, as defined in Bruce Schneier's Applied Cryptography.
+
+#### func [NewCipher](https://pkg.go.dev/crypto/rc4#NewCipher)
+
+```go
+func rc4.NewCipher() rc4.Cipher
+```
+
+NewCipher creates and returns a new Cipher. The key argument should be the RC4 key, at least 1 byte and at most 256 bytes.
+
+**Implementation**
+
+<details><summary>OpenSSL (click for details)</summary>
+
+The cipher is generated using [EVP_CIPHER_CTX_new] and [EVP_CipherInit_ex] with the cipher type [EVP_rc4].
+
+The rc4.Cipher methods are implemented as follows:
+
+- `Reset` using [EVP_CIPHER_CTX_free].
+- `XORKeyStream` using [EVP_EncryptUpdate].
+
+</details>
+
+<details><summary>CNG (click for details)</summary>
+
+The cipher is generated using [GenerateSymmetricKey] using the `BCRYPT_RC4_ALGORITHM` mode.
+
+The rc4.Cipher methods are implemented as follows:
+
+- `Reset` using [BCryptDestroyKey].
+- `XORKeyStream` using [BCryptEncrypt].
+
+</details>
 
 ### [crypto/sha1](https://pkg.go.dev/crypto/sha1)
 
@@ -1437,6 +1470,7 @@ When using TLS in FIPS-only mode the TLS handshake has the following restriction
 [EVP_aes_128_cbc]: https://www.openssl.org/docs/man3.0/man3/EVP_aes_128_cbc.html
 [EVP_aes_192_cbc]: https://www.openssl.org/docs/man3.0/man3/EVP_aes_192_cbc.html
 [EVP_aes_256_cbc]: https://www.openssl.org/docs/man3.0/man3/EVP_aes_256_cbc.html
+[EVP_rc4]: https://www.openssl.org/docs/man3.0/man3/EVP_rc4.html
 [EVP_sha1]: https://www.openssl.org/docs/man3.0/man3/EVP_sha1.html
 [EVP_sha224]: https://www.openssl.org/docs/man3.0/man3/EVP_sha224.html
 [EVP_sha256]: https://www.openssl.org/docs/man3.0/man3/EVP_sha256.html
@@ -1450,6 +1484,9 @@ When using TLS in FIPS-only mode the TLS handshake has the following restriction
 [EVP_MAC_init]: https://www.openssl.org/docs/man3.0/man3/EVP_MAC_init.html
 [EVP_MAC_update]: https://www.openssl.org/docs/man3.0/man3/EVP_MAC_update.html
 [EVP_MAC_final]: https://www.openssl.org/docs/man3.0/man3/EVP_MAC_final.html
+[EVP_CIPHER_CTX_new]: https://www.openssl.org/docs/man3.0/man3/EVP_CIPHER_CTX_new.html
+[EVP_CipherInit_ex]: https://www.openssl.org/docs/man3.0/man3/EVP_CipherInit_ex.html
+[EVP_CIPHER_CTX_free]: https://www.openssl.org/docs/man3.0/man3/EVP_CIPHER_CTX_free.html
 
 [algorithm identifier]: https://docs.microsoft.com/en-us/windows/win32/seccng/cng-algorithm-identifiers
 [named elliptic curve]: https://docs.microsoft.com/en-us/windows/win32/seccng/cng-named-elliptic-curves
@@ -1470,3 +1507,4 @@ When using TLS in FIPS-only mode the TLS handshake has the following restriction
 [BCRYPT_PKCS1_PADDING_INFO]: https://docs.microsoft.com/en-us/windows/win32/api/Bcrypt/ns-bcrypt-bcrypt_pkcs1_padding_info
 [BCRYPT_PSS_PADDING_INFO]: https://docs.microsoft.com/en-us/windows/win32/api/Bcrypt/ns-bcrypt-bcrypt_pss_padding_info
 [BCryptDeriveKey]: https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptderivekey
+[BCryptDestroyKey]: https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptdestroykey

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -17,15 +17,16 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/hmac/hmac.go                      |   2 +-
  src/crypto/hmac/hmac_test.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go  |  30 ++++
- src/crypto/internal/backend/bbig/big.go      |  17 +++
+ src/crypto/internal/backend/bbig/big.go      |  17 ++
  src/crypto/internal/backend/common.go        |  78 ++++++++++
  src/crypto/internal/backend/isrequirefips.go |   9 ++
- src/crypto/internal/backend/nobackend.go     | 145 +++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go     | 154 +++++++++++++++++++
  src/crypto/internal/backend/norequirefips.go |   9 ++
  src/crypto/internal/backend/stub.s           |  10 ++
  src/crypto/md5/md5.go                        |   7 +
  src/crypto/md5/md5_test.go                   |   4 +
  src/crypto/rand/rand_unix.go                 |   2 +-
+ src/crypto/rc4/rc4.go                        |  18 +++
  src/crypto/rsa/boring.go                     |   4 +-
  src/crypto/rsa/notboring.go                  |   2 +-
  src/crypto/rsa/pkcs1v15.go                   |   2 +-
@@ -39,14 +40,14 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/sha512/sha512.go                  |   2 +-
  src/crypto/sha512/sha512_test.go             |   2 +-
  src/crypto/tls/cipher_suites.go              |   2 +-
- src/crypto/tls/handshake_client.go           |  25 +++-
- src/crypto/tls/handshake_server.go           |  25 +++-
+ src/crypto/tls/handshake_client.go           |  25 ++-
+ src/crypto/tls/handshake_server.go           |  25 ++-
  src/crypto/tls/key_schedule.go               |  18 ++-
  src/crypto/tls/prf.go                        |  77 +++++++---
  src/crypto/tls/prf_test.go                   |  12 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 42 files changed, 473 insertions(+), 65 deletions(-)
+ 43 files changed, 500 insertions(+), 65 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
@@ -395,10 +396,10 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..275a6078f90514
+index 00000000000000..f45f2fe76d54f1
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,154 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -544,6 +545,15 @@ index 00000000000000..275a6078f90514
 +func NewDESCipher(key []byte) (cipher.Block, error) { panic("cryptobackend: not available") }
 +
 +func NewTripleDESCipher(key []byte) (cipher.Block, error) { panic("cryptobackend: not available") }
++
++func SupportsRC4() bool { panic("cryptobackend: not available") }
++
++type RC4Cipher struct{}
++
++func (c *RC4Cipher) Reset()                       { panic("cryptobackend: not available") }
++func (c *RC4Cipher) XORKeyStream(dst, src []byte) { panic("cryptobackend: not available") }
++
++func NewRC4Cipher(key []byte) (*RC4Cipher, error) { panic("cryptobackend: not available") }
 diff --git a/src/crypto/internal/backend/norequirefips.go b/src/crypto/internal/backend/norequirefips.go
 new file mode 100644
 index 00000000000000..26bfb5f6a643f3
@@ -642,6 +652,63 @@ index 40fce36314adfa..1d6231ae91d5ae 100644
  	"errors"
  	"io"
  	"os"
+diff --git a/src/crypto/rc4/rc4.go b/src/crypto/rc4/rc4.go
+index f08da0e469cd07..b3e7db0413ed72 100644
+--- a/src/crypto/rc4/rc4.go
++++ b/src/crypto/rc4/rc4.go
+@@ -11,6 +11,7 @@ package rc4
+ 
+ import (
+ 	"crypto/internal/alias"
++	boring "crypto/internal/backend"
+ 	"strconv"
+ )
+ 
+@@ -18,6 +19,8 @@ import (
+ type Cipher struct {
+ 	s    [256]uint32
+ 	i, j uint8
++
++	boring *boring.RC4Cipher
+ }
+ 
+ type KeySizeError int
+@@ -33,6 +36,13 @@ func NewCipher(key []byte) (*Cipher, error) {
+ 	if k < 1 || k > 256 {
+ 		return nil, KeySizeError(k)
+ 	}
++	if boring.Enabled && boring.SupportsRC4() {
++		c, err := boring.NewRC4Cipher(key)
++		if err != nil {
++			return nil, err
++		}
++		return &Cipher{boring: c}, nil
++	}
+ 	var c Cipher
+ 	for i := 0; i < 256; i++ {
+ 		c.s[i] = uint32(i)
+@@ -50,6 +60,10 @@ func NewCipher(key []byte) (*Cipher, error) {
+ // Deprecated: Reset can't guarantee that the key will be entirely removed from
+ // the process's memory.
+ func (c *Cipher) Reset() {
++	if boring.Enabled && boring.SupportsRC4() {
++		c.boring.Reset()
++		return
++	}
+ 	for i := range c.s {
+ 		c.s[i] = 0
+ 	}
+@@ -59,6 +73,10 @@ func (c *Cipher) Reset() {
+ // XORKeyStream sets dst to the result of XORing src with the key stream.
+ // Dst and src must overlap entirely or not at all.
+ func (c *Cipher) XORKeyStream(dst, src []byte) {
++	if boring.Enabled && boring.SupportsRC4() {
++		c.boring.XORKeyStream(dst, src)
++		return
++	}
+ 	if len(src) == 0 {
+ 		return
+ 	}
 diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
 index b9f9d3154f2589..ecb43aaf264743 100644
 --- a/src/crypto/rsa/boring.go
@@ -1187,7 +1254,7 @@ index 8233985a62bd22..f46d4636557714 100644
  		serverMACString := hex.EncodeToString(serverMAC)
  		clientKeyString := hex.EncodeToString(clientKey)
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 187dff74cfcb54..0fc11c2fb3ae7b 100644
+index fcd5e939980f52..f10ecff5168acc 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -428,6 +428,7 @@ var depsRules = `

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 ++
- src/crypto/internal/backend/boring_linux.go   | 175 ++++++++++++++++++
- 2 files changed, 187 insertions(+)
+ src/crypto/internal/backend/boring_linux.go   | 186 ++++++++++++++++++
+ 2 files changed, 198 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..bc5c54b02acf2f
+index 00000000000000..af2d4b857df333
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,175 @@
+@@ -0,0 +1,186 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -207,5 +207,16 @@ index 00000000000000..bc5c54b02acf2f
 +}
 +
 +func NewTripleDESCipher(key []byte) (cipher.Block, error) {
++	panic("cryptobackend: not available")
++}
++
++func SupportsRC4() bool { return false }
++
++type RC4Cipher struct{}
++
++func (c *RC4Cipher) Reset()                       { panic("cryptobackend: not available") }
++func (c *RC4Cipher) XORKeyStream(dst, src []byte) { panic("cryptobackend: not available") }
++
++func NewRC4Cipher(key []byte) (*RC4Cipher, error) {
 +	panic("cryptobackend: not available")
 +}

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -677,24 +677,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 8f7dd5c0b69932..c67dd4f5ad8ffe 100644
+index 8f7dd5c0b69932..0a9f28adb67211 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.22
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae
++	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd
  	golang.org/x/crypto v0.14.0
  	golang.org/x/net v0.17.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index 22511da608a07b..fba31b71ecde5e 100644
+index 22511da608a07b..afa147f35171de 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae h1:EbuCPM6kcy1UjlfXiby4c5arMnbdvMvnR+7tZ/QEGyc=
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd h1:+SvJEqhqQ8d/wzyk+xmTgBpHDOYQtnS/F8283hznEAc=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
  golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
  golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
  golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 279 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 287 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -37,7 +37,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 33 files changed, 361 insertions(+), 23 deletions(-)
+ 33 files changed, 369 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -190,10 +190,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..d342e4b0f11e23
+index 00000000000000..ff02e561452aa3
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,279 @@
+@@ -0,0 +1,287 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -322,14 +322,14 @@ index 00000000000000..d342e4b0f11e23
 +	return openssl.SupportsHash(h)
 +}
 +
-+func NewMD5() hash.Hash   { return openssl.NewMD5() }
++func NewMD5() hash.Hash    { return openssl.NewMD5() }
 +func NewSHA1() hash.Hash   { return openssl.NewSHA1() }
 +func NewSHA224() hash.Hash { return openssl.NewSHA224() }
 +func NewSHA256() hash.Hash { return openssl.NewSHA256() }
 +func NewSHA384() hash.Hash { return openssl.NewSHA384() }
 +func NewSHA512() hash.Hash { return openssl.NewSHA512() }
 +
-+func MD5(p []byte) (sum [16]byte)   { return openssl.MD5(p) }
++func MD5(p []byte) (sum [16]byte)    { return openssl.MD5(p) }
 +func SHA1(p []byte) (sum [20]byte)   { return openssl.SHA1(p) }
 +func SHA224(p []byte) (sum [28]byte) { return openssl.SHA224(p) }
 +func SHA256(p []byte) (sum [32]byte) { return openssl.SHA256(p) }
@@ -473,6 +473,14 @@ index 00000000000000..d342e4b0f11e23
 +func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 +	return openssl.NewTripleDESCipher(key)
 +}
++
++func SupportsRC4() bool {
++	return openssl.SupportsRC4()
++}
++
++type RC4Cipher = openssl.RC4Cipher
++
++func NewRC4Cipher(key []byte) (*RC4Cipher, error) { return openssl.NewRC4Cipher(key) }
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
 index f2e5a503eaacb6..1dc7116efdff2e 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
@@ -669,24 +677,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 8f7dd5c0b69932..b5222cd4fb66b3 100644
+index 8f7dd5c0b69932..c67dd4f5ad8ffe 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.22
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6
++	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae
  	golang.org/x/crypto v0.14.0
  	golang.org/x/net v0.17.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index 22511da608a07b..2e071695221e13 100644
+index 22511da608a07b..fba31b71ecde5e 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6 h1:htngJbDceHA29WbezaO55msU/iITDkdto1p1iHHmjC0=
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae h1:EbuCPM6kcy1UjlfXiby4c5arMnbdvMvnR+7tZ/QEGyc=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
  golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
  golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
  golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1049,24 +1049,24 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index c67dd4f5ad8ffe..235e5eba8906cb 100644
+index 0a9f28adb67211..d3b7820873d23a 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae
+ 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54
  	golang.org/x/crypto v0.14.0
  	golang.org/x/net v0.17.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index fba31b71ecde5e..2ab2edb43a5f82 100644
+index afa147f35171de..9640b9c12da10a 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae h1:EbuCPM6kcy1UjlfXiby4c5arMnbdvMvnR+7tZ/QEGyc=
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd h1:+SvJEqhqQ8d/wzyk+xmTgBpHDOYQtnS/F8283hznEAc=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54 h1:TCT5sTFxoPwPQkdegvnmgmcZRpecDsrLSCyWYUwAWTs=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 226 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 232 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -47,7 +47,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 43 files changed, 423 insertions(+), 40 deletions(-)
+ 43 files changed, 429 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -166,10 +166,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..fc6aa711558fe5
+index 00000000000000..9edcbcc24814c1
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,226 @@
+@@ -0,0 +1,232 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -396,6 +396,12 @@ index 00000000000000..fc6aa711558fe5
 +func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 +	return cng.NewTripleDESCipher(key)
 +}
++
++func SupportsRC4() bool { return true }
++
++type RC4Cipher = cng.RC4Cipher
++
++func NewRC4Cipher(key []byte) (*RC4Cipher, error) { return cng.NewRC4Cipher(key) }
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 index efdd080a1b7708..9d7f7b849d6485 100644
 --- a/src/crypto/internal/backend/common.go
@@ -1043,26 +1049,26 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index b5222cd4fb66b3..7f8a27aa51d405 100644
+index c67dd4f5ad8ffe..235e5eba8906cb 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7
+ 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae
++	github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54
  	golang.org/x/crypto v0.14.0
  	golang.org/x/net v0.17.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index 2e071695221e13..459b367e045642 100644
+index fba31b71ecde5e..2ab2edb43a5f82 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6 h1:htngJbDceHA29WbezaO55msU/iITDkdto1p1iHHmjC0=
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7 h1:FDuMHAVeFPpxVCdoMkwOjzuLWlvyxOQQPbOBjsJCC2E=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae h1:EbuCPM6kcy1UjlfXiby4c5arMnbdvMvnR+7tZ/QEGyc=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54 h1:TCT5sTFxoPwPQkdegvnmgmcZRpecDsrLSCyWYUwAWTs=
++github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
  golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
  golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -11,12 +11,13 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../github.com/golang-fips/openssl/v2/aes.go  |  90 ++
  .../golang-fips/openssl/v2/bbig/big.go        |  37 +
  .../github.com/golang-fips/openssl/v2/big.go  |  11 +
- .../golang-fips/openssl/v2/cgo_go122.go       |  15 +
+ .../golang-fips/openssl/v2/cgo_go122.go       |  19 +
  .../golang-fips/openssl/v2/cipher.go          | 534 ++++++++++++
  .../github.com/golang-fips/openssl/v2/des.go  | 113 +++
  .../github.com/golang-fips/openssl/v2/ec.go   |  59 ++
  .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
  .../golang-fips/openssl/v2/ecdsa.go           | 217 +++++
+ .../golang-fips/openssl/v2/ed25519.go         | 216 +++++
  .../github.com/golang-fips/openssl/v2/evp.go  | 473 +++++++++++
  .../golang-fips/openssl/v2/goopenssl.c        | 218 +++++
  .../golang-fips/openssl/v2/goopenssl.h        | 183 ++++
@@ -30,9 +31,9 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../golang-fips/openssl/v2/pbkdf2.go          |  28 +
  .../openssl/v2/port_evp_md5_sha1.c            | 126 +++
  .../github.com/golang-fips/openssl/v2/rand.go |  20 +
- .../github.com/golang-fips/openssl/v2/rc4.go  |  63 ++
+ .../github.com/golang-fips/openssl/v2/rc4.go  |  66 ++
  .../github.com/golang-fips/openssl/v2/rsa.go  | 419 +++++++++
- .../github.com/golang-fips/openssl/v2/shims.h | 360 ++++++++
+ .../github.com/golang-fips/openssl/v2/shims.h | 370 ++++++++
  .../openssl/v2/thread_setup_unix.c            |  35 +
  .../openssl/v2/thread_setup_windows.c         |  33 +
  .../golang-fips/openssl/v2/tls1prf.go         | 104 +++
@@ -59,7 +60,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 54 files changed, 8552 insertions(+)
+ 55 files changed, 8785 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -72,6 +73,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/ec.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/ecdh.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/evp.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/goopenssl.c
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/goopenssl.h
@@ -382,10 +384,10 @@ index 00000000000000..6461f241f863fc
 +type BigInt []uint
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cgo_go122.go b/src/vendor/github.com/golang-fips/openssl/v2/cgo_go122.go
 new file mode 100644
-index 00000000000000..17ad0afb5d5bf6
+index 00000000000000..ba6abde2b89c2e
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cgo_go122.go
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,19 @@
 +//go:build go1.22 && !cmd_go_bootstrap
 +
 +package openssl
@@ -397,8 +399,12 @@ index 00000000000000..17ad0afb5d5bf6
 +// functions that are known to allocate.
 +#cgo noescape go_openssl_EVP_PKEY_derive
 +#cgo nocallback go_openssl_EVP_PKEY_derive
-+#cgo noescape go_openssl_EVP_EncryptUpdate
-+#cgo nocallback go_openssl_EVP_EncryptUpdate
++#cgo noescape go_openssl_EVP_PKEY_get_raw_public_key
++#cgo nocallback go_openssl_EVP_PKEY_get_raw_public_key
++#cgo noescape go_openssl_EVP_PKEY_get_raw_private_key
++#cgo nocallback go_openssl_EVP_PKEY_get_raw_private_key
++#cgo noescape go_openssl_EVP_DigestSign
++#cgo nocallback go_openssl_EVP_DigestSign
 +*/
 +import "C"
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cipher.go b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
@@ -1677,9 +1683,231 @@ index 00000000000000..46b16abf483e65
 +	defer C.go_openssl_OSSL_PARAM_free(params)
 +	return newEvpFromParams(C.GO_EVP_PKEY_EC, selection, params)
 +}
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go b/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
+new file mode 100644
+index 00000000000000..81961da8e943bc
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
+@@ -0,0 +1,216 @@
++//go:build !cmd_go_bootstrap
++
++package openssl
++
++// #include "goopenssl.h"
++import "C"
++import (
++	"errors"
++	"runtime"
++	"strconv"
++	"sync"
++	"unsafe"
++)
++
++const (
++	// publicKeySizeEd25519 is the size, in bytes, of public keys as used in crypto/ed25519.
++	publicKeySizeEd25519 = 32
++	// privateKeySizeEd25519 is the size, in bytes, of private keys as used in crypto/ed25519.
++	privateKeySizeEd25519 = 64
++	// signatureSizeEd25519 is the size, in bytes, of signatures generated and verified by crypto/ed25519.
++	signatureSizeEd25519 = 64
++	// seedSizeEd25519 is the size, in bytes, of private key seeds. These are the private key representations used by RFC 8032.
++	seedSizeEd25519 = 32
++)
++
++// TODO: Add support for Ed25519ph and Ed25519ctx when OpenSSL supports them,
++// which will probably be in 3.2.0 (https://github.com/openssl/openssl/issues/20418).
++
++var (
++	onceSupportsEd25519 sync.Once
++	supportsEd25519     bool
++)
++
++// SupportsEd25519 returns true if the current OpenSSL version supports
++// GenerateKeyEd25519, NewKeyFromSeedEd25519, SignEd25519 and VerifyEd25519.
++func SupportsEd25519() bool {
++	onceSupportsEd25519.Do(func() {
++		switch vMajor {
++		case 1:
++			supportsEd25519 = version1_1_1_or_above()
++		case 3:
++			name := C.CString("ED25519")
++			defer C.free(unsafe.Pointer(name))
++			sig := C.go_openssl_EVP_SIGNATURE_fetch(nil, name, nil)
++			if sig != nil {
++				C.go_openssl_EVP_SIGNATURE_free(sig)
++				supportsEd25519 = true
++			}
++		}
++	})
++	return supportsEd25519
++}
++
++type PublicKeyEd25519 struct {
++	_pkey C.GO_EVP_PKEY_PTR
++}
++
++func (k *PublicKeyEd25519) finalize() {
++	C.go_openssl_EVP_PKEY_free(k._pkey)
++}
++
++func (k *PublicKeyEd25519) Bytes() ([]byte, error) {
++	defer runtime.KeepAlive(k)
++	pub := make([]byte, publicKeySizeEd25519)
++	if err := extractPKEYPubEd25519(k._pkey, pub); err != nil {
++		return nil, err
++	}
++	return pub, nil
++}
++
++type PrivateKeyEd25519 struct {
++	_pkey C.GO_EVP_PKEY_PTR
++}
++
++func (k *PrivateKeyEd25519) finalize() {
++	C.go_openssl_EVP_PKEY_free(k._pkey)
++}
++
++func (k *PrivateKeyEd25519) Bytes() ([]byte, error) {
++	defer runtime.KeepAlive(k)
++	priv := make([]byte, privateKeySizeEd25519)
++	if err := extractPKEYPrivEd25519(k._pkey, priv); err != nil {
++		return nil, err
++	}
++	return priv, nil
++}
++
++// GenerateKeyEd25519 generates a public/private key pair.
++func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
++	pkeyPriv, err := generateEVPPKey(C.GO_EVP_PKEY_ED25519, 0, "")
++	if err != nil {
++		return nil, nil, err
++	}
++	pub := make([]byte, publicKeySizeEd25519)
++	if err := extractPKEYPubEd25519(pkeyPriv, pub); err != nil {
++		C.go_openssl_EVP_PKEY_free(pkeyPriv)
++		return nil, nil, err
++	}
++	pubk, err := NewPublicKeyEd25119(pub)
++	if err != nil {
++		C.go_openssl_EVP_PKEY_free(pkeyPriv)
++		return nil, nil, err
++	}
++	privk := &PrivateKeyEd25519{_pkey: pkeyPriv}
++	runtime.SetFinalizer(privk, (*PrivateKeyEd25519).finalize)
++	return pubk, privk, nil
++}
++
++func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
++	if len(priv) != privateKeySizeEd25519 {
++		panic("ed25519: bad private key length: " + strconv.Itoa(len(priv)))
++	}
++	return NewPrivateKeyEd25519FromSeed(priv[:seedSizeEd25519])
++}
++
++func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
++	if len(pub) != publicKeySizeEd25519 {
++		panic("ed25519: bad public key length: " + strconv.Itoa(len(pub)))
++	}
++	pkey := C.go_openssl_EVP_PKEY_new_raw_public_key(C.GO_EVP_PKEY_ED25519, nil, base(pub), C.size_t(len(pub)))
++	if pkey == nil {
++		return nil, newOpenSSLError("EVP_PKEY_new_raw_public_key")
++	}
++	pubk := &PublicKeyEd25519{_pkey: pkey}
++	runtime.SetFinalizer(pubk, (*PublicKeyEd25519).finalize)
++	return pubk, nil
++}
++
++// NewPrivateKeyEd25519FromSeed calculates a private key from a seed. It will panic if
++// len(seed) is not [SeedSize]. RFC 8032's private keys correspond to seeds in this
++// package.
++func NewPrivateKeyEd25519FromSeed(seed []byte) (*PrivateKeyEd25519, error) {
++	if len(seed) != seedSizeEd25519 {
++		panic("ed25519: bad seed length: " + strconv.Itoa(len(seed)))
++	}
++	pkey := C.go_openssl_EVP_PKEY_new_raw_private_key(C.GO_EVP_PKEY_ED25519, nil, base(seed), C.size_t(len(seed)))
++	if pkey == nil {
++		return nil, newOpenSSLError("EVP_PKEY_new_raw_private_key")
++	}
++	priv := &PrivateKeyEd25519{_pkey: pkey}
++	runtime.SetFinalizer(priv, (*PrivateKeyEd25519).finalize)
++	return priv, nil
++}
++
++func extractPKEYPubEd25519(pkey C.GO_EVP_PKEY_PTR, pub []byte) error {
++	pubSize := C.size_t(publicKeySizeEd25519)
++	if C.go_openssl_EVP_PKEY_get_raw_public_key(pkey, base(pub), &pubSize) != 1 {
++		return newOpenSSLError("EVP_PKEY_get_raw_public_key")
++	}
++	if pubSize != publicKeySizeEd25519 {
++		return errors.New("ed25519: bad public key length: " + strconv.Itoa(int(pubSize)))
++	}
++	return nil
++}
++
++func extractPKEYPrivEd25519(pkey C.GO_EVP_PKEY_PTR, priv []byte) error {
++	if err := extractPKEYPubEd25519(pkey, priv[seedSizeEd25519:]); err != nil {
++		return err
++	}
++	privSize := C.size_t(seedSizeEd25519)
++	if C.go_openssl_EVP_PKEY_get_raw_private_key(pkey, base(priv), &privSize) != 1 {
++		return newOpenSSLError("EVP_PKEY_get_raw_private_key")
++	}
++	if privSize != seedSizeEd25519 {
++		return errors.New("ed25519: bad private key length: " + strconv.Itoa(int(privSize)))
++	}
++	return nil
++}
++
++// SignEd25519 signs the message with priv and returns a signature.
++func SignEd25519(priv *PrivateKeyEd25519, message []byte) (sig []byte, err error) {
++	// Outline the function body so that the returned key can be stack-allocated.
++	sig = make([]byte, signatureSizeEd25519)
++	err = signEd25519(priv, sig, message)
++	if err != nil {
++		return nil, err
++	}
++	return sig, err
++}
++
++func signEd25519(priv *PrivateKeyEd25519, sig, message []byte) error {
++	defer runtime.KeepAlive(priv)
++	ctx := C.go_openssl_EVP_MD_CTX_new()
++	if ctx == nil {
++		return newOpenSSLError("EVP_MD_CTX_new")
++	}
++	defer C.go_openssl_EVP_MD_CTX_free(ctx)
++	if C.go_openssl_EVP_DigestSignInit(ctx, nil, nil, nil, priv._pkey) != 1 {
++		return newOpenSSLError("EVP_DigestSignInit")
++	}
++	siglen := C.size_t(signatureSizeEd25519)
++	if C.go_openssl_EVP_DigestSign(ctx, base(sig), &siglen, base(message), C.size_t(len(message))) != 1 {
++		return newOpenSSLError("EVP_DigestSign")
++	}
++	if siglen != signatureSizeEd25519 {
++		return errors.New("ed25519: bad signature length: " + strconv.Itoa(int(siglen)))
++	}
++	return nil
++}
++
++// VerifyEd25519 reports whether sig is a valid signature of message by pub.
++func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
++	defer runtime.KeepAlive(pub)
++	ctx := C.go_openssl_EVP_MD_CTX_new()
++	if ctx == nil {
++		return newOpenSSLError("EVP_MD_CTX_new")
++	}
++	defer C.go_openssl_EVP_MD_CTX_free(ctx)
++	if C.go_openssl_EVP_DigestVerifyInit(ctx, nil, nil, nil, pub._pkey) != 1 {
++		return newOpenSSLError("EVP_DigestVerifyInit")
++	}
++	if C.go_openssl_EVP_DigestVerify(ctx, base(sig), C.size_t(len(sig)), base(message), C.size_t(len(message))) != 1 {
++		return errors.New("ed25519: invalid signature")
++	}
++	return nil
++}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/evp.go b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 new file mode 100644
-index 00000000000000..c7f53e3e553a3d
+index 00000000000000..3775fa42a41559
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 @@ -0,0 +1,473 @@
@@ -1791,7 +2019,7 @@ index 00000000000000..c7f53e3e553a3d
 +}
 +
 +func generateEVPPKey(id C.int, bits int, curve string) (C.GO_EVP_PKEY_PTR, error) {
-+	if (bits == 0 && curve == "") || (bits != 0 && curve != "") {
++	if bits != 0 && curve != "" {
 +		return nil, fail("incorrect generateEVPPKey parameters")
 +	}
 +	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(id, nil)
@@ -4553,10 +4781,10 @@ index 00000000000000..9fd709635c3b40
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rc4.go b/src/vendor/github.com/golang-fips/openssl/v2/rc4.go
 new file mode 100644
-index 00000000000000..db28b61f3d1bea
+index 00000000000000..94a96b2091635c
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/rc4.go
-@@ -0,0 +1,63 @@
+@@ -0,0 +1,66 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -4611,6 +4839,9 @@ index 00000000000000..db28b61f3d1bea
 +	if inexactOverlap(dst[:len(src)], src) {
 +		panic("crypto/rc4: invalid buffer overlap")
 +	}
++	// panic if len(dst) < len(src) with a runtime out of bound error,
++	// which is what crypto/rc4 does.
++	_ = dst[len(src)-1]
 +	var outLen C.int
 +	if C.go_openssl_EVP_EncryptUpdate(c.ctx, base(dst), &outLen, base(src), C.int(len(src))) != 1 {
 +		panic("crypto/cipher: EncryptUpdate failed")
@@ -5047,10 +5278,10 @@ index 00000000000000..5aef65b84f6781
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/shims.h b/src/vendor/github.com/golang-fips/openssl/v2/shims.h
 new file mode 100644
-index 00000000000000..071bf706b93b93
+index 00000000000000..4457a3e491c806
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/shims.h
-@@ -0,0 +1,360 @@
+@@ -0,0 +1,370 @@
 +#include <stdlib.h> // size_t
 +#include <stdint.h> // uint64_t
 +
@@ -5071,6 +5302,7 @@ index 00000000000000..071bf706b93b93
 +    GO_EVP_PKEY_EC = 408,
 +    GO_EVP_PKEY_TLS1_PRF = 1021,
 +    GO_EVP_PKEY_HKDF = 1036,
++    GO_EVP_PKEY_ED25519 = 1087,
 +    /* This is defined differently in OpenSSL 3 (1 << 11), but in our
 +     * code it is only used in OpenSSL 1.
 +    */
@@ -5153,6 +5385,7 @@ index 00000000000000..071bf706b93b93
 +typedef void* GO_OSSL_PARAM_BLD_PTR;
 +typedef void* GO_OSSL_PARAM_PTR;
 +typedef void* GO_CRYPTO_THREADID_PTR;
++typedef void* GO_EVP_SIGNATURE_PTR;
 +
 +// #include <openssl/md5.h>
 +typedef void* GO_MD5_CTX_PTR;
@@ -5252,10 +5485,12 @@ index 00000000000000..071bf706b93b93
 +DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \
 +DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
 +DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
++DEFINEFUNC_1_1_1(int, EVP_DigestSign, (GO_EVP_MD_CTX_PTR ctx, unsigned char *sigret, size_t *siglen, const unsigned char *tbs, size_t tbslen), (ctx, sigret, siglen, tbs, tbslen)) \
 +DEFINEFUNC(int, EVP_DigestSignInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
 +DEFINEFUNC(int, EVP_DigestSignFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen), (ctx, sig, siglen)) \
 +DEFINEFUNC(int, EVP_DigestVerifyInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
 +DEFINEFUNC(int, EVP_DigestVerifyFinal, (GO_EVP_MD_CTX_PTR ctx, const unsigned char *sig, size_t siglen), (ctx, sig, siglen)) \
++DEFINEFUNC_1_1_1(int, EVP_DigestVerify, (GO_EVP_MD_CTX_PTR ctx, const unsigned char *sigret, size_t siglen, const unsigned char *tbs, size_t tbslen), (ctx, sigret, siglen, tbs, tbslen)) \
 +DEFINEFUNC_LEGACY_1_0(int, MD5_Init, (GO_MD5_CTX_PTR c), (c)) \
 +DEFINEFUNC_LEGACY_1_0(int, MD5_Update, (GO_MD5_CTX_PTR c, const void *data, size_t len), (c, data, len)) \
 +DEFINEFUNC_LEGACY_1_0(int, MD5_Final, (unsigned char *md, GO_MD5_CTX_PTR c), (md, c)) \
@@ -5316,6 +5551,8 @@ index 00000000000000..071bf706b93b93
 +DEFINEFUNC(void, EVP_CIPHER_CTX_free, (GO_EVP_CIPHER_CTX_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EVP_CIPHER_CTX_ctrl, (GO_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr), (ctx, type, arg, ptr)) \
 +DEFINEFUNC(GO_EVP_PKEY_PTR, EVP_PKEY_new, (void), ()) \
++DEFINEFUNC_1_1_1(GO_EVP_PKEY_PTR, EVP_PKEY_new_raw_private_key, (int type, GO_ENGINE_PTR e, const unsigned char *key, size_t keylen), (type, e, key, keylen)) \
++DEFINEFUNC_1_1_1(GO_EVP_PKEY_PTR, EVP_PKEY_new_raw_public_key, (int type, GO_ENGINE_PTR e, const unsigned char *key, size_t keylen), (type, e, key, keylen)) \
 +/* EVP_PKEY_size and EVP_PKEY_get_bits pkey parameter is const since OpenSSL 1.1.1. */ \
 +/* Exclude it from headercheck tool when using previous OpenSSL versions. */ \
 +/*check:from=1.1.1*/ DEFINEFUNC_RENAMED_3_0(int, EVP_PKEY_get_size, EVP_PKEY_size, (const GO_EVP_PKEY_PTR pkey), (pkey)) \
@@ -5410,6 +5647,10 @@ index 00000000000000..071bf706b93b93
 +DEFINEFUNC_3_0(int, EVP_PKEY_CTX_set_tls1_prf_md, (GO_EVP_PKEY_CTX_PTR arg0, const GO_EVP_MD_PTR arg1), (arg0, arg1)) \
 +DEFINEFUNC_3_0(int, EVP_PKEY_CTX_set1_tls1_prf_secret, (GO_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2), (arg0, arg1, arg2)) \
 +DEFINEFUNC_3_0(int, EVP_PKEY_CTX_add1_tls1_prf_seed, (GO_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2), (arg0, arg1, arg2)) \
++DEFINEFUNC_1_1_1(int, EVP_PKEY_get_raw_public_key, (const GO_EVP_PKEY_PTR pkey, unsigned char *pub, size_t *len), (pkey, pub, len)) \
++DEFINEFUNC_1_1_1(int, EVP_PKEY_get_raw_private_key, (const GO_EVP_PKEY_PTR pkey, unsigned char *priv, size_t *len), (pkey, priv, len)) \
++DEFINEFUNC_3_0(GO_EVP_SIGNATURE_PTR, EVP_SIGNATURE_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
++DEFINEFUNC_3_0(void, EVP_SIGNATURE_free, (GO_EVP_SIGNATURE_PTR signature), (signature)) \
 +
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/thread_setup_unix.c b/src/vendor/github.com/golang-fips/openssl/v2/thread_setup_unix.c
 new file mode 100644
@@ -8976,11 +9217,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index bc4eb872eb8495..79c81153f285e5 100644
+index bc4eb872eb8495..fcb646c35d9286 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae
++# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -11,8 +11,8 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../github.com/golang-fips/openssl/v2/aes.go  |  90 ++
  .../golang-fips/openssl/v2/bbig/big.go        |  37 +
  .../github.com/golang-fips/openssl/v2/big.go  |  11 +
- .../golang-fips/openssl/v2/cgo_go122.go       |  13 +
- .../golang-fips/openssl/v2/cipher.go          | 511 +++++++++++
+ .../golang-fips/openssl/v2/cgo_go122.go       |  15 +
+ .../golang-fips/openssl/v2/cipher.go          | 534 ++++++++++++
  .../github.com/golang-fips/openssl/v2/des.go  | 113 +++
  .../github.com/golang-fips/openssl/v2/ec.go   |  59 ++
  .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
@@ -30,8 +30,9 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../golang-fips/openssl/v2/pbkdf2.go          |  28 +
  .../openssl/v2/port_evp_md5_sha1.c            | 126 +++
  .../github.com/golang-fips/openssl/v2/rand.go |  20 +
+ .../github.com/golang-fips/openssl/v2/rc4.go  |  63 ++
  .../github.com/golang-fips/openssl/v2/rsa.go  | 419 +++++++++
- .../github.com/golang-fips/openssl/v2/shims.h | 358 ++++++++
+ .../github.com/golang-fips/openssl/v2/shims.h | 360 ++++++++
  .../openssl/v2/thread_setup_unix.c            |  35 +
  .../openssl/v2/thread_setup_windows.c         |  33 +
  .../golang-fips/openssl/v2/tls1prf.go         | 104 +++
@@ -44,20 +45,21 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../microsoft/go-crypto-winnative/cng/des.go  | 107 +++
  .../microsoft/go-crypto-winnative/cng/ecdh.go | 260 ++++++
  .../go-crypto-winnative/cng/ecdsa.go          | 175 ++++
- .../microsoft/go-crypto-winnative/cng/hash.go | 298 +++++++
- .../microsoft/go-crypto-winnative/cng/hkdf.go | 150 ++++
- .../microsoft/go-crypto-winnative/cng/hmac.go |  55 ++
+ .../microsoft/go-crypto-winnative/cng/hash.go | 320 +++++++
+ .../microsoft/go-crypto-winnative/cng/hkdf.go | 179 ++++
+ .../microsoft/go-crypto-winnative/cng/hmac.go |  35 +
  .../microsoft/go-crypto-winnative/cng/keys.go | 178 ++++
  .../go-crypto-winnative/cng/pbkdf2.go         |  74 ++
  .../microsoft/go-crypto-winnative/cng/rand.go |  28 +
+ .../microsoft/go-crypto-winnative/cng/rc4.go  |  61 ++
  .../microsoft/go-crypto-winnative/cng/rsa.go  | 374 +++++++++
  .../go-crypto-winnative/cng/tls1prf.go        |  92 ++
- .../internal/bcrypt/bcrypt_windows.go         | 283 +++++++
+ .../internal/bcrypt/bcrypt_windows.go         | 284 +++++++
  .../internal/bcrypt/zsyscall_windows.go       | 389 +++++++++
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 52 files changed, 8369 insertions(+)
+ 54 files changed, 8552 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -83,6 +85,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/pbkdf2.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/port_evp_md5_sha1.c
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/rand.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/rc4.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/rsa.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/shims.h
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/thread_setup_unix.c
@@ -103,6 +106,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/rand.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/rc4.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
@@ -378,10 +382,10 @@ index 00000000000000..6461f241f863fc
 +type BigInt []uint
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cgo_go122.go b/src/vendor/github.com/golang-fips/openssl/v2/cgo_go122.go
 new file mode 100644
-index 00000000000000..555f58c59979a8
+index 00000000000000..17ad0afb5d5bf6
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cgo_go122.go
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,15 @@
 +//go:build go1.22 && !cmd_go_bootstrap
 +
 +package openssl
@@ -393,14 +397,16 @@ index 00000000000000..555f58c59979a8
 +// functions that are known to allocate.
 +#cgo noescape go_openssl_EVP_PKEY_derive
 +#cgo nocallback go_openssl_EVP_PKEY_derive
++#cgo noescape go_openssl_EVP_EncryptUpdate
++#cgo nocallback go_openssl_EVP_EncryptUpdate
 +*/
 +import "C"
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cipher.go b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
 new file mode 100644
-index 00000000000000..c88286905ee4d8
+index 00000000000000..aadba3e77aab70
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
-@@ -0,0 +1,511 @@
+@@ -0,0 +1,534 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -425,6 +431,7 @@ index 00000000000000..c88286905ee4d8
 +	cipherAES256
 +	cipherDES
 +	cipherDES3
++	cipherRC4
 +)
 +
 +func (c cipherKind) String() string {
@@ -439,6 +446,8 @@ index 00000000000000..c88286905ee4d8
 +		return "DES"
 +	case cipherDES3:
 +		return "DES3"
++	case cipherRC4:
++		return "RC4"
 +	default:
 +		panic("unknown cipher kind: " + strconv.Itoa(int(c)))
 +	}
@@ -447,7 +456,8 @@ index 00000000000000..c88286905ee4d8
 +type cipherMode int8
 +
 +const (
-+	cipherModeECB cipherMode = iota
++	cipherModeNone cipherMode = -1
++	cipherModeECB  cipherMode = iota
 +	cipherModeCBC
 +	cipherModeCTR
 +	cipherModeGCM
@@ -536,6 +546,8 @@ index 00000000000000..c88286905ee4d8
 +		case cipherModeCBC:
 +			cipher = C.go_openssl_EVP_des_ede3_cbc()
 +		}
++	case cipherRC4:
++		cipher = C.go_openssl_EVP_rc4()
 +	}
 +	return cipher
 +}
@@ -882,17 +894,34 @@ index 00000000000000..c88286905ee4d8
 +	return
 +}
 +
-+func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []byte) (C.GO_EVP_CIPHER_CTX_PTR, error) {
++func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []byte) (ctx C.GO_EVP_CIPHER_CTX_PTR, err error) {
 +	cipher := loadCipher(kind, mode)
 +	if cipher == nil {
 +		panic("crypto/cipher: unsupported cipher: " + kind.String())
 +	}
-+	ctx := C.go_openssl_EVP_CIPHER_CTX_new()
++	ctx = C.go_openssl_EVP_CIPHER_CTX_new()
 +	if ctx == nil {
 +		return nil, fail("unable to create EVP cipher ctx")
 +	}
++	defer func() {
++		if err != nil {
++			C.go_openssl_EVP_CIPHER_CTX_free(ctx)
++		}
++	}()
++	if kind == cipherRC4 {
++		// RC4 cipher supports a variable key length.
++		// We need to set the key length before setting the key,
++		// and to do so we need to have an initialized cipher ctx.
++		if C.go_openssl_EVP_CipherInit_ex(ctx, cipher, nil, nil, nil, C.int(encrypt)) != 1 {
++			return nil, newOpenSSLError("EVP_CipherInit_ex")
++		}
++		if C.go_openssl_EVP_CIPHER_CTX_set_key_length(ctx, C.int(len(key))) != 1 {
++			return nil, newOpenSSLError("EVP_CIPHER_CTX_set_key_length")
++		}
++		// Pass nil to the next call to EVP_CipherInit_ex to avoid resetting ctx's cipher.
++		cipher = nil
++	}
 +	if C.go_openssl_EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), C.int(encrypt)) != 1 {
-+		C.go_openssl_EVP_CIPHER_CTX_free(ctx)
 +		return nil, fail("unable to initialize EVP cipher ctx")
 +	}
 +	return ctx, nil
@@ -4522,6 +4551,75 @@ index 00000000000000..9fd709635c3b40
 +}
 +
 +const RandReader = randReader(0)
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rc4.go b/src/vendor/github.com/golang-fips/openssl/v2/rc4.go
+new file mode 100644
+index 00000000000000..db28b61f3d1bea
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/rc4.go
+@@ -0,0 +1,63 @@
++//go:build !cmd_go_bootstrap
++
++package openssl
++
++// #include "goopenssl.h"
++import "C"
++import "runtime"
++
++// SupportsRC4 returns true if NewRC4Cipher is supported.
++func SupportsRC4() bool {
++	// True for stock OpenSSL 1.
++	// False for stock OpenSSL 3 unless the legacy provider is available.
++	return loadCipher(cipherRC4, cipherModeNone) != nil
++}
++
++// A RC4Cipher is an instance of RC4 using a particular key.
++type RC4Cipher struct {
++	ctx C.GO_EVP_CIPHER_CTX_PTR
++}
++
++// NewRC4Cipher creates and returns a new Cipher.
++func NewRC4Cipher(key []byte) (*RC4Cipher, error) {
++	ctx, err := newCipherCtx(cipherRC4, cipherModeNone, cipherOpEncrypt, key, nil)
++	if err != nil {
++		return nil, err
++	}
++	c := &RC4Cipher{ctx}
++	runtime.SetFinalizer(c, (*RC4Cipher).finalize)
++	return c, nil
++}
++
++func (c *RC4Cipher) finalize() {
++	if c.ctx != nil {
++		C.go_openssl_EVP_CIPHER_CTX_free(c.ctx)
++	}
++}
++
++// Reset zeros the key data and makes the Cipher unusable.
++func (c *RC4Cipher) Reset() {
++	if c.ctx != nil {
++		C.go_openssl_EVP_CIPHER_CTX_free(c.ctx)
++		c.ctx = nil
++	}
++}
++
++// XORKeyStream sets dst to the result of XORing src with the key stream.
++// Dst and src must overlap entirely or not at all.
++func (c *RC4Cipher) XORKeyStream(dst, src []byte) {
++	if c.ctx == nil || len(src) == 0 {
++		return
++	}
++	if inexactOverlap(dst[:len(src)], src) {
++		panic("crypto/rc4: invalid buffer overlap")
++	}
++	var outLen C.int
++	if C.go_openssl_EVP_EncryptUpdate(c.ctx, base(dst), &outLen, base(src), C.int(len(src))) != 1 {
++		panic("crypto/cipher: EncryptUpdate failed")
++	}
++	if int(outLen) != len(src) {
++		panic("crypto/rc4: src not fully XORed")
++	}
++	runtime.KeepAlive(c)
++}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rsa.go b/src/vendor/github.com/golang-fips/openssl/v2/rsa.go
 new file mode 100644
 index 00000000000000..5aef65b84f6781
@@ -4949,10 +5047,10 @@ index 00000000000000..5aef65b84f6781
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/shims.h b/src/vendor/github.com/golang-fips/openssl/v2/shims.h
 new file mode 100644
-index 00000000000000..858c47e747026c
+index 00000000000000..071bf706b93b93
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/shims.h
-@@ -0,0 +1,358 @@
+@@ -0,0 +1,360 @@
 +#include <stdlib.h> // size_t
 +#include <stdint.h> // uint64_t
 +
@@ -5212,7 +5310,9 @@ index 00000000000000..858c47e747026c
 +DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_des_cbc, (void), ()) \
 +DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_des_ede3_ecb, (void), ()) \
 +DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_des_ede3_cbc, (void), ()) \
++DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_rc4, (void), ()) \
 +DEFINEFUNC_RENAMED_3_0(int, EVP_CIPHER_get_block_size, EVP_CIPHER_block_size, (const GO_EVP_CIPHER_PTR cipher), (cipher)) \
++DEFINEFUNC(int, EVP_CIPHER_CTX_set_key_length, (GO_EVP_CIPHER_CTX_PTR x, int keylen), (x, keylen)) \
 +DEFINEFUNC(void, EVP_CIPHER_CTX_free, (GO_EVP_CIPHER_CTX_PTR arg0), (arg0)) \
 +DEFINEFUNC(int, EVP_CIPHER_CTX_ctrl, (GO_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr), (ctx, type, arg, ptr)) \
 +DEFINEFUNC(GO_EVP_PKEY_PTR, EVP_PKEY_new, (void), ()) \
@@ -6698,10 +6798,10 @@ index 00000000000000..a77ff97bb8f521
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
 new file mode 100644
-index 00000000000000..d894c07822fa8c
+index 00000000000000..bebbc999337efb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
-@@ -0,0 +1,298 @@
+@@ -0,0 +1,320 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -6855,11 +6955,12 @@ index 00000000000000..d894c07822fa8c
 +
 +type hashAlgorithm struct {
 +	handle    bcrypt.ALG_HANDLE
++	id        string
 +	size      uint32
 +	blockSize uint32
 +}
 +
-+func loadHash(id string, flags bcrypt.AlgorithmProviderFlags) (hashAlgorithm, error) {
++func loadHash(id string, flags bcrypt.AlgorithmProviderFlags) (*hashAlgorithm, error) {
 +	v, err := loadOrStoreAlg(id, flags, "", func(h bcrypt.ALG_HANDLE) (interface{}, error) {
 +		size, err := getUint32(bcrypt.HANDLE(h), bcrypt.HASH_LENGTH)
 +		if err != nil {
@@ -6869,89 +6970,108 @@ index 00000000000000..d894c07822fa8c
 +		if err != nil {
 +			return nil, err
 +		}
-+		return hashAlgorithm{h, size, blockSize}, nil
++		return &hashAlgorithm{h, id, size, blockSize}, nil
 +	})
 +	if err != nil {
-+		return hashAlgorithm{}, err
++		return nil, err
 +	}
-+	return v.(hashAlgorithm), nil
++	return v.(*hashAlgorithm), nil
++}
++
++// hashToID converts a hash.Hash implementation from this package
++// to a CNG hash ID
++func hashToID(h hash.Hash) string {
++	hx, ok := h.(*hashX)
++	if !ok {
++		return ""
++	}
++	return hx.alg.id
 +}
 +
 +type hashX struct {
-+	h         bcrypt.ALG_HANDLE
-+	ctx       bcrypt.HASH_HANDLE
-+	size      int
-+	blockSize int
-+	buf       []byte
-+	key       []byte
++	alg  *hashAlgorithm
++	_ctx bcrypt.HASH_HANDLE // access it using withCtx
++
++	buf []byte
++	key []byte
 +}
 +
++// newHashX returns a new hash.Hash using the specified algorithm.
 +func newHashX(id string, flag bcrypt.AlgorithmProviderFlags, key []byte) *hashX {
-+	h, err := loadHash(id, flag)
++	alg, err := loadHash(id, flag)
 +	if err != nil {
 +		panic(err)
 +	}
-+	hx := new(hashX)
-+	hx.h = h.handle
-+	hx.size = int(h.size)
-+	hx.blockSize = int(h.blockSize)
-+	hx.buf = make([]byte, hx.size)
++	h := new(hashX)
++	h.alg = alg
 +	if len(key) > 0 {
-+		hx.key = make([]byte, len(key))
-+		copy(hx.key, key)
++		h.key = make([]byte, len(key))
++		copy(h.key, key)
 +	}
-+	hx.Reset()
-+	runtime.SetFinalizer(hx, (*hashX).finalize)
-+	return hx
++	// Don't allocate hx.buf nor call bcrypt.CreateHash yet,
++	// which would be wasteful if the caller only wants to know
++	// the hash type. This is a common pattern in this package,
++	// as some functions accept a `func() hash.Hash` parameter
++	// and call it just to know the hash type.
++	runtime.SetFinalizer(h, (*hashX).finalize)
++	return h
 +}
 +
 +func (h *hashX) finalize() {
-+	if h.ctx != 0 {
-+		bcrypt.DestroyHash(h.ctx)
++	if h._ctx != 0 {
++		bcrypt.DestroyHash(h._ctx)
 +	}
++}
++
++func (h *hashX) withCtx(fn func(ctx bcrypt.HASH_HANDLE) error) error {
++	defer runtime.KeepAlive(h)
++	if h._ctx == 0 {
++		err := bcrypt.CreateHash(h.alg.handle, &h._ctx, nil, h.key, 0)
++		if err != nil {
++			panic(err)
++		}
++	}
++	return fn(h._ctx)
 +}
 +
 +func (h *hashX) Clone() (hash.Hash, error) {
 +	h2 := &hashX{
-+		h:         h.h,
-+		size:      h.size,
-+		blockSize: h.blockSize,
-+		buf:       make([]byte, len(h.buf)),
-+		key:       make([]byte, len(h.key)),
++		alg: h.alg,
 +	}
-+	copy(h2.key, h.key)
-+	err := bcrypt.DuplicateHash(h.ctx, &h2.ctx, nil, 0)
++	if h.key != nil {
++		h2.key = make([]byte, len(h.key))
++		copy(h2.key, h.key)
++	}
++	err := h.withCtx(func(ctx bcrypt.HASH_HANDLE) error {
++		return bcrypt.DuplicateHash(ctx, &h2._ctx, nil, 0)
++	})
 +	if err != nil {
 +		return nil, err
 +	}
 +	runtime.SetFinalizer(h2, (*hashX).finalize)
-+	runtime.KeepAlive(h)
 +	return h2, nil
 +}
 +
 +func (h *hashX) Reset() {
-+	if h.ctx != 0 {
-+		bcrypt.DestroyHash(h.ctx)
-+		h.ctx = 0
++	if h._ctx != 0 {
++		bcrypt.DestroyHash(h._ctx)
++		h._ctx = 0
 +	}
-+	err := bcrypt.CreateHash(h.h, &h.ctx, nil, h.key, 0)
-+	if err != nil {
-+		panic(err)
-+	}
-+	runtime.KeepAlive(h)
 +}
 +
 +func (h *hashX) Write(p []byte) (n int, err error) {
-+	for n < len(p) && err == nil {
-+		nn := len32(p[n:])
-+		err = bcrypt.HashData(h.ctx, p[n:n+nn], 0)
-+		n += nn
-+	}
++	err = h.withCtx(func(ctx bcrypt.HASH_HANDLE) error {
++		for n < len(p) && err == nil {
++			nn := len32(p[n:])
++			err = bcrypt.HashData(h._ctx, p[n:n+nn], 0)
++			n += nn
++		}
++		return err
++	})
 +	if err != nil {
 +		// hash.Hash interface mandates Write should never return an error.
 +		panic(err)
 +	}
-+	runtime.KeepAlive(h)
 +	return len(p), nil
 +}
 +
@@ -6966,46 +7086,48 @@ index 00000000000000..d894c07822fa8c
 +}
 +
 +func (h *hashX) WriteByte(c byte) error {
-+	if err := bcrypt.HashDataRaw(h.ctx, &c, 1, 0); err != nil {
++	err := h.withCtx(func(ctx bcrypt.HASH_HANDLE) error {
++		return bcrypt.HashDataRaw(h._ctx, &c, 1, 0)
++	})
++	if err != nil {
 +		// hash.Hash interface mandates Write should never return an error.
 +		panic(err)
 +	}
-+	runtime.KeepAlive(h)
 +	return nil
 +}
 +
 +func (h *hashX) Size() int {
-+	return h.size
++	return int(h.alg.size)
 +}
 +
 +func (h *hashX) BlockSize() int {
-+	return h.blockSize
++	return int(h.alg.blockSize)
 +}
 +
 +func (h *hashX) Sum(in []byte) []byte {
-+	h.sum(h.buf)
-+	return append(in, h.buf...)
-+}
-+
-+func (h *hashX) sum(out []byte) {
 +	var ctx2 bcrypt.HASH_HANDLE
-+	err := bcrypt.DuplicateHash(h.ctx, &ctx2, nil, 0)
++	err := h.withCtx(func(ctx bcrypt.HASH_HANDLE) error {
++		return bcrypt.DuplicateHash(ctx, &ctx2, nil, 0)
++	})
 +	if err != nil {
 +		panic(err)
 +	}
 +	defer bcrypt.DestroyHash(ctx2)
-+	err = bcrypt.FinishHash(ctx2, out, 0)
++	if h.buf == nil {
++		h.buf = make([]byte, h.alg.size)
++	}
++	err = bcrypt.FinishHash(ctx2, h.buf, 0)
 +	if err != nil {
 +		panic(err)
 +	}
-+	runtime.KeepAlive(h)
++	return append(in, h.buf...)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
 new file mode 100644
-index 00000000000000..725fa5c1b45784
+index 00000000000000..6f164ced8a9656
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
-@@ -0,0 +1,150 @@
+@@ -0,0 +1,179 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -7045,45 +7167,74 @@ index 00000000000000..725fa5c1b45784
 +	info []byte
 +
 +	hashLen int
-+	buf     []byte
++	n       int // count of bytes requested from Read
++	// buf contains the derived data.
++	// len(buf) can be larger than n, as Read may derive
++	// more data than requested and cache it in buf.
++	buf []byte
 +}
 +
 +func (c *hkdf) finalize() {
 +	bcrypt.DestroyKey(c.hkey)
 +}
 +
-+func (c *hkdf) Read(p []byte) (int, error) {
++func hkdfDerive(hkey bcrypt.KEY_HANDLE, info, out []byte) (int, error) {
 +	var params *bcrypt.BufferDesc
-+	if len(c.info) > 0 {
++	if len(info) > 0 {
 +		params = &bcrypt.BufferDesc{
 +			Count: 1,
 +			Buffers: &bcrypt.Buffer{
-+				Length: uint32(len(c.info)),
++				Length: uint32(len(info)),
 +				Type:   bcrypt.KDF_HKDF_INFO,
-+				Data:   uintptr(unsafe.Pointer(&c.info[0])),
++				Data:   uintptr(unsafe.Pointer(&info[0])),
 +			},
 +		}
++		defer runtime.KeepAlive(params)
 +	}
++	var n uint32
++	err := bcrypt.KeyDerivation(hkey, params, out, &n, 0)
++	return int(n), err
++}
++
++func (c *hkdf) Read(p []byte) (int, error) {
 +	// KeyDerivation doesn't support incremental output, each call
 +	// derives the key from scratch and returns the requested bytes.
 +	// To implement io.Reader, we need to ask for len(c.buf) + len(p)
 +	// bytes and copy the last derived len(p) bytes to p.
-+	// We use c.buf to know how many bytes we've already derived and
-+	// to avoid allocating the whole output buffer on each call.
-+	prevLen := len(c.buf)
-+	needLen := len(p)
-+	remains := 255*c.hashLen - prevLen
-+	// Check whether enough data can be generated.
-+	if remains < needLen {
++	maxDerived := 255 * c.hashLen
++	totalDerived := c.n + len(p)
++	// Check whether enough data can be derived.
++	if totalDerived > maxDerived {
 +		return 0, errors.New("hkdf: entropy limit reached")
 +	}
-+	c.buf = append(c.buf, make([]byte, needLen)...)
-+	var size uint32
-+	if err := bcrypt.KeyDerivation(c.hkey, params, c.buf, &size, 0); err != nil {
-+		return 0, err
++	// Check whether c.buf already contains enough derived data,
++	// otherwise derive more data.
++	if bytesNeeded := totalDerived - len(c.buf); bytesNeeded > 0 {
++		// It is common to derive multiple equally sized keys from the same HKDF instance.
++		// Optimize this case by allocating a buffer large enough to hold
++		// at least 3 of such keys each time there is not enough data.
++		// Round up to the next multiple of hashLen.
++		blocks := (bytesNeeded-1)/c.hashLen + 1
++		const minBlocks = 3
++		if blocks < minBlocks {
++			blocks = minBlocks
++		}
++		alloc := blocks * c.hashLen
++		if len(c.buf)+alloc > maxDerived {
++			// The buffer can't grow beyond maxDerived.
++			alloc = maxDerived - len(c.buf)
++		}
++		c.buf = append(c.buf, make([]byte, alloc)...)
++		n, err := hkdfDerive(c.hkey, c.info, c.buf)
++		if err != nil {
++			c.buf = c.buf[:c.n]
++			return 0, err
++		}
++		// Adjust totalDerived to the actual number of bytes derived.
++		totalDerived = n
 +	}
-+	runtime.KeepAlive(params)
-+	n := copy(p, c.buf[prevLen:size])
++	n := copy(p, c.buf[c.n:totalDerived])
++	c.n += n
 +	return n, nil
 +}
 +
@@ -7116,7 +7267,7 @@ index 00000000000000..725fa5c1b45784
 +		bcrypt.DestroyKey(kh)
 +		return nil, err
 +	}
-+	k := &hkdf{kh, info, ch.Size(), nil}
++	k := &hkdf{kh, info, ch.Size(), 0, nil}
 +	runtime.SetFinalizer(k, (*hkdf).finalize)
 +	return k, nil
 +}
@@ -7158,10 +7309,10 @@ index 00000000000000..725fa5c1b45784
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
 new file mode 100644
-index 00000000000000..76a80ce8c3bc56
+index 00000000000000..2d9fd36ce7252e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,35 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -7175,26 +7326,6 @@ index 00000000000000..76a80ce8c3bc56
 +
 +	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
 +)
-+
-+// hashToID converts a hash.Hash implementation from this package
-+// to a CNG hash ID
-+func hashToID(h hash.Hash) string {
-+	if _, ok := h.(*hashX); !ok {
-+		return ""
-+	}
-+	var id string
-+	switch h.Size() {
-+	case 20:
-+		id = bcrypt.SHA1_ALGORITHM
-+	case 256 / 8:
-+		id = bcrypt.SHA256_ALGORITHM
-+	case 384 / 8:
-+		id = bcrypt.SHA384_ALGORITHM
-+	case 512 / 8:
-+		id = bcrypt.SHA512_ALGORITHM
-+	}
-+	return id
-+}
 +
 +// NewHMAC returns a new HMAC using BCrypt.
 +// The function h must return a hash implemented by
@@ -7515,6 +7646,73 @@ index 00000000000000..cdd845ab5bea98
 +}
 +
 +const RandReader = randReader(0)
+diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rc4.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rc4.go
+new file mode 100644
+index 00000000000000..e0d45070f26723
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rc4.go
+@@ -0,0 +1,61 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build windows
++// +build windows
++
++package cng
++
++import (
++	"runtime"
++
++	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
++	"github.com/microsoft/go-crypto-winnative/internal/subtle"
++)
++
++// A RC4Cipher is an instance of RC4 using a particular key.
++type RC4Cipher struct {
++	kh bcrypt.KEY_HANDLE
++}
++
++// NewRC4Cipher creates and returns a new Cipher.
++func NewRC4Cipher(key []byte) (*RC4Cipher, error) {
++	kh, err := newCipherHandle(bcrypt.RC4_ALGORITHM, "", key)
++	if err != nil {
++		return nil, err
++	}
++	c := &RC4Cipher{kh: kh}
++	runtime.SetFinalizer(c, (*RC4Cipher).finalize)
++	return c, nil
++}
++
++func (c *RC4Cipher) finalize() {
++	if c.kh != 0 {
++		bcrypt.DestroyKey(c.kh)
++	}
++}
++
++// Reset zeros the key data and makes the Cipher unusable.
++func (c *RC4Cipher) Reset() {
++	bcrypt.DestroyKey(c.kh)
++	c.kh = 0
++}
++
++// XORKeyStream sets dst to the result of XORing src with the key stream.
++// Dst and src must overlap entirely or not at all.
++func (c *RC4Cipher) XORKeyStream(dst, src []byte) {
++	if c.kh == 0 || len(src) == 0 {
++		return
++	}
++	if subtle.InexactOverlap(dst[:len(src)], src) {
++		panic("crypto/rc4: invalid buffer overlap")
++	}
++	var outLen uint32
++	if err := bcrypt.Encrypt(c.kh, src, nil, nil, dst, &outLen, 0); err != nil {
++		panic("crypto/rc4: encryption failed: " + err.Error())
++	}
++	if int(outLen) != len(src) {
++		panic("crypto/rc4: src not fully XORed")
++	}
++	runtime.KeepAlive(c)
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
 new file mode 100644
 index 00000000000000..7e3f7abe3487cb
@@ -7995,10 +8193,10 @@ index 00000000000000..30ef2242bc3cf3
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000000..829ec6611c1d86
+index 00000000000000..37c64ba6a7fa96
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
-@@ -0,0 +1,283 @@
+@@ -0,0 +1,284 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -8020,6 +8218,7 @@ index 00000000000000..829ec6611c1d86
 +	SHA3_384_ALGORITHM   = "SHA3-384"
 +	SHA3_512_ALGORITHM   = "SHA3-512"
 +	AES_ALGORITHM        = "AES"
++	RC4_ALGORITHM        = "RC4"
 +	RSA_ALGORITHM        = "RSA"
 +	MD4_ALGORITHM        = "MD4"
 +	MD5_ALGORITHM        = "MD5"
@@ -8777,15 +8976,15 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index bc4eb872eb8495..1cafbc7fb60d2e 100644
+index bc4eb872eb8495..79c81153f285e5 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20230926133027-251d5fd9efa6
++# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231012073833-78dacc36e1ae
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20230927101859-4de4807139a7
++# github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
This PR patches [crypto/rc4](https://pkg.go.dev/crypto/rc4) so it is implemented using the OpenSSL and CNG backends.