### PR TITLE
Add pipeline for CodeQL runs

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -19,10 +19,6 @@ parameters:
     displayName: '[Release automation input] The version being built. Leave "nil" for non-release builds.'
     type: string
     default: nil
-  - name: enableCodeQLOnNonDefaultBranches
-    displayName: '[Debug input] Enable CodeQL even on non-main branches. Use to try modifications in dev branches.'
-    type: boolean
-    default: false
 
 variables:
   - template: variables/pool-providers.yml
@@ -47,7 +43,9 @@ extends:
       os: windows
     sdl:
       codeql:
-        enabledOnNonDefaultBranches: ${{ parameters.enableCodeQLOnNonDefaultBranches }}
+        compiled:
+          enabled: false
+          justificationForDisabling: 'Scan runs in validation pipeline.'
       suppression:
         suppressionFile: $(Build.SourcesDirectory)/eng/compliance/.gdnsuppress
       tsa:
@@ -59,6 +57,7 @@ extends:
         parameters:
           buildandpack: true
           official: true
+          sign: true
           createSourceArchive: true
           releaseVersion: ${{ parameters.releaseVersion }}
 

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -1,0 +1,82 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This pipeline runs rolling validation, like CodeQL.
+
+trigger: none
+pr: none
+
+# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
+parameters:
+  - name: enableCodeQL
+    displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications in dev branches.'
+    type: boolean
+    default: false
+  - name: disableTSA
+    displayName: '[Debug input] Disable TSA reporting. Use to try modifications in dev branches.'
+    type: boolean
+    default: false
+
+variables:
+  - template: variables/pool-providers.yml
+  - name: Codeql.PublishDatabase
+    value: true
+  - name: Codeql.PublishDatabaseLog
+    value: true
+  - name: Codeql.PublishDatabaseLog
+    value: true
+  - ${{ if parameters.enableCodeQL }}:
+    # The default cadence is ok for official branches. The cadence is per-branch.
+    # For a dev build, the cadence would prevent dev iteration.
+    # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-general-faq#how-do-i-check-if-my-project-is-onboarded
+    - name: Codeql.Cadence
+      value: 0
+
+resources:
+  pipelines:
+    - pipeline: build
+      # The rolling pipeline and this validation pipeline share the same source repository. AzDO
+      # sees this and makes this pipeline's "checkout" steps download the same source code that was
+      # built by the microsoft-go pipeline:
+      # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=schema#define-a-pipelines-resource
+      #
+      # This means we can have SDL scan the currently-checked-out source code as the way to scan the
+      # source code of the internal rolling build.
+      source: microsoft-go
+      trigger:
+        branches:
+          include:
+            - microsoft/main
+            - microsoft/release-branch.*
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: 1es-windows-2022
+      os: windows
+    sdl:
+      codeql:
+        enabledOnNonDefaultBranches: ${{ parameters.enableCodeQL }}
+        language: go,cpp,powershell
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)/eng/compliance/.gdnsuppress
+      tsa:
+        enabled: ${{ not(parameters.disableTSA) }}
+        configFile: $(Build.SourcesDirectory)/eng/compliance/tsaoptions.json
+
+    stages:
+      - template: /eng/pipeline/stages/shorthand-builders-to-builders.yml@self
+        parameters:
+          jobsTemplate: builders-to-stages.yml
+          jobsParameters:
+            official: true
+          shorthandBuilders:
+            - { os: linux, arch: amd64, config: codeql }

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -8,7 +8,8 @@ parameters:
   # [] of { id, os, arch, hostarch, config, distro?, experiment? }
   builders: []
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.
-  # 'official' is passed through into run-stage.yml, where it has other effects.
+  sign: false
+  # If true, the stage will run in 1ES PT Official template compatibility mode.
   official: false
   # If true, generate source archive tarballs.
   createSourceArchive: false
@@ -30,7 +31,7 @@ stages:
             ${{ if eq(builder.os, 'windows') }}:
               retryAttempts: [1, 2, 3, 4, "FINAL"]
 
-  - ${{ if eq(parameters.official, true) }}:
+  - ${{ if eq(parameters.sign, true) }}:
     - template: pool.yml
       parameters:
         inner:

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -28,6 +28,9 @@ parameters:
   - name: official
     type: boolean
     default: false
+  - name: sign
+    type: boolean
+    default: false
   - name: createSourceArchive
     type: boolean
     default: false
@@ -41,6 +44,7 @@ stages:
       jobsTemplate: builders-to-stages.yml
       jobsParameters:
         official: ${{ parameters.official }}
+        sign: ${{ parameters.sign }}
         createSourceArchive: ${{ parameters.createSourceArchive }}
         releaseVersion: ${{ parameters.releaseVersion }}
       shorthandBuilders:

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -8,7 +8,7 @@ parameters:
   # { id, os, arch, hostArch, config, distro?, experiment?, fips? }
   - name: builder
     type: object
-  
+
   - name: createSourceArchive
     type: boolean
     default: false
@@ -49,6 +49,9 @@ stages:
           # we should also give the tests a shorter timeout to make sure this doesn't balloon too far:
           # https://github.com/microsoft/go/issues/568
           timeoutInMinutes: 180
+        ${{ if eq(parameters.builder.config, 'codeql') }}:
+          # Allow CodeQL to take a while. https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#other-issues
+          timeoutInMinutes: 360
 
         pool: ${{ parameters.pool }}
 
@@ -140,6 +143,13 @@ stages:
               - pwsh: |
                   pwsh eng/run.ps1 write-checksum eng/artifacts/bin/*
                 displayName: Write checksum
+
+          # CodeQL plugs into the compiler to find the code. Just build.
+          - ${{ elseif eq(parameters.builder.config, 'codeql' ) }}:
+            - pwsh: |
+                eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -- `
+                  pwsh eng/run.ps1 build
+              displayName: Build
 
           # Use run-builder for any configuration that includes tests. run-builder uses the "gotestsum"
           # module to convert test results to a JUnit file that Azure DevOps can understand.


### PR DESCRIPTION
Remove CodeQL from the primary pipeline: enabling it there seems to cause failure during SBOM generation (https://dev.azure.com/dnceng/internal/_build/results?buildId=2414008&view=results) and also slows down the build.

Add a new pipeline that is specifically for periodic SDL tasks like CodeQL. This is how we did it before 1ES PT, and it turns out that's still a valid way to approach CodeQL.

Even though the pipeline is classified as non-production, use the Official 1ES PT template. I didn't see a way to enable CodeQL in the Unofficial 1ES PT template, and there doesn't seem to be any reason that we *must* use the Unofficial template.

Test runs (ongoing when I submitted the PR):

* Test microsoft-go: https://dev.azure.com/dnceng/internal/_build/results?buildId=2414438&view=results
* Test microsoft-go-rolling-internal-validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=2414439&view=results