### PR TITLE
[microsoft/release-branch.go1.22] Enable fipstls when running in FIPS mode

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -17,7 +17,7 @@ The Go `crypto` package is not FIPS certified, and the Go team has stated that i
 
 On the other hand, Google maintains the [goexperiment](https://pkg.go.dev/internal/goexperiment) `boringcrypto`, that uses cgo and BoringSSL to implement various crypto primitives. As BoringSSL is FIPS 140-2 certified, an application built using this flag is more likely to be FIPS 140-2 compliant, yet Google does not provide any liability about the suitability of this code in relation to the FIPS 140-2 standard.
 
-In addition to that, the boringcrypto flag also provides a mechanism to restrict all TLS configuration to FIPS-approved settings. The effect is triggered by importing the fipsonly package anywhere in a program, as in:
+In addition to that, the boringcrypto flag also provides a mechanism to restrict all TLS configuration to FIPS-compliant settings. The effect is triggered by importing the fipsonly package anywhere in a program, as in:
 
 ```go
   import _ "crypto/tls/fipsonly"
@@ -40,7 +40,7 @@ The Microsoft Go fork provides several ways to configure the crypto backend and 
   - [`goexperiment.<backend>crypto` build tag](#usage-build)
   - [`requirefips` build tag](#build-option-to-require-fips-mode)
   - [`GOEXPERIMENT` `allowcryptofallback`](#build-option-to-use-go-crypto-if-the-backend-compatibility-check-fails)
-  - [`import _ "crypto/tls/fipsonly"` source change](#tls-with-fips-approved-settings)
+  - [`import _ "crypto/tls/fipsonly"` source change](#tls-with-fips-compliant-settings)
 - Runtime configuration:
   - [`GOFIPS` environment variable](#usage-runtime)
   - (OpenSSL backend) [`GO_OPENSSL_VERSION_OVERRIDE` environment variable](#runtime-openssl-version-override)
@@ -66,7 +66,7 @@ There are typically two goals that lead to this document. Creating a FIPS compli
 
 Other notes for common configurations:
 
-- If the app uses TLS, `import _ "crypto/tls/fipsonly"` is also necessary for FIPS compliance. See [TLS with FIPS-approved settings](#tls-with-fips-approved-settings)
+- Prior to Go 1.22, if the app uses TLS, `import _ "crypto/tls/fipsonly"` is also necessary for FIPS compliance. See [TLS with FIPS-compliant settings](#tls-with-fips-compliant-settings)
 - A Docker image is available that includes suitable build-time config in the environment. See [Dockerfile base image](#dockerfile-base-image)
 
 Some configurations are invalid and intentionally result in a build error or runtime panic:
@@ -344,17 +344,17 @@ The OpenSSL version present when building a program does not have to match the O
 
 This feature does not require any additional configuration, but it only works with OpenSSL versions known and supported by the Go toolchain.
 
-### TLS with FIPS-approved settings
+### TLS with FIPS-compliant settings
 
-The Go TLS stack will automatically use OpenSSL crypto primitives when running in FIPS mode. Yet, the FIPS 140-2 standard places additional restrictions on TLS communications, mainly on which cyphers and signers are allowed.
+The Go TLS stack will automatically use crypto primitives from the selected crypto backend. Yet, this isn't enough for FIPS compliance: the FIPS 140-2 standard places additional restrictions on TLS communications, mainly on which cyphers and signers are allowed. Note that this can reduce compatibility with old devices that do not support modern cryptography techniques such as TLS 1.2.
 
-A program can import the `crypto/tls/fipsonly` package to configure the Go TLS stack so it is compliant with these restrictions. The configuration is done by an `init()` function, so only importing it is necessary:
+Since Go 1.22, the Microsoft Go runtime automatically enforces that `crypto/tls` and `crypto/x509` only use FIPS-compliant settings when running in FIPS mode. This differs from upstream's BoringCrypto backend, which requires you to import `crypto/tls/fipsonly` to apply the FIPS-mandated restrictions. The Microsoft Go crypto backends do this automatically to reduce the source code changes necessary to produce a FIPS-compliant Go application, and to make it easier to use the same binary in both FIPS and non-FIPS environments.
+
+Prior to Go 1.22, a program using the Go TLS stack must import the `crypto/tls/fipsonly` package to be compliant with these restrictions. The configuration is done by an `init()` function, so only importing it is necessary:
 
 ```go
   import _ "crypto/tls/fipsonly"
 ```
-
-Note that this can reduce compatibility with old devices that do not support modern cryptography techniques such as TLS 1.2.
 
 ## Acknowledgements
 
@@ -371,6 +371,10 @@ A program running in FIPS mode can claim it is using a FIPS-certified cryptograp
 ## Changelog
 
 This list of major changes is intended for quick reference and for access to historical information about versions that are no longer supported. The behavior of all in-support versions are documented in the sections above with notes for version-specific differences where necessary.
+
+### Go 1.22 (Feb 2023)
+
+- Automatically enforce that `crypto/tls` and `crypto/x509` only use FIPS-approved settings when running in FIPS mode.
 
 ### Go 1.21 (Aug 2023)
 

--- a/eng/doc/fips/UserGuide.md
+++ b/eng/doc/fips/UserGuide.md
@@ -1534,7 +1534,10 @@ Does not contain crypto primitives, out of FIPS scope.
 
 Package tls partially implements TLS 1.2, as specified in RFC 5246, and TLS 1.3, as specified in RFC 8446.
 
-Package tls will automatically use FIPS compliant primitives implemented in other crypto packages, but it will accept non-FIPS ciphers and signature algorithms unless `crypto/tls/fipsonly` is imported.
+Package tls will automatically use FIPS compliant primitives implemented in other crypto packages.
+
+Since Go 1.22, the Microsoft Go runtime automatically enforces that tls only uses FIPS-approved settings when running in FIPS mode.
+Prior to Go 1.22, a program using tls must import the `crypto/tls/fipsonly` package to be compliant with these restrictions.
 
 When using TLS in FIPS-only mode the TLS handshake has the following restrictions:
 

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -42,15 +42,19 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/sha256/sha256_test.go             |   2 +-
  src/crypto/sha512/sha512.go                  |   2 +-
  src/crypto/sha512/sha512_test.go             |   2 +-
+ src/crypto/tls/boring_test.go                |   5 +
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/crypto/tls/handshake_client.go           |  25 ++-
  src/crypto/tls/handshake_server.go           |  25 ++-
  src/crypto/tls/key_schedule.go               |  18 +-
  src/crypto/tls/prf.go                        |  77 +++++---
  src/crypto/tls/prf_test.go                   |  12 +-
- src/go/build/deps_test.go                    |   2 +
+ src/crypto/x509/boring_test.go               |   5 +
+ src/go/build/deps_test.go                    |   3 +
+ src/net/http/client_test.go                  |   6 +-
+ src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 46 files changed, 700 insertions(+), 66 deletions(-)
+ 50 files changed, 761 insertions(+), 94 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -1038,7 +1042,7 @@ index b63b6eb01db637..27241df1867cb5 100644
  	"hash"
  	"io"
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index 0715421187d8b1..90d05432ed102b 100644
+index 9342930dc1236f..72c31368f1cc2e 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
 @@ -27,9 +27,9 @@ package rsa
@@ -1054,7 +1058,7 @@ index 0715421187d8b1..90d05432ed102b 100644
  	"crypto/rand"
  	"crypto/subtle"
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 3278a7ff305766..95f4b8e98d2fb0 100644
+index 2afa045a3a0bd2..86466e67e87eeb 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -8,7 +8,7 @@ import (
@@ -1144,8 +1148,24 @@ index 921cdbb7bbd477..2fef7ddae07480 100644
  	"crypto/rand"
  	"encoding"
  	"encoding/hex"
+diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
+index 085ff5713ec52f..23bc4f6eea82ab 100644
+--- a/src/crypto/tls/boring_test.go
++++ b/src/crypto/tls/boring_test.go
+@@ -25,6 +25,11 @@ import (
+ 	"time"
+ )
+ 
++func init() {
++	// crypto/tls expects fipstls.Required() to be false.
++	fipstls.Abandon()
++}
++
+ func TestBoringServerProtocolVersion(t *testing.T) {
+ 	test := func(name string, v uint16, msg string) {
+ 		t.Run(name, func(t *testing.T) {
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
-index 636689beb4dcef..7c732805725cd8 100644
+index 6f5bc37197a4f4..9079b5a2e3d50d 100644
 --- a/src/crypto/tls/cipher_suites.go
 +++ b/src/crypto/tls/cipher_suites.go
 @@ -10,7 +10,7 @@ import (
@@ -1158,10 +1178,10 @@ index 636689beb4dcef..7c732805725cd8 100644
  	"crypto/sha1"
  	"crypto/sha256"
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
-index 89004c28989627..eafbb221c07a33 100644
+index f016e01b4b5182..e685339c29780a 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
-@@ -659,12 +659,16 @@ func (hs *clientHandshakeState) doFullHandshake() error {
+@@ -657,12 +657,16 @@ func (hs *clientHandshakeState) doFullHandshake() error {
  
  	if hs.serverHello.extendedMasterSecret {
  		c.extMasterSecret = true
@@ -1180,7 +1200,7 @@ index 89004c28989627..eafbb221c07a33 100644
  	if err := c.config.writeKeyLog(keyLogLabelTLS12, hs.hello.random, hs.masterSecret); err != nil {
  		c.sendAlert(alertInternalError)
  		return errors.New("tls: failed to write to key log: " + err.Error())
-@@ -725,8 +729,12 @@ func (hs *clientHandshakeState) doFullHandshake() error {
+@@ -723,8 +727,12 @@ func (hs *clientHandshakeState) doFullHandshake() error {
  func (hs *clientHandshakeState) establishKeys() error {
  	c := hs.c
  
@@ -1194,7 +1214,7 @@ index 89004c28989627..eafbb221c07a33 100644
  	var clientCipher, serverCipher any
  	var clientHash, serverHash hash.Hash
  	if hs.suite.cipher != nil {
-@@ -866,7 +874,11 @@ func (hs *clientHandshakeState) readFinished(out []byte) error {
+@@ -864,7 +872,11 @@ func (hs *clientHandshakeState) readFinished(out []byte) error {
  		return unexpectedMessageError(serverFinished, msg)
  	}
  
@@ -1207,7 +1227,7 @@ index 89004c28989627..eafbb221c07a33 100644
  	if len(verify) != len(serverFinished.verifyData) ||
  		subtle.ConstantTimeCompare(verify, serverFinished.verifyData) != 1 {
  		c.sendAlert(alertHandshakeFailure)
-@@ -936,7 +948,10 @@ func (hs *clientHandshakeState) sendFinished(out []byte) error {
+@@ -934,7 +946,10 @@ func (hs *clientHandshakeState) sendFinished(out []byte) error {
  	}
  
  	finished := new(finishedMsg)
@@ -1527,11 +1547,35 @@ index 8233985a62bd22..f46d4636557714 100644
  		clientMACString := hex.EncodeToString(clientMAC)
  		serverMACString := hex.EncodeToString(serverMAC)
  		clientKeyString := hex.EncodeToString(clientKey)
+diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
+index 33fd0ed52b1ff6..ffc3eeca9dbf95 100644
+--- a/src/crypto/x509/boring_test.go
++++ b/src/crypto/x509/boring_test.go
+@@ -26,6 +26,11 @@ const (
+ 	boringCertFIPSOK = 0x80
+ )
+ 
++func init() {
++	// crypto/tls expects fipstls.Required() to be false.
++	fipstls.Abandon()
++}
++
+ func boringRSAKey(t *testing.T, size int) *rsa.PrivateKey {
+ 	k, err := rsa.GenerateKey(rand.Reader, size)
+ 	if err != nil {
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 7ce8d346b406ae..3dd2595b34b07b 100644
+index 47a0f3a0b409d4..05b15b6dc022ef 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -439,6 +439,7 @@ var depsRules = `
+@@ -427,6 +427,7 @@ var depsRules = `
+ 	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
+ 	# Unfortunately, stuck with reflect via encoding/binary.
+ 	crypto/internal/boring/sig,
++	crypto/internal/boring/fipstls,
+ 	crypto/internal/boring/syso,
+ 	encoding/binary,
+ 	golang.org/x/sys/cpu,
+@@ -439,6 +440,7 @@ var depsRules = `
  	crypto/cipher,
  	crypto/internal/boring/bcache
  	< crypto/internal/boring
@@ -1539,7 +1583,7 @@ index 7ce8d346b406ae..3dd2595b34b07b 100644
  	< crypto/boring;
  
  	crypto/internal/alias
-@@ -472,6 +473,7 @@ var depsRules = `
+@@ -472,6 +474,7 @@ var depsRules = `
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
  	< crypto/internal/boring/bbig
@@ -1547,6 +1591,121 @@ index 7ce8d346b406ae..3dd2595b34b07b 100644
  	< crypto/rand
  	< crypto/ed25519
  	< encoding/asn1
+diff --git a/src/net/http/client_test.go b/src/net/http/client_test.go
+index 7459b9cb6ed1df..e0ca4f7cedad8a 100644
+--- a/src/net/http/client_test.go
++++ b/src/net/http/client_test.go
+@@ -946,7 +946,9 @@ func testResponseSetsTLSConnectionState(t *testing.T, mode testMode) {
+ 
+ 	c := ts.Client()
+ 	tr := c.Transport.(*Transport)
+-	tr.TLSClientConfig.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA}
++	// The cipher suite doesn't really matter, but we need a FIPS-compliant one
++	// in case fipstls.Required() is true.
++	tr.TLSClientConfig.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}
+ 	tr.TLSClientConfig.MaxVersion = tls.VersionTLS12 // to get to pick the cipher suite
+ 	tr.Dial = func(netw, addr string) (net.Conn, error) {
+ 		return net.Dial(netw, ts.Listener.Addr().String())
+@@ -959,7 +961,7 @@ func testResponseSetsTLSConnectionState(t *testing.T, mode testMode) {
+ 	if res.TLS == nil {
+ 		t.Fatal("Response didn't set TLS Connection State.")
+ 	}
+-	if got, want := res.TLS.CipherSuite, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA; got != want {
++	if got, want := res.TLS.CipherSuite, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256; got != want {
+ 		t.Errorf("TLS Cipher Suite = %d; want %d", got, want)
+ 	}
+ }
+diff --git a/src/net/smtp/smtp_test.go b/src/net/smtp/smtp_test.go
+index 259b10b93d9e36..0d48576b358644 100644
+--- a/src/net/smtp/smtp_test.go
++++ b/src/net/smtp/smtp_test.go
+@@ -1105,40 +1105,60 @@ func sendMail(hostPort string) error {
+ 
+ // localhostCert is a PEM-encoded TLS cert generated from src/crypto/tls:
+ //
+-//	go run generate_cert.go --rsa-bits 1024 --host 127.0.0.1,::1,example.com \
++//	Use a 2048-bits RSA key to make it FIPS-compliant.
++//	go run generate_cert.go --rsa-bits 2048 --host 127.0.0.1,::1,example.com \
+ //		--ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+ var localhostCert = []byte(`
+ -----BEGIN CERTIFICATE-----
+-MIICFDCCAX2gAwIBAgIRAK0xjnaPuNDSreeXb+z+0u4wDQYJKoZIhvcNAQELBQAw
+-EjEQMA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2
+-MDAwMFowEjEQMA4GA1UEChMHQWNtZSBDbzCBnzANBgkqhkiG9w0BAQEFAAOBjQAw
+-gYkCgYEA0nFbQQuOWsjbGtejcpWz153OlziZM4bVjJ9jYruNw5n2Ry6uYQAffhqa
+-JOInCmmcVe2siJglsyH9aRh6vKiobBbIUXXUU1ABd56ebAzlt0LobLlx7pZEMy30
+-LqIi9E6zmL3YvdGzpYlkFRnRrqwEtWYbGBf3znO250S56CCWH2UCAwEAAaNoMGYw
+-DgYDVR0PAQH/BAQDAgKkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1UdEwEB/wQF
+-MAMBAf8wLgYDVR0RBCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAAAAAAAAAA
+-AAAAAAEwDQYJKoZIhvcNAQELBQADgYEAbZtDS2dVuBYvb+MnolWnCNqvw1w5Gtgi
+-NmvQQPOMgM3m+oQSCPRTNGSg25e1Qbo7bgQDv8ZTnq8FgOJ/rbkyERw2JckkHpD4
+-n4qcK27WkEDBtQFlPihIM8hLIuzWoi/9wygiElTy/tVL3y7fGCvY2/k1KBthtZGF
+-tN8URjVmyEo=
++MIIDOTCCAiGgAwIBAgIQKhWw7zkzXjX78HaPlVbNrjANBgkqhkiG9w0BAQsFADAS
++MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
++MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
++MIIBCgKCAQEAy1EYLA8IFvZyUPY+uI7KToneaQPvIzQiOeWlDnFnoanw6h3KpoVc
+++yNbinK41WfXoSN/1kJ9gmGiFhJTPZ4rQ7DJsD7ethcpuz4uIimdWPohcBzwgbx4
++wjhUgfUsCO6m76fFqrhbkHMDiS2iUjg2gyMVQCrqi8EuBW16yFQdJqPU04p+2rYw
++eJ9lzdeSLR4yvx7p1JS8sS4DbSyrAUaJ9J1sH/gu0nSHNMo7WtIu9K8JmPeYR4X5
++5KLURBU9PmvoGW+5ss/xS6SnacHAD9FebNPQqGB/soBA9gdJIN+5KW0xcE38Zz5Q
++wAAUiU+VlWuZmge0sI8Ix8uIPIvGQSKN0wIDAQABo4GIMIGFMA4GA1UdDwEB/wQE
++AwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1Ud
++DgQWBBRNMP9Cr0yrXpMpsgEtDr8FPmUEazAuBgNVHREEJzAlggtleGFtcGxlLmNv
++bYcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAQEAF0/z
++KEnZrAsz4ov4fEvKY42EbKPm8s0pklPLmKVIh/iS7jTxxxvgDtOToiJ6IXY8Cfb3
++nG1i78YakoVPUL5Cfh5LKDefMoefk6575ur2+gSdzgNmKUnlVfOMfpflia/ugATZ
++5ORhpmKRKWzwXQ67S5XeVlZAehTsywQstsDu8WEVoSUnRSk1jZsCThOQfdlpox+K
++71rGPSTxB9yCHMzZsk4xyZlGLaC0vDSJ+Zb5gWvAcvkSnpREvmc3/9TaW/lbUed6
++uhO17lARcUhPCzkR5wAZCo/PihHMSXL8cqT4QdIux75OBxB/3EgLHL7KQw28A50g
++DogldK8zx1ZADmupUA==
+ -----END CERTIFICATE-----`)
+ 
+ // localhostKey is the private key for localhostCert.
+ var localhostKey = []byte(testingKey(`
+ -----BEGIN RSA TESTING KEY-----
+-MIICXgIBAAKBgQDScVtBC45ayNsa16NylbPXnc6XOJkzhtWMn2Niu43DmfZHLq5h
+-AB9+Gpok4icKaZxV7ayImCWzIf1pGHq8qKhsFshRddRTUAF3np5sDOW3QuhsuXHu
+-lkQzLfQuoiL0TrOYvdi90bOliWQVGdGurAS1ZhsYF/fOc7bnRLnoIJYfZQIDAQAB
+-AoGBAMst7OgpKyFV6c3JwyI/jWqxDySL3caU+RuTTBaodKAUx2ZEmNJIlx9eudLA
+-kucHvoxsM/eRxlxkhdFxdBcwU6J+zqooTnhu/FE3jhrT1lPrbhfGhyKnUrB0KKMM
+-VY3IQZyiehpxaeXAwoAou6TbWoTpl9t8ImAqAMY8hlULCUqlAkEA+9+Ry5FSYK/m
+-542LujIcCaIGoG1/Te6Sxr3hsPagKC2rH20rDLqXwEedSFOpSS0vpzlPAzy/6Rbb
+-PHTJUhNdwwJBANXkA+TkMdbJI5do9/mn//U0LfrCR9NkcoYohxfKz8JuhgRQxzF2
+-6jpo3q7CdTuuRixLWVfeJzcrAyNrVcBq87cCQFkTCtOMNC7fZnCTPUv+9q1tcJyB
+-vNjJu3yvoEZeIeuzouX9TJE21/33FaeDdsXbRhQEj23cqR38qFHsF1qAYNMCQQDP
+-QXLEiJoClkR2orAmqjPLVhR3t2oB3INcnEjLNSq8LHyQEfXyaFfu4U9l5+fRPL2i
+-jiC0k/9L5dHUsF0XZothAkEA23ddgRs+Id/HxtojqqUT27B8MT/IGNrYsp4DvS/c
+-qgkeluku4GjxRlDMBuXk94xOBEinUs+p/hwP1Alll80Tpg==
++MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDLURgsDwgW9nJQ
++9j64jspOid5pA+8jNCI55aUOcWehqfDqHcqmhVz7I1uKcrjVZ9ehI3/WQn2CYaIW
++ElM9nitDsMmwPt62Fym7Pi4iKZ1Y+iFwHPCBvHjCOFSB9SwI7qbvp8WquFuQcwOJ
++LaJSODaDIxVAKuqLwS4FbXrIVB0mo9TTin7atjB4n2XN15ItHjK/HunUlLyxLgNt
++LKsBRon0nWwf+C7SdIc0yjta0i70rwmY95hHhfnkotREFT0+a+gZb7myz/FLpKdp
++wcAP0V5s09CoYH+ygED2B0kg37kpbTFwTfxnPlDAABSJT5WVa5maB7SwjwjHy4g8
++i8ZBIo3TAgMBAAECggEAc7dv/oN/ozIY1iOQhxId6p1lTHfEv1CIulMNoi7BQK2s
++RFM4Z5Y32WfCTgYFVNCJVVkTBStKq85Npio/3i4Libcw03K05wY/5iX5s8/jkiSq
++q1iNOgm+4SuWTXDw4xSRRo1CX2wWERykwoqKfCkqPXDWQ3Mpkukb/FLXMvVMshRA
++9v9L6MyrCnsFHl8q2J6hcC+RQJ0pb5I4NF6KhMxABWxxxlDO0zYLA0wfhEn8nj/l
++J37QLHmsA7pzxo+NqDTPgpfBuuTbRVGMkC+fPCXYinbubBeURFO2j2yBlseK+Vbd
++sEffiAnPr4ocCz0k0tHAMMY7hKHup2HWuJGFu0IhAQKBgQDkKFEEcYWNx5Ybl1LV
++qr2qIYofpFL+Gu5MWSZxzZbE8u9v0tTsp8SRhXkgjeHY6qjBUBnLgklOKwSigQAm
++j9de44cXjnUIArzeAHsH3fzpYrLfsvBla6wQyr34D0chVCZ0cX/s/zXkSN4PcEkA
++GGfKAENrGskDyc4uq1sIactu8wKBgQDkIL/XT7ysvsaxA+SfIs2CHgb8GNKgtoI1
++QyR0+MfeJGCLwI9qcLbVzXda34qrzQw3YLIm2VHqhzJ4zb0gnyJ4adPZYwpLTgiU
++jVksBVIwBTfbxYvF2+07poCSobCFKLGQnAujhDDIGDAUKQXQmFcqUNWw0QHfQzkS
++xs36H27doQKBgQCjM8+YLRgKbc0LGXhwTHz1GJ6zuZiAGYWB6XddimEhqmDpjVcv
++nWY3bdFSHwuBXYGvHfwFncGP/6eGEl6oNtYpEvoMOKOwQj0VVCStYPZLf4VSDK52
++7ckcDdpLeao4xffn7VRDk97Z1+G4C2q8fbioPv36vCMz6YPp0DsCzqJtTwKBgCUN
++4LtDW10fu7xC6p6ik4jgAbhu+79ZBbtLBZ/uTOCbPgdVJrZeSoRd1FYxWx/etW5F
++SYqf3/tdLGiM2nxy/LFcVynHOYPTz/b5IpPQ5XGhV1peMv7XYyg+OkIW+0oVuwnH
++HujXbukBbMXJiAVCyV25NYx71ncCP0H6grhu5J4hAoGAUaketZWHD/ks9JCoPtfy
++pNnXqrIvTp1cSGJpVUQT/DUqAjevyZ5Q8PFPf09BZ6uYlXtCqsp7pA/fqNdlJRPR
++tHRjpZ5XauBiFdpRNH4tJBTiWWhyuWhkWn369Az7HP3CIlJLeq2FlKCvMClcO4op
++Qc9LHT7jqtcy+LqAVBpsJ/o=
+ -----END RSA TESTING KEY-----`))
+ 
+ func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "PRIVATE KEY") }
 diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
 index 5a98b20253181c..9042f2c2795e19 100644
 --- a/src/runtime/runtime_boring.go

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 317 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 323 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -37,7 +37,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 33 files changed, 399 insertions(+), 23 deletions(-)
+ 33 files changed, 405 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -57,10 +57,10 @@ index f0e3575637c62a..0e9aceeb832d3b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 5e62bbf4c22c66..7fd1dfcb8e9592 100644
+index fa6a0dd84d41e9..8ebfa08b6ed5be 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1222,12 +1222,11 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1225,12 +1225,11 @@ func (t *tester) registerCgoTests(heading string) {
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
@@ -107,10 +107,10 @@ index 4aaf46b5d0f0dc..6fe798cf4a94e9 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index eab74dc32864ed..d9a41aa26d8908 100644
+index df83896100872f..5d9c1ecbd5eb54 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
-@@ -1162,6 +1162,7 @@ var hostobj []Hostobj
+@@ -1158,6 +1158,7 @@ var hostobj []Hostobj
  // These packages can use internal linking mode.
  // Others trigger external mode.
  var internalpkg = []string{
@@ -190,10 +190,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..d929b3e516bdb0
+index 00000000000000..69af0ffe2fcf80
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,317 @@
+@@ -0,0 +1,323 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -208,6 +208,7 @@ index 00000000000000..d929b3e516bdb0
 +import (
 +	"crypto"
 +	"crypto/cipher"
++	"crypto/internal/boring/fipstls"
 +	"crypto/internal/boring/sig"
 +	"hash"
 +	"io"
@@ -281,6 +282,11 @@ index 00000000000000..d929b3e516bdb0
 +			}
 +		}
 +	}
++	if openssl.FIPS() {
++		// FIPS mode is enabled,
++		// so force FIPS mode for crypto/tls and crypto/x509.
++		fipstls.Force()
++	}
 +	sig.BoringCrypto()
 +}
 +
@@ -338,8 +344,8 @@ index 00000000000000..d929b3e516bdb0
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return openssl.NewHMAC(h, key) }
 +
-+func NewAESCipher(key []byte) (cipher.Block, error) { return openssl.NewAESCipher(key) }
-+func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) { return openssl.NewGCMTLS(c) }
++func NewAESCipher(key []byte) (cipher.Block, error)   { return openssl.NewAESCipher(key) }
++func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return openssl.NewGCMTLS(c) }
 +func NewGCMTLS13(c cipher.Block) (cipher.AEAD, error) { return openssl.NewGCMTLS13(c) }
 +
 +type PublicKeyECDSA = openssl.PublicKeyECDSA
@@ -577,10 +583,10 @@ index 34c22c8fbba7da..933ac569e034a8 100644
  package rsa
  
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 95f4b8e98d2fb0..3bb307e7bddc48 100644
+index 86466e67e87eeb..dbcc1bec58bd46 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
-@@ -680,6 +680,9 @@ func TestDecryptOAEP(t *testing.T) {
+@@ -690,6 +690,9 @@ func TestDecryptOAEP(t *testing.T) {
  }
  
  func Test2DecryptOAEP(t *testing.T) {
@@ -591,7 +597,7 @@ index 95f4b8e98d2fb0..3bb307e7bddc48 100644
  
  	msg := []byte{0xed, 0x36, 0x90, 0x8d, 0xbe, 0xfc, 0x35, 0x40, 0x70, 0x4f, 0xf5, 0x9d, 0x6e, 0xc2, 0xeb, 0xf5, 0x27, 0xae, 0x65, 0xb0, 0x59, 0x29, 0x45, 0x25, 0x8c, 0xc1, 0x91, 0x22}
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index aad96b1c747784..9ee834e5a5952b 100644
+index 1827f764589b58..70baa62d63754a 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -2,7 +2,7 @@
@@ -604,7 +610,7 @@ index aad96b1c747784..9ee834e5a5952b 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index a192a657b4d79c..2b7e197946e4f8 100644
+index 23bc4f6eea82ab..41983b9074fab3 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -655,7 +661,7 @@ index 14a85fbf1bd465..5caa181eec51a5 100644
  	"fmt"
  	"hash"
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index edccb44d87a553..cae24d19c9f444 100644
+index 7d85b39c59319e..1aaabd5ef486aa 100644
 --- a/src/crypto/tls/notboring.go
 +++ b/src/crypto/tls/notboring.go
 @@ -2,7 +2,7 @@
@@ -668,7 +674,7 @@ index edccb44d87a553..cae24d19c9f444 100644
  package tls
  
 diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
-index e6237e96bb3b17..e4086bd90feb83 100644
+index 095b58c31590d4..9aec21dbcd3bff 100644
 --- a/src/crypto/x509/boring.go
 +++ b/src/crypto/x509/boring.go
 @@ -2,7 +2,7 @@
@@ -681,7 +687,7 @@ index e6237e96bb3b17..e4086bd90feb83 100644
  package x509
  
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index 33fd0ed52b1ff6..e8fce393d29b00 100644
+index ffc3eeca9dbf95..b3227dc2560ff8 100644
 --- a/src/crypto/x509/boring_test.go
 +++ b/src/crypto/x509/boring_test.go
 @@ -2,7 +2,7 @@
@@ -707,7 +713,7 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index c18ae7760f61c5..eea762d89ae327 100644
+index 6b0e3c58ee013f..4ac30a14a69b37 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -719,7 +725,7 @@ index c18ae7760f61c5..eea762d89ae327 100644
  	golang.org/x/net v0.19.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index 7c3519882a5b78..a271094177aaee 100644
+index c59bf5956bf6c5..771683f602d365 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
@@ -729,10 +735,10 @@ index 7c3519882a5b78..a271094177aaee 100644
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
  golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 3dd2595b34b07b..f126cad1f5c460 100644
+index 05b15b6dc022ef..6d9bccdaddede6 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -438,6 +438,8 @@ var depsRules = `
+@@ -439,6 +439,8 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -741,7 +747,7 @@ index 3dd2595b34b07b..f126cad1f5c460 100644
  	< crypto/internal/boring
  	< crypto/internal/backend
  	< crypto/boring;
-@@ -472,6 +474,7 @@ var depsRules = `
+@@ -473,6 +475,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -749,7 +755,7 @@ index 3dd2595b34b07b..f126cad1f5c460 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -757,7 +760,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -763,7 +766,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -758,7 +764,7 @@ index 3dd2595b34b07b..f126cad1f5c460 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -767,7 +770,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -773,7 +776,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -12,7 +12,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 274 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 280 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  33 ++-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
@@ -47,7 +47,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 43 files changed, 471 insertions(+), 40 deletions(-)
+ 43 files changed, 477 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -166,10 +166,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..3d05fa70409666
+index 00000000000000..3d3d13709de5ac
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,274 @@
+@@ -0,0 +1,280 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -184,6 +184,7 @@ index 00000000000000..3d05fa70409666
 +import (
 +	"crypto"
 +	"crypto/cipher"
++	"crypto/internal/boring/fipstls"
 +	"crypto/internal/boring/sig"
 +	"hash"
 +	"io"
@@ -206,6 +207,11 @@ index 00000000000000..3d05fa70409666
 +		if !enabled {
 +			panic("cngcrypto: not in FIPS mode")
 +		}
++	}
++	if enabled, _ := cng.FIPS(); enabled {
++		// FIPS mode is enabled,
++		// so force FIPS mode for crypto/tls and crypto/x509.
++		fipstls.Force()
 +	}
 +	sig.BoringCrypto()
 +}
@@ -1065,7 +1071,7 @@ index 9aec21dbcd3bff..05324f731bedc4 100644
  package x509
  
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index e8fce393d29b00..9818c9b7d6b6b8 100644
+index b3227dc2560ff8..49639cd1ebaa8a 100644
 --- a/src/crypto/x509/boring_test.go
 +++ b/src/crypto/x509/boring_test.go
 @@ -2,7 +2,7 @@
@@ -1091,10 +1097,10 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index eea762d89ae327..0ebd229e72b1ef 100644
+index 4ac30a14a69b37..d70da97418df23 100644
 --- a/src/go.mod
 +++ b/src/go.mod
-@@ -4,6 +4,7 @@ go 1.22
+@@ -4,6 +4,7 @@ go 1.23
  
  require (
  	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240109234540-66bdd798d334
@@ -1103,7 +1109,7 @@ index eea762d89ae327..0ebd229e72b1ef 100644
  	golang.org/x/net v0.19.0
  )
 diff --git a/src/go.sum b/src/go.sum
-index a271094177aaee..1df18639209201 100644
+index 771683f602d365..7c3816ad12846f 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
@@ -1115,10 +1121,10 @@ index a271094177aaee..1df18639209201 100644
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
  golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index f126cad1f5c460..c437493faaaad1 100644
+index 6d9bccdaddede6..40cadb74389d2c 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -438,6 +438,10 @@ var depsRules = `
+@@ -439,6 +439,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1129,7 +1135,7 @@ index f126cad1f5c460..c437493faaaad1 100644
  	< github.com/golang-fips/openssl/v2/internal/subtle
  	< github.com/golang-fips/openssl/v2
  	< crypto/internal/boring
-@@ -474,6 +478,7 @@ var depsRules = `
+@@ -475,6 +479,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big

--- a/patches/0010-Support-TLS-1.3-in-fipstls-mode.patch
+++ b/patches/0010-Support-TLS-1.3-in-fipstls-mode.patch
@@ -59,12 +59,12 @@ index ecd0f5a7b3e9ed..07f15ab91eefd3 100644
  // defaultSupportedSignatureAlgorithms without Ed25519 and SHA-1.
  var fipsSupportedSignatureAlgorithms = []SignatureScheme{
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 86595e588cf604..2ae19d7b1e745e 100644
+index f452aa95b2eb08..a892fb03487392 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
-@@ -25,6 +25,31 @@ import (
- 	"time"
- )
+@@ -30,6 +30,31 @@ func init() {
+ 	fipstls.Abandon()
+ }
  
 +func allCipherSuitesIncludingTLS13() []uint16 {
 +	s := allCipherSuites()
@@ -94,7 +94,7 @@ index 86595e588cf604..2ae19d7b1e745e 100644
  func TestBoringServerProtocolVersion(t *testing.T) {
  	test := func(name string, v uint16, msg string) {
  		t.Run(name, func(t *testing.T) {
-@@ -33,8 +58,11 @@ func TestBoringServerProtocolVersion(t *testing.T) {
+@@ -38,8 +63,11 @@ func TestBoringServerProtocolVersion(t *testing.T) {
  			clientHello := &clientHelloMsg{
  				vers:               v,
  				random:             make([]byte, 32),
@@ -107,7 +107,7 @@ index 86595e588cf604..2ae19d7b1e745e 100644
  				supportedVersions:  []uint16{v},
  			}
  			testClientHelloFailure(t, serverConfig, clientHello, msg)
-@@ -48,25 +76,25 @@ func TestBoringServerProtocolVersion(t *testing.T) {
+@@ -53,25 +81,25 @@ func TestBoringServerProtocolVersion(t *testing.T) {
  
  	fipstls.Force()
  	defer fipstls.Abandon()
@@ -143,7 +143,7 @@ index 86595e588cf604..2ae19d7b1e745e 100644
  		return true
  	}
  	return false
-@@ -86,7 +114,7 @@ func isECDSA(id uint16) bool {
+@@ -91,7 +119,7 @@ func isECDSA(id uint16) bool {
  			return suite.flags&suiteECSign == suiteECSign
  		}
  	}
@@ -152,7 +152,7 @@ index 86595e588cf604..2ae19d7b1e745e 100644
  }
  
  func isBoringSignatureScheme(alg SignatureScheme) bool {
-@@ -109,10 +137,9 @@ func isBoringSignatureScheme(alg SignatureScheme) bool {
+@@ -114,10 +142,9 @@ func isBoringSignatureScheme(alg SignatureScheme) bool {
  
  func TestBoringServerCipherSuites(t *testing.T) {
  	serverConfig := testConfig.Clone()
@@ -164,7 +164,7 @@ index 86595e588cf604..2ae19d7b1e745e 100644
  		if isECDSA(id) {
  			serverConfig.Certificates[0].Certificate = [][]byte{testECDSACertificate}
  			serverConfig.Certificates[0].PrivateKey = testECDSAPrivateKey
-@@ -121,14 +148,19 @@ func TestBoringServerCipherSuites(t *testing.T) {
+@@ -126,14 +153,19 @@ func TestBoringServerCipherSuites(t *testing.T) {
  			serverConfig.Certificates[0].PrivateKey = testRSAPrivateKey
  		}
  		serverConfig.BuildNameToCertificate()
@@ -185,7 +185,7 @@ index 86595e588cf604..2ae19d7b1e745e 100644
  			}
  
  			testClientHello(t, serverConfig, clientHello)
-@@ -160,7 +192,9 @@ func TestBoringServerCurves(t *testing.T) {
+@@ -165,7 +197,9 @@ func TestBoringServerCurves(t *testing.T) {
  				cipherSuites:       []uint16{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
  				compressionMethods: []uint8{compressionNone},
  				supportedCurves:    []CurveID{curveid},
@@ -195,7 +195,7 @@ index 86595e588cf604..2ae19d7b1e745e 100644
  			}
  
  			testClientHello(t, serverConfig, clientHello)
-@@ -279,7 +313,7 @@ func TestBoringClientHello(t *testing.T) {
+@@ -284,7 +318,7 @@ func TestBoringClientHello(t *testing.T) {
  	}
  
  	if !isBoringVersion(hello.vers) {


### PR DESCRIPTION
Port of #1127 into go1.22 release branch.