### PR TITLE
Add second CodeQL job to validation pipeline for Go mirror

### DIFF
--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -79,4 +79,8 @@ extends:
           jobsParameters:
             official: true
           shorthandBuilders:
-            - { os: linux, arch: amd64, config: codeql }
+            # CodeQL doesn't submit the scan to both the outer repo
+            # (microsoft-go) and inner repo (microsoft-go-mirror).
+            # Use two jobs to submit two scans.
+            - { os: linux, arch: amd64, config: codeql_outer }
+            - { os: linux, arch: amd64, config: codeql_inner }

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -48,12 +48,17 @@ stages:
         workspace:
           clean: all
 
+        # Validation for complex inputs.
+        ${{ if startsWith(parameters.builder.config, 'codeql') }}:
+          ${{ if not(or(eq(parameters.builder.config, 'codeql_inner'), eq(parameters.builder.config, 'codeql_outer'))) }}:
+            'The CodeQL configuration must include "_inner" or "_outer" suffix': error
+
         ${{ if eq(parameters.builder.config, 'longtest') }}:
           # longtest has been seen to succeed after 53 minutes. Give around 3x headroom. In the future,
           # we should also give the tests a shorter timeout to make sure this doesn't balloon too far:
           # https://github.com/microsoft/go/issues/568
           timeoutInMinutes: 180
-        ${{ if eq(parameters.builder.config, 'codeql') }}:
+        ${{ if startsWith(parameters.builder.config, 'codeql') }}:
           # Allow CodeQL to take a while. https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#other-issues
           timeoutInMinutes: 360
 
@@ -73,6 +78,15 @@ stages:
           - group: go-cmdscan-rules
           - name: createPDB
             value: ${{ and(eq(parameters.createSymbols, true), eq(parameters.builder.config, 'buildandpack'), eq(parameters.builder.os, 'windows')) }} # Only create PDBs on Windows
+
+          - ${{ if eq(parameters.builder.config, 'codeql_inner') }}:
+            # Manually specify the repository being scanned by this job because
+            # CodeQL can't detect the inner repository (the submodule)
+            # automatically. See https://stackoverflow.microsoft.com/a/368419
+            - name: Codeql.ADO.Build.Repository.Provider
+              value: override
+            - name: Codeql.ADO.Build.Repository.Uri
+              value: https://dev.azure.com/dnceng/internal/_git/microsoft-go-mirror
 
         ${{ if and(parameters.official, eq(parameters.builder.config, 'buildandpack')) }}:
           templateContext:
@@ -100,7 +114,7 @@ stages:
 
             - template: ../steps/checkout-unix-task.yml
             - template: ../steps/init-pwsh-task.yml
-          
+
           - pwsh: |
               New-Item eng/artifacts/bin -ItemType Directory -ErrorAction Ignore
               New-Item eng/artifacts/symbols -ItemType Directory -ErrorAction Ignore
@@ -164,7 +178,7 @@ stages:
                 displayName: Write checksum
 
           # CodeQL plugs into the compiler to find the code. Just build.
-          - ${{ elseif eq(parameters.builder.config, 'codeql' ) }}:
+          - ${{ elseif startsWith(parameters.builder.config, 'codeql' ) }}:
             - pwsh: |
                 eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -- `
                   pwsh eng/run.ps1 build


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go-lab/issues/73

This PR changes the validation pipeline to run two jobs: the "outer" one submits a CodeQL database for microsoft-go, and the "inner" one is manually assigned to point at microsoft-go-mirror so that the CodeQL coverage is recognized by tooling.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2459481&view=results, which uploaded (note the language and repo):
* https://codeql.microsoft.com/job/f95bf6bc-ee0e-405e-a042-e42fdf2b961a
* https://codeql.microsoft.com/job/24a9450d-9e62-4c8d-b256-0728232a733c
* https://codeql.microsoft.com/job/0991cceb-1599-4be1-82c6-9944ddc48b78
* https://codeql.microsoft.com/job/549f7ead-6770-4e60-9ce8-5312c1bed9c3