### PR TITLE
Improve Windows builder retry diagnosability

### DIFF
--- a/eng/_core/README.md
+++ b/eng/_core/README.md
@@ -18,10 +18,13 @@ The high-level execution flow looks roughly like this when running in CI:
 
 * `eng/pipeline/jobs/run-stage.yml`  
   runs:
-* `eng/run.ps1 run-builder -builder linux-amd64-test -junitfile [...]`  
+* `eng/run.ps1 run-builder -test -builder linux-amd64-test -junitfile [...]`  
   which runs the Go function:
 * `gotestsum.Run(... eng/run.ps1 build -test -json ...)`  
   which runs and captures the output of:
 * `eng/run.ps1 build -test -json`  
   which runs [`cmd/build/build.go`](cmd/build/build.go) in this module.
 
+This is not currently used in our CI because this process seems to cut off
+some test output:
+[microsoft/go#1114](https://github.com/microsoft/go/issues/1114).

--- a/eng/_core/buildutil/buildutil.go
+++ b/eng/_core/buildutil/buildutil.go
@@ -39,12 +39,6 @@ func MaxMakeRetryAttemptsOrExit() int {
 	return maxAttemptsOrExit("GO_MAKE_MAX_RETRY_ATTEMPTS")
 }
 
-// MaxTestRetryAttemptsOrExit returns the max test retry attempts according to an env var. Shared
-// between the build command and run-builder command.
-func MaxTestRetryAttemptsOrExit() int {
-	return maxAttemptsOrExit("GO_TEST_MAX_RETRY_ATTEMPTS")
-}
-
 func maxAttemptsOrExit(varName string) int {
 	attempts, err := getEnvIntOrDefault(varName, 1)
 	if err != nil {

--- a/eng/_core/cmd/cmdscan/cmdscan.go
+++ b/eng/_core/cmd/cmdscan/cmdscan.go
@@ -21,7 +21,8 @@ import (
 const description = `
 Cmdscan runs the command given to it as args and monitors the output for text patterns that should
 be elevated to AzDO Pipeline warnings using AzDO logging commands. Timeline events can be discovered
-more easily in the UI and by automated tools like runfo.
+more easily in the UI and by automated tools like runfo. This tool is also able to set a specified
+AzDO variable to 'true' if the command succeeds, to help with retry implementation.
 
 Uses the "log issue" pipeline logging command to create timeline warnings:
 https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning
@@ -67,6 +68,7 @@ var filters []filter
 func main() {
 	help := flag.Bool("h", false, "Print this help message.")
 	prefix := flag.String("envprefix", "", "The env var prefix to use to find scan rules.")
+	successVar := flag.String("successvar", "", "The AzDO pipeline variable name to set to 'true' upon success.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage:\n")
@@ -100,6 +102,10 @@ func main() {
 
 	if err := run(); err != nil {
 		log.Fatalln(err)
+	}
+
+	if *successVar != "" {
+		fmt.Printf("##vso[task.setvariable variable=%v]true\n", *successVar)
 	}
 }
 

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -24,6 +24,10 @@ stages:
             builder: ${{ builder }}
             createSourceArchive: ${{ parameters.createSourceArchive }}
             releaseVersion: ${{ parameters.releaseVersion }}
+            # Attempt to retry the build on Windows to mitigate flakiness:
+            # "Access Denied" during EXE copying and general flakiness during tests.
+            ${{ if eq(builder.os, 'windows') }}:
+              retryAttempts: [1, 2, 3, 4, "FINAL"]
 
   - ${{ if eq(parameters.sign, true) }}:
     - template: pool.yml

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -9,6 +9,10 @@ parameters:
   builder: {}
   createSourceArchive: false
   releaseVersion: ''
+  # List of retry attempt numbers. Pass a list of each index (values are only for display purposes),
+  # where the final element is "FINAL" instead. AzDO has limited looping capabilities, and this is a
+  # way around that.
+  retryAttempts: ["FINAL"]
 
 stages:
   - stage: ${{ parameters.builder.id }}
@@ -104,8 +108,6 @@ stages:
             - pwsh: |
                 Write-Host "Increasing max build retries to mitigate 'Access denied' flakiness during EXE copying on Windows."
                 Write-Host "##vso[task.setvariable variable=GO_MAKE_MAX_RETRY_ATTEMPTS]5"
-                Write-Host "Increasing max test retries to mitigate access denied issues as well as general test flakiness on Windows."
-                Write-Host "##vso[task.setvariable variable=GO_TEST_MAX_RETRY_ATTEMPTS]5"
               displayName: Increase 'make' retry attempts
 
           # Initialize stage 0 toolset ahead of time so we can track timing data separately from the
@@ -192,21 +194,6 @@ stages:
           - ${{ else }}:
             - ${{ if eq(parameters.builder.os, 'windows') }}:
               - pwsh: |
-                  # Use the version of getmingw specified in the util module.
-                  cd eng\_util
-                  go install github.com/microsoft/go-infra/cmd/getmingw
-                  & "$(go env GOPATH)/bin/getmingw" diagnose
-                  & "$(go env GOPATH)/bin/getmingw" run -ci azdo -source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -exception seh -runtime msvcrt
-                displayName: Install MinGW
-
-            - pwsh: |
-                if ($IsWindows) {
-                  Write-Host "Removing Git usr\bin from PATH to avoid running a Linux test that would fail, 'TestScript/script_wait'..."
-                  Write-Host $env:PATH
-                  $env:PATH = (
-                    $env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\Git\usr\bin' }
-                  ) -join ';'
-
                   function RemovePathBinary($name) {
                     $src = (Get-Command $name -ErrorAction SilentlyContinue).Source
                     if ($src) {
@@ -224,26 +211,59 @@ stages:
                   # The Chocolatey shims are located in a single folder in PATH, so we can't change PATH to exclude it.
                   # Upstream Windows builders don't have SWIG installed, so this makes coverage even.
                   RemovePathBinary 'swig'
-                }
+                displayName: Remove unexpected tools
 
-                eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -- `
-                  pwsh eng/run.ps1 run-builder `
+              - pwsh: |
+                  # Use the version of getmingw specified in the util module.
+                  cd eng\_util
+                  go install github.com/microsoft/go-infra/cmd/getmingw
+                  & "$(go env GOPATH)/bin/getmingw" diagnose
+                  & "$(go env GOPATH)/bin/getmingw" run -ci azdo -source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -exception seh -runtime msvcrt
+                displayName: Install MinGW
+
+            # Build. This includes retry logic internally if necessary for this builder.
+            - pwsh: |
+                eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ `
+                  pwsh eng/run.ps1 run-builder -build `
                     -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
                     $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
-                    $(if ('${{ parameters.builder.fips }}') { '-fipsmode' }) `
-                    -junitfile '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml'
-              displayName: Run ${{ parameters.builder.config }}
+                    $(if ('${{ parameters.builder.fips }}') { '-fipsmode' })
+              displayName: Build
 
-            - task: PublishTestResults@2
-              displayName: Publish test results
-              condition: succeededOrFailed()
-              inputs:
-                testResultsFormat: JUnit
-                testResultsFiles: $(Build.SourcesDirectory)/eng/artifacts/TestResults.xml
-                testRunTitle: $(System.JobDisplayName)
-                buildPlatform: ${{ parameters.builder.arch }}
-                buildConfiguration: ${{ parameters.builder.config }}
-                publishRunAttachments: true
+            # Run each test retry attempt in its own step. Benefits over a single step:
+            #
+            # - The dev can immediately see whether any retries happened
+            # - Easier to navigate to a specific retry attempt
+            # - More stable viewing experience if job is ongoing
+            # - Automated tools can more easily check number of retries by relying on structure
+            #
+            # Test retries get their own steps but builds don't because builds are relatively quick,
+            # don't produce much output, and errors are easier to reproduce.
+            - ${{ each attempt in parameters.retryAttempts }}:
+              - pwsh: |
+                  if ($IsWindows) {
+                    Write-Host "Removing Git usr\bin from PATH to avoid running a Linux test that would fail, 'TestScript/script_wait'..."
+                    Write-Host $env:PATH
+                    $env:PATH = (
+                      $env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\Git\usr\bin' }
+                    ) -join ';'
+                  }
+
+                  eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -successvar TEST_BUILDER_SUCCESSFUL -- `
+                    pwsh eng/run.ps1 run-builder -test `
+                      -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
+                      $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
+                      $(if ('${{ parameters.builder.fips }}') { '-fipsmode' })
+                ${{ if eq(length(parameters.retryAttempts), 1) }}:
+                  displayName: Test
+                ${{ else }}:
+                  displayName: Test (🔁 ${{ attempt }})
+                name: test_${{ attempt }}
+                # Run unless a previous retry was successful or something catastrophic happens.
+                # Note: test failure returns success, so it doesn't count as catastrophic.
+                condition: and(ne(variables['TEST_BUILDER_SUCCESSFUL'], 'true'), succeeded())
+                ${{ if ne(attempt, 'FINAL') }}:
+                  ignoreLASTEXITCODE: true
 
           - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
             - template: ../../common/templates/steps/generate-sbom.yml


### PR DESCRIPTION
* Switch to pipeline logic for test retries. Makes it easier to find the failure and see if retries were necessary.
  * Fixes https://github.com/microsoft/go/issues/1060
* Remove junit test output conversion: this seemed to cut off test output in some cases.
  * Fixes https://github.com/microsoft/go/issues/1049
  * Opened https://github.com/microsoft/go/issues/1114 to get this (or something like it) working again in the future.