### PR TITLE
[release-branch.go1.21] Remove long path support hack

### DIFF
--- a/patches/0012-remove-long-path-support-hack.patch
+++ b/patches/0012-remove-long-path-support-hack.patch
@@ -1,0 +1,96 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: qmuntal <qmuntaldiaz@microsoft.com>
+Date: Wed, 3 Apr 2024 14:27:11 +0200
+Subject: [PATCH] remove long path support hack
+
+Upstream Go tricks Windows into enabling long path support by setting an
+undocumented flag in the PEB. The Microsoft Go fork can't use undocumented
+APIs, so this commit removes the hack.
+
+There is no documented way to enable long path support from within the
+process, so this this is a breaking change for the Microsoft Go fork.
+Note that the Go standard library makes a best effort to support long
+paths by using the `\\?\` prefix when possible, so this change should
+only affect long relative paths, which can't be used with the `\\?\`.
+
+---
+ src/runtime/os_windows.go | 52 +--------------------------------------
+ 1 file changed, 1 insertion(+), 51 deletions(-)
+
+diff --git a/src/runtime/os_windows.go b/src/runtime/os_windows.go
+index 766b087c18dd02..4cb57232ed4a03 100644
+--- a/src/runtime/os_windows.go
++++ b/src/runtime/os_windows.go
+@@ -134,7 +134,6 @@ var (
+ 	// links wrong printf function to cgo executable (see issue
+ 	// 12030 for details).
+ 	_NtWaitForSingleObject stdFunction
+-	_RtlGetCurrentPeb      stdFunction
+ 	_RtlGetVersion         stdFunction
+ 
+ 	// These are from non-kernel32.dll, so we prefer to LoadLibraryEx them.
+@@ -260,7 +259,6 @@ func loadOptionalSyscalls() {
+ 		throw("ntdll.dll not found")
+ 	}
+ 	_NtWaitForSingleObject = windowsFindfunc(n32, []byte("NtWaitForSingleObject\000"))
+-	_RtlGetCurrentPeb = windowsFindfunc(n32, []byte("RtlGetCurrentPeb\000"))
+ 	_RtlGetVersion = windowsFindfunc(n32, []byte("RtlGetVersion\000"))
+ 
+ 	if !haveCputicksAsm {
+@@ -460,55 +458,7 @@ var longFileName [(_MAX_PATH+1)*2 + 1]byte
+ // canUseLongPaths is set to true, and later when called, os.fixLongPath
+ // returns early without doing work.
+ func initLongPathSupport() {
+-	const (
+-		IsLongPathAwareProcess = 0x80
+-		PebBitFieldOffset      = 3
+-		OPEN_EXISTING          = 3
+-		ERROR_PATH_NOT_FOUND   = 3
+-	)
+-
+-	// Check that we're ≥ 10.0.15063.
+-	info := _OSVERSIONINFOW{}
+-	info.osVersionInfoSize = uint32(unsafe.Sizeof(info))
+-	stdcall1(_RtlGetVersion, uintptr(unsafe.Pointer(&info)))
+-	if info.majorVersion < 10 || (info.majorVersion == 10 && info.minorVersion == 0 && info.buildNumber < 15063) {
+-		return
+-	}
+-
+-	// Set the IsLongPathAwareProcess flag of the PEB's bit field.
+-	bitField := (*byte)(unsafe.Pointer(stdcall0(_RtlGetCurrentPeb) + PebBitFieldOffset))
+-	originalBitField := *bitField
+-	*bitField |= IsLongPathAwareProcess
+-
+-	// Check that this actually has an effect, by constructing a large file
+-	// path and seeing whether we get ERROR_PATH_NOT_FOUND, rather than
+-	// some other error, which would indicate the path is too long, and
+-	// hence long path support is not successful. This whole section is NOT
+-	// strictly necessary, but is a nice validity check for the near to
+-	// medium term, when this functionality is still relatively new in
+-	// Windows.
+-	getRandomData(longFileName[len(longFileName)-33 : len(longFileName)-1])
+-	start := copy(longFileName[:], sysDirectory[:sysDirectoryLen])
+-	const dig = "0123456789abcdef"
+-	for i := 0; i < 32; i++ {
+-		longFileName[start+i*2] = dig[longFileName[len(longFileName)-33+i]>>4]
+-		longFileName[start+i*2+1] = dig[longFileName[len(longFileName)-33+i]&0xf]
+-	}
+-	start += 64
+-	for i := start; i < len(longFileName)-1; i++ {
+-		longFileName[i] = 'A'
+-	}
+-	stdcall7(_CreateFileA, uintptr(unsafe.Pointer(&longFileName[0])), 0, 0, 0, OPEN_EXISTING, 0, 0)
+-	// The ERROR_PATH_NOT_FOUND error value is distinct from
+-	// ERROR_FILE_NOT_FOUND or ERROR_INVALID_NAME, the latter of which we
+-	// expect here due to the final component being too long.
+-	if getlasterror() == ERROR_PATH_NOT_FOUND {
+-		*bitField = originalBitField
+-		println("runtime: warning: IsLongPathAwareProcess failed to enable long paths; proceeding in fixup mode")
+-		return
+-	}
+-
+-	canUseLongPaths = true
++	canUseLongPaths = false
+ }
+ 
+ func osinit() {

--- a/patches/0012-remove-long-path-support-hack.patch
+++ b/patches/0012-remove-long-path-support-hack.patch
@@ -12,7 +12,6 @@ process, so this this is a breaking change for the Microsoft Go fork.
 Note that the Go standard library makes a best effort to support long
 paths by using the `\\?\` prefix when possible, so this change should
 only affect long relative paths, which can't be used with the `\\?\`.
-
 ---
  src/runtime/os_windows.go | 52 +--------------------------------------
  1 file changed, 1 insertion(+), 51 deletions(-)

--- a/patches/0013-os-support-UNC-paths-and-.-segments-in-fixLongPath.patch
+++ b/patches/0013-os-support-UNC-paths-and-.-segments-in-fixLongPath.patch
@@ -1,0 +1,211 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: qmuntal <qmuntaldiaz@microsoft.com>
+Date: Tue, 12 Mar 2024 12:26:53 +0100
+Subject: [PATCH] os: support UNC paths and .. segments in fixLongPath
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This CL reimplements fixLongPath using syscall.GetFullPathName instead
+of a custom implementation that was not handling UNC paths and ..
+segments correctly. It also fixes a bug here multiple trailing \
+were removed instead of replaced by a single one.
+
+The new implementation is slower than the previous one, as it does a
+syscall and needs to convert UTF-8 to UTF-16 (and back), but it is
+correct and should be fast enough for most use cases.
+
+goos: windows
+goarch: amd64
+pkg: os
+cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
+            │   old.txt    │                new.txt                 │
+            │    sec/op    │    sec/op      vs base                 │
+LongPath-12   1.007µ ± 53%   4.093µ ± 109%  +306.41% (p=0.000 n=10)
+
+            │  old.txt   │               new.txt                │
+            │    B/op    │    B/op      vs base                 │
+LongPath-12   576.0 ± 0%   1376.0 ± 0%  +138.89% (p=0.000 n=10)
+
+            │  old.txt   │              new.txt               │
+            │ allocs/op  │ allocs/op   vs base                │
+LongPath-12   2.000 ± 0%   3.000 ± 0%  +50.00% (p=0.000 n=10)
+
+Fixes #41734.
+
+Change-Id: Iced5cf47f56f6ab0ca74a6e2374c31a75100902d
+Reviewed-on: https://go-review.googlesource.com/c/go/+/570995
+Reviewed-by: Damien Neil <dneil@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Reviewed-by: David Chase <drchase@google.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+(cherry picked from commit 2e8d84f148c69404b8eec86d9149785a3f4e3e92)
+---
+ src/os/path_windows.go      | 80 ++++++++++++++++---------------------
+ src/os/path_windows_test.go | 21 ++++++----
+ 2 files changed, 48 insertions(+), 53 deletions(-)
+
+diff --git a/src/os/path_windows.go b/src/os/path_windows.go
+index 3356908a3609ec..a8147f4e431f3b 100644
+--- a/src/os/path_windows.go
++++ b/src/os/path_windows.go
+@@ -4,6 +4,8 @@
+ 
+ package os
+ 
++import "syscall"
++
+ const (
+ 	PathSeparator     = '\\' // OS-specific path separator
+ 	PathListSeparator = ';'  // OS-specific path list separator
+@@ -134,10 +136,8 @@ var canUseLongPaths bool
+ 
+ // fixLongPath returns the extended-length (\\?\-prefixed) form of
+ // path when needed, in order to avoid the default 260 character file
+-// path limit imposed by Windows. If path is not easily converted to
+-// the extended-length form (for example, if path is a relative path
+-// or contains .. elements), or is short enough, fixLongPath returns
+-// path unmodified.
++// path limit imposed by Windows. If the path is short enough or is relative,
++// fixLongPath returns path unmodified.
+ //
+ // See https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
+ func fixLongPath(path string) string {
+@@ -161,19 +161,8 @@ func fixLongPath(path string) string {
+ 		return path
+ 	}
+ 
+-	// The extended form begins with \\?\, as in
+-	// \\?\c:\windows\foo.txt or \\?\UNC\server\share\foo.txt.
+-	// The extended form disables evaluation of . and .. path
+-	// elements and disables the interpretation of / as equivalent
+-	// to \. The conversion here rewrites / to \ and elides
+-	// . elements as well as trailing or duplicate separators. For
+-	// simplicity it avoids the conversion entirely for relative
+-	// paths or paths containing .. elements. For now,
+-	// \\server\share paths are not converted to
+-	// \\?\UNC\server\share paths because the rules for doing so
+-	// are less well-specified.
+-	if len(path) >= 2 && path[:2] == `\\` {
+-		// Don't canonicalize UNC paths.
++	if prefix := path[:4]; prefix == `\\.\` || prefix == `\\?\` || prefix == `\??\` {
++		// Don't fix. Device path or extended path form.
+ 		return path
+ 	}
+ 	if !isAbs(path) {
+@@ -181,38 +170,39 @@ func fixLongPath(path string) string {
+ 		return path
+ 	}
+ 
+-	const prefix = `\\?`
+-
+-	pathbuf := make([]byte, len(prefix)+len(path)+len(`\`))
+-	copy(pathbuf, prefix)
+-	n := len(path)
+-	r, w := 0, len(prefix)
+-	for r < n {
+-		switch {
+-		case IsPathSeparator(path[r]):
+-			// empty block
+-			r++
+-		case path[r] == '.' && (r+1 == n || IsPathSeparator(path[r+1])):
+-			// /./
+-			r++
+-		case r+1 < n && path[r] == '.' && path[r+1] == '.' && (r+2 == n || IsPathSeparator(path[r+2])):
+-			// /../ is currently unhandled
++	var prefix []uint16
++	var isUNC bool
++	if path[:2] == `\\` {
++		// UNC path, prepend the \\?\UNC\ prefix.
++		prefix = []uint16{'\\', '\\', '?', '\\', 'U', 'N', 'C', '\\'}
++		isUNC = true
++	} else {
++		prefix = []uint16{'\\', '\\', '?', '\\'}
++	}
++
++	p, err := syscall.UTF16FromString(path)
++	if err != nil {
++		return path
++	}
++	n := uint32(len(p))
++	var buf []uint16
++	for {
++		buf = make([]uint16, n+uint32(len(prefix)))
++		n, err = syscall.GetFullPathName(&p[0], n, &buf[len(prefix)], nil)
++		if err != nil {
+ 			return path
+-		default:
+-			pathbuf[w] = '\\'
+-			w++
+-			for ; r < n && !IsPathSeparator(path[r]); r++ {
+-				pathbuf[w] = path[r]
+-				w++
+-			}
++		}
++		if n <= uint32(len(buf)-len(prefix)) {
++			buf = buf[:n+uint32(len(prefix))]
++			break
+ 		}
+ 	}
+-	// A drive's root directory needs a trailing \
+-	if w == len(`\\?\c:`) {
+-		pathbuf[w] = '\\'
+-		w++
++	if isUNC {
++		// Remove leading \\.
++		buf = buf[2:]
+ 	}
+-	return string(pathbuf[:w])
++	copy(buf, prefix)
++	return syscall.UTF16ToString(buf)
+ }
+ 
+ // fixRootDirectory fixes a reference to a drive's root directory to
+diff --git a/src/os/path_windows_test.go b/src/os/path_windows_test.go
+index 2506b4f0d8dca7..3ed43986bba4d8 100644
+--- a/src/os/path_windows_test.go
++++ b/src/os/path_windows_test.go
+@@ -12,10 +12,14 @@ import (
+ )
+ 
+ func TestFixLongPath(t *testing.T) {
+-	if os.CanUseLongPaths {
+-		return
+-	}
+-	t.Parallel()
++	// Test fixLongPath even if long path are supported by the system,
++	// else the function might not be tested at all when the test builders
++	// support long paths.
++	old := os.CanUseLongPaths
++	os.CanUseLongPaths = false
++	t.Cleanup(func() {
++		os.CanUseLongPaths = old
++	})
+ 
+ 	// 248 is long enough to trigger the longer-than-248 checks in
+ 	// fixLongPath, but short enough not to make a path component
+@@ -34,19 +38,20 @@ func TestFixLongPath(t *testing.T) {
+ 		// cases below where it doesn't.
+ 		{`C:\long\foo.txt`, `\\?\C:\long\foo.txt`},
+ 		{`C:/long/foo.txt`, `\\?\C:\long\foo.txt`},
+-		{`C:\long\foo\\bar\.\baz\\`, `\\?\C:\long\foo\bar\baz`},
+-		{`\\unc\path`, `\\unc\path`},
++		{`C:\long\foo\\bar\.\baz\\`, `\\?\C:\long\foo\bar\baz\`},
++		{`\\server\path\long`, `\\?\UNC\server\path\long`},
+ 		{`long.txt`, `long.txt`},
+ 		{`C:long.txt`, `C:long.txt`},
+-		{`c:\long\..\bar\baz`, `c:\long\..\bar\baz`},
++		{`c:\long\..\bar\baz`, `\\?\c:\bar\baz`},
+ 		{`\\?\c:\long\foo.txt`, `\\?\c:\long\foo.txt`},
+ 		{`\\?\c:\long/foo.txt`, `\\?\c:\long/foo.txt`},
++		{`\??\c:\long/foo.txt`, `\??\c:\long/foo.txt`},
+ 	} {
+ 		in := strings.ReplaceAll(test.in, "long", veryLong)
+ 		want := strings.ReplaceAll(test.want, "long", veryLong)
+ 		if got := os.FixLongPath(in); got != want {
+ 			got = strings.ReplaceAll(got, veryLong, "long")
+-			t.Errorf("fixLongPath(%q) = %q; want %q", test.in, got, test.want)
++			t.Errorf("fixLongPath(%#q) = %#q; want %#q", test.in, got, test.want)
+ 		}
+ 	}
+ }

--- a/patches/0014-os-support-relative-paths-in-fixLongPath.patch
+++ b/patches/0014-os-support-relative-paths-in-fixLongPath.patch
@@ -1,0 +1,420 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: qmuntal <qmuntaldiaz@microsoft.com>
+Date: Wed, 27 Mar 2024 14:24:10 +0100
+Subject: [PATCH] os: support relative paths in fixLongPath
+
+(This CL takes the tests and some ideas from the abandoned CL 263538).
+
+fixLongPath is used on Windows to process all path names
+before syscalls to switch them to extended-length format
+(with prefix \\?\) to workaround a historical limit
+of 260-ish characters.
+
+This CL updates fixLongPath to convert relative paths to absolute
+paths if the working directory plus the relative path exceeds
+MAX_PATH. This is necessary because the Windows API does not
+support extended-length paths for relative paths.
+
+This CL also adds support for fixing device paths (\\.\-prefixed),
+which were not previously normalized.
+
+Fixes #41734
+Fixes #21782
+Fixes #36375
+
+Cq-Include-Trybots: luci.golang.try:gotip-windows-amd64-longtest,gotip-windows-amd64-race,gotip-windows-arm64
+Co-authored-by: Giovanni Bajo <rasky@develer.com>
+Change-Id: I63cfb79f3ae6b9d42e07deac435b730d97a6f492
+Reviewed-on: https://go-review.googlesource.com/c/go/+/574695
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Reviewed-by: Damien Neil <dneil@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Reviewed-by: Than McIntosh <thanm@google.com>
+(cherry picked from commit 7c89ad6a80020e3654129183c528054921899650)
+---
+ src/os/export_windows_test.go |   3 +-
+ src/os/file.go                |   5 +
+ src/os/file_windows.go        |  13 ++-
+ src/os/path_windows.go        |  74 +++++++++++---
+ src/os/path_windows_test.go   | 175 +++++++++++++++++++++++++++-------
+ 5 files changed, 220 insertions(+), 50 deletions(-)
+
+diff --git a/src/os/export_windows_test.go b/src/os/export_windows_test.go
+index ff4f8995f8c721..1ddd35b2a19a59 100644
+--- a/src/os/export_windows_test.go
++++ b/src/os/export_windows_test.go
+@@ -7,8 +7,7 @@ package os
+ // Export for testing.
+ 
+ var (
+-	FixLongPath       = fixLongPath
+-	CanUseLongPaths   = canUseLongPaths
++	AddExtendedPrefix = addExtendedPrefix
+ 	NewConsoleFile    = newConsoleFile
+ 	CommandLineToArgv = commandLineToArgv
+ )
+diff --git a/src/os/file.go b/src/os/file.go
+index 7fd2f5d2027142..2278921b706af4 100644
+--- a/src/os/file.go
++++ b/src/os/file.go
+@@ -297,6 +297,11 @@ func Chdir(dir string) error {
+ 		testlog.Open(dir) // observe likely non-existent directory
+ 		return &PathError{Op: "chdir", Path: dir, Err: e}
+ 	}
++	if runtime.GOOS == "windows" {
++		getwdCache.Lock()
++		getwdCache.dir = dir
++		getwdCache.Unlock()
++	}
+ 	if log := testlog.Logger(); log != nil {
+ 		wd, err := Getwd()
+ 		if err == nil {
+diff --git a/src/os/file_windows.go b/src/os/file_windows.go
+index 8d77a63d37faa5..dbf9a2baca7db3 100644
+--- a/src/os/file_windows.go
++++ b/src/os/file_windows.go
+@@ -381,7 +381,18 @@ func Symlink(oldname, newname string) error {
+ 	if err != nil {
+ 		return &LinkError{"symlink", oldname, newname, err}
+ 	}
+-	o, err := syscall.UTF16PtrFromString(fixLongPath(oldname))
++	var o *uint16
++	if isAbs(oldname) {
++		o, err = syscall.UTF16PtrFromString(fixLongPath(oldname))
++	} else {
++		// Do not use fixLongPath on oldname for relative symlinks,
++		// as it would turn the name into an absolute path thus making
++		// an absolute symlink instead.
++		// Notice that CreateSymbolicLinkW does not fail for relative
++		// symlinks beyond MAX_PATH, so this does not prevent the
++		// creation of an arbitrary long path name.
++		o, err = syscall.UTF16PtrFromString(oldname)
++	}
+ 	if err != nil {
+ 		return &LinkError{"symlink", oldname, newname, err}
+ 	}
+diff --git a/src/os/path_windows.go b/src/os/path_windows.go
+index a8147f4e431f3b..8a6cfd68708511 100644
+--- a/src/os/path_windows.go
++++ b/src/os/path_windows.go
+@@ -136,14 +136,33 @@ var canUseLongPaths bool
+ 
+ // fixLongPath returns the extended-length (\\?\-prefixed) form of
+ // path when needed, in order to avoid the default 260 character file
+-// path limit imposed by Windows. If the path is short enough or is relative,
+-// fixLongPath returns path unmodified.
++// path limit imposed by Windows. If the path is short enough or already
++// has the extended-length prefix, fixLongPath returns path unmodified.
++// If the path is relative and joining it with the current working
++// directory results in a path that is too long, fixLongPath returns
++// the absolute path with the extended-length prefix.
+ //
+ // See https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
+ func fixLongPath(path string) string {
+ 	if canUseLongPaths {
+ 		return path
+ 	}
++	return addExtendedPrefix(path)
++}
++
++// addExtendedPrefix adds the extended path prefix (\\?\) to path.
++func addExtendedPrefix(path string) string {
++	if len(path) >= 4 {
++		if path[:4] == `\??\` {
++			// Already extended with \??\
++			return path
++		}
++		if IsPathSeparator(path[0]) && IsPathSeparator(path[1]) && path[2] == '?' && IsPathSeparator(path[3]) {
++			// Already extended with \\?\ or any combination of directory separators.
++			return path
++		}
++	}
++
+ 	// Do nothing (and don't allocate) if the path is "short".
+ 	// Empirically (at least on the Windows Server 2013 builder),
+ 	// the kernel is arbitrarily okay with < 248 bytes. That
+@@ -155,27 +174,47 @@ func fixLongPath(path string) string {
+ 	//
+ 	// The MSDN docs appear to say that a normal path that is 248 bytes long
+ 	// will work; empirically the path must be less then 248 bytes long.
+-	if len(path) < 248 {
++	pathLength := len(path)
++	if !isAbs(path) {
++		// If the path is relative, we need to prepend the working directory
++		// plus a separator to the path before we can determine if it's too long.
++		// We don't want to call syscall.Getwd here, as that call is expensive to do
++		// every time fixLongPath is called with a relative path, so we use a cache.
++		// Note that getwdCache might be outdated if the working directory has been
++		// changed without using os.Chdir, i.e. using syscall.Chdir directly or cgo.
++		// This is fine, as the worst that can happen is that we fail to fix the path.
++		getwdCache.Lock()
++		if getwdCache.dir == "" {
++			// Init the working directory cache.
++			getwdCache.dir, _ = syscall.Getwd()
++		}
++		pathLength += len(getwdCache.dir) + 1
++		getwdCache.Unlock()
++	}
++
++	if pathLength < 248 {
+ 		// Don't fix. (This is how Go 1.7 and earlier worked,
+ 		// not automatically generating the \\?\ form)
+ 		return path
+ 	}
+ 
+-	if prefix := path[:4]; prefix == `\\.\` || prefix == `\\?\` || prefix == `\??\` {
+-		// Don't fix. Device path or extended path form.
+-		return path
+-	}
+-	if !isAbs(path) {
+-		// Relative path
+-		return path
++	var isUNC, isDevice bool
++	if len(path) >= 2 && IsPathSeparator(path[0]) && IsPathSeparator(path[1]) {
++		if len(path) >= 4 && path[2] == '.' && IsPathSeparator(path[3]) {
++			// Starts with //./
++			isDevice = true
++		} else {
++			// Starts with //
++			isUNC = true
++		}
+ 	}
+-
+ 	var prefix []uint16
+-	var isUNC bool
+-	if path[:2] == `\\` {
++	if isUNC {
+ 		// UNC path, prepend the \\?\UNC\ prefix.
+ 		prefix = []uint16{'\\', '\\', '?', '\\', 'U', 'N', 'C', '\\'}
+-		isUNC = true
++	} else if isDevice {
++		// Don't add the extended prefix to device paths, as it would
++		// change its meaning.
+ 	} else {
+ 		prefix = []uint16{'\\', '\\', '?', '\\'}
+ 	}
+@@ -184,7 +223,10 @@ func fixLongPath(path string) string {
+ 	if err != nil {
+ 		return path
+ 	}
+-	n := uint32(len(p))
++	// Estimate the required buffer size using the path length plus the null terminator.
++	// pathLength includes the working directory. This should be accurate unless
++	// the working directory has changed without using os.Chdir.
++	n := uint32(pathLength) + 1
+ 	var buf []uint16
+ 	for {
+ 		buf = make([]uint16, n+uint32(len(prefix)))
+@@ -195,6 +237,8 @@ func fixLongPath(path string) string {
+ 		if n <= uint32(len(buf)-len(prefix)) {
+ 			buf = buf[:n+uint32(len(prefix))]
+ 			break
++		} else {
++			continue
+ 		}
+ 	}
+ 	if isUNC {
+diff --git a/src/os/path_windows_test.go b/src/os/path_windows_test.go
+index 3ed43986bba4d8..ba3049202bc9fe 100644
+--- a/src/os/path_windows_test.go
++++ b/src/os/path_windows_test.go
+@@ -6,52 +6,112 @@ package os_test
+ 
+ import (
+ 	"os"
++	"path/filepath"
+ 	"strings"
+ 	"syscall"
+ 	"testing"
+ )
+ 
+-func TestFixLongPath(t *testing.T) {
+-	// Test fixLongPath even if long path are supported by the system,
+-	// else the function might not be tested at all when the test builders
+-	// support long paths.
+-	old := os.CanUseLongPaths
+-	os.CanUseLongPaths = false
+-	t.Cleanup(func() {
+-		os.CanUseLongPaths = old
+-	})
+-
+-	// 248 is long enough to trigger the longer-than-248 checks in
+-	// fixLongPath, but short enough not to make a path component
+-	// longer than 255, which is illegal on Windows. (which
+-	// doesn't really matter anyway, since this is purely a string
+-	// function we're testing, and it's not actually being used to
+-	// do a system call)
+-	veryLong := "l" + strings.Repeat("o", 248) + "ng"
++func TestAddExtendedPrefix(t *testing.T) {
++	// Test addExtendedPrefix instead of fixLongPath so the path manipulation code
++	// is exercised even if long path are supported by the system, else the
++	// function might not be tested at all if/when all test builders support long paths.
++	cwd, err := os.Getwd()
++	if err != nil {
++		t.Fatal("cannot get cwd")
++	}
++	drive := strings.ToLower(filepath.VolumeName(cwd))
++	cwd = strings.ToLower(cwd[len(drive)+1:])
++	// Build a very long pathname. Paths in Go are supposed to be arbitrarily long,
++	// so let's make a long path which is comfortably bigger than MAX_PATH on Windows
++	// (256) and thus requires fixLongPath to be correctly interpreted in I/O syscalls.
++	veryLong := "l" + strings.Repeat("o", 500) + "ng"
+ 	for _, test := range []struct{ in, want string }{
+-		// Short; unchanged:
++		// Testcases use word subsitutions:
++		//   * "long" is replaced with a very long pathname
++		//   * "c:" or "C:" are replaced with the drive of the current directory (preserving case)
++		//   * "cwd" is replaced with the current directory
++
++		// Drive Absolute
++		{`C:\long\foo.txt`, `\\?\C:\long\foo.txt`},
++		{`C:/long/foo.txt`, `\\?\C:\long\foo.txt`},
++		{`C:\\\long///foo.txt`, `\\?\C:\long\foo.txt`},
++		{`C:\long\.\foo.txt`, `\\?\C:\long\foo.txt`},
++		{`C:\long\..\foo.txt`, `\\?\C:\foo.txt`},
++		{`C:\long\..\..\foo.txt`, `\\?\C:\foo.txt`},
++
++		// Drive Relative
++		{`C:long\foo.txt`, `\\?\C:\cwd\long\foo.txt`},
++		{`C:long/foo.txt`, `\\?\C:\cwd\long\foo.txt`},
++		{`C:long///foo.txt`, `\\?\C:\cwd\long\foo.txt`},
++		{`C:long\.\foo.txt`, `\\?\C:\cwd\long\foo.txt`},
++		{`C:long\..\foo.txt`, `\\?\C:\cwd\foo.txt`},
++
++		// Rooted
++		{`\long\foo.txt`, `\\?\C:\long\foo.txt`},
++		{`/long/foo.txt`, `\\?\C:\long\foo.txt`},
++		{`\long///foo.txt`, `\\?\C:\long\foo.txt`},
++		{`\long\.\foo.txt`, `\\?\C:\long\foo.txt`},
++		{`\long\..\foo.txt`, `\\?\C:\foo.txt`},
++
++		// Relative
++		{`long\foo.txt`, `\\?\C:\cwd\long\foo.txt`},
++		{`long/foo.txt`, `\\?\C:\cwd\long\foo.txt`},
++		{`long///foo.txt`, `\\?\C:\cwd\long\foo.txt`},
++		{`long\.\foo.txt`, `\\?\C:\cwd\long\foo.txt`},
++		{`long\..\foo.txt`, `\\?\C:\cwd\foo.txt`},
++		{`.\long\foo.txt`, `\\?\C:\cwd\long\foo.txt`},
++
++		// UNC Absolute
++		{`\\srv\share\long`, `\\?\UNC\srv\share\long`},
++		{`//srv/share/long`, `\\?\UNC\srv\share\long`},
++		{`/\srv/share/long`, `\\?\UNC\srv\share\long`},
++		{`\\srv\share\long\`, `\\?\UNC\srv\share\long\`},
++		{`\\srv\share\bar\.\long`, `\\?\UNC\srv\share\bar\long`},
++		{`\\srv\share\bar\..\long`, `\\?\UNC\srv\share\long`},
++		{`\\srv\share\bar\..\..\long`, `\\?\UNC\srv\share\long`}, // share name is not removed by ".."
++
++		// Local Device
++		{`\\.\C:\long\foo.txt`, `\\.\C:\long\foo.txt`},
++		{`//./C:/long/foo.txt`, `\\.\C:\long\foo.txt`},
++		{`/\./C:/long/foo.txt`, `\\.\C:\long\foo.txt`},
++		{`\\.\C:\long///foo.txt`, `\\.\C:\long\foo.txt`},
++		{`\\.\C:\long\.\foo.txt`, `\\.\C:\long\foo.txt`},
++		{`\\.\C:\long\..\foo.txt`, `\\.\C:\foo.txt`},
++
++		// Misc tests
+ 		{`C:\short.txt`, `C:\short.txt`},
+ 		{`C:\`, `C:\`},
+ 		{`C:`, `C:`},
+-		// The "long" substring is replaced by a looooooong
+-		// string which triggers the rewriting. Except in the
+-		// cases below where it doesn't.
+-		{`C:\long\foo.txt`, `\\?\C:\long\foo.txt`},
+-		{`C:/long/foo.txt`, `\\?\C:\long\foo.txt`},
++		{`\\srv\path`, `\\srv\path`},
++		{`long.txt`, `\\?\C:\cwd\long.txt`},
++		{`C:long.txt`, `\\?\C:\cwd\long.txt`},
++		{`C:\long\.\bar\baz`, `\\?\C:\long\bar\baz`},
++		{`C:long\.\bar\baz`, `\\?\C:\cwd\long\bar\baz`},
++		{`C:\long\..\bar\baz`, `\\?\C:\bar\baz`},
++		{`C:long\..\bar\baz`, `\\?\C:\cwd\bar\baz`},
+ 		{`C:\long\foo\\bar\.\baz\\`, `\\?\C:\long\foo\bar\baz\`},
+-		{`\\server\path\long`, `\\?\UNC\server\path\long`},
+-		{`long.txt`, `long.txt`},
+-		{`C:long.txt`, `C:long.txt`},
+-		{`c:\long\..\bar\baz`, `\\?\c:\bar\baz`},
+-		{`\\?\c:\long\foo.txt`, `\\?\c:\long\foo.txt`},
+-		{`\\?\c:\long/foo.txt`, `\\?\c:\long/foo.txt`},
+-		{`\??\c:\long/foo.txt`, `\??\c:\long/foo.txt`},
++		{`C:\long\..`, `\\?\C:\`},
++		{`C:\.\long\..\.`, `\\?\C:\`},
++		{`\\?\C:\long\foo.txt`, `\\?\C:\long\foo.txt`},
++		{`\\?\C:\long/foo.txt`, `\\?\C:\long/foo.txt`},
+ 	} {
+ 		in := strings.ReplaceAll(test.in, "long", veryLong)
++		in = strings.ToLower(in)
++		in = strings.ReplaceAll(in, "c:", drive)
++
+ 		want := strings.ReplaceAll(test.want, "long", veryLong)
+-		if got := os.FixLongPath(in); got != want {
++		want = strings.ToLower(want)
++		want = strings.ReplaceAll(want, "c:", drive)
++		want = strings.ReplaceAll(want, "cwd", cwd)
++
++		got := os.AddExtendedPrefix(in)
++		got = strings.ToLower(got)
++		if got != want {
++			in = strings.ReplaceAll(in, veryLong, "long")
+ 			got = strings.ReplaceAll(got, veryLong, "long")
+-			t.Errorf("fixLongPath(%#q) = %#q; want %#q", test.in, got, test.want)
++			want = strings.ReplaceAll(want, veryLong, "long")
++			t.Errorf("addExtendedPrefix(%#q) = %#q; want %#q", in, got, want)
+ 		}
+ 	}
+ }
+@@ -111,3 +171,54 @@ func TestOpenRootSlash(t *testing.T) {
+ 		dir.Close()
+ 	}
+ }
++
++func TestRemoveAllLongPathRelative(t *testing.T) {
++	// Test that RemoveAll doesn't hang with long relative paths.
++	// See go.dev/issue/36375.
++	tmp := t.TempDir()
++	chdir(t, tmp)
++	dir := filepath.Join(tmp, "foo", "bar", strings.Repeat("a", 150), strings.Repeat("b", 150))
++	err := os.MkdirAll(dir, 0755)
++	if err != nil {
++		t.Fatal(err)
++	}
++	err = os.RemoveAll("foo")
++	if err != nil {
++		t.Fatal(err)
++	}
++}
++
++func testLongPathAbs(t *testing.T, target string) {
++	t.Helper()
++	testWalkFn := func(path string, info os.FileInfo, err error) error {
++		if err != nil {
++			t.Error(err)
++		}
++		return err
++	}
++	if err := os.MkdirAll(target, 0777); err != nil {
++		t.Fatal(err)
++	}
++	// Test that Walk doesn't fail with long paths.
++	// See go.dev/issue/21782.
++	filepath.Walk(target, testWalkFn)
++	// Test that RemoveAll doesn't hang with long paths.
++	// See go.dev/issue/36375.
++	if err := os.RemoveAll(target); err != nil {
++		t.Error(err)
++	}
++}
++
++func TestLongPathAbs(t *testing.T) {
++	t.Parallel()
++
++	target := t.TempDir() + "\\" + strings.Repeat("a\\", 300)
++	testLongPathAbs(t, target)
++}
++
++func TestLongPathRel(t *testing.T) {
++	chdir(t, t.TempDir())
++
++	target := strings.Repeat("b\\", 300)
++	testLongPathAbs(t, target)
++}


### PR DESCRIPTION
This commit backports https://github.com/microsoft/go/pull/1171, https://go-review.googlesource.com/c/go/+/570995 and https://go-review.googlesource.com/c/go/+/574695 to the Go 1.21 release branch.

CL 570995 and CL 574695 have been backported because they fix many edge-cases related to long path not being supported by the system.

It is necessary for APIScan compliance.