### PR TITLE
Update submodule to latest; fix patch conflicts: move TLS defaults

### DIFF
--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -206,6 +206,11 @@ stages:
                   # The Chocolatey shims are located in a single folder in PATH, so we can't change PATH to exclude it.
                   # Upstream Windows builders don't have SWIG installed, so this makes coverage even.
                   RemovePathBinary 'swig'
+                  
+                  Write-Host "Removing 'patch' to avoid parts of cmd/go TestScript/mod_tidy_diff on Windows."
+                  # patch here doesn't seem to be the same as a Linux-style patch tool, and fails:
+                  # FAIL: testdata\script\mod_tidy_diff.txt:78: exec patch -p1 -i diff.patch: exit status 57005
+                  RemovePathBinary 'patch'
                 displayName: Remove unexpected tools
 
               - pwsh: |

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -53,10 +53,9 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/prf_test.go                   |  12 +-
  src/crypto/x509/boring_test.go               |   5 +
  src/go/build/deps_test.go                    |   4 +
- src/net/http/client_test.go                  |   6 +-
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 52 files changed, 768 insertions(+), 95 deletions(-)
+ 51 files changed, 764 insertions(+), 93 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -180,10 +179,10 @@ index 275c60b4de49eb..61e70f981db4eb 100644
  	"math/big"
  )
 diff --git a/src/crypto/ecdsa/ecdsa.go b/src/crypto/ecdsa/ecdsa.go
-index f0b68225103935..5386926b8e79e2 100644
+index 2179b01e8e3db5..9eb763cecfe687 100644
 --- a/src/crypto/ecdsa/ecdsa.go
 +++ b/src/crypto/ecdsa/ecdsa.go
-@@ -26,9 +26,9 @@ import (
+@@ -30,9 +30,9 @@ import (
  	"crypto/cipher"
  	"crypto/ecdh"
  	"crypto/elliptic"
@@ -286,10 +285,10 @@ index 00000000000000..3a7d7b76c8d8d7
 +	return key, nil
 +}
 diff --git a/src/crypto/ed25519/ed25519.go b/src/crypto/ed25519/ed25519.go
-index 1dda9e5e9a5ab3..a1f9a7b963654f 100644
+index b75c5a6458a218..303ea08c4b747f 100644
 --- a/src/crypto/ed25519/ed25519.go
 +++ b/src/crypto/ed25519/ed25519.go
-@@ -15,6 +15,7 @@ package ed25519
+@@ -18,6 +18,7 @@ package ed25519
  import (
  	"bytes"
  	"crypto"
@@ -297,7 +296,7 @@ index 1dda9e5e9a5ab3..a1f9a7b963654f 100644
  	"crypto/internal/edwards25519"
  	cryptorand "crypto/rand"
  	"crypto/sha512"
-@@ -22,6 +23,7 @@ import (
+@@ -25,6 +26,7 @@ import (
  	"errors"
  	"io"
  	"strconv"
@@ -305,7 +304,7 @@ index 1dda9e5e9a5ab3..a1f9a7b963654f 100644
  )
  
  const (
-@@ -139,6 +141,22 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
+@@ -142,6 +144,22 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
  	if rand == nil {
  		rand = cryptorand.Reader
  	}
@@ -328,7 +327,7 @@ index 1dda9e5e9a5ab3..a1f9a7b963654f 100644
  
  	seed := make([]byte, SeedSize)
  	if _, err := io.ReadFull(rand, seed); err != nil {
-@@ -157,6 +175,17 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
+@@ -160,6 +178,17 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
  // with RFC 8032. RFC 8032's private keys correspond to seeds in this
  // package.
  func NewKeyFromSeed(seed []byte) PrivateKey {
@@ -346,7 +345,7 @@ index 1dda9e5e9a5ab3..a1f9a7b963654f 100644
  	// Outline the function body so that the returned key can be stack-allocated.
  	privateKey := make([]byte, PrivateKeySize)
  	newKeyFromSeed(privateKey, seed)
-@@ -184,6 +213,17 @@ func newKeyFromSeed(privateKey, seed []byte) {
+@@ -187,6 +216,17 @@ func newKeyFromSeed(privateKey, seed []byte) {
  // Sign signs the message with privateKey and returns a signature. It will
  // panic if len(privateKey) is not [PrivateKeySize].
  func Sign(privateKey PrivateKey, message []byte) []byte {
@@ -364,9 +363,9 @@ index 1dda9e5e9a5ab3..a1f9a7b963654f 100644
  	// Outline the function body so that the returned signature can be
  	// stack-allocated.
  	signature := make([]byte, SignatureSize)
-@@ -259,9 +299,42 @@ func sign(signature, privateKey, message []byte, domPrefix, context string) {
- // Verify reports whether sig is a valid signature of message by publicKey. It
- // will panic if len(publicKey) is not [PublicKeySize].
+@@ -265,9 +305,42 @@ func sign(signature, privateKey, message []byte, domPrefix, context string) {
+ // The inputs are not considered confidential, and may leak through timing side
+ // channels, or if an attacker has control of part of the inputs.
  func Verify(publicKey PublicKey, message, sig []byte) bool {
 +	if boring.Enabled && boring.SupportsEd25519() && testMalleability() {
 +		pub, err := boringPublicKey(publicKey)
@@ -407,7 +406,7 @@ index 1dda9e5e9a5ab3..a1f9a7b963654f 100644
  // VerifyWithOptions reports whether sig is a valid signature of message by
  // publicKey. A valid signature is indicated by returning a nil error. It will
  // panic if len(publicKey) is not [PublicKeySize].
-@@ -292,7 +365,7 @@ func VerifyWithOptions(publicKey PublicKey, message, sig []byte, opts *Options)
+@@ -301,7 +374,7 @@ func VerifyWithOptions(publicKey PublicKey, message, sig []byte, opts *Options)
  		}
  		return nil
  	case opts.Hash == crypto.Hash(0): // Ed25519
@@ -1031,12 +1030,12 @@ index 2abc0436405f8a..34c22c8fbba7da 100644
  func boringPublicKey(*PublicKey) (*boring.PublicKeyRSA, error) {
  	panic("boringcrypto: not available")
 diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
-index 2705036fddf4c1..fc1cba42579f1e 100644
+index 2f958022f98584..9e243dcd6b4af8 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
-@@ -6,7 +6,7 @@ package rsa
- 
+@@ -7,7 +7,7 @@ package rsa
  import (
+ 	"bytes"
  	"crypto"
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
@@ -1067,7 +1066,7 @@ index dfa1eddc886ff3..849dafacf93d0f 100644
  	_, err := DecryptPKCS1v15(nil, rsaPrivateKey, ciphertext)
  	if err == nil {
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
-index b63b6eb01db637..27241df1867cb5 100644
+index e996e7aaa36b9c..89c5afd83de88a 100644
 --- a/src/crypto/rsa/pss.go
 +++ b/src/crypto/rsa/pss.go
 @@ -9,7 +9,7 @@ package rsa
@@ -1080,10 +1079,10 @@ index b63b6eb01db637..27241df1867cb5 100644
  	"hash"
  	"io"
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index 9342930dc1236f..72c31368f1cc2e 100644
+index 4d78d1eaaa6be0..614e63324c2b46 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
-@@ -27,9 +27,9 @@ package rsa
+@@ -26,9 +26,9 @@ package rsa
  
  import (
  	"crypto"
@@ -1187,7 +1186,7 @@ index 921cdbb7bbd477..2fef7ddae07480 100644
  	"encoding"
  	"encoding/hex"
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 77374abe341c2f..f4a2210b517308 100644
+index be10b71bd2269b..d879139773d1d7 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -25,6 +25,11 @@ import (
@@ -1203,7 +1202,7 @@ index 77374abe341c2f..f4a2210b517308 100644
  	test := func(t *testing.T, name string, v uint16, msg string) {
  		t.Run(name, func(t *testing.T) {
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
-index 6f5bc37197a4f4..9079b5a2e3d50d 100644
+index eebc66880d631f..42a26005ff31f2 100644
 --- a/src/crypto/tls/cipher_suites.go
 +++ b/src/crypto/tls/cipher_suites.go
 @@ -10,7 +10,7 @@ import (
@@ -1216,10 +1215,10 @@ index 6f5bc37197a4f4..9079b5a2e3d50d 100644
  	"crypto/sha1"
  	"crypto/sha256"
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
-index d046c86679ea51..4215d99122e585 100644
+index 553d2dde01de2d..6873e8daf631a7 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
-@@ -657,12 +657,16 @@ func (hs *clientHandshakeState) doFullHandshake() error {
+@@ -763,12 +763,16 @@ func (hs *clientHandshakeState) doFullHandshake() error {
  
  	if hs.serverHello.extendedMasterSecret {
  		c.extMasterSecret = true
@@ -1238,7 +1237,7 @@ index d046c86679ea51..4215d99122e585 100644
  	if err := c.config.writeKeyLog(keyLogLabelTLS12, hs.hello.random, hs.masterSecret); err != nil {
  		c.sendAlert(alertInternalError)
  		return errors.New("tls: failed to write to key log: " + err.Error())
-@@ -723,8 +727,12 @@ func (hs *clientHandshakeState) doFullHandshake() error {
+@@ -829,8 +833,12 @@ func (hs *clientHandshakeState) doFullHandshake() error {
  func (hs *clientHandshakeState) establishKeys() error {
  	c := hs.c
  
@@ -1252,7 +1251,7 @@ index d046c86679ea51..4215d99122e585 100644
  	var clientCipher, serverCipher any
  	var clientHash, serverHash hash.Hash
  	if hs.suite.cipher != nil {
-@@ -864,7 +872,11 @@ func (hs *clientHandshakeState) readFinished(out []byte) error {
+@@ -970,7 +978,11 @@ func (hs *clientHandshakeState) readFinished(out []byte) error {
  		return unexpectedMessageError(serverFinished, msg)
  	}
  
@@ -1265,7 +1264,7 @@ index d046c86679ea51..4215d99122e585 100644
  	if len(verify) != len(serverFinished.verifyData) ||
  		subtle.ConstantTimeCompare(verify, serverFinished.verifyData) != 1 {
  		c.sendAlert(alertHandshakeFailure)
-@@ -931,7 +943,10 @@ func (hs *clientHandshakeState) sendFinished(out []byte) error {
+@@ -1038,7 +1050,10 @@ func (hs *clientHandshakeState) sendFinished(out []byte) error {
  	}
  
  	finished := new(finishedMsg)
@@ -1278,10 +1277,10 @@ index d046c86679ea51..4215d99122e585 100644
  		return err
  	}
 diff --git a/src/crypto/tls/handshake_server.go b/src/crypto/tls/handshake_server.go
-index d5f8cc843ed6da..815d80fc9b6ab0 100644
+index ac3d915d1746d7..631db82b9ab3ae 100644
 --- a/src/crypto/tls/handshake_server.go
 +++ b/src/crypto/tls/handshake_server.go
-@@ -676,12 +676,16 @@ func (hs *serverHandshakeState) doFullHandshake() error {
+@@ -686,12 +686,16 @@ func (hs *serverHandshakeState) doFullHandshake() error {
  	}
  	if hs.hello.extendedMasterSecret {
  		c.extMasterSecret = true
@@ -1300,7 +1299,7 @@ index d5f8cc843ed6da..815d80fc9b6ab0 100644
  	if err := c.config.writeKeyLog(keyLogLabelTLS12, hs.clientHello.random, hs.masterSecret); err != nil {
  		c.sendAlert(alertInternalError)
  		return err
-@@ -745,8 +749,12 @@ func (hs *serverHandshakeState) doFullHandshake() error {
+@@ -755,8 +759,12 @@ func (hs *serverHandshakeState) doFullHandshake() error {
  func (hs *serverHandshakeState) establishKeys() error {
  	c := hs.c
  
@@ -1314,7 +1313,7 @@ index d5f8cc843ed6da..815d80fc9b6ab0 100644
  
  	var clientCipher, serverCipher any
  	var clientHash, serverHash hash.Hash
-@@ -787,7 +795,11 @@ func (hs *serverHandshakeState) readFinished(out []byte) error {
+@@ -797,7 +805,11 @@ func (hs *serverHandshakeState) readFinished(out []byte) error {
  		return unexpectedMessageError(clientFinished, msg)
  	}
  
@@ -1327,7 +1326,7 @@ index d5f8cc843ed6da..815d80fc9b6ab0 100644
  	if len(verify) != len(clientFinished.verifyData) ||
  		subtle.ConstantTimeCompare(verify, clientFinished.verifyData) != 1 {
  		c.sendAlert(alertHandshakeFailure)
-@@ -849,7 +861,10 @@ func (hs *serverHandshakeState) sendFinished(out []byte) error {
+@@ -859,7 +871,10 @@ func (hs *serverHandshakeState) sendFinished(out []byte) error {
  	}
  
  	finished := new(finishedMsg)
@@ -1340,10 +1339,10 @@ index d5f8cc843ed6da..815d80fc9b6ab0 100644
  		return err
  	}
 diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
-index d7f082c9ee1e04..14a85fbf1bd465 100644
+index 1636baf79e7288..c9a5877d3d504f 100644
 --- a/src/crypto/tls/key_schedule.go
 +++ b/src/crypto/tls/key_schedule.go
-@@ -59,7 +59,16 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
+@@ -61,7 +61,16 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
  		panic(fmt.Errorf("failed to construct HKDF label: %s", err))
  	}
  	out := make([]byte, length)
@@ -1361,7 +1360,7 @@ index d7f082c9ee1e04..14a85fbf1bd465 100644
  	if err != nil || n != length {
  		panic("tls: HKDF-Expand-Label invocation failed unexpectedly")
  	}
-@@ -79,6 +88,13 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
+@@ -81,6 +90,13 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
  	if newSecret == nil {
  		newSecret = make([]byte, c.hash.Size())
  	}
@@ -1602,10 +1601,10 @@ index 33fd0ed52b1ff6..ffc3eeca9dbf95 100644
  	k, err := rsa.GenerateKey(rand.Reader, size)
  	if err != nil {
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index f7015ff33b7dd2..f2db98cfd10762 100644
+index 84b0096c770f44..68d3b0578d18b1 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -442,7 +442,9 @@ var depsRules = `
+@@ -447,7 +447,9 @@ var depsRules = `
  
  	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
  	crypto/internal/boring/sig,
@@ -1615,7 +1614,7 @@ index f7015ff33b7dd2..f2db98cfd10762 100644
  	golang.org/x/sys/cpu,
  	hash, embed
  	< crypto
-@@ -453,6 +455,7 @@ var depsRules = `
+@@ -458,6 +460,7 @@ var depsRules = `
  	crypto/cipher,
  	crypto/internal/boring/bcache
  	< crypto/internal/boring
@@ -1623,7 +1622,7 @@ index f7015ff33b7dd2..f2db98cfd10762 100644
  	< crypto/boring;
  
  	crypto/internal/alias
-@@ -490,6 +493,7 @@ var depsRules = `
+@@ -495,6 +498,7 @@ var depsRules = `
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
  	< crypto/internal/boring/bbig
@@ -1631,32 +1630,8 @@ index f7015ff33b7dd2..f2db98cfd10762 100644
  	< crypto/rand
  	< crypto/internal/mlkem768
  	< crypto/ed25519
-diff --git a/src/net/http/client_test.go b/src/net/http/client_test.go
-index 33e69467c6a3f4..7b186b39c2bb4f 100644
---- a/src/net/http/client_test.go
-+++ b/src/net/http/client_test.go
-@@ -946,7 +946,9 @@ func testResponseSetsTLSConnectionState(t *testing.T, mode testMode) {
- 
- 	c := ts.Client()
- 	tr := c.Transport.(*Transport)
--	tr.TLSClientConfig.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA}
-+	// The cipher suite doesn't really matter, but we need a FIPS-compliant one
-+	// in case fipstls.Required() is true.
-+	tr.TLSClientConfig.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}
- 	tr.TLSClientConfig.MaxVersion = tls.VersionTLS12 // to get to pick the cipher suite
- 	tr.Dial = func(netw, addr string) (net.Conn, error) {
- 		return net.Dial(netw, ts.Listener.Addr().String())
-@@ -959,7 +961,7 @@ func testResponseSetsTLSConnectionState(t *testing.T, mode testMode) {
- 	if res.TLS == nil {
- 		t.Fatal("Response didn't set TLS Connection State.")
- 	}
--	if got, want := res.TLS.CipherSuite, tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA; got != want {
-+	if got, want := res.TLS.CipherSuite, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256; got != want {
- 		t.Errorf("TLS Cipher Suite = %d; want %d", got, want)
- 	}
- }
 diff --git a/src/net/smtp/smtp_test.go b/src/net/smtp/smtp_test.go
-index 259b10b93d9e36..0d48576b358644 100644
+index c91c99b1f53111..7d273ae17cb83f 100644
 --- a/src/net/smtp/smtp_test.go
 +++ b/src/net/smtp/smtp_test.go
 @@ -1105,40 +1105,60 @@ func sendMail(hostPort string) error {

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -58,10 +58,10 @@ index f0e3575637c62a..0e9aceeb832d3b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 95d9cab816bae6..10119880285187 100644
+index d7cbadf7b17aef..61685c5359bfde 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1235,12 +1235,11 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1238,12 +1238,11 @@ func (t *tester) registerCgoTests(heading string) {
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
@@ -108,10 +108,10 @@ index 4aaf46b5d0f0dc..6fe798cf4a94e9 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index 35b9ca01d2147f..7c0c4f7c50d29b 100644
+index 755c889585e729..bcb591a380b74c 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
-@@ -1158,6 +1158,7 @@ var hostobj []Hostobj
+@@ -1162,6 +1162,7 @@ var hostobj []Hostobj
  // These packages can use internal linking mode.
  // Others trigger external mode.
  var internalpkg = []string{
@@ -532,7 +532,7 @@ index f2e5a503eaacb6..1dc7116efdff2e 100644
  // runtime_arg0 is declared in tls.go without a body.
  // It's provided by package runtime,
 diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
-index 3bf1471fb0bce9..4e629a4db8f7c7 100644
+index b51f142fde8311..f5b4827c688f3b 100644
 --- a/src/crypto/internal/boring/fipstls/tls.go
 +++ b/src/crypto/internal/boring/fipstls/tls.go
 @@ -2,7 +2,7 @@
@@ -598,7 +598,7 @@ index 86466e67e87eeb..dbcc1bec58bd46 100644
  
  	msg := []byte{0xed, 0x36, 0x90, 0x8d, 0xbe, 0xfc, 0x35, 0x40, 0x70, 0x4f, 0xf5, 0x9d, 0x6e, 0xc2, 0xeb, 0xf5, 0x27, 0xae, 0x65, 0xb0, 0x59, 0x29, 0x45, 0x25, 0x8c, 0xc1, 0x91, 0x22}
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 1827f764589b58..70baa62d63754a 100644
+index c44ae92f2528f3..698efc6751e12c 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -2,7 +2,7 @@
@@ -611,7 +611,7 @@ index 1827f764589b58..70baa62d63754a 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 23bc4f6eea82ab..41983b9074fab3 100644
+index d879139773d1d7..50330a2cd77cf7 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -650,7 +650,7 @@ index f8485dc3ca1c29..9c1d3d279c472f 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
-index 14a85fbf1bd465..5caa181eec51a5 100644
+index c9a5877d3d504f..952eadd09e38ab 100644
 --- a/src/crypto/tls/key_schedule.go
 +++ b/src/crypto/tls/key_schedule.go
 @@ -7,6 +7,7 @@ package tls
@@ -658,11 +658,11 @@ index 14a85fbf1bd465..5caa181eec51a5 100644
  	"crypto/ecdh"
  	"crypto/hmac"
 +	boring "crypto/internal/backend"
+ 	"crypto/internal/mlkem768"
  	"errors"
  	"fmt"
- 	"hash"
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index 7d85b39c59319e..1aaabd5ef486aa 100644
+index bdbc32e05b35dd..36b4ceab0046c6 100644
 --- a/src/crypto/tls/notboring.go
 +++ b/src/crypto/tls/notboring.go
 @@ -2,7 +2,7 @@
@@ -714,7 +714,7 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 5ea6c94dd243e8..2beaccb4bf11e2 100644
+index 0141668dc3f6f4..87e9c5ffbbffd2 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -726,7 +726,7 @@ index 5ea6c94dd243e8..2beaccb4bf11e2 100644
  	golang.org/x/net v0.24.1-0.20240405221309-ec05fdcd7114
  )
 diff --git a/src/go.sum b/src/go.sum
-index 7d9b29679ec3b9..f5dd98dedf2f66 100644
+index 564f8b30a5b183..354008e0265c80 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
@@ -736,10 +736,10 @@ index 7d9b29679ec3b9..f5dd98dedf2f66 100644
  golang.org/x/crypto v0.22.1-0.20240415215343-5defcc193aab/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
  golang.org/x/net v0.24.1-0.20240405221309-ec05fdcd7114 h1:0+DQSN4OXt0ivfKIOXFQ+8vsRb1pNvvdl7DZ6AR07OQ=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 7bf1909f92437e..5f1e639335fa02 100644
+index 68d3b0578d18b1..15f4bb124b8528 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -442,6 +442,8 @@ var depsRules = `
+@@ -459,6 +459,8 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -748,7 +748,7 @@ index 7bf1909f92437e..5f1e639335fa02 100644
  	< crypto/internal/boring
  	< crypto/internal/backend
  	< crypto/boring;
-@@ -476,6 +478,7 @@ var depsRules = `
+@@ -497,6 +499,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -756,7 +756,7 @@ index 7bf1909f92437e..5f1e639335fa02 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -769,7 +772,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -793,7 +796,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -765,7 +765,7 @@ index 7bf1909f92437e..5f1e639335fa02 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -779,7 +782,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -803,7 +806,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}
@@ -817,7 +817,7 @@ index 00000000000000..a7f2712e9e1464
 +const OpenSSLCrypto = true
 +const OpenSSLCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 2f423aefd14076..e58baf9fa0ef4e 100644
+index 777337d92d3c72..ef00871d619651 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,7 @@ type Flags struct {
@@ -829,7 +829,7 @@ index 2f423aefd14076..e58baf9fa0ef4e 100644
  	// SystemCrypto enables the OpenSSL or CNG crypto experiment depending on
  	// which one is appropriate on the target GOOS.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index c4b89e019924d2..db4e015fe61b05 100644
+index c749de99db69e1..3b405e621df529 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
 @@ -14,6 +14,7 @@ import (

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -653,10 +653,10 @@ index 933ac569e034a8..0f152b210fdd84 100644
  package rsa
  
 diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
-index fc1cba42579f1e..7e59e4ef238781 100644
+index 9e243dcd6b4af8..e4bba544ff12ac 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
-@@ -94,7 +94,9 @@ func DecryptPKCS1v15(random io.Reader, priv *PrivateKey, ciphertext []byte) ([]b
+@@ -95,7 +95,9 @@ func DecryptPKCS1v15(random io.Reader, priv *PrivateKey, ciphertext []byte) ([]b
  		return nil, err
  	}
  
@@ -667,7 +667,7 @@ index fc1cba42579f1e..7e59e4ef238781 100644
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
-@@ -188,7 +190,9 @@ func decryptPKCS1v15(priv *PrivateKey, ciphertext []byte) (valid int, em []byte,
+@@ -189,7 +191,9 @@ func decryptPKCS1v15(priv *PrivateKey, ciphertext []byte) (valid int, em []byte,
  		return
  	}
  
@@ -678,8 +678,8 @@ index fc1cba42579f1e..7e59e4ef238781 100644
  		var bkey *boring.PrivateKeyRSA
  		bkey, err = boringPrivateKey(priv)
  		if err != nil {
-@@ -296,7 +300,9 @@ func SignPKCS1v15(random io.Reader, priv *PrivateKey, hash crypto.Hash, hashed [
- 		return nil, ErrMessageTooLong
+@@ -293,7 +297,9 @@ func SignPKCS1v15(random io.Reader, priv *PrivateKey, hash crypto.Hash, hashed [
+ 		return nil, err
  	}
  
 -	if boring.Enabled {
@@ -689,9 +689,9 @@ index fc1cba42579f1e..7e59e4ef238781 100644
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
-@@ -322,7 +328,9 @@ func SignPKCS1v15(random io.Reader, priv *PrivateKey, hash crypto.Hash, hashed [
- // returning a nil error. If hash is zero then hashed is used directly. This
- // isn't advisable except for interoperability.
+@@ -343,7 +349,9 @@ func pkcs1v15ConstructEM(pub *PublicKey, hash crypto.Hash, hashed []byte) ([]byt
+ // The inputs are not considered confidential, and may leak through timing side
+ // channels, or if an attacker has control of part of the inputs.
  func VerifyPKCS1v15(pub *PublicKey, hash crypto.Hash, hashed []byte, sig []byte) error {
 -	if boring.Enabled {
 +	if boring.Enabled &&
@@ -701,7 +701,7 @@ index fc1cba42579f1e..7e59e4ef238781 100644
  		if err != nil {
  			return err
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
-index 27241df1867cb5..fbe07cfa6ad76b 100644
+index 89c5afd83de88a..e9e80bcf7e6a26 100644
 --- a/src/crypto/rsa/pss.go
 +++ b/src/crypto/rsa/pss.go
 @@ -214,7 +214,9 @@ func signPSSWithSalt(priv *PrivateKey, hash crypto.Hash, hashed, salt []byte) ([
@@ -726,9 +726,9 @@ index 27241df1867cb5..fbe07cfa6ad76b 100644
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
-@@ -339,7 +342,9 @@ func SignPSS(rand io.Reader, priv *PrivateKey, hash crypto.Hash, digest []byte,
- // argument may be nil, in which case sensible defaults are used. opts.Hash is
- // ignored.
+@@ -342,7 +345,9 @@ func SignPSS(rand io.Reader, priv *PrivateKey, hash crypto.Hash, digest []byte,
+ // The inputs are not considered confidential, and may leak through timing side
+ // channels, or if an attacker has control of part of the inputs.
  func VerifyPSS(pub *PublicKey, hash crypto.Hash, digest []byte, sig []byte, opts *PSSOptions) error {
 -	if boring.Enabled {
 +	if boring.Enabled &&
@@ -738,7 +738,7 @@ index 27241df1867cb5..fbe07cfa6ad76b 100644
  		if err != nil {
  			return err
 diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
-index cf03e3cb7ed2cc..361eab5db6137d 100644
+index 7e908d4389d506..9a8311568c806e 100644
 --- a/src/crypto/rsa/pss_test.go
 +++ b/src/crypto/rsa/pss_test.go
 @@ -283,7 +283,7 @@ func fromHex(hexStr string) []byte {
@@ -751,10 +751,10 @@ index cf03e3cb7ed2cc..361eab5db6137d 100644
  		t.Fatal(err)
  	}
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index 72c31368f1cc2e..2dff6527ca87f1 100644
+index 614e63324c2b46..faa47afc515ff4 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
-@@ -35,6 +35,7 @@ import (
+@@ -34,6 +34,7 @@ import (
  	"crypto/subtle"
  	"errors"
  	"hash"
@@ -762,7 +762,7 @@ index 72c31368f1cc2e..2dff6527ca87f1 100644
  	"io"
  	"math"
  	"math/big"
-@@ -480,7 +481,11 @@ func mgf1XOR(out []byte, hash hash.Hash, seed []byte) {
+@@ -479,7 +480,11 @@ func mgf1XOR(out []byte, hash hash.Hash, seed []byte) {
  var ErrMessageTooLong = errors.New("crypto/rsa: message too long for RSA key size")
  
  func encrypt(pub *PublicKey, plaintext []byte) ([]byte, error) {
@@ -775,7 +775,7 @@ index 72c31368f1cc2e..2dff6527ca87f1 100644
  
  	N, err := bigmod.NewModulusFromBig(pub.N)
  	if err != nil {
-@@ -639,7 +644,9 @@ const noCheck = false
+@@ -638,7 +643,9 @@ const noCheck = false
  // m^e is calculated and compared with ciphertext, in order to defend against
  // errors in the CRT computation.
  func decrypt(priv *PrivateKey, ciphertext []byte, check bool) ([]byte, error) {
@@ -786,7 +786,7 @@ index 72c31368f1cc2e..2dff6527ca87f1 100644
  		boring.Unreachable()
  	}
  
-@@ -719,7 +726,9 @@ func decryptOAEP(hash, mgfHash hash.Hash, random io.Reader, priv *PrivateKey, ci
+@@ -718,7 +725,9 @@ func decryptOAEP(hash, mgfHash hash.Hash, random io.Reader, priv *PrivateKey, ci
  		return nil, ErrDecryption
  	}
  
@@ -991,7 +991,7 @@ index 2fef7ddae07480..979e4c69ab710c 100644
  
  		h := New()
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 70baa62d63754a..ecd0f5a7b3e9ed 100644
+index 698efc6751e12c..575d51b02298c8 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -2,7 +2,7 @@
@@ -1004,7 +1004,7 @@ index 70baa62d63754a..ecd0f5a7b3e9ed 100644
  package tls
  
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 8bc24d05499555..c28aa8f1bfbe8c 100644
+index 50330a2cd77cf7..1b47fc8bffdf1d 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,7 +2,7 @@
@@ -1043,10 +1043,10 @@ index 9c1d3d279c472f..0ca7a863b73690 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index a7d3890ba9c8fc..ab030568430ff7 100644
+index f24c2671acd435..f88fcad4e78f0d 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
-@@ -13,6 +13,7 @@ import (
+@@ -14,6 +14,7 @@ import (
  	"errors"
  	"hash"
  	"internal/byteorder"
@@ -1054,7 +1054,7 @@ index a7d3890ba9c8fc..ab030568430ff7 100644
  	"io"
  	"slices"
  	"time"
-@@ -414,6 +415,15 @@ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
+@@ -442,6 +443,15 @@ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
  	}
  	marshaler, ok := in.(binaryMarshaler)
  	if !ok {
@@ -1071,7 +1071,7 @@ index a7d3890ba9c8fc..ab030568430ff7 100644
  	}
  	state, err := marshaler.MarshalBinary()
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index 1aaabd5ef486aa..5a133c9b2f94c7 100644
+index 36b4ceab0046c6..c87df4ad695f1b 100644
 --- a/src/crypto/tls/notboring.go
 +++ b/src/crypto/tls/notboring.go
 @@ -2,7 +2,7 @@
@@ -1147,10 +1147,10 @@ index 354008e0265c80..cecd373aab5a04 100644
  golang.org/x/crypto v0.22.1-0.20240415215343-5defcc193aab/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
  golang.org/x/net v0.24.1-0.20240405221309-ec05fdcd7114 h1:0+DQSN4OXt0ivfKIOXFQ+8vsRb1pNvvdl7DZ6AR07OQ=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 3df66d8479d507..8fa404a403f2c8 100644
+index 15f4bb124b8528..82b38763d02d6c 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -454,6 +454,10 @@ var depsRules = `
+@@ -459,6 +459,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1161,7 +1161,7 @@ index 3df66d8479d507..8fa404a403f2c8 100644
  	< github.com/golang-fips/openssl/v2/internal/subtle
  	< github.com/golang-fips/openssl/v2
  	< crypto/internal/boring
-@@ -494,6 +498,7 @@ var depsRules = `
+@@ -499,6 +503,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big

--- a/patches/0008-Update-default-go.env.patch
+++ b/patches/0008-Update-default-go.env.patch
@@ -4,8 +4,9 @@ Date: Thu, 8 Jun 2023 14:17:13 +0200
 Subject: [PATCH] Update default go.env
 
 ---
- go.env                                           | 6 ++++--
- 1 files changed, 4 insertions(+), 2 deletions(-)
+ go.env                                     | 6 ++++--
+ src/cmd/go/testdata/script/env_changed.txt | 3 +++
+ 2 files changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/go.env b/go.env
 index 6ff2b921d464bc..4aca2ff2c63dbc 100644
@@ -22,3 +23,16 @@ index 6ff2b921d464bc..4aca2ff2c63dbc 100644
  # See https://go.dev/doc/toolchain for details.
 -GOTOOLCHAIN=auto
 +GOTOOLCHAIN=local
+diff --git a/src/cmd/go/testdata/script/env_changed.txt b/src/cmd/go/testdata/script/env_changed.txt
+index a3d368cd39e480..2253bb202d8397 100644
+--- a/src/cmd/go/testdata/script/env_changed.txt
++++ b/src/cmd/go/testdata/script/env_changed.txt
+@@ -1,5 +1,8 @@
+ # Test query for non-defaults in the env
+ 
++# See https://github.com/golang/go/issues/67793
++skip 'test relies on the standard go.env file, but Microsoft Go has a modified go.env file'
++
+ env GOTOOLCHAIN=local
+ env GOSUMDB=nodefault
+ env GOPROXY=nodefault

--- a/patches/0010-Support-TLS-1.3-in-fipstls-mode.patch
+++ b/patches/0010-Support-TLS-1.3-in-fipstls-mode.patch
@@ -4,62 +4,17 @@ Date: Tue, 30 Jan 2024 11:40:31 +0100
 Subject: [PATCH] Support TLS 1.3 in fipstls mode
 
 ---
- src/crypto/tls/boring.go                 | 14 +++---
  src/crypto/tls/boring_test.go            | 54 +++++++++++++++++++-----
  src/crypto/tls/cipher_suites.go          | 15 +++++--
+ src/crypto/tls/defaults.go               |  3 +-
  src/crypto/tls/handshake_client.go       | 13 +++++-
  src/crypto/tls/handshake_client_tls13.go |  4 --
  src/crypto/tls/handshake_server_test.go  |  3 ++
  src/crypto/tls/handshake_server_tls13.go |  7 ++-
- src/crypto/tls/notboring.go              |  2 +
- 8 files changed, 83 insertions(+), 29 deletions(-)
+ 7 files changed, 73 insertions(+), 26 deletions(-)
 
-diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index ecd0f5a7b3e9ed..07f15ab91eefd3 100644
---- a/src/crypto/tls/boring.go
-+++ b/src/crypto/tls/boring.go
-@@ -17,14 +17,14 @@ func needFIPS() bool {
- 
- // fipsMinVersion replaces c.minVersion in FIPS-only mode.
- func fipsMinVersion(c *Config) uint16 {
--	// FIPS requires TLS 1.2.
-+	// FIPS requires TLS 1.2 or TLS 1.3.
- 	return VersionTLS12
- }
- 
- // fipsMaxVersion replaces c.maxVersion in FIPS-only mode.
- func fipsMaxVersion(c *Config) uint16 {
--	// FIPS requires TLS 1.2.
--	return VersionTLS12
-+	// FIPS requires TLS 1.2 or TLS 1.3.
-+	return VersionTLS13
- }
- 
- // default defaultFIPSCurvePreferences is the FIPS-allowed curves,
-@@ -54,8 +54,6 @@ var defaultCipherSuitesFIPS = []uint16{
- 	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
- 	TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
- 	TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
--	TLS_RSA_WITH_AES_128_GCM_SHA256,
--	TLS_RSA_WITH_AES_256_GCM_SHA384,
- }
- 
- // fipsCipherSuites replaces c.cipherSuites in FIPS-only mode.
-@@ -75,6 +73,12 @@ func fipsCipherSuites(c *Config) []uint16 {
- 	return list
- }
- 
-+// defaultCipherSuitesTLS13FIPS are the FIPS-allowed cipher suites for TLS 1.3.
-+var defaultCipherSuitesTLS13FIPS = []uint16{
-+	TLS_AES_128_GCM_SHA256,
-+	TLS_AES_256_GCM_SHA384,
-+}
-+
- // fipsSupportedSignatureAlgorithms currently are a subset of
- // defaultSupportedSignatureAlgorithms without Ed25519 and SHA-1.
- var fipsSupportedSignatureAlgorithms = []SignatureScheme{
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index c28aa8f1bfbe8c..4c7b827f1288bf 100644
+index 1b47fc8bffdf1d..eda147261bbc96 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -30,6 +30,31 @@ func init() {
@@ -155,7 +110,7 @@ index c28aa8f1bfbe8c..4c7b827f1288bf 100644
  				random:             make([]byte, 32),
  				cipherSuites:       []uint16{id},
  				compressionMethods: []uint8{compressionNone},
- 				supportedCurves:    defaultCurvePreferences,
+ 				supportedCurves:    defaultCurvePreferences(),
 +				keyShares:          []keyShare{generateKeyShare(CurveP256)},
  				supportedPoints:    []uint8{pointFormatUncompressed},
 +				supportedVersions:  []uint16{VersionTLS12},
@@ -168,7 +123,7 @@ index c28aa8f1bfbe8c..4c7b827f1288bf 100644
  			}
  
  			testClientHello(t, serverConfig, clientHello)
-@@ -289,7 +321,7 @@ func TestBoringClientHello(t *testing.T) {
+@@ -293,7 +325,7 @@ func TestBoringClientHello(t *testing.T) {
  	}
  
  	if !isBoringVersion(hello.vers) {
@@ -178,7 +133,7 @@ index c28aa8f1bfbe8c..4c7b827f1288bf 100644
  	for _, v := range hello.supportedVersions {
  		if !isBoringVersion(v) {
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
-index 9079b5a2e3d50d..bda80e81cd5396 100644
+index 42a26005ff31f2..0c16bd8a884e14 100644
 --- a/src/crypto/tls/cipher_suites.go
 +++ b/src/crypto/tls/cipher_suites.go
 @@ -17,6 +17,7 @@ import (
@@ -187,9 +142,9 @@ index 9079b5a2e3d50d..bda80e81cd5396 100644
  	"internal/cpu"
 +	"internal/goexperiment"
  	"runtime"
+ 	_ "unsafe" // for linkname
  
- 	"golang.org/x/crypto/chacha20poly1305"
-@@ -556,9 +557,17 @@ func aeadAESGCMTLS13(key, nonceMask []byte) aead {
+@@ -552,9 +553,17 @@ func aeadAESGCMTLS13(key, nonceMask []byte) aead {
  	if err != nil {
  		panic(err)
  	}
@@ -210,11 +165,32 @@ index 9079b5a2e3d50d..bda80e81cd5396 100644
  	}
  
  	ret := &xorNonceAEAD{aead: aead}
+diff --git a/src/crypto/tls/defaults.go b/src/crypto/tls/defaults.go
+index 9b28acdc2d866a..3e780f447b522b 100644
+--- a/src/crypto/tls/defaults.go
++++ b/src/crypto/tls/defaults.go
+@@ -92,6 +92,7 @@ var defaultCipherSuitesTLS13NoAES = []uint16{
+ 
+ var defaultSupportedVersionsFIPS = []uint16{
+ 	VersionTLS12,
++	VersionTLS13,
+ }
+ 
+ // defaultCurvePreferencesFIPS are the FIPS-allowed curves,
+@@ -118,8 +119,6 @@ var defaultCipherSuitesFIPS = []uint16{
+ 	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+ 	TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+ 	TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+-	TLS_RSA_WITH_AES_128_GCM_SHA256,
+-	TLS_RSA_WITH_AES_256_GCM_SHA384,
+ }
+ 
+ // defaultCipherSuitesTLS13FIPS are the FIPS-allowed cipher suites for TLS 1.3.
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
-index 4215d99122e585..1258a591ce1f3a 100644
+index 6873e8daf631a7..585640d4b1a4d5 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
-@@ -139,13 +139,22 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
+@@ -141,13 +141,22 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCon
  		if len(hello.supportedVersions) == 1 {
  			hello.cipherSuites = nil
  		}
@@ -227,23 +203,23 @@ index 4215d99122e585..1258a591ce1f3a 100644
  			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13NoAES...)
  		}
  
--		curveID := config.curvePreferences()[0]
-+		curveIDs := config.curvePreferences()
+-		curveID := config.curvePreferences(maxVersion)[0]
++		curveIDs := config.curvePreferences(maxVersion)
 +		if len(curveIDs) == 0 {
 +			// If TLS 1.3 FIPS restrictions are enabled, the filter applied by
 +			// curvePreferences() may exclude all curves specified by config.
 +			// In this case, there are certainly no supported curves.
-+			return nil, nil, errors.New("tls: CurvePreferences includes no supported curves")
++			return nil, nil, nil, errors.New("tls: CurvePreferences includes no supported curves")
 +		}
 +		curveID := curveIDs[0]
- 		if _, ok := curveForCurveID(curveID); !ok {
- 			return nil, nil, errors.New("tls: CurvePreferences includes unsupported curve")
- 		}
+ 		keyShareKeys = &keySharePrivateKeys{curveID: curveID}
+ 		if curveID == x25519Kyber768Draft00 {
+ 			keyShareKeys.ecdhe, err = generateECDHEKey(config.rand(), X25519)
 diff --git a/src/crypto/tls/handshake_client_tls13.go b/src/crypto/tls/handshake_client_tls13.go
-index 88ec383bf8351f..db06b0f4dad2bc 100644
+index 6744e713c9ffa8..5b4c4568555d3d 100644
 --- a/src/crypto/tls/handshake_client_tls13.go
 +++ b/src/crypto/tls/handshake_client_tls13.go
-@@ -41,10 +41,6 @@ type clientHandshakeStateTLS13 struct {
+@@ -45,10 +45,6 @@ type clientHandshakeStateTLS13 struct {
  func (hs *clientHandshakeStateTLS13) handshake() error {
  	c := hs.c
  
@@ -255,7 +231,7 @@ index 88ec383bf8351f..db06b0f4dad2bc 100644
  	// sections 4.1.2 and 4.1.3.
  	if c.handshakes > 0 {
 diff --git a/src/crypto/tls/handshake_server_test.go b/src/crypto/tls/handshake_server_test.go
-index 813495d7b99497..f891fd0c318d17 100644
+index bc45a289c1ed70..47e2ce17bb9e8e 100644
 --- a/src/crypto/tls/handshake_server_test.go
 +++ b/src/crypto/tls/handshake_server_test.go
 @@ -27,6 +27,7 @@ import (
@@ -266,8 +242,8 @@ index 813495d7b99497..f891fd0c318d17 100644
  	testClientHelloFailure(t, serverConfig, m, "")
  }
  
-@@ -83,9 +84,11 @@ func testClientHelloFailure(t *testing.T, serverConfig *Config, m handshakeMessa
- 	s.Close()
+@@ -84,9 +85,11 @@ func testClientHelloFailure(t *testing.T, serverConfig *Config, m handshakeMessa
+ 	t.Helper()
  	if len(expectedSubStr) == 0 {
  		if err != nil && err != io.EOF {
 +			t.Helper()
@@ -279,10 +255,10 @@ index 813495d7b99497..f891fd0c318d17 100644
  	}
  }
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index ab030568430ff7..c47237dd0cbc4a 100644
+index f88fcad4e78f0d..b95299a44c8fc1 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
-@@ -47,10 +47,6 @@ type serverHandshakeStateTLS13 struct {
+@@ -48,10 +48,6 @@ type serverHandshakeStateTLS13 struct {
  func (hs *serverHandshakeStateTLS13) handshake() error {
  	c := hs.c
  
@@ -293,7 +269,7 @@ index ab030568430ff7..c47237dd0cbc4a 100644
  	// For an overview of the TLS 1.3 handshake, see RFC 8446, Section 2.
  	if err := hs.processClientHello(); err != nil {
  		return err
-@@ -165,6 +161,9 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
+@@ -166,6 +162,9 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
  	if !hasAESGCMHardwareSupport || !aesgcmPreferred(hs.clientHello.cipherSuites) {
  		preferenceList = defaultCipherSuitesTLS13NoAES
  	}
@@ -303,13 +279,3 @@ index ab030568430ff7..c47237dd0cbc4a 100644
  	for _, suiteID := range preferenceList {
  		hs.suite = mutualCipherSuiteTLS13(hs.clientHello.cipherSuites, suiteID)
  		if hs.suite != nil {
-diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index 5a133c9b2f94c7..7625ccb867dd92 100644
---- a/src/crypto/tls/notboring.go
-+++ b/src/crypto/tls/notboring.go
-@@ -18,3 +18,5 @@ func fipsCurvePreferences(c *Config) []CurveID { panic("fipsCurvePreferences") }
- func fipsCipherSuites(c *Config) []uint16      { panic("fipsCipherSuites") }
- 
- var fipsSupportedSignatureAlgorithms []SignatureScheme
-+
-+var defaultCipherSuitesTLS13FIPS []uint16

--- a/patches/0012-add-support-for-logging-used-Windows-APIs.patch
+++ b/patches/0012-add-support-for-logging-used-Windows-APIs.patch
@@ -29,11 +29,11 @@ index 4aabc29644e6f9..fc7296f28ab12f 100644
  	return stdFunction(unsafe.Pointer(f))
  }
 diff --git a/src/runtime/syscall_windows.go b/src/runtime/syscall_windows.go
-index f0e7661a1ba9e2..4485fe459cd749 100644
+index 69d720a395c48d..2772c019a15af2 100644
 --- a/src/runtime/syscall_windows.go
 +++ b/src/runtime/syscall_windows.go
-@@ -435,6 +435,7 @@ func syscall_loadlibrary(filename *uint16) (handle, err uintptr) {
- 
+@@ -443,6 +443,7 @@ func syscall_loadlibrary(filename *uint16) (handle, err uintptr) {
+ //
  //go:linkname syscall_getprocaddress syscall.getprocaddress
  func syscall_getprocaddress(handle uintptr, procname *byte) (outhandle, err uintptr) {
 +	syscallTrace(handle, procname)


### PR DESCRIPTION
* Builds on https://github.com/microsoft/go/pull/1232

Update to latest version of Go and fix patch conflicts. Mostly automatic, but:

* patches/0002-Add-crypto-backend-foundation.patch
  * Upstream incorporated the change in src/net/http/client_test.go so that no longer appears.
* patches/0004-Add-OpenSSL-crypto-backend.patch
  * Trivial: neighboring line to an import.
* patches/0008-Update-default-go.env.patch
  * Skip a test with logic that conflicts with this change: https://github.com/golang/go/issues/67793
* patches/0010-Support-TLS-1.3-in-fipstls-mode.patch
  * https://github.com/golang/go/commit/0b57881571a78e3ee9fe9001d1d7d4cc48fdc32d moved some FIPS settings to a more centralized location and made them simpler to configure.
  * Had to manually resolve some conflicts with the https://github.com/microsoft/go/pull/1232 fix for `TestBoringServerCurves/curve=29/fipstls` because the return values and neighboring lines were changed, but behavior is the same.