### PR TITLE
Specify that only certain OpenSSL configurations are supported

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -342,6 +342,8 @@ Not all OpenSSL versions are supported. OpenSSL does not maintain ABI compatibil
 
 Versions not listed above are not supported at all.
 
+Note that one can enable or disable certain [OpenSSL features] when building it, diverging from the default configuration. The Go runtime does not support all possible configurations, and some may cause the Go runtime to panic during initialization or not work as expected. The Go runtime is tested with the default configuration of the supported versions and with the OpenSSL configuration shipped in [Azure Linux]. 
+
 ### Dynamic linking
 
 Dynamic linking (as opposed to static linking) is a requirement for an app to be considered FIPS compliant in Microsoft. The approach the modified Go runtime takes meets that requirement.
@@ -426,3 +428,5 @@ This list of major changes is intended for quick reference and for access to his
 [dlopen]: https://man7.org/linux/man-pages/man3/dlopen.3.html
 [microsoft-go-download]: https://github.com/microsoft/go#binary-distribution
 [microsoft-go-images]: https://github.com/microsoft/go-images
+[OpenSSL features]: https://github.com/openssl/openssl/blob/4114964865435edc475c9ba49a7fa2b78956ab76/INSTALL.md#enable-and-disable-features
+[Azure Linux]: https://github.com/microsoft/azurelinux

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -342,7 +342,8 @@ Not all OpenSSL versions are supported. OpenSSL does not maintain ABI compatibil
 
 Versions not listed above are not supported at all.
 
-Note that one can enable or disable certain [OpenSSL features] when building it, diverging from the default configuration. The Go runtime does not support all possible configurations, and some may cause the Go runtime to panic during initialization or not work as expected. The Go runtime is tested with the default configuration of the supported versions and with the OpenSSL configuration shipped in [Azure Linux]. 
+> [!NOTE]
+> Note that one can enable or disable certain [OpenSSL features] when building it, diverging from the default configuration. The Go runtime does not support all possible configurations, and some may cause the Go runtime to panic during initialization or not work as expected. The Go runtime is tested with the default configuration of the supported versions and with the OpenSSL configuration shipped in [Azure Linux]. 
 
 ### Dynamic linking
 


### PR DESCRIPTION
We are already stating that only certain OpenSSL versions are supported/tested. We should go a little bit further and clarify that only some configurations of those versions are really supported.