### PR TITLE
Generate symbols for all Go toolchain binaries

### DIFF
--- a/eng/_core/cmd/build/build.go
+++ b/eng/_core/cmd/build/build.go
@@ -45,7 +45,7 @@ func main() {
 	flag.BoolVar(&o.JSON, "json", false, "Runs tests with -json flag to emit verbose results in JSON format. For use in CI.")
 	flag.BoolVar(&o.PackBuild, "packbuild", false, "Enable creating an archive of this build using upstream 'distpack' and placing it in eng/artifacts/bin.")
 	flag.BoolVar(&o.PackSource, "packsource", false, "Enable creating a source archive using upstream 'distpack' and placing it in eng/artifacts/bin.")
-	flag.BoolVar(&o.CreatePDB, "pdb", false, "Create PDB files for all the binaries in the bin and tool directories and place them in eng/artifacts/symbols.")
+	flag.BoolVar(&o.CreatePDB, "pdb", false, "Create PDB files for all the PE binaries in the bin and tool directories. The PE files are modified in place and PDBs are placed in eng/artifacts/symbols.")
 
 	flag.BoolVar(
 		&o.Refresh, "refresh", false,

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -59,24 +59,6 @@ extends:
           official: true
           sign: true
           createSourceArchive: true
+          createSymbols: true
+          publish: true
           releaseVersion: ${{ parameters.releaseVersion }}
-
-      - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/')) }}:
-        - template: stages/pool.yml
-          parameters:
-            inner:
-              template: publish-stage.yml
-              parameters:
-                # This is not a builder, but provide partial builder info for agent selection.
-                builder: { os: linux, arch: amd64 }
-                official: true
-                public: true
-
-      - template: stages/pool.yml
-        parameters:
-          inner:
-            template: publish-stage.yml
-            parameters:
-              builder: { os: linux, arch: amd64 }
-              official: true
-              public: false

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -9,7 +9,7 @@ parameters:
   builders: []
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.
   sign: false
-  # If true, the publish build artifacts to blob storage.
+  # If true, publish build artifacts to blob storage.
   publish: false
   # If true, the stage will run in 1ES PT Official template compatibility mode.
   official: false

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -72,7 +72,7 @@ stages:
             official: true
             public: false
             builders:
-            - ${{ each builder in parameters.builders }}:
-              - ${{ if eq(builder.config, 'buildandpack') }}:
-                - ${{ builder }}
+              - ${{ each builder in parameters.builders }}:
+                - ${{ if eq(builder.config, 'buildandpack') }}:
+                  - ${{ builder }}
             publishSymbols: ${{ parameters.createSymbols }}

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -9,10 +9,14 @@ parameters:
   builders: []
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.
   sign: false
+  # If true, the publish build artifacts to blob storage.
+  publish: false
   # If true, the stage will run in 1ES PT Official template compatibility mode.
   official: false
   # If true, generate source archive tarballs.
   createSourceArchive: false
+  # If true, generate and publish symbols (aka PDBs).
+  createSymbols: false
   releaseVersion: 'nil'
 
 stages:
@@ -26,6 +30,7 @@ stages:
             createSourceArchive: ${{ parameters.createSourceArchive }}
             releaseVersion: ${{ parameters.releaseVersion }}
             official: ${{ parameters.official }}
+            createSymbols: ${{ parameters.createSymbols }}
             # Attempt to retry the build on Windows to mitigate flakiness:
             # "Access Denied" during EXE copying and general flakiness during tests.
             ${{ if eq(builder.os, 'windows') }}:
@@ -45,3 +50,29 @@ stages:
               - ${{ each builder in parameters.builders }}:
                 - ${{ if eq(builder.config, 'buildandpack') }}:
                   - ${{ builder }}
+
+  - ${{ if eq(parameters.publish, true) }}:
+    - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/')) }}:
+      - template: pool.yml
+        parameters:
+          inner:
+            template: publish-stage.yml
+            parameters:
+              # This is not a builder, but provide partial builder info for agent selection.
+              builder: { os: linux, arch: amd64 }
+              official: true
+              public: true
+
+    - template: pool.yml
+      parameters:
+        inner:
+          template: publish-stage.yml
+          parameters:
+            builder: { os: linux, arch: amd64 }
+            official: true
+            public: false
+            builders:
+            - ${{ each builder in parameters.builders }}:
+              - ${{ if eq(builder.config, 'buildandpack') }}:
+                - ${{ builder }}
+            publishSymbols: ${{ parameters.createSymbols }}

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -31,7 +31,13 @@ parameters:
   - name: sign
     type: boolean
     default: false
+  - name: publish
+    type: boolean
+    default: false
   - name: createSourceArchive
+    type: boolean
+    default: false
+  - name: createSymbols
     type: boolean
     default: false
   - name: releaseVersion
@@ -45,7 +51,9 @@ stages:
       jobsParameters:
         official: ${{ parameters.official }}
         sign: ${{ parameters.sign }}
+        publish: ${{ parameters.publish }}
         createSourceArchive: ${{ parameters.createSourceArchive }}
+        createSymbols: ${{ parameters.createSymbols }}
         releaseVersion: ${{ parameters.releaseVersion }}
       shorthandBuilders:
         # Individually enable buildandpack.

--- a/eng/pipeline/stages/publish-stage.yml
+++ b/eng/pipeline/stages/publish-stage.yml
@@ -66,7 +66,7 @@ stages:
                 artifact: BuildAssets
               ${{ else }}:
                 artifact: BuildAssetsInternal
-            - ${{ if eq(parameters.publishSymbols, true) }}:
+            - ${{ if parameters.publishSymbols }}:
               - output: pipelineArtifact
                 path: $(Pipeline.Workspace)/Symbols
                 ${{ if parameters.public }}:

--- a/eng/pipeline/stages/publish-stage.yml
+++ b/eng/pipeline/stages/publish-stage.yml
@@ -167,5 +167,6 @@ stages:
                 SymbolServerType: TeamServices
                 # Source indexing doesn't work for us. It needs the source files to be available
                 # in the AzDO repo, but we pull them at build time using a git submodule.
+                # See https://github.com/microsoft/go-lab/issues/67.
                 IndexSources: false
               displayName: Publish symbols

--- a/eng/pipeline/stages/publish-stage.yml
+++ b/eng/pipeline/stages/publish-stage.yml
@@ -16,6 +16,12 @@ parameters:
     type: object
   - name: official
     type: boolean
+  - name: builders
+    type: object
+    default: []
+  - name: publishSymbols
+    type: boolean
+    default: false
 
 stages:
   - stage: Publish${{ parameters.public }}
@@ -60,6 +66,13 @@ stages:
                 artifact: BuildAssets
               ${{ else }}:
                 artifact: BuildAssetsInternal
+            - ${{ if eq(parameters.publishSymbols, true) }}:
+              - output: pipelineArtifact
+                path: $(Pipeline.Workspace)/Symbols
+                ${{ if parameters.public }}:
+                  artifact: Symbols
+                ${{ else }}:
+                  artifact: SymbolsInternal
 
         steps:
           - template: ../steps/checkout-unix-task.yml
@@ -124,3 +137,35 @@ stages:
               done
             displayName: Show uploaded URLs
             workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
+
+          - ${{ if eq(parameters.publishSymbols, true) }}:
+            - ${{ each builder in parameters.builders }}:
+              - download: current
+                artifact: Symbols ${{ builder.id }}
+                # Filter out manifests added by 1ES pipeline template.
+                patterns: '!_manifest/**'
+                displayName: 'Download: Symbols ${{ builder.id }}'
+
+              - powershell: |
+                  $flatDir = "$(Pipeline.Workspace)/Symbols"
+                  New-Item $flatDir -ItemType Directory -ErrorAction Ignore
+
+                  Get-ChildItem -Recurse -File -Path @(
+                    'Symbols ${{ builder.id }}'
+                  ) | %{
+                    if (Test-Path "$flatDir\$($_.Name)") {
+                      throw "Duplicate filename, unable to flatten: $($_.FullName)"
+                    }
+                    Copy-Item $_.FullName $flatDir
+                  }
+                displayName: 'Copy to flat dir: ${{ builder.id }}'
+                workingDirectory: '$(Pipeline.Workspace)'
+            - task: PublishSymbols@2
+              inputs:
+                SymbolsFolder: $(Pipeline.Workspace)/Symbols
+                SearchPattern: '*.pdb'
+                SymbolServerType: TeamServices
+                # Source indexing doesn't work for us. It needs the source files to be available
+                # in the AzDO repo, but we pull them at build time using a git submodule.
+                IndexSources: false
+              displayName: Publish symbols

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -13,6 +13,10 @@ parameters:
     type: boolean
     default: false
 
+  - name: createSymbols
+    type: boolean
+    default: false
+
   - name: releaseVersion
     type: string
     default: 'nil'
@@ -67,6 +71,8 @@ stages:
 
         variables:
           - group: go-cmdscan-rules
+          - name: createPDB
+            value: ${{ and(eq(parameters.createSymbols, true), eq(parameters.builder.config, 'buildandpack'), eq(parameters.builder.os, 'windows')) }} # Only create PDBs on Windows
 
         ${{ if and(parameters.official, eq(parameters.builder.config, 'buildandpack')) }}:
           templateContext:
@@ -75,6 +81,9 @@ stages:
               - output: pipelineArtifact
                 path: eng/artifacts/bin
                 artifact: Binaries ${{ parameters.builder.id }}
+              - output: pipelineArtifact
+                path: eng/artifacts/symbols
+                artifact: Symbols ${{ parameters.builder.id }}
 
         steps:
           - ${{ if eq(parameters.builder.os, 'linux') }}:
@@ -91,6 +100,11 @@ stages:
 
             - template: ../steps/checkout-unix-task.yml
             - template: ../steps/init-pwsh-task.yml
+          
+          - pwsh: |
+              New-Item eng/artifacts/bin -ItemType Directory -ErrorAction Ignore
+              New-Item eng/artifacts/symbols -ItemType Directory -ErrorAction Ignore
+            displayName: Create artifact directories
 
           - ${{ if eq(parameters.builder.os, 'windows') }}:
             - template: ../steps/checkout-windows-task.yml
@@ -124,16 +138,21 @@ stages:
               - pwsh: Write-Host "##vso[task.setvariable variable=GOARM]6"
                 displayName: Set GOARM for cross-compile
 
+          - ${{ if eq(variables.createPDB, true) }}:
+            - template: ../steps/install-gopdb.yml
+
           # Use build script directly for "buildandpack". If we used run-builder, we would need to
           # download its external module dependencies.
           - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
             - pwsh: |
                 eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -- `
-                  pwsh eng/run.ps1 build -packbuild $env:PACK_SOURCE_ARG
+                  pwsh eng/run.ps1 build -packbuild $env:PACK_SOURCE_ARG $env:CREATE_PDB_ARG
               env:
                 # Generate the source archive on one job only. The os choice is arbitrary.
                 ${{ if and(eq(parameters.createSourceArchive, true), eq(parameters.builder.config, 'buildandpack'), eq(parameters.builder.os, 'linux'), eq(parameters.builder.arch, 'amd64')) }}:
                   PACK_SOURCE_ARG: '-packsource'
+                ${{ if eq(variables.createPDB, true) }}:
+                  CREATE_PDB_ARG: '-pdb'
               displayName: Build and Pack
 
             # We want to create a checksum as early as possible, but Windows signing involves

--- a/eng/pipeline/steps/install-gopdb.yml
+++ b/eng/pipeline/steps/install-gopdb.yml
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# go-pdb is experimental and not available publicly.
+
+parameters:
+  - name: version
+    type: string
+    default: 0.2.1
+
+steps:
+  - pwsh: |
+      $pdbPath = "$(System.ArtifactsDirectory)/gopdb"
+      New-Item $pdbPath -ItemType Directory -ErrorAction Ignore
+      Write-Host "##vso[task.setvariable variable=pdbPath;]$pdbPath"
+      Write-Host "##vso[task.prependpath]$pdbPath"
+    displayName: Setup gopdb path
+
+  # Clone the go-pdb repo from the AzDO mirror, the bot doesn't have access to the GitHub repo.
+  # Use "git clone" instead of "go install", the later doesn't work because the module name points to GitHub, not AzDO.
+  - pwsh: |
+      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" `
+        clone --depth 1 --branch v${{ parameters.version }} https://dev.azure.com/dnceng/internal/_git/microsoft-go-pdb go-pdb
+    displayName: Clone gopdb
+
+  - pwsh: |
+      . eng/utilities.ps1
+      $gobin = Get-Stage0GoRoot # Make sure we have a Go toolchain available
+      cd go-pdb
+      & $gobin/bin/go.exe build -o $(pdbPath)/gopdb.exe ./cmd/gopdb
+    displayName: Install gopdb
+
+  - pwsh: |
+      Remove-Item -Path go-pdb -Force -Recurse
+    displayName: Cleanup go-pdb

--- a/eng/pipeline/steps/install-gopdb.yml
+++ b/eng/pipeline/steps/install-gopdb.yml
@@ -15,7 +15,7 @@ steps:
       New-Item $pdbPath -ItemType Directory -ErrorAction Ignore
       Write-Host "##vso[task.setvariable variable=pdbPath;]$pdbPath"
       Write-Host "##vso[task.prependpath]$pdbPath"
-    displayName: Setup gopdb path
+    displayName: Set up gopdb path
 
   # Clone the go-pdb repo from the AzDO mirror, the bot doesn't have access to the GitHub repo.
   # Use "git clone" instead of "go install", the later doesn't work because the module name points to GitHub, not AzDO.
@@ -33,4 +33,4 @@ steps:
 
   - pwsh: |
       Remove-Item -Path go-pdb -Force -Recurse
-    displayName: Cleanup go-pdb
+    displayName: Cleanup gopdb


### PR DESCRIPTION
> [!NOTE]
> This PR uses a PDB generation tool, gopdb, which is still experimental and not available publicly.

This PR adds support for publishing symbols in the form of PDBs. It is enabled by default for the `rolling-internal` pipeline.

This is a summary of the changes:
- Download and build gopdb from the internal AzDO mirror.
- Update the build command to run the `gopdb` tool for all the Go toolchain binaries.
- Store all PDBs as pipeline artifacts
- Update the publish stage to also publish the PDB files using [PublishSymbols@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-symbols-v2?view=azure-pipelines). Symbols are published into the private dnceng symbol server, which is the only server that our pipeline has access to.
- To achieve the previous task, I had to move the `publish-stage.yml` execution to `builders-to-stages.yml`, as it now needs to know which builders were run in order to download the symbol artifacts they published.

See these changes in action in https://dev.azure.com/dnceng/internal/_build/results?buildId=2439083&view=results.