### PR TITLE
Add Javascript to list of CodeQL scan languages

### DIFF
--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -65,7 +65,7 @@ extends:
     sdl:
       codeql:
         enabledOnNonDefaultBranches: ${{ parameters.enableCodeQL }}
-        language: go,cpp,powershell
+        language: go,cpp,powershell,javascript
       suppression:
         suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
       tsa:


### PR DESCRIPTION
The microsoft-go repo doesn't complain about lacking a Javascript scan. I think this is probably because the js is in the Go submodule, and the infra that detects what languages to *expect* scans for can't look at the content of the submodule.

However, microsoft-go-mirror does complain about lacking js scans. No submodule there.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2464566&view=results
Made https://codeql.microsoft.com/job/cd91c8a1-580d-4947-9325-8c7157d00c8a