### PR TITLE
Update submodule and fix crypto/tls TLS 1.3 support

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -1187,7 +1187,7 @@ index 921cdbb7bbd477..2fef7ddae07480 100644
  	"encoding"
  	"encoding/hex"
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 085ff5713ec52f..23bc4f6eea82ab 100644
+index 77374abe341c2f..f4a2210b517308 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -25,6 +25,11 @@ import (
@@ -1200,7 +1200,7 @@ index 085ff5713ec52f..23bc4f6eea82ab 100644
 +}
 +
  func TestBoringServerProtocolVersion(t *testing.T) {
- 	test := func(name string, v uint16, msg string) {
+ 	test := func(t *testing.T, name string, v uint16, msg string) {
  		t.Run(name, func(t *testing.T) {
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
 index 6f5bc37197a4f4..9079b5a2e3d50d 100644
@@ -1602,10 +1602,10 @@ index 33fd0ed52b1ff6..ffc3eeca9dbf95 100644
  	k, err := rsa.GenerateKey(rand.Reader, size)
  	if err != nil {
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index ee53b3114031f6..c3320e0e5c648f 100644
+index f7015ff33b7dd2..f2db98cfd10762 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -431,7 +431,9 @@ var depsRules = `
+@@ -442,7 +442,9 @@ var depsRules = `
  
  	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
  	crypto/internal/boring/sig,
@@ -1615,7 +1615,7 @@ index ee53b3114031f6..c3320e0e5c648f 100644
  	golang.org/x/sys/cpu,
  	hash, embed
  	< crypto
-@@ -442,6 +444,7 @@ var depsRules = `
+@@ -453,6 +455,7 @@ var depsRules = `
  	crypto/cipher,
  	crypto/internal/boring/bcache
  	< crypto/internal/boring
@@ -1623,7 +1623,7 @@ index ee53b3114031f6..c3320e0e5c648f 100644
  	< crypto/boring;
  
  	crypto/internal/alias
-@@ -479,6 +482,7 @@ var depsRules = `
+@@ -490,6 +493,7 @@ var depsRules = `
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
  	< crypto/internal/boring/bbig

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1004,7 +1004,7 @@ index 70baa62d63754a..ecd0f5a7b3e9ed 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 41983b9074fab3..f452aa95b2eb08 100644
+index 8bc24d05499555..c28aa8f1bfbe8c 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -1043,7 +1043,7 @@ index 9c1d3d279c472f..0ca7a863b73690 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index 7f15d05b288170..6cd5a57016fe7c 100644
+index a7d3890ba9c8fc..ab030568430ff7 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
 @@ -13,6 +13,7 @@ import (
@@ -1052,9 +1052,9 @@ index 7f15d05b288170..6cd5a57016fe7c 100644
  	"internal/byteorder"
 +	"internal/goexperiment"
  	"io"
+ 	"slices"
  	"time"
- )
-@@ -409,6 +410,15 @@ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
+@@ -414,6 +415,15 @@ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
  	}
  	marshaler, ok := in.(binaryMarshaler)
  	if !ok {
@@ -1147,10 +1147,10 @@ index 354008e0265c80..cecd373aab5a04 100644
  golang.org/x/crypto v0.22.1-0.20240415215343-5defcc193aab/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
  golang.org/x/net v0.24.1-0.20240405221309-ec05fdcd7114 h1:0+DQSN4OXt0ivfKIOXFQ+8vsRb1pNvvdl7DZ6AR07OQ=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 4ac04657461a9a..6d36946619144e 100644
+index 3df66d8479d507..8fa404a403f2c8 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -443,6 +443,10 @@ var depsRules = `
+@@ -454,6 +454,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1161,7 +1161,7 @@ index 4ac04657461a9a..6d36946619144e 100644
  	< github.com/golang-fips/openssl/v2/internal/subtle
  	< github.com/golang-fips/openssl/v2
  	< crypto/internal/boring
-@@ -483,6 +487,7 @@ var depsRules = `
+@@ -494,6 +498,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -1247,7 +1247,7 @@ index 00000000000000..99ee2542ca38a9
 +const CNGCrypto = true
 +const CNGCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 995c405fb54d2b..9c6bb5b4bedfe6 100644
+index ef00871d619651..c0f1a8a0322dbf 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,7 @@ type Flags struct {

--- a/patches/0010-Support-TLS-1.3-in-fipstls-mode.patch
+++ b/patches/0010-Support-TLS-1.3-in-fipstls-mode.patch
@@ -4,15 +4,15 @@ Date: Tue, 30 Jan 2024 11:40:31 +0100
 Subject: [PATCH] Support TLS 1.3 in fipstls mode
 
 ---
- src/crypto/tls/boring.go                 | 14 +++--
- src/crypto/tls/boring_test.go            | 66 ++++++++++++++++++------
- src/crypto/tls/cipher_suites.go          | 15 ++++--
- src/crypto/tls/handshake_client.go       |  4 +-
+ src/crypto/tls/boring.go                 | 14 +++---
+ src/crypto/tls/boring_test.go            | 54 +++++++++++++++++++-----
+ src/crypto/tls/cipher_suites.go          | 15 +++++--
+ src/crypto/tls/handshake_client.go       | 13 +++++-
  src/crypto/tls/handshake_client_tls13.go |  4 --
- src/crypto/tls/handshake_server_test.go  | 28 ++++++----
+ src/crypto/tls/handshake_server_test.go  |  3 ++
  src/crypto/tls/handshake_server_tls13.go |  7 ++-
  src/crypto/tls/notboring.go              |  2 +
- 8 files changed, 98 insertions(+), 42 deletions(-)
+ 8 files changed, 83 insertions(+), 29 deletions(-)
 
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
 index ecd0f5a7b3e9ed..07f15ab91eefd3 100644
@@ -59,7 +59,7 @@ index ecd0f5a7b3e9ed..07f15ab91eefd3 100644
  // defaultSupportedSignatureAlgorithms without Ed25519 and SHA-1.
  var fipsSupportedSignatureAlgorithms = []SignatureScheme{
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index f452aa95b2eb08..a892fb03487392 100644
+index c28aa8f1bfbe8c..4c7b827f1288bf 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -30,6 +30,31 @@ func init() {
@@ -92,35 +92,15 @@ index f452aa95b2eb08..a892fb03487392 100644
 +}
 +
  func TestBoringServerProtocolVersion(t *testing.T) {
- 	test := func(name string, v uint16, msg string) {
+ 	test := func(t *testing.T, name string, v uint16, msg string) {
  		t.Run(name, func(t *testing.T) {
-@@ -38,8 +63,11 @@ func TestBoringServerProtocolVersion(t *testing.T) {
- 			clientHello := &clientHelloMsg{
- 				vers:               v,
- 				random:             make([]byte, 32),
--				cipherSuites:       allCipherSuites(),
-+				cipherSuites:       allCipherSuitesIncludingTLS13(),
- 				compressionMethods: []uint8{compressionNone},
-+				supportedCurves:    defaultCurvePreferences,
-+				keyShares:          []keyShare{generateKeyShare(CurveP256)},
-+				supportedPoints:    []uint8{pointFormatUncompressed},
- 				supportedVersions:  []uint16{v},
- 			}
- 			testClientHelloFailure(t, serverConfig, clientHello, msg)
-@@ -53,25 +81,25 @@ func TestBoringServerProtocolVersion(t *testing.T) {
- 
- 	fipstls.Force()
- 	defer fipstls.Abandon()
--	test("VersionSSL30", VersionSSL30, "client offered only unsupported versions")
--	test("VersionTLS10", VersionTLS10, "client offered only unsupported versions")
--	test("VersionTLS11", VersionTLS11, "client offered only unsupported versions")
--	test("VersionTLS12", VersionTLS12, "")
--	test("VersionTLS13", VersionTLS13, "client offered only unsupported versions")
-+	test("VersionSSL30/fipstls", VersionSSL30, "client offered only unsupported versions")
-+	test("VersionTLS10/fipstls", VersionTLS10, "client offered only unsupported versions")
-+	test("VersionTLS11/fipstls", VersionTLS11, "client offered only unsupported versions")
-+	test("VersionTLS12/fipstls", VersionTLS12, "")
-+	test("VersionTLS13/fipstls", VersionTLS13, "")
+@@ -65,22 +90,22 @@ func TestBoringServerProtocolVersion(t *testing.T) {
+ 		test(t, "VersionTLS10", VersionTLS10, "supported versions")
+ 		test(t, "VersionTLS11", VersionTLS11, "supported versions")
+ 		test(t, "VersionTLS12", VersionTLS12, "")
+-		test(t, "VersionTLS13", VersionTLS13, "supported versions")
++		test(t, "VersionTLS13", VersionTLS13, "")
+ 	})
  }
  
  func isBoringVersion(v uint16) bool {
@@ -143,7 +123,7 @@ index f452aa95b2eb08..a892fb03487392 100644
  		return true
  	}
  	return false
-@@ -91,7 +119,7 @@ func isECDSA(id uint16) bool {
+@@ -100,7 +125,7 @@ func isECDSA(id uint16) bool {
  			return suite.flags&suiteECSign == suiteECSign
  		}
  	}
@@ -152,7 +132,7 @@ index f452aa95b2eb08..a892fb03487392 100644
  }
  
  func isBoringSignatureScheme(alg SignatureScheme) bool {
-@@ -114,10 +142,9 @@ func isBoringSignatureScheme(alg SignatureScheme) bool {
+@@ -123,10 +148,9 @@ func isBoringSignatureScheme(alg SignatureScheme) bool {
  
  func TestBoringServerCipherSuites(t *testing.T) {
  	serverConfig := testConfig.Clone()
@@ -164,7 +144,7 @@ index f452aa95b2eb08..a892fb03487392 100644
  		if isECDSA(id) {
  			serverConfig.Certificates[0].Certificate = [][]byte{testECDSACertificate}
  			serverConfig.Certificates[0].PrivateKey = testECDSAPrivateKey
-@@ -126,14 +153,19 @@ func TestBoringServerCipherSuites(t *testing.T) {
+@@ -135,14 +159,22 @@ func TestBoringServerCipherSuites(t *testing.T) {
  			serverConfig.Certificates[0].PrivateKey = testRSAPrivateKey
  		}
  		serverConfig.BuildNameToCertificate()
@@ -180,22 +160,15 @@ index f452aa95b2eb08..a892fb03487392 100644
  				supportedPoints:    []uint8{pointFormatUncompressed},
 +				supportedVersions:  []uint16{VersionTLS12},
 +			}
++			// This test runs for both TLS 1.2 and 1.3. For TLS 1.3, we need to
++			// specify more about the supported versions/algorithms.
 +			if isTLS13CipherSuite(id) {
 +				clientHello.supportedVersions = []uint16{VersionTLS13}
++				clientHello.supportedSignatureAlgorithms = supportedSignatureAlgorithms()
  			}
  
  			testClientHello(t, serverConfig, clientHello)
-@@ -165,7 +197,9 @@ func TestBoringServerCurves(t *testing.T) {
- 				cipherSuites:       []uint16{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
- 				compressionMethods: []uint8{compressionNone},
- 				supportedCurves:    []CurveID{curveid},
-+				keyShares:          []keyShare{generateKeyShare(curveid)},
- 				supportedPoints:    []uint8{pointFormatUncompressed},
-+				supportedVersions:  []uint16{VersionTLS12},
- 			}
- 
- 			testClientHello(t, serverConfig, clientHello)
-@@ -284,7 +318,7 @@ func TestBoringClientHello(t *testing.T) {
+@@ -289,7 +321,7 @@ func TestBoringClientHello(t *testing.T) {
  	}
  
  	if !isBoringVersion(hello.vers) {
@@ -238,10 +211,10 @@ index 9079b5a2e3d50d..bda80e81cd5396 100644
  
  	ret := &xorNonceAEAD{aead: aead}
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
-index e685339c29780a..eafbb221c07a33 100644
+index 4215d99122e585..1258a591ce1f3a 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
-@@ -139,7 +139,9 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
+@@ -139,13 +139,22 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
  		if len(hello.supportedVersions) == 1 {
  			hello.cipherSuites = nil
  		}
@@ -252,8 +225,22 @@ index e685339c29780a..eafbb221c07a33 100644
  			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13...)
  		} else {
  			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13NoAES...)
+ 		}
+ 
+-		curveID := config.curvePreferences()[0]
++		curveIDs := config.curvePreferences()
++		if len(curveIDs) == 0 {
++			// If TLS 1.3 FIPS restrictions are enabled, the filter applied by
++			// curvePreferences() may exclude all curves specified by config.
++			// In this case, there are certainly no supported curves.
++			return nil, nil, errors.New("tls: CurvePreferences includes no supported curves")
++		}
++		curveID := curveIDs[0]
+ 		if _, ok := curveForCurveID(curveID); !ok {
+ 			return nil, nil, errors.New("tls: CurvePreferences includes unsupported curve")
+ 		}
 diff --git a/src/crypto/tls/handshake_client_tls13.go b/src/crypto/tls/handshake_client_tls13.go
-index 2f59f6888c5d81..a84cede1b0b518 100644
+index 88ec383bf8351f..db06b0f4dad2bc 100644
 --- a/src/crypto/tls/handshake_client_tls13.go
 +++ b/src/crypto/tls/handshake_client_tls13.go
 @@ -41,10 +41,6 @@ type clientHandshakeStateTLS13 struct {
@@ -268,7 +255,7 @@ index 2f59f6888c5d81..a84cede1b0b518 100644
  	// sections 4.1.2 and 4.1.3.
  	if c.handshakes > 0 {
 diff --git a/src/crypto/tls/handshake_server_test.go b/src/crypto/tls/handshake_server_test.go
-index 15db760716c3df..c0a86a49841d61 100644
+index 813495d7b99497..f891fd0c318d17 100644
 --- a/src/crypto/tls/handshake_server_test.go
 +++ b/src/crypto/tls/handshake_server_test.go
 @@ -27,6 +27,7 @@ import (
@@ -279,37 +266,7 @@ index 15db760716c3df..c0a86a49841d61 100644
  	testClientHelloFailure(t, serverConfig, m, "")
  }
  
-@@ -52,23 +53,32 @@ func testClientHelloFailure(t *testing.T, serverConfig *Config, m handshakeMessa
- 	ctx := context.Background()
- 	conn := Server(s, serverConfig)
- 	ch, err := conn.readClientHello(ctx)
--	hs := serverHandshakeState{
--		c:           conn,
--		ctx:         ctx,
--		clientHello: ch,
--	}
--	if err == nil {
-+	if err == nil && conn.vers == VersionTLS13 {
-+		hs := serverHandshakeStateTLS13{
-+			c:           conn,
-+			ctx:         ctx,
-+			clientHello: ch,
-+		}
- 		err = hs.processClientHello()
--	}
--	if err == nil {
--		err = hs.pickCipherSuite()
-+	} else if err == nil {
-+		hs := serverHandshakeState{
-+			c:           conn,
-+			ctx:         ctx,
-+			clientHello: ch,
-+		}
-+		err = hs.processClientHello()
-+		if err == nil {
-+			err = hs.pickCipherSuite()
-+		}
- 	}
+@@ -83,9 +84,11 @@ func testClientHelloFailure(t *testing.T, serverConfig *Config, m handshakeMessa
  	s.Close()
  	if len(expectedSubStr) == 0 {
  		if err != nil && err != io.EOF {
@@ -322,10 +279,10 @@ index 15db760716c3df..c0a86a49841d61 100644
  	}
  }
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index 6c65da0ab04f9f..8234985d1f627a 100644
+index ab030568430ff7..c47237dd0cbc4a 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
-@@ -46,10 +46,6 @@ type serverHandshakeStateTLS13 struct {
+@@ -47,10 +47,6 @@ type serverHandshakeStateTLS13 struct {
  func (hs *serverHandshakeStateTLS13) handshake() error {
  	c := hs.c
  
@@ -336,7 +293,7 @@ index 6c65da0ab04f9f..8234985d1f627a 100644
  	// For an overview of the TLS 1.3 handshake, see RFC 8446, Section 2.
  	if err := hs.processClientHello(); err != nil {
  		return err
-@@ -164,6 +160,9 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
+@@ -165,6 +161,9 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
  	if !hasAESGCMHardwareSupport || !aesgcmPreferred(hs.clientHello.cipherSuites) {
  		preferenceList = defaultCipherSuitesTLS13NoAES
  	}


### PR DESCRIPTION
* Update submodule to https://github.com/golang/go/commit/3128ebfad748b5f160faa8cb8981bd0eaf6e3227
  * Part of https://github.com/microsoft/go/pull/1228
* Fix merge conflicts
* Fix tests, which includes a change to `crypto/tls/handshake_client.go` ❗ 

There were two test failures after initially resolving conflicts:

---

```
--- FAIL: TestBoringServerCipherSuites (0.01s)
    --- FAIL: TestBoringServerCipherSuites/suite=0x544c535f4145535f3132385f47434d5f534841323536 (0.00s)
        boring_test.go:179: Got error: local error: tls: missing extension; expected to succeed
        --- FAIL: TestBoringServerCipherSuites/suite=0x544c535f4145535f3132385f47434d5f534841323536/fipstls (0.00s)
            boring_test.go:187: Got error: local error: tls: missing extension; expected to succeed
    --- FAIL: TestBoringServerCipherSuites/suite=0x544c535f43484143484132305f504f4c59313330355f534841323536 (0.00s)
        boring_test.go:179: Got error: local error: tls: missing extension; expected to succeed
    --- FAIL: TestBoringServerCipherSuites/suite=0x544c535f4145535f3235365f47434d5f534841333834 (0.00s)
        boring_test.go:179: Got error: local error: tls: missing extension; expected to succeed
        --- FAIL: TestBoringServerCipherSuites/suite=0x544c535f4145535f3235365f47434d5f534841333834/fipstls (0.00s)
            boring_test.go:187: Got error: local error: tls: missing extension; expected to succeed
```

This "missing extension" shows up when a hello message doesn't include `supportedSignatureAlgorithms`.

So, I added `clientHello.supportedSignatureAlgorithms = supportedSignatureAlgorithms()` in the test case when simulating a hello. This fix seems straightforward and makes sense to me given the adjacent line `clientHello.supportedVersions = []uint16{VersionTLS13}`.

---

```
=== RUN   TestBoringServerCurves/curve=29/fipstls
panic: runtime error: index out of range [0] with length 0

goroutine 92 [running]:
crypto/tls.(*Conn).makeClientHello(0xc0000cd188)
        /home/dagood/git/go/go/src/crypto/tls/handshake_client.go:150 +0xfba
crypto/tls.(*Conn).clientHandshake(0xc0000cd188, {0x876640, 0xc0000991d0})
        /home/dagood/git/go/go/src/crypto/tls/handshake_client.go:184 +0x7d
crypto/tls.(*Conn).handshakeContext(0xc0000cd188, {0x8764f0, 0xae1420})
        /home/dagood/git/go/go/src/crypto/tls/conn.go:1554 +0x3a6
crypto/tls.(*Conn).HandshakeContext(...)
        /home/dagood/git/go/go/src/crypto/tls/conn.go:1494
crypto/tls.(*Conn).Handshake(...)
        /home/dagood/git/go/go/src/crypto/tls/conn.go:1478
crypto/tls.testHandshake.func1()
        /home/dagood/git/go/go/src/crypto/tls/handshake_test.go:407 +0x145
created by crypto/tls.testHandshake in goroutine 122
        /home/dagood/git/go/go/src/crypto/tls/handshake_test.go:405 +0x16c
FAIL    crypto/tls      11.034s
FAIL
```

Caused by `[0]` in this code in `crypto/tls/handshake_client.go`:

```go
curveID := config.curvePreferences()[0]
if _, ok := curveForCurveID(curveID); !ok {
	return nil, nil, errors.New("tls: CurvePreferences includes unsupported curve")
}
```

Here, the client `config` specifies a list of curve preferences, in this case only `X25519`. The test case runs with TLS FIPS restrictions enabled, which causes `curvePreferences()` to filter out `X25519` because it is not allowed with FIPS. Then the indexing panics on the 0-length slice.

It seems pretty clear to me from the code that detecting a 0-length slice and returning an error would match the intent, so I changed it to:

```go
curveIDs := config.curvePreferences()
if len(curveIDs) == 0 {
	return nil, nil, errors.New("tls: CurvePreferences includes no supported curves")
}
curveID := curveIDs[0]
if _, ok := curveForCurveID(curveID); !ok {
	return nil, nil, errors.New("tls: CurvePreferences includes unsupported curve")
}
```

*Perhaps* it is impossible to construct a `config` that triggers this error in real code. If that's true, the test case is actually invalid and `X25519` should be handled differently by the test code (e.g. skipped). However, I don't know for sure, and simply handling a 0-length slice here seems like an easy and safe fix.