### PR TITLE
Remove long path support hack and stop using the RtlGetCurrentPeb undocumented API

### DIFF
--- a/patches/0013-remove-long-path-support-hack.patch
+++ b/patches/0013-remove-long-path-support-hack.patch
@@ -3,6 +3,16 @@ From: qmuntal <qmuntaldiaz@microsoft.com>
 Date: Thu, 21 Mar 2024 11:36:42 +0100
 Subject: [PATCH] remove long path support hack
 
+Upstream Go tricks Windows into enabling long path support by setting an
+undocumented flag in the PEB. The Microsoft Go fork can't use undocumented
+APIs, so this commit removes the hack.
+
+There is no documented way to enable long path support from within the
+process, so this this is a breaking change for the Microsoft Go fork.
+Note that the Go standard library makes a best effort to support long
+paths by using the `\\?\` prefix when possible, so this change should
+only affect long relative paths, which can't be used with the `\\?\`.
+
 ---
  src/runtime/os_windows.go | 22 +---------------------
  1 file changed, 1 insertion(+), 21 deletions(-)

--- a/patches/0013-remove-long-path-support-hack.patch
+++ b/patches/0013-remove-long-path-support-hack.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: qmuntal <qmuntaldiaz@microsoft.com>
+Date: Thu, 21 Mar 2024 11:36:42 +0100
+Subject: [PATCH] remove long path support hack
+
+---
+ src/runtime/os_windows.go | 22 +---------------------
+ 1 file changed, 1 insertion(+), 21 deletions(-)
+
+diff --git a/src/runtime/os_windows.go b/src/runtime/os_windows.go
+index 6273b9dba5d47e..04adfefe2f34c6 100644
+--- a/src/runtime/os_windows.go
++++ b/src/runtime/os_windows.go
+@@ -134,7 +134,6 @@ var (
+ 	_NtCreateWaitCompletionPacket    stdFunction
+ 	_NtAssociateWaitCompletionPacket stdFunction
+ 	_NtCancelWaitCompletionPacket    stdFunction
+-	_RtlGetCurrentPeb                stdFunction
+ 	_RtlGetNtVersionNumbers          stdFunction
+ 
+ 	// These are from non-kernel32.dll, so we prefer to LoadLibraryEx them.
+@@ -268,7 +267,6 @@ func loadOptionalSyscalls() {
+ 			throw("NtCreateWaitCompletionPacket exists but NtCancelWaitCompletionPacket does not")
+ 		}
+ 	}
+-	_RtlGetCurrentPeb = windowsFindfunc(n32, []byte("RtlGetCurrentPeb\000"))
+ 	_RtlGetNtVersionNumbers = windowsFindfunc(n32, []byte("RtlGetNtVersionNumbers\000"))
+ }
+ 
+@@ -432,25 +430,7 @@ var canUseLongPaths bool
+ 
+ // initLongPathSupport enables long path support.
+ func initLongPathSupport() {
+-	const (
+-		IsLongPathAwareProcess = 0x80
+-		PebBitFieldOffset      = 3
+-	)
+-
+-	// Check that we're ≥ 10.0.15063.
+-	var maj, min, build uint32
+-	stdcall3(_RtlGetNtVersionNumbers, uintptr(unsafe.Pointer(&maj)), uintptr(unsafe.Pointer(&min)), uintptr(unsafe.Pointer(&build)))
+-	if maj < 10 || (maj == 10 && min == 0 && build&0xffff < 15063) {
+-		return
+-	}
+-
+-	// Set the IsLongPathAwareProcess flag of the PEB's bit field.
+-	// This flag is not documented, but it's known to be used
+-	// by Windows to enable long path support.
+-	bitField := (*byte)(unsafe.Pointer(stdcall0(_RtlGetCurrentPeb) + PebBitFieldOffset))
+-	*bitField |= IsLongPathAwareProcess
+-
+-	canUseLongPaths = true
++	canUseLongPaths = false
+ }
+ 
+ func osinit() {


### PR DESCRIPTION
The Go runtime enables long path support using an undocumented API -RtlGetCurrentPeb- and an undocumented procedure -modifying a PEB bit-.

This PR remove those uncompliant usages. The side effect is that the Windows APIs will no longer support long paths by default. Users will have to opt-in into it using the officially documented way: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later.

Note that the Go `os` package does provide partial support for absolute long paths by prepending the `\\?\` prefix to long paths before calling Windows file and directory functions. This is officially documented in here: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces.

> Because it turns off automatic expansion of the path string, the `\\?\` prefix also allows the use of ".." and "." in the path names, which can be useful if you are attempting to perform operations on a file with these otherwise reserved relative path specifiers as part of the fully qualified path.

On the other hand, the `\\?\` prefix doesn't work for relative paths, so this PR will break users using long relative paths. The workaround is to follow the official documentation to enable long paths. I plan to submit some upstream PRs to mitigate this breaking change, but there is no silver bullet here.