### PR TITLE
[release-branch.go1.21] Use unofficial 1ES PT for internal test builds

### DIFF
--- a/eng/pipeline/README.md
+++ b/eng/pipeline/README.md
@@ -4,17 +4,22 @@ This directory contains Azure DevOps (AzDO) YAML pipelines for CI.
 
 Pipeline definitions currently using each YAML file are:
 
+### dnceng-public
+
 * [`pr-pipeline.yml`](pr-pipeline.yml) - Required PR check.
-  * (Public) [microsoft-go](https://dev.azure.com/dnceng/public/_build?definitionId=1099)
+  * [microsoft-go](https://dev.azure.com/dnceng/public/_build?definitionId=1099)
 * [`pr-outerloop-pipeline.yml`](pr-outerloop-pipeline.yml) - Optional PR check. Runs outerloop.
-  * (Public) [microsoft-go-outerloop](https://dev.azure.com/dnceng/public/_build/index?definitionId=1100)
+  * [microsoft-go-outerloop](https://dev.azure.com/dnceng/public/_build/index?definitionId=1100)
     * Comment `/azp run microsoft-go-outerloop` on a PR to run.
-* [`rolling-innerloop-pipeline.yml`](rolling-pipeline.yml) - Triggers on merge, runs innerloop.
-  * (Internal) [microsoft-go-innerloop](https://dev.azure.com/dnceng/internal/_build?definitionId=1342)
+
+### dnceng (internal)
+
+* [`rolling-innerloop-pipeline.yml`](rolling-innerloop-pipeline.yml) - Triggers on merge, runs innerloop.
+  * [microsoft-go-innerloop](https://dev.azure.com/dnceng/internal/_build?definitionId=1342)
 * [`rolling-pipeline.yml`](rolling-pipeline.yml) - Triggers on merge, runs outerloop.
-  * (Internal) [microsoft-go-rolling](https://dev.azure.com/dnceng/internal/_build?definitionId=987)
+  * [microsoft-go-rolling](https://dev.azure.com/dnceng/internal/_build?definitionId=987)
 * [`rolling-internal-pipeline.yml`](rolling-internal-pipeline.yml) - Triggers on merge. Builds, signs, and publishes. Does not run tests.
-  * (Internal) [microsoft-go](https://dev.azure.com/dnceng/internal/_build?definitionId=958)
+  * [microsoft-go](https://dev.azure.com/dnceng/internal/_build?definitionId=958)
 
 The pipeline filenames are (mostly) based on the trigger scenario, not what they
 do. This means we can change their content later without worrying about

--- a/eng/pipeline/pr-outerloop-pipeline.yml
+++ b/eng/pipeline/pr-outerloop-pipeline.yml
@@ -16,6 +16,15 @@ pr:
   - microsoft/*
   - dev/*
 
+resources:
+  containers:
+    - container: ubuntu1804
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+    - container: mariner1
+      image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
+    - container: mariner1arm64
+      image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
+
 stages:
   - template: stages/go-builder-matrix-stages.yml
     parameters:

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -9,6 +9,19 @@ pr:
   - microsoft/*
   - dev/*
 
+resources:
+  containers:
+    # Predefine named containers. Using "container:" inside the job would work, because this is not
+    # 1ES PT. However, to share code, use the same names here. Unfortunately the format used here
+    # (container: ... image: ...) is not the same as the one 1ES PT uses, so updating these requires
+    # separate changes.
+    - container: ubuntu1804
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+    - container: mariner1
+      image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
+    - container: mariner1arm64
+      image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
+
 stages:
   - template: stages/go-builder-matrix-stages.yml
     parameters:

--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -20,11 +20,34 @@ parameters:
     type: boolean
     default: false
 
-stages:
-  - template: stages/go-builder-matrix-stages.yml
-    parameters:
-      innerloop: true
-      # Include buildandpack builders. The official internal build uses slightly different build
-      # machines than this pipeline. This one tests against our minimum requirements.
-      buildandpack: true
-      includeArm64Host: ${{ parameters.includeArm64Host }}
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Internal
+        image: 1es-windows-2022
+        os: windows
+    containers:
+      ubuntu1804:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+      mariner1:
+        image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
+      mariner1arm64:
+        image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
+
+    stages:
+      - template: stages/go-builder-matrix-stages.yml
+        parameters:
+          innerloop: true
+          # Include buildandpack builders. The official internal build uses slightly different build
+          # machines than this pipeline. This one tests against our minimum requirements.
+          buildandpack: true
+          includeArm64Host: ${{ parameters.includeArm64Host }}

--- a/eng/pipeline/rolling-pipeline.yml
+++ b/eng/pipeline/rolling-pipeline.yml
@@ -13,7 +13,30 @@ trigger:
       - dev/official/*
 pr: none
 
-stages:
-  - template: stages/go-builder-matrix-stages.yml
-    parameters:
-      outerloop: true
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Internal
+        image: 1es-windows-2022
+        os: windows
+    containers:
+      ubuntu1804:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+      mariner1:
+        image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
+      mariner1arm64:
+        image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
+
+    stages:
+      - template: stages/go-builder-matrix-stages.yml
+        parameters:
+          outerloop: true

--- a/eng/pipeline/stages/pool-2.yml
+++ b/eng/pipeline/stages/pool-2.yml
@@ -37,6 +37,7 @@ stages:
             demands: ImageOverride -equals 1es-windows-2022-open
           ${{ else }}:
             demands: ImageOverride -equals 1es-windows-2022
+            os: windows
 
         ${{ elseif eq(parameters.os, 'linux') }}:
           # The arm64 pool doesn't need demands: it runs on a uniform pool.
@@ -48,3 +49,4 @@ stages:
               demands: ImageOverride -equals 1es-ubuntu-2004-open
             ${{ else }}:
               demands: ImageOverride -equals 1es-ubuntu-2004
+              os: linux

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -56,11 +56,11 @@ stages:
           ${{ if eq(parameters.builder.os, 'linux') }}:
             ${{ if eq(parameters.builder.hostArch, 'amd64') }}:
               ${{ if eq(parameters.builder.distro, 'ubuntu') }}:
-                container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
+                container: ubuntu1804
               ${{ else }}:
-                container: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
+                container: mariner1
             ${{ elseif eq(parameters.builder.hostArch, 'arm64') }}:
-              container: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
+              container: mariner1arm64
 
         variables:
           - group: go-cmdscan-rules


### PR DESCRIPTION
(cherry picked from commit ad0209c9264309f59563450f2b9307fb51304d98, #1186, clean pick)