### PR TITLE
Implement support for crypto/ed25519 using the OpenSSL backend

### DIFF
--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -703,6 +703,10 @@ func Verify(publicKey ed25519.PublicKey, message, sig []byte) bool
 
 Verify reports whether sig is a valid signature of message by publicKey. It will panic if len(publicKey) is not PublicKeySize.
 
+**Requirements**
+
+- Falls back to standard Go code when using OpenSSL 1.1.1a or lower.
+
 **Implementation**
 
 <details><summary>OpenSSL (click for details)</summary>

--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -675,7 +675,7 @@ GenerateKey generates a public/private key pair using entropy from rand. If rand
 
 <details><summary>OpenSSL (click for details)</summary>
 
-`pub` and `priv` are generated using using [EVP_PKEY_keygen] using the `EVP_PKEY_ED25519` algorithm.
+`pub` and `priv` are generated using [EVP_PKEY_keygen] with the `EVP_PKEY_ED25519` algorithm.
 
 </details>
 
@@ -705,13 +705,14 @@ Verify reports whether sig is a valid signature of message by publicKey. It will
 
 **Requirements**
 
-- Falls back to standard Go code when using OpenSSL 1.1.1a or lower.
+- OpenSSL version must be 1.1.1b or higher. Otherwise, falls back to standard Go crypto.
 
 **Implementation**
 
 <details><summary>OpenSSL (click for details)</summary>
 
-`message` is verified against `sig` using [EVP_MD_CTX_new], [DigestVerifyInit] and [EVP_DigestVerify].
+`message` is verified against `sig` using [EVP_MD_CTX_new], [EVP_DigestVerifyInit] and [EVP_DigestVerify].
+
 
 </details>
 
@@ -731,7 +732,8 @@ VerifyWithOptions reports whether sig is a valid signature of message by publicK
 
 <details><summary>OpenSSL (click for details)</summary>
 
-`message` is verified against `sig` using [EVP_MD_CTX_new], [DigestVerifyInit] and [EVP_DigestVerify].
+`message` is verified against `sig` using [EVP_MD_CTX_new], [EVP_DigestVerifyInit] and [EVP_DigestVerify].
+
 
 </details>
 
@@ -747,7 +749,8 @@ NewKeyFromSeed calculates a private key from a seed. It will panic if len(seed) 
 
 <details><summary>OpenSSL (click for details)</summary>
 
-`priv` is generated using using [EVP_PKEY_new_raw_private_key] using the `EVP_PKEY_ED25519` algorithm.
+`priv` is generated using [EVP_PKEY_new_raw_private_key] with the `EVP_PKEY_ED25519` algorithm.
+
 
 </details>
 
@@ -1581,6 +1584,7 @@ When using TLS in FIPS-only mode the TLS handshake has the following restriction
 [EVP_DigestSign]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestSign.html
 [EVP_DigestVerify]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestVerify.html
 [EVP_DigestSign]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestSign.html
+[EVP_DigestSignInit]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestSignInit.html
 [EVP_DigestVerifyInit]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestVerifyInit.html
 [EVP_EncryptFinal_ex]: https://www.openssl.org/docs/man3.0/man3/EVP_EncryptFinal_ex.html
 [EVP_DecryptFinal_ex]: https://www.openssl.org/docs/man3.0/man3/EVP_DecryptFinal_ex.html

--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -652,7 +652,120 @@ The message is signed using [BCryptSignHash].
 
 ### [crypto/ed25519](https://pkg.go.dev/crypto/ed25519)
 
-Not implemented by any backend.
+Package ed25519 implements the Ed25519 signature algorithm. See https://ed25519.cr.yp.to/.
+
+**Requirements**
+
+The CNG backend and some old OpenSSL distributions don't support ED25519.
+In those cases, the code will fall back to standard Go crypto.
+
+#### func [GenerateKey](https://pkg.go.dev/crypto/ed25519#GenerateKey)
+
+```go
+func GenerateKey(rand io.Reader) (pub ed25519.PublicKey, priv ed25519.PrivateKey, error)
+```
+
+GenerateKey generates a public/private key pair using entropy from rand. If rand is nil, crypto/rand.Reader will be used.
+
+**Requirements**
+
+- `rand` must be boring.RandReader or nil, else GenerateKey will panic. `crypto/rand.Reader` normally meets this invariant as it is assigned to boring.RandReader in the crypto/rand init function.
+
+**Implementation**
+
+<details><summary>OpenSSL (click for details)</summary>
+
+`pub` and `priv` are generated using using [EVP_PKEY_keygen] using the `EVP_PKEY_ED25519` algorithm.
+
+</details>
+
+#### func [Sign](https://pkg.go.dev/crypto/ed25519#Sign)
+
+```go
+func Sign(privateKey ed25519.PrivateKey, message []byte) []byte
+```
+
+Sign signs the message with privateKey and returns a signature. It will panic if len(privateKey) is not PrivateKeySize.
+
+**Implementation**
+
+<details><summary>OpenSSL (click for details)</summary>
+
+`message` is signed using [EVP_MD_CTX_new], [EVP_DigestSignInit] and [EVP_DigestSign].
+
+</details>
+
+#### func [Verify](https://pkg.go.dev/crypto/ed25519#Verify)
+
+```go
+func Verify(publicKey ed25519.PublicKey, message, sig []byte) bool
+```
+
+Verify reports whether sig is a valid signature of message by publicKey. It will panic if len(publicKey) is not PublicKeySize.
+
+**Implementation**
+
+<details><summary>OpenSSL (click for details)</summary>
+
+`message` is verified against `sig` using [EVP_MD_CTX_new], [DigestVerifyInit] and [EVP_DigestVerify].
+
+</details>
+
+#### func [VerifyWithOptions](https://pkg.go.dev/crypto/ed25519#VerifyWithOptions)
+
+```go
+func VerifyWithOptions(publicKey PublicKey, message, sig []byte, opts *Options) error
+```
+
+VerifyWithOptions reports whether sig is a valid signature of message by publicKey. A valid signature is indicated by returning a nil error. It will panic if len(publicKey) is not PublicKeySize.
+
+**Requirements**
+
+- Only `opts.Hash == nil && opts.Context == ""` is implemented using the OpenSSL backend. Other combinations fall back to standard Go code.
+
+**Implementation**
+
+<details><summary>OpenSSL (click for details)</summary>
+
+`message` is verified against `sig` using [EVP_MD_CTX_new], [DigestVerifyInit] and [EVP_DigestVerify].
+
+</details>
+
+#### func [NewKeyFromSeed](https://pkg.go.dev/crypto/ed25519#NewKeyFromSeed)
+
+```go
+func NewKeyFromSeed(seed []byte) (priv ed25519.PrivateKey)
+```
+
+NewKeyFromSeed calculates a private key from a seed. It will panic if len(seed) is not SeedSize.
+
+**Implementation**
+
+<details><summary>OpenSSL (click for details)</summary>
+
+`priv` is generated using using [EVP_PKEY_new_raw_private_key] using the `EVP_PKEY_ED25519` algorithm.
+
+</details>
+
+#### func [PrivateKey.Sign](https://pkg.go.dev/crypto/ed25519#PrivateKey.Sign)
+
+```go
+func (priv ed25519.PrivateKey) Sign(rand io.Reader, message []byte, opts crypto.SignerOpts) (signature []byte, err error)
+```
+
+Sign signs the given message with `priv`. `rand` is ignored and can be nil.
+
+**Requirements**
+
+- Only `opts.Hash == nil && opts.Context == ""` is implemented using the OpenSSL backend. Other combinations fall back to standard Go code.
+
+**Implementation**
+
+<details><summary>OpenSSL (click for details)</summary>
+
+`message` is signed using [EVP_MD_CTX_new], [EVP_DigestSignInit] and [EVP_DigestSign].
+
+</details>
 
 ### [crypto/elliptic](https://pkg.go.dev/crypto/elliptic)
 
@@ -1449,6 +1562,7 @@ When using TLS in FIPS-only mode the TLS handshake has the following restriction
 [RAND_bytes]: https://www.openssl.org/docs/man3.0/man3/RAND_bytes.html
 [EVP_PKEY]: https://www.openssl.org/docs/man3.0/man3/EVP_PKEY.html
 [EVP_PKEY_new]: https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_new.html
+[EVP_PKEY_new_raw_private_key]: https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_new_raw_private_key.html
 [EVP_PKEY_keygen]: https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_keygen.html
 [EVP_PKEY_sign]: https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_sign.html
 [EVP_PKEY_verify]: https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_verify.html
@@ -1460,6 +1574,10 @@ When using TLS in FIPS-only mode the TLS handshake has the following restriction
 [EVP_DigestFinal]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestFinal.html
 [EVP_DigestInit]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestInit.html
 [EVP_DigestInit_ex]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestInit_ex.html
+[EVP_DigestSign]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestSign.html
+[EVP_DigestVerify]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestVerify.html
+[EVP_DigestSign]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestSign.html
+[EVP_DigestVerifyInit]: https://www.openssl.org/docs/man3.0/man3/EVP_DigestVerifyInit.html
 [EVP_EncryptFinal_ex]: https://www.openssl.org/docs/man3.0/man3/EVP_EncryptFinal_ex.html
 [EVP_DecryptFinal_ex]: https://www.openssl.org/docs/man3.0/man3/EVP_DecryptFinal_ex.html
 [EVP_CIPHER_CTX_set_padding]: https://www.openssl.org/docs/man3.0/man3/EVP_CIPHER_CTX_set_padding.html

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -394,10 +394,10 @@ index 00000000000000..ec914ec68412ad
 +
 +import boring "crypto/internal/backend"
 +
-+func boringPublicKey(*PublicKey) (*boring.PublicKeyEd25519, error) {
++func boringPublicKey(PublicKey) (*boring.PublicKeyEd25519, error) {
 +	panic("boringcrypto: not available")
 +}
-+func boringPrivateKey(*PrivateKey) (*boring.PrivateKeyEd25519, error) {
++func boringPrivateKey(PrivateKey) (*boring.PrivateKeyEd25519, error) {
 +	panic("boringcrypto: not available")
 +}
 diff --git a/src/crypto/hmac/hmac.go b/src/crypto/hmac/hmac.go

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/ecdsa/boring.go                   |   4 +-
  src/crypto/ecdsa/ecdsa.go                    |   4 +-
  src/crypto/ecdsa/notboring.go                |   2 +-
- src/crypto/ed25519/boring.go                 |  67 +++++++
+ src/crypto/ed25519/boring.go                 |  71 +++++++
  src/crypto/ed25519/ed25519.go                |  75 +++++++-
  src/crypto/ed25519/ed25519_test.go           |   2 +-
- src/crypto/ed25519/notboring.go              |  12 ++
+ src/crypto/ed25519/notboring.go              |  16 ++
  src/crypto/hmac/hmac.go                      |   2 +-
  src/crypto/hmac/hmac_test.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go  |  30 +++
@@ -50,7 +50,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/prf_test.go                   |  12 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 46 files changed, 691 insertions(+), 66 deletions(-)
+ 46 files changed, 699 insertions(+), 66 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -204,10 +204,14 @@ index 039bd82ed21f9f..19188518e85e65 100644
  	panic("boringcrypto: not available")
 diff --git a/src/crypto/ed25519/boring.go b/src/crypto/ed25519/boring.go
 new file mode 100644
-index 00000000000000..0620ae327207a3
+index 00000000000000..3a7d7b76c8d8d7
 --- /dev/null
 +++ b/src/crypto/ed25519/boring.go
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,71 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
 +//go:build goexperiment.systemcrypto
 +
 +package ed25519
@@ -276,7 +280,7 @@ index 00000000000000..0620ae327207a3
 +	return key, nil
 +}
 diff --git a/src/crypto/ed25519/ed25519.go b/src/crypto/ed25519/ed25519.go
-index 1dda9e5e9a5ab3..c9fdbf2cfbf1cc 100644
+index 1dda9e5e9a5ab3..a1f9a7b963654f 100644
 --- a/src/crypto/ed25519/ed25519.go
 +++ b/src/crypto/ed25519/ed25519.go
 @@ -15,6 +15,7 @@ package ed25519
@@ -301,7 +305,7 @@ index 1dda9e5e9a5ab3..c9fdbf2cfbf1cc 100644
  	}
 +	if boring.Enabled && boring.SupportsEd25519() {
 +		if rand == boring.RandReader {
-+			_, priv, err := boring.GenerateKeyEd25519()
++			priv, err := boring.GenerateKeyEd25519()
 +			if err != nil {
 +				return nil, nil, err
 +			}
@@ -421,10 +425,14 @@ index 47c8698e2a5945..02eff207ae365a 100644
  	"encoding/hex"
 diff --git a/src/crypto/ed25519/notboring.go b/src/crypto/ed25519/notboring.go
 new file mode 100644
-index 00000000000000..577c297c1ffe0e
+index 00000000000000..b0cdd44d81c753
 --- /dev/null
 +++ b/src/crypto/ed25519/notboring.go
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,16 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
 +//go:build !goexperiment.systemcrypto
 +
 +package ed25519
@@ -623,7 +631,7 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..abdafcaacbc3a0
+index 00000000000000..db9ec456db705e
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -0,0 +1,192 @@
@@ -796,7 +804,7 @@ index 00000000000000..abdafcaacbc3a0
 +	panic("cryptobackend: not available")
 +}
 +
-+func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
++func GenerateKeyEd25519() (*PrivateKeyEd25519, error) {
 +	panic("cryptobackend: not available")
 +}
 +

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -23,7 +23,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/internal/backend/bbig/big.go      |  17 ++
  src/crypto/internal/backend/common.go        |  78 ++++++++
  src/crypto/internal/backend/isrequirefips.go |   9 +
- src/crypto/internal/backend/nobackend.go     | 183 +++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go     | 192 +++++++++++++++++++
  src/crypto/internal/backend/norequirefips.go |   9 +
  src/crypto/internal/backend/stub.s           |  10 +
  src/crypto/md5/md5.go                        |   7 +
@@ -50,7 +50,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/prf_test.go                   |  12 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 46 files changed, 655 insertions(+), 66 deletions(-)
+ 46 files changed, 664 insertions(+), 66 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -586,10 +586,10 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..c55629a4b35292
+index 00000000000000..abdafcaacbc3a0
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,183 @@
+@@ -0,0 +1,192 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -748,7 +748,16 @@ index 00000000000000..c55629a4b35292
 +func SupportsEd25519() bool { panic("cryptobackend: not available") }
 +
 +type PublicKeyEd25519 struct{}
++
++func (k *PublicKeyEd25519) Bytes() ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
 +type PrivateKeyEd25519 struct{}
++
++func (k *PrivateKeyEd25519) Bytes() ([]byte, error) {
++	panic("cryptobackend: not available")
++}
 +
 +func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
 +	panic("cryptobackend: not available")

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -208,7 +208,7 @@ index 00000000000000..b1c1017eddc47a
 --- /dev/null
 +++ b/src/crypto/ed25519/boring.go
 @@ -0,0 +1,67 @@
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
++//go:build goexperiment.systemcrypto
 +
 +package ed25519
 +
@@ -222,7 +222,7 @@ index 00000000000000..b1c1017eddc47a
 +var privCache bcache.Cache[byte, boringPriv]
 +
 +func init() {
-+	if boring.SupportsEd25519() {
++	if boring.Enabled && boring.SupportsEd25519() {
 +		pubCache.Register()
 +		privCache.Register()
 +	}
@@ -388,7 +388,7 @@ index 00000000000000..ec914ec68412ad
 --- /dev/null
 +++ b/src/crypto/ed25519/notboring.go
 @@ -0,0 +1,12 @@
-+//go:build !boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
++//go:build !goexperiment.systemcrypto
 +
 +package ed25519
 +

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/ecdsa/ecdsa.go                    |   4 +-
  src/crypto/ecdsa/notboring.go                |   2 +-
  src/crypto/ed25519/boring.go                 |  67 +++++++
- src/crypto/ed25519/ed25519.go                |  48 ++++-
+ src/crypto/ed25519/ed25519.go                |  75 +++++++-
  src/crypto/ed25519/ed25519_test.go           |   2 +-
  src/crypto/ed25519/notboring.go              |  12 ++
  src/crypto/hmac/hmac.go                      |   2 +-
@@ -50,7 +50,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/prf_test.go                   |  12 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 46 files changed, 664 insertions(+), 66 deletions(-)
+ 46 files changed, 691 insertions(+), 66 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -204,7 +204,7 @@ index 039bd82ed21f9f..19188518e85e65 100644
  	panic("boringcrypto: not available")
 diff --git a/src/crypto/ed25519/boring.go b/src/crypto/ed25519/boring.go
 new file mode 100644
-index 00000000000000..b1c1017eddc47a
+index 00000000000000..0620ae327207a3
 --- /dev/null
 +++ b/src/crypto/ed25519/boring.go
 @@ -0,0 +1,67 @@
@@ -276,7 +276,7 @@ index 00000000000000..b1c1017eddc47a
 +	return key, nil
 +}
 diff --git a/src/crypto/ed25519/ed25519.go b/src/crypto/ed25519/ed25519.go
-index 1dda9e5e9a5ab3..511ca7cd1301d2 100644
+index 1dda9e5e9a5ab3..c9fdbf2cfbf1cc 100644
 --- a/src/crypto/ed25519/ed25519.go
 +++ b/src/crypto/ed25519/ed25519.go
 @@ -15,6 +15,7 @@ package ed25519
@@ -287,7 +287,15 @@ index 1dda9e5e9a5ab3..511ca7cd1301d2 100644
  	"crypto/internal/edwards25519"
  	cryptorand "crypto/rand"
  	"crypto/sha512"
-@@ -139,6 +140,22 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
+@@ -22,6 +23,7 @@ import (
+ 	"errors"
+ 	"io"
+ 	"strconv"
++	"sync"
+ )
+ 
+ const (
+@@ -139,6 +141,22 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
  	if rand == nil {
  		rand = cryptorand.Reader
  	}
@@ -310,7 +318,7 @@ index 1dda9e5e9a5ab3..511ca7cd1301d2 100644
  
  	seed := make([]byte, SeedSize)
  	if _, err := io.ReadFull(rand, seed); err != nil {
-@@ -157,6 +174,17 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
+@@ -157,6 +175,17 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
  // with RFC 8032. RFC 8032's private keys correspond to seeds in this
  // package.
  func NewKeyFromSeed(seed []byte) PrivateKey {
@@ -328,7 +336,7 @@ index 1dda9e5e9a5ab3..511ca7cd1301d2 100644
  	// Outline the function body so that the returned key can be stack-allocated.
  	privateKey := make([]byte, PrivateKeySize)
  	newKeyFromSeed(privateKey, seed)
-@@ -184,6 +212,17 @@ func newKeyFromSeed(privateKey, seed []byte) {
+@@ -184,6 +213,17 @@ func newKeyFromSeed(privateKey, seed []byte) {
  // Sign signs the message with privateKey and returns a signature. It will
  // panic if len(privateKey) is not [PrivateKeySize].
  func Sign(privateKey PrivateKey, message []byte) []byte {
@@ -346,11 +354,11 @@ index 1dda9e5e9a5ab3..511ca7cd1301d2 100644
  	// Outline the function body so that the returned signature can be
  	// stack-allocated.
  	signature := make([]byte, SignatureSize)
-@@ -259,6 +298,13 @@ func sign(signature, privateKey, message []byte, domPrefix, context string) {
+@@ -259,9 +299,42 @@ func sign(signature, privateKey, message []byte, domPrefix, context string) {
  // Verify reports whether sig is a valid signature of message by publicKey. It
  // will panic if len(publicKey) is not [PublicKeySize].
  func Verify(publicKey PublicKey, message, sig []byte) bool {
-+	if boring.Enabled && boring.SupportsEd25519() {
++	if boring.Enabled && boring.SupportsEd25519() && testMalleability() {
 +		pub, err := boringPublicKey(publicKey)
 +		if err != nil {
 +			return false
@@ -360,7 +368,36 @@ index 1dda9e5e9a5ab3..511ca7cd1301d2 100644
  	return verify(publicKey, message, sig, domPrefixPure, "")
  }
  
-@@ -292,7 +338,7 @@ func VerifyWithOptions(publicKey PublicKey, message, sig []byte, opts *Options)
++// testMalleability returns true if the crypto backend correctly rejects
++// malleable signatures. The only known backend that fails to do so is
++// OpenSSL version 1.1.1a or lower.
++// See https://github.com/openssl/openssl/issues/7693.
++var testMalleability = sync.OnceValue(func() bool {
++	msg := []byte{0x54, 0x65, 0x73, 0x74}
++	sig := []byte{
++		0x7c, 0x38, 0xe0, 0x26, 0xf2, 0x9e, 0x14, 0xaa, 0xbd, 0x05, 0x9a,
++		0x0f, 0x2d, 0xb8, 0xb0, 0xcd, 0x78, 0x30, 0x40, 0x60, 0x9a, 0x8b,
++		0xe6, 0x84, 0xdb, 0x12, 0xf8, 0x2a, 0x27, 0x77, 0x4a, 0xb0, 0x67,
++		0x65, 0x4b, 0xce, 0x38, 0x32, 0xc2, 0xd7, 0x6f, 0x8f, 0x6f, 0x5d,
++		0xaf, 0xc0, 0x8d, 0x93, 0x39, 0xd4, 0xee, 0xf6, 0x76, 0x57, 0x33,
++		0x36, 0xa5, 0xc5, 0x1e, 0xb6, 0xf9, 0x46, 0xb3, 0x1d,
++	}
++	pkey := []byte{
++		0x7d, 0x4d, 0x0e, 0x7f, 0x61, 0x53, 0xa6, 0x9b, 0x62, 0x42, 0xb5,
++		0x22, 0xab, 0xbe, 0xe6, 0x85, 0xfd, 0xa4, 0x42, 0x0f, 0x88, 0x34,
++		0xb1, 0x08, 0xc3, 0xbd, 0xae, 0x36, 0x9e, 0xf5, 0x49, 0xfa,
++	}
++	pub, err := boring.NewPublicKeyEd25119(pkey)
++	if err != nil {
++		return false
++	}
++	return boring.VerifyEd25519(pub, msg, sig) != nil
++})
++
+ // VerifyWithOptions reports whether sig is a valid signature of message by
+ // publicKey. A valid signature is indicated by returning a nil error. It will
+ // panic if len(publicKey) is not [PublicKeySize].
+@@ -292,7 +365,7 @@ func VerifyWithOptions(publicKey PublicKey, message, sig []byte, opts *Options)
  		}
  		return nil
  	case opts.Hash == crypto.Hash(0): // Ed25519
@@ -384,7 +421,7 @@ index 47c8698e2a5945..02eff207ae365a 100644
  	"encoding/hex"
 diff --git a/src/crypto/ed25519/notboring.go b/src/crypto/ed25519/notboring.go
 new file mode 100644
-index 00000000000000..ec914ec68412ad
+index 00000000000000..577c297c1ffe0e
 --- /dev/null
 +++ b/src/crypto/ed25519/notboring.go
 @@ -0,0 +1,12 @@

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -13,20 +13,23 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/ecdsa/boring.go                   |   4 +-
  src/crypto/ecdsa/ecdsa.go                    |   4 +-
  src/crypto/ecdsa/notboring.go                |   2 +-
+ src/crypto/ed25519/boring.go                 |  67 +++++++
+ src/crypto/ed25519/ed25519.go                |  48 ++++-
  src/crypto/ed25519/ed25519_test.go           |   2 +-
+ src/crypto/ed25519/notboring.go              |  12 ++
  src/crypto/hmac/hmac.go                      |   2 +-
  src/crypto/hmac/hmac_test.go                 |   2 +-
- src/crypto/internal/backend/backend_test.go  |  30 ++++
+ src/crypto/internal/backend/backend_test.go  |  30 +++
  src/crypto/internal/backend/bbig/big.go      |  17 ++
- src/crypto/internal/backend/common.go        |  78 ++++++++++
- src/crypto/internal/backend/isrequirefips.go |   9 ++
- src/crypto/internal/backend/nobackend.go     | 154 +++++++++++++++++++
- src/crypto/internal/backend/norequirefips.go |   9 ++
- src/crypto/internal/backend/stub.s           |  10 ++
+ src/crypto/internal/backend/common.go        |  78 ++++++++
+ src/crypto/internal/backend/isrequirefips.go |   9 +
+ src/crypto/internal/backend/nobackend.go     | 183 +++++++++++++++++++
+ src/crypto/internal/backend/norequirefips.go |   9 +
+ src/crypto/internal/backend/stub.s           |  10 +
  src/crypto/md5/md5.go                        |   7 +
  src/crypto/md5/md5_test.go                   |   4 +
  src/crypto/rand/rand_unix.go                 |   2 +-
- src/crypto/rc4/rc4.go                        |  18 +++
+ src/crypto/rc4/rc4.go                        |  18 ++
  src/crypto/rsa/boring.go                     |   4 +-
  src/crypto/rsa/notboring.go                  |   2 +-
  src/crypto/rsa/pkcs1v15.go                   |   2 +-
@@ -42,12 +45,14 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/crypto/tls/handshake_client.go           |  25 ++-
  src/crypto/tls/handshake_server.go           |  25 ++-
- src/crypto/tls/key_schedule.go               |  18 ++-
- src/crypto/tls/prf.go                        |  77 +++++++---
+ src/crypto/tls/key_schedule.go               |  18 +-
+ src/crypto/tls/prf.go                        |  77 +++++---
  src/crypto/tls/prf_test.go                   |  12 +-
  src/go/build/deps_test.go                    |   2 +
  src/runtime/runtime_boring.go                |   5 +
- 43 files changed, 500 insertions(+), 65 deletions(-)
+ 46 files changed, 655 insertions(+), 66 deletions(-)
+ create mode 100644 src/crypto/ed25519/boring.go
+ create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
@@ -197,6 +202,173 @@ index 039bd82ed21f9f..19188518e85e65 100644
  
  func boringPublicKey(*PublicKey) (*boring.PublicKeyECDSA, error) {
  	panic("boringcrypto: not available")
+diff --git a/src/crypto/ed25519/boring.go b/src/crypto/ed25519/boring.go
+new file mode 100644
+index 00000000000000..b1c1017eddc47a
+--- /dev/null
++++ b/src/crypto/ed25519/boring.go
+@@ -0,0 +1,67 @@
++//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
++
++package ed25519
++
++import (
++	boring "crypto/internal/backend"
++	"crypto/internal/boring/bcache"
++	"unsafe"
++)
++
++var pubCache bcache.Cache[byte, boringPub]
++var privCache bcache.Cache[byte, boringPriv]
++
++func init() {
++	if boring.SupportsEd25519() {
++		pubCache.Register()
++		privCache.Register()
++	}
++}
++
++type boringPub struct {
++	key  *boring.PublicKeyEd25519
++	orig [PublicKeySize]byte
++}
++
++func boringPublicKey(pub PublicKey) (*boring.PublicKeyEd25519, error) {
++	// Use the pointer to the underlying pub array as key.
++	p := unsafe.SliceData(pub)
++	b := pubCache.Get(p)
++	if b != nil && PublicKey(b.orig[:]).Equal(pub) {
++		return b.key, nil
++	}
++
++	b = new(boringPub)
++	copy(b.orig[:], pub)
++	key, err := boring.NewPublicKeyEd25119(b.orig[:])
++	if err != nil {
++		return nil, err
++	}
++	b.key = key
++	pubCache.Put(p, b)
++	return key, nil
++}
++
++type boringPriv struct {
++	key  *boring.PrivateKeyEd25519
++	orig [PrivateKeySize]byte
++}
++
++func boringPrivateKey(priv PrivateKey) (*boring.PrivateKeyEd25519, error) {
++	// Use the pointer to the underlying priv array as key.
++	p := unsafe.SliceData(priv)
++	b := privCache.Get(p)
++	if b != nil && PrivateKey(b.orig[:]).Equal(priv) {
++		return b.key, nil
++	}
++
++	b = new(boringPriv)
++	copy(b.orig[:], priv)
++	key, err := boring.NewPrivateKeyEd25119(b.orig[:])
++	if err != nil {
++		return nil, err
++	}
++	b.key = key
++	privCache.Put(p, b)
++	return key, nil
++}
+diff --git a/src/crypto/ed25519/ed25519.go b/src/crypto/ed25519/ed25519.go
+index 1dda9e5e9a5ab3..511ca7cd1301d2 100644
+--- a/src/crypto/ed25519/ed25519.go
++++ b/src/crypto/ed25519/ed25519.go
+@@ -15,6 +15,7 @@ package ed25519
+ import (
+ 	"bytes"
+ 	"crypto"
++	boring "crypto/internal/backend"
+ 	"crypto/internal/edwards25519"
+ 	cryptorand "crypto/rand"
+ 	"crypto/sha512"
+@@ -139,6 +140,22 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
+ 	if rand == nil {
+ 		rand = cryptorand.Reader
+ 	}
++	if boring.Enabled && boring.SupportsEd25519() {
++		if rand == boring.RandReader {
++			_, priv, err := boring.GenerateKeyEd25519()
++			if err != nil {
++				return nil, nil, err
++			}
++			privData, err := priv.Bytes()
++			if err != nil {
++				return nil, nil, err
++			}
++			privKey := PrivateKey(privData)
++			pubKey := privKey.Public().(PublicKey)
++			return pubKey, privKey, err
++		}
++		boring.UnreachableExceptTests()
++	}
+ 
+ 	seed := make([]byte, SeedSize)
+ 	if _, err := io.ReadFull(rand, seed); err != nil {
+@@ -157,6 +174,17 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
+ // with RFC 8032. RFC 8032's private keys correspond to seeds in this
+ // package.
+ func NewKeyFromSeed(seed []byte) PrivateKey {
++	if boring.Enabled && boring.SupportsEd25519() {
++		key, err := boring.NewPrivateKeyEd25519FromSeed(seed)
++		if err != nil {
++			panic(err)
++		}
++		d, err := key.Bytes()
++		if err != nil {
++			panic(err)
++		}
++		return PrivateKey(d)
++	}
+ 	// Outline the function body so that the returned key can be stack-allocated.
+ 	privateKey := make([]byte, PrivateKeySize)
+ 	newKeyFromSeed(privateKey, seed)
+@@ -184,6 +212,17 @@ func newKeyFromSeed(privateKey, seed []byte) {
+ // Sign signs the message with privateKey and returns a signature. It will
+ // panic if len(privateKey) is not [PrivateKeySize].
+ func Sign(privateKey PrivateKey, message []byte) []byte {
++	if boring.Enabled && boring.SupportsEd25519() {
++		priv, err := boringPrivateKey(privateKey)
++		if err != nil {
++			panic(err)
++		}
++		signature, err := boring.SignEd25519(priv, message)
++		if err != nil {
++			panic(err)
++		}
++		return signature
++	}
+ 	// Outline the function body so that the returned signature can be
+ 	// stack-allocated.
+ 	signature := make([]byte, SignatureSize)
+@@ -259,6 +298,13 @@ func sign(signature, privateKey, message []byte, domPrefix, context string) {
+ // Verify reports whether sig is a valid signature of message by publicKey. It
+ // will panic if len(publicKey) is not [PublicKeySize].
+ func Verify(publicKey PublicKey, message, sig []byte) bool {
++	if boring.Enabled && boring.SupportsEd25519() {
++		pub, err := boringPublicKey(publicKey)
++		if err != nil {
++			return false
++		}
++		return boring.VerifyEd25519(pub, message, sig) == nil
++	}
+ 	return verify(publicKey, message, sig, domPrefixPure, "")
+ }
+ 
+@@ -292,7 +338,7 @@ func VerifyWithOptions(publicKey PublicKey, message, sig []byte, opts *Options)
+ 		}
+ 		return nil
+ 	case opts.Hash == crypto.Hash(0): // Ed25519
+-		if !verify(publicKey, message, sig, domPrefixPure, "") {
++		if !Verify(publicKey, message, sig) {
+ 			return errors.New("ed25519: invalid signature")
+ 		}
+ 		return nil
 diff --git a/src/crypto/ed25519/ed25519_test.go b/src/crypto/ed25519/ed25519_test.go
 index 47c8698e2a5945..02eff207ae365a 100644
 --- a/src/crypto/ed25519/ed25519_test.go
@@ -210,6 +382,24 @@ index 47c8698e2a5945..02eff207ae365a 100644
  	"crypto/rand"
  	"crypto/sha512"
  	"encoding/hex"
+diff --git a/src/crypto/ed25519/notboring.go b/src/crypto/ed25519/notboring.go
+new file mode 100644
+index 00000000000000..ec914ec68412ad
+--- /dev/null
++++ b/src/crypto/ed25519/notboring.go
+@@ -0,0 +1,12 @@
++//go:build !boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
++
++package ed25519
++
++import boring "crypto/internal/backend"
++
++func boringPublicKey(*PublicKey) (*boring.PublicKeyEd25519, error) {
++	panic("boringcrypto: not available")
++}
++func boringPrivateKey(*PrivateKey) (*boring.PrivateKeyEd25519, error) {
++	panic("boringcrypto: not available")
++}
 diff --git a/src/crypto/hmac/hmac.go b/src/crypto/hmac/hmac.go
 index 35b9d5a17aa545..d6dc0244f7eba8 100644
 --- a/src/crypto/hmac/hmac.go
@@ -396,10 +586,10 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..f45f2fe76d54f1
+index 00000000000000..c55629a4b35292
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,154 @@
+@@ -0,0 +1,183 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -554,6 +744,35 @@ index 00000000000000..f45f2fe76d54f1
 +func (c *RC4Cipher) XORKeyStream(dst, src []byte) { panic("cryptobackend: not available") }
 +
 +func NewRC4Cipher(key []byte) (*RC4Cipher, error) { panic("cryptobackend: not available") }
++
++func SupportsEd25519() bool { panic("cryptobackend: not available") }
++
++type PublicKeyEd25519 struct{}
++type PrivateKeyEd25519 struct{}
++
++func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewPrivateKeyEd25519FromSeed(seed []byte) (*PrivateKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func SignEd25519(priv *PrivateKeyEd25519, message []byte) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
++func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
++	panic("cryptobackend: not available")
++}
 diff --git a/src/crypto/internal/backend/norequirefips.go b/src/crypto/internal/backend/norequirefips.go
 new file mode 100644
 index 00000000000000..26bfb5f6a643f3

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -4,9 +4,9 @@ Date: Wed, 22 Jun 2022 12:16:05 +0000
 Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
- .../internal/backend/bbig/big_boring.go       |  12 ++
- src/crypto/internal/backend/boring_linux.go   | 186 ++++++++++++++++++
- 2 files changed, 198 insertions(+)
+ .../internal/backend/bbig/big_boring.go       |  12 +
+ src/crypto/internal/backend/boring_linux.go   | 215 ++++++++++++++++++
+ 2 files changed, 227 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..af2d4b857df333
+index 00000000000000..8086157549579d
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,186 @@
+@@ -0,0 +1,215 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -218,5 +218,34 @@ index 00000000000000..af2d4b857df333
 +func (c *RC4Cipher) XORKeyStream(dst, src []byte) { panic("cryptobackend: not available") }
 +
 +func NewRC4Cipher(key []byte) (*RC4Cipher, error) {
++	panic("cryptobackend: not available")
++}
++
++func SupportsEd25519() bool { return false }
++
++type PublicKeyEd25519 struct{}
++type PrivateKeyEd25519 struct{}
++
++func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewPrivateKeyEd25519FromSeed(seed []byte) (*PrivateKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func SignEd25519(priv *PrivateKeyEd25519, message []byte) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
++func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
 +	panic("cryptobackend: not available")
 +}

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -30,7 +30,7 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..d7f7f14ab9475f
+index 00000000000000..55454cbf880fd3
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
 @@ -0,0 +1,224 @@
@@ -235,7 +235,7 @@ index 00000000000000..d7f7f14ab9475f
 +	panic("cryptobackend: not available")
 +}
 +
-+func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
++func GenerateKeyEd25519() (*PrivateKeyEd25519, error) {
 +	panic("cryptobackend: not available")
 +}
 +

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 +
- src/crypto/internal/backend/boring_linux.go   | 215 ++++++++++++++++++
- 2 files changed, 227 insertions(+)
+ src/crypto/internal/backend/boring_linux.go   | 224 ++++++++++++++++++
+ 2 files changed, 236 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..8086157549579d
+index 00000000000000..d7f7f14ab9475f
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,215 @@
+@@ -0,0 +1,224 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -224,7 +224,16 @@ index 00000000000000..8086157549579d
 +func SupportsEd25519() bool { return false }
 +
 +type PublicKeyEd25519 struct{}
++
++func (k *PublicKeyEd25519) Bytes() ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
 +type PrivateKeyEd25519 struct{}
++
++func (k *PrivateKeyEd25519) Bytes() ([]byte, error) {
++	panic("cryptobackend: not available")
++}
 +
 +func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
 +	panic("cryptobackend: not available")

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 287 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 316 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -37,7 +37,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 33 files changed, 369 insertions(+), 23 deletions(-)
+ 33 files changed, 398 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -190,10 +190,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..ff02e561452aa3
+index 00000000000000..01d8544cff9e1e
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,287 @@
+@@ -0,0 +1,316 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -481,6 +481,35 @@ index 00000000000000..ff02e561452aa3
 +type RC4Cipher = openssl.RC4Cipher
 +
 +func NewRC4Cipher(key []byte) (*RC4Cipher, error) { return openssl.NewRC4Cipher(key) }
++
++func SupportsEd25519() bool { return openssl.SupportsEd25519() }
++
++type PublicKeyEd25519 = openssl.PublicKeyEd25519
++type PrivateKeyEd25519 = openssl.PrivateKeyEd25519
++
++func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
++	return openssl.GenerateKeyEd25519()
++}
++
++func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
++	return openssl.NewPrivateKeyEd25119(priv)
++}
++
++func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
++	return openssl.NewPublicKeyEd25119(pub)
++}
++
++func NewPrivateKeyEd25519FromSeed(seed []byte) (*PrivateKeyEd25519, error) {
++	return openssl.NewPrivateKeyEd25519FromSeed(seed)
++}
++
++func SignEd25519(priv *PrivateKeyEd25519, message []byte) ([]byte, error) {
++	return openssl.SignEd25519(priv, message)
++}
++
++func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
++	return openssl.VerifyEd25519(pub, message, sig)
++}
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
 index f2e5a503eaacb6..1dc7116efdff2e 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -190,7 +190,7 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..01d8544cff9e1e
+index 00000000000000..2ff516a44638ac
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,316 @@
@@ -487,7 +487,7 @@ index 00000000000000..01d8544cff9e1e
 +type PublicKeyEd25519 = openssl.PublicKeyEd25519
 +type PrivateKeyEd25519 = openssl.PrivateKeyEd25519
 +
-+func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
++func GenerateKeyEd25519() (*PrivateKeyEd25519, error) {
 +	return openssl.GenerateKeyEd25519()
 +}
 +
@@ -706,24 +706,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 8f7dd5c0b69932..0a9f28adb67211 100644
+index 8f7dd5c0b69932..d437d420a0ff10 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.22
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd
++	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231017103527-08f07a7a41c3
  	golang.org/x/crypto v0.14.0
  	golang.org/x/net v0.17.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index 22511da608a07b..afa147f35171de 100644
+index 22511da608a07b..a8a68395888272 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd h1:+SvJEqhqQ8d/wzyk+xmTgBpHDOYQtnS/F8283hznEAc=
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231017103527-08f07a7a41c3 h1:EUdE8vQSqj5vTtLHwomurgliWNAO5A7GpCfUa0S1AtU=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231017103527-08f07a7a41c3/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
  golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
  golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
  golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 261 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 270 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -47,7 +47,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 43 files changed, 458 insertions(+), 40 deletions(-)
+ 43 files changed, 467 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -166,10 +166,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..d365756de55b3a
+index 00000000000000..22510e0eb04abe
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,261 @@
+@@ -0,0 +1,270 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -406,7 +406,16 @@ index 00000000000000..d365756de55b3a
 +func SupportsEd25519() bool { return false }
 +
 +type PublicKeyEd25519 struct{}
++
++func (k *PublicKeyEd25519) Bytes() ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
 +type PrivateKeyEd25519 struct{}
++
++func (k *PrivateKeyEd25519) Bytes() ([]byte, error) {
++	panic("cryptobackend: not available")
++}
 +
 +func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
 +	panic("cryptobackend: not available")

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 232 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 261 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -47,7 +47,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 43 files changed, 429 insertions(+), 40 deletions(-)
+ 43 files changed, 458 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -166,10 +166,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..9edcbcc24814c1
+index 00000000000000..d365756de55b3a
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,232 @@
+@@ -0,0 +1,261 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -402,6 +402,35 @@ index 00000000000000..9edcbcc24814c1
 +type RC4Cipher = cng.RC4Cipher
 +
 +func NewRC4Cipher(key []byte) (*RC4Cipher, error) { return cng.NewRC4Cipher(key) }
++
++func SupportsEd25519() bool { return false }
++
++type PublicKeyEd25519 struct{}
++type PrivateKeyEd25519 struct{}
++
++func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func NewPrivateKeyEd25519FromSeed(seed []byte) (*PrivateKeyEd25519, error) {
++	panic("cryptobackend: not available")
++}
++
++func SignEd25519(priv *PrivateKeyEd25519, message []byte) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
++func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
++	panic("cryptobackend: not available")
++}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 index efdd080a1b7708..9d7f7b849d6485 100644
 --- a/src/crypto/internal/backend/common.go

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -166,7 +166,7 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..22510e0eb04abe
+index 00000000000000..80ef0a4c9bfa9d
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,270 @@
@@ -417,7 +417,7 @@ index 00000000000000..22510e0eb04abe
 +	panic("cryptobackend: not available")
 +}
 +
-+func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
++func GenerateKeyEd25519() (*PrivateKeyEd25519, error) {
 +	panic("cryptobackend: not available")
 +}
 +
@@ -1087,24 +1087,24 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 0a9f28adb67211..d3b7820873d23a 100644
+index d437d420a0ff10..4bf3850e1ec873 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd
+ 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231017103527-08f07a7a41c3
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54
  	golang.org/x/crypto v0.14.0
  	golang.org/x/net v0.17.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index afa147f35171de..9640b9c12da10a 100644
+index a8a68395888272..8bc402c806c35c 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd h1:+SvJEqhqQ8d/wzyk+xmTgBpHDOYQtnS/F8283hznEAc=
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231017103527-08f07a7a41c3 h1:EUdE8vQSqj5vTtLHwomurgliWNAO5A7GpCfUa0S1AtU=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231017103527-08f07a7a41c3/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54 h1:TCT5sTFxoPwPQkdegvnmgmcZRpecDsrLSCyWYUwAWTs=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20231013074141-ebaf9de20b54/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -17,8 +17,8 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../github.com/golang-fips/openssl/v2/ec.go   |  59 ++
  .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
  .../golang-fips/openssl/v2/ecdsa.go           | 217 +++++
- .../golang-fips/openssl/v2/ed25519.go         | 216 +++++
- .../github.com/golang-fips/openssl/v2/evp.go  | 473 +++++++++++
+ .../golang-fips/openssl/v2/ed25519.go         | 218 +++++
+ .../github.com/golang-fips/openssl/v2/evp.go  | 467 +++++++++++
  .../golang-fips/openssl/v2/goopenssl.c        | 218 +++++
  .../golang-fips/openssl/v2/goopenssl.h        | 183 ++++
  .../github.com/golang-fips/openssl/v2/hash.go | 793 ++++++++++++++++++
@@ -60,7 +60,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 55 files changed, 8785 insertions(+)
+ 55 files changed, 8781 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -1685,10 +1685,10 @@ index 00000000000000..46b16abf483e65
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go b/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
 new file mode 100644
-index 00000000000000..81961da8e943bc
+index 00000000000000..33e26a5535ddb2
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
-@@ -0,0 +1,216 @@
+@@ -0,0 +1,218 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1776,25 +1776,27 @@ index 00000000000000..81961da8e943bc
 +	return priv, nil
 +}
 +
-+// GenerateKeyEd25519 generates a public/private key pair.
-+func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
-+	pkeyPriv, err := generateEVPPKey(C.GO_EVP_PKEY_ED25519, 0, "")
-+	if err != nil {
-+		return nil, nil, err
-+	}
++func (k *PrivateKeyEd25519) Public() (*PublicKeyEd25519, error) {
 +	pub := make([]byte, publicKeySizeEd25519)
-+	if err := extractPKEYPubEd25519(pkeyPriv, pub); err != nil {
-+		C.go_openssl_EVP_PKEY_free(pkeyPriv)
-+		return nil, nil, err
++	if err := extractPKEYPubEd25519(k._pkey, pub); err != nil {
++		return nil, err
 +	}
 +	pubk, err := NewPublicKeyEd25119(pub)
 +	if err != nil {
-+		C.go_openssl_EVP_PKEY_free(pkeyPriv)
-+		return nil, nil, err
++		return nil, err
 +	}
-+	privk := &PrivateKeyEd25519{_pkey: pkeyPriv}
-+	runtime.SetFinalizer(privk, (*PrivateKeyEd25519).finalize)
-+	return pubk, privk, nil
++	return pubk, nil
++}
++
++// GenerateKeyEd25519 generates a private key.
++func GenerateKeyEd25519() (*PrivateKeyEd25519, error) {
++	pkeyPriv, err := generateEVPPKey(C.GO_EVP_PKEY_ED25519, 0, "")
++	if err != nil {
++		return nil, err
++	}
++	priv := &PrivateKeyEd25519{_pkey: pkeyPriv}
++	runtime.SetFinalizer(priv, (*PrivateKeyEd25519).finalize)
++	return priv, nil
 +}
 +
 +func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
@@ -1907,10 +1909,10 @@ index 00000000000000..81961da8e943bc
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/evp.go b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 new file mode 100644
-index 00000000000000..3775fa42a41559
+index 00000000000000..68adf7cd627675
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
-@@ -0,0 +1,473 @@
+@@ -0,0 +1,467 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -2122,28 +2124,22 @@ index 00000000000000..3775fa42a41559
 +		if len(label) > 0 {
 +			clabel = (*C.uchar)(cryptoMalloc(len(label)))
 +			copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
-+		}
-+		var err error
-+		if vMajor == 3 {
-+			// Docs say EVP_PKEY_CTX_set0_rsa_oaep_label accepts a null label,
-+			// but it does not: https://github.com/openssl/openssl/issues/21288
-+			if len(label) == 0 {
-+				// cryptoMalloc can't create a zero-length array: use size 1.
-+				clabel = (*C.uchar)(cryptoMalloc(1))
++			var err error
++			if vMajor == 3 {
++				ret := C.go_openssl_EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Pointer(clabel), C.int(len(label)))
++				if ret != 1 {
++					err = newOpenSSLError("EVP_PKEY_CTX_set0_rsa_oaep_label failed")
++				}
++			} else {
++				ret := C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL, C.int(len(label)), unsafe.Pointer(clabel))
++				if ret != 1 {
++					err = newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
++				}
 +			}
-+			ret := C.go_openssl_EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Pointer(clabel), C.int(len(label)))
-+			if ret != 1 {
-+				err = newOpenSSLError("EVP_PKEY_CTX_set0_rsa_oaep_label failed")
++			if err != nil {
++				cryptoFree(unsafe.Pointer(clabel))
++				return nil, err
 +			}
-+		} else {
-+			ret := C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL, C.int(len(label)), unsafe.Pointer(clabel))
-+			if ret != 1 {
-+				err = newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
-+			}
-+		}
-+		if err != nil {
-+			cryptoFree(unsafe.Pointer(clabel))
-+			return nil, err
 +		}
 +	case C.GO_RSA_PKCS1_PSS_PADDING:
 +		md := cryptoHashToMD(ch)
@@ -9217,11 +9213,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index bc4eb872eb8495..fcb646c35d9286 100644
+index bc4eb872eb8495..aa6be1b04abb53 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231013091736-92d3f16e56cd
++# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20231017103527-08f07a7a41c3
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig


### PR DESCRIPTION
This PR patches [crypto/ed25519](https://pkg.go.dev/crypto/ed25519) so it is implemented using the OpenSSL backend. CNG doesn't support ED25519 yet, so there is no way to implement it there yet.

The public ed25519 API is tricky to implement efficiently using OpenSSL types, as [ed25519.PublicKey](https://pkg.go.dev/crypto/ed25519#PublicKey) and [ed25519.PrivateKey](https://pkg.go.dev/crypto/ed25519#PrivateKey) are plain `[]byte`, so they can't be extended with private properties. To sidestep this limitation, I've cached the conversion from `crypto/ed25519` key types to boring key types using a global weak map. The resulting performance is not that bad:

```cmd
goos: linux
goarch: amd64
pkg: crypto/ed25519
cpu: AMD EPYC 7763 64-Core Processor                
                  │   old.txt   │                new.txt                │
                  │   sec/op    │    sec/op     vs base                 │
KeyGeneration-32    22.57µ ± 0%    44.80µ ± 1%   +98.47% (p=0.000 n=10)
NewKeyFromSeed-32   22.40µ ± 1%    46.08µ ± 1%  +105.78% (p=0.000 n=10)
Signing-32          30.77µ ± 1%    44.31µ ± 1%   +44.02% (p=0.000 n=10)
Verification-32     66.20µ ± 0%   124.29µ ± 1%   +87.74% (p=0.000 n=10)
geomean             31.85µ         58.07µ        +82.29%

                  │    old.txt    │                new.txt                │
                  │     B/op      │    B/op     vs base                   │
KeyGeneration-32     128.0 ± 0%     136.0 ± 0%    +6.25% (p=0.000 n=10)
NewKeyFromSeed-32     0.00 ± 0%     72.00 ± 0%         ? (p=0.000 n=10)
Signing-32          224.00 ± 0%     64.00 ± 0%   -71.43% (p=0.000 n=10)
Verification-32      112.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
geomean                         ¹               ?                       ¹
¹ summaries must be >0 to compute geomean

                  │   old.txt    │                new.txt                │
                  │  allocs/op   │ allocs/op   vs base                   │
KeyGeneration-32    3.000 ± 0%     4.000 ± 0%   +33.33% (p=0.000 n=10)
NewKeyFromSeed-32   0.000 ± 0%     2.000 ± 0%         ? (p=0.000 n=10)
Signing-32          4.000 ± 0%     1.000 ± 0%   -75.00% (p=0.000 n=10)
Verification-32     2.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                        ¹               ?                       ¹
```