### PR TITLE
[microsoft/release-branch.go1.21] Port symbol publish and changes necessary to publish to PME

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -60,24 +60,6 @@ extends:
           buildandpack: true
           official: true
           createSourceArchive: true
+          createSymbols: true
+          publish: true
           releaseVersion: ${{ parameters.releaseVersion }}
-
-      - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/')) }}:
-        - template: stages/pool.yml
-          parameters:
-            inner:
-              template: publish-stage.yml
-              parameters:
-                # This is not a builder, but provide partial builder info for agent selection.
-                builder: { os: linux, arch: amd64 }
-                official: true
-                public: true
-
-      - template: stages/pool.yml
-        parameters:
-          inner:
-            template: publish-stage.yml
-            parameters:
-              builder: { os: linux, arch: amd64 }
-              official: true
-              public: false

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -24,6 +24,11 @@ parameters:
     type: boolean
     default: false
 
+  - name: publishExistingRunID
+    displayName: 'For debugging publish steps: skip building, and instead publish the artifacts from an existing run. Leave "nil" otherwise.'
+    type: string
+    default: nil
+
 variables:
   - template: variables/pool-providers.yml
   # MicroBuild configuration.
@@ -62,4 +67,5 @@ extends:
           createSourceArchive: true
           createSymbols: true
           publish: true
+          publishExistingRunID: ${{ parameters.publishExistingRunID }}
           releaseVersion: ${{ parameters.releaseVersion }}

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -7,11 +7,15 @@
 parameters:
   # [] of { id, os, arch, hostarch, config, distro?, experiment? }
   builders: []
+  # If true, publish build artifacts to blob storage.
+  publish: false
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.
   # 'official' is passed through into run-stage.yml, where it has other effects.
   official: false
   # If true, generate source archive tarballs.
   createSourceArchive: false
+  # If true, generate and publish symbols (aka PDBs).
+  createSymbols: false
   releaseVersion: 'nil'
 
 stages:
@@ -25,6 +29,7 @@ stages:
             createSourceArchive: ${{ parameters.createSourceArchive }}
             releaseVersion: ${{ parameters.releaseVersion }}
             official: ${{ parameters.official }}
+            createSymbols: ${{ parameters.createSymbols }}
             # Attempt to retry the build on Windows to mitigate flakiness:
             # "Access Denied" during EXE copying and general flakiness during tests.
             ${{ if eq(builder.os, 'windows') }}:
@@ -44,3 +49,29 @@ stages:
               - ${{ each builder in parameters.builders }}:
                 - ${{ if eq(builder.config, 'buildandpack') }}:
                   - ${{ builder }}
+
+  - ${{ if eq(parameters.publish, true) }}:
+    - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/')) }}:
+      - template: pool.yml
+        parameters:
+          inner:
+            template: publish-stage.yml
+            parameters:
+              # This is not a builder, but provide partial builder info for agent selection.
+              builder: { os: linux, arch: amd64 }
+              official: true
+              public: true
+
+    - template: pool.yml
+      parameters:
+        inner:
+          template: publish-stage.yml
+          parameters:
+            builder: { os: linux, arch: amd64 }
+            official: true
+            public: false
+            builders:
+              - ${{ each builder in parameters.builders }}:
+                - ${{ if eq(builder.config, 'buildandpack') }}:
+                  - ${{ builder }}
+            publishSymbols: ${{ parameters.createSymbols }}

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -9,6 +9,8 @@ parameters:
   builders: []
   # If true, publish build artifacts to blob storage.
   publish: false
+  # If changed to specify an existing pipeline run, skip build/sign and publish the existing run.
+  publishExistingRunID: 'nil'
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.
   # 'official' is passed through into run-stage.yml, where it has other effects.
   official: false
@@ -19,36 +21,37 @@ parameters:
   releaseVersion: 'nil'
 
 stages:
-  - ${{ each builder in parameters.builders }}:
-    - template: pool.yml
-      parameters:
-        inner:
-          template: run-stage.yml
-          parameters:
-            builder: ${{ builder }}
-            createSourceArchive: ${{ parameters.createSourceArchive }}
-            releaseVersion: ${{ parameters.releaseVersion }}
-            official: ${{ parameters.official }}
-            createSymbols: ${{ parameters.createSymbols }}
-            # Attempt to retry the build on Windows to mitigate flakiness:
-            # "Access Denied" during EXE copying and general flakiness during tests.
-            ${{ if eq(builder.os, 'windows') }}:
-              retryAttempts: [1, 2, 3, 4, "FINAL"]
+  - ${{ if eq(parameters.publishExistingRunID, 'nil') }}:
+    - ${{ each builder in parameters.builders }}:
+      - template: pool.yml
+        parameters:
+          inner:
+            template: run-stage.yml
+            parameters:
+              builder: ${{ builder }}
+              createSourceArchive: ${{ parameters.createSourceArchive }}
+              releaseVersion: ${{ parameters.releaseVersion }}
+              official: ${{ parameters.official }}
+              createSymbols: ${{ parameters.createSymbols }}
+              # Attempt to retry the build on Windows to mitigate flakiness:
+              # "Access Denied" during EXE copying and general flakiness during tests.
+              ${{ if eq(builder.os, 'windows') }}:
+                retryAttempts: [1, 2, 3, 4, "FINAL"]
 
-  - ${{ if eq(parameters.official, true) }}:
-    - template: pool.yml
-      parameters:
-        inner:
-          template: sign-stage.yml
-          parameters:
-            # This is not a builder, but provide partial builder info for agent selection.
-            builder: { os: windows, arch: amd64 }
-            official: ${{ parameters.official }}
-            # The list of builders to depend on and grab artifacts from.
-            builders:
-              - ${{ each builder in parameters.builders }}:
-                - ${{ if eq(builder.config, 'buildandpack') }}:
-                  - ${{ builder }}
+    - ${{ if eq(parameters.official, true) }}:
+      - template: pool.yml
+        parameters:
+          inner:
+            template: sign-stage.yml
+            parameters:
+              # This is not a builder, but provide partial builder info for agent selection.
+              builder: { os: windows, arch: amd64 }
+              official: ${{ parameters.official }}
+              # The list of builders to depend on and grab artifacts from.
+              builders:
+                - ${{ each builder in parameters.builders }}:
+                  - ${{ if eq(builder.config, 'buildandpack') }}:
+                    - ${{ builder }}
 
   - ${{ if eq(parameters.publish, true) }}:
     - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/')) }}:
@@ -58,16 +61,17 @@ stages:
             template: publish-stage.yml
             parameters:
               # This is not a builder, but provide partial builder info for agent selection.
-              builder: { os: linux, arch: amd64 }
+              builder: { os: windows, arch: amd64 }
               official: true
               public: true
+              publishExistingRunID: ${{ parameters.publishExistingRunID }}
 
     - template: pool.yml
       parameters:
         inner:
           template: publish-stage.yml
           parameters:
-            builder: { os: linux, arch: amd64 }
+            builder: { os: windows, arch: amd64 }
             official: true
             public: false
             builders:
@@ -75,3 +79,4 @@ stages:
                 - ${{ if eq(builder.config, 'buildandpack') }}:
                   - ${{ builder }}
             publishSymbols: ${{ parameters.createSymbols }}
+            publishExistingRunID: ${{ parameters.publishExistingRunID }}

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -28,7 +28,13 @@ parameters:
   - name: official
     type: boolean
     default: false
+  - name: publish
+    type: boolean
+    default: false
   - name: createSourceArchive
+    type: boolean
+    default: false
+  - name: createSymbols
     type: boolean
     default: false
   - name: releaseVersion
@@ -41,7 +47,9 @@ stages:
       jobsTemplate: builders-to-stages.yml
       jobsParameters:
         official: ${{ parameters.official }}
+        publish: ${{ parameters.publish }}
         createSourceArchive: ${{ parameters.createSourceArchive }}
+        createSymbols: ${{ parameters.createSymbols }}
         releaseVersion: ${{ parameters.releaseVersion }}
       shorthandBuilders:
         # Individually enable buildandpack.

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -40,6 +40,9 @@ parameters:
   - name: releaseVersion
     type: string
     default: 'nil'
+  - name: publishExistingRunID
+    type: string
+    default: 'nil'
 
 stages:
   - template: shorthand-builders-to-builders.yml
@@ -48,6 +51,7 @@ stages:
       jobsParameters:
         official: ${{ parameters.official }}
         publish: ${{ parameters.publish }}
+        publishExistingRunID: ${{ parameters.publishExistingRunID }}
         createSourceArchive: ${{ parameters.createSourceArchive }}
         createSymbols: ${{ parameters.createSymbols }}
         releaseVersion: ${{ parameters.releaseVersion }}

--- a/eng/pipeline/stages/publish-stage.yml
+++ b/eng/pipeline/stages/publish-stage.yml
@@ -11,6 +11,10 @@ parameters:
   - name: pool
     type: object
 
+  - name: publishExistingRunID
+    type: string
+    default: 'nil'
+
   # Unused. Declared so pool selection doesn't fail when trying to pass them.
   - name: builder
     type: object
@@ -29,25 +33,25 @@ stages:
       displayName: Publish Public
     ${{ else }}:
       displayName: Publish Internal
-    dependsOn: Sign
+    ${{ if eq(parameters.publishExistingRunID, 'nil') }}:
+      dependsOn: Sign
+    ${{ else }}:
+      dependsOn: []
     jobs:
       - job: Publish
         pool: ${{ parameters.pool }}
 
         variables:
-          - ${{ if parameters.public }}:
-            - name: blobContainer
+          - name: blobContainer
+            ${{ if parameters.public }}:
               value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft'
-            - name: blobSASArg
-              value: --sas-token '$(dotnetbuildoutput-golang-write-sas-query)'
-          - ${{ else }}:
-            - name: blobContainer
+            ${{ else }}:
               value: 'https://golangartifacts.blob.core.windows.net/microsoft'
-            - name: blobSASArg
-              value: '' # golangartifacts is set up with service connection auth.
 
+          - name: blobPrefix
+            value: '$(PublishBranchAlias)/$(Build.BuildNumber)'
           - name: blobDestinationUrl
-            value: '$(blobContainer)/$(PublishBranchAlias)/$(Build.BuildNumber)'
+            value: '$(blobContainer)/$(blobPrefix)'
 
           - group: go-storage
 
@@ -75,8 +79,7 @@ stages:
                   artifact: SymbolsInternal
 
         steps:
-          - template: ../steps/checkout-unix-task.yml
-          - template: ../steps/init-pwsh-task.yml
+          - template: ../steps/checkout-windows-task.yml
           - template: ../steps/init-submodule-task.yml
 
           - pwsh: |
@@ -102,11 +105,25 @@ stages:
               Write-Host "##vso[task.setvariable variable=PublishBranchAlias;]$branch"
             displayName: Find publish branch alias
 
-          - download: current
-            artifact: Binaries Signed
-            # Filter out manifests added by 1ES pipeline template.
-            patterns: '!_manifest/**'
-            displayName: 'Download: Binaries Signed'
+          - ${{ if eq(parameters.publishExistingRunID, 'nil') }}:
+            - download: current
+              artifact: Binaries Signed
+              # Filter out manifests added by 1ES pipeline template.
+              patterns: '!_manifest/**'
+              displayName: 'Download: Binaries Signed'
+          - ${{ else }}:
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download: Binaries Signed (Specific)'
+              inputs:
+                buildType: specific
+                project: $(System.TeamProject)
+                definition: $(System.DefinitionId)
+                runVersion: 'specific'
+                runId: ${{ parameters.publishExistingRunID }}
+                artifact: Binaries Signed
+                # Filter out manifests added by 1ES pipeline template.
+                patterns: '!_manifest/**'
+                targetPath: '$(Pipeline.Workspace)/Binaries Signed'
 
           - pwsh: |
               eng/run.ps1 createbuildassetjson `
@@ -117,36 +134,61 @@ stages:
                 -o '$(Pipeline.Workspace)/Binaries Signed/assets.json'
             displayName: 'Create build asset JSON'
 
-          - task: AzureCLI@2
-            displayName: Upload to blob storage
-            inputs:
-              azureSubscription: GoLang
-              scriptType: bash
-              scriptLocation: inlineScript
-              # Send literal '*' to az: it handles the wildcard itself. Az copy only accepts one
-              # "from" argument, so we can't use the shell's wildcard expansion.
-              inlineScript: |
-                az storage copy -s '*' -d '$(blobDestinationUrl)' $(blobSASArg)
-              workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
+          - ${{ if parameters.public }}:
+            - task: AzureCLI@2
+              displayName: Upload to blob storage
+              inputs:
+                azureSubscription: GoLang
+                scriptType: bash
+                scriptLocation: inlineScript
+                # Send literal '*' to az: it handles the wildcard itself. Az copy only accepts one
+                # "from" argument, so we can't use the shell's wildcard expansion.
+                inlineScript: |
+                  az storage copy -s '*' -d '$(blobDestinationUrl)' --sas-token '$(dotnetbuildoutput-golang-write-sas-query)'
+                workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
+          - ${{ else }}:
+            - task: AzureFileCopy@6
+              displayName: Upload to blob storage
+              inputs:
+                Destination: AzureBlob
+                azureSubscription: GoLang
+                storage: golangartifacts
+                ContainerName: microsoft
+                SourcePath: '$(Pipeline.Workspace)/Binaries Signed/*'
+                BlobPrefix: $(blobPrefix)
 
-          - script: |
-              echo 'Generated links to artifacts in blob storage:'
-              echo ''
-              for f in *; do
-                echo "$(blobDestinationUrl)/$f"
-              done
-            displayName: Show uploaded URLs
+          - pwsh: |
+              Write-Host 'Generated links to artifacts in blob storage:'
+              Write-Host ''
+              Get-ChildItem -File -Path '.' | %{
+                Write-Host "$(blobDestinationUrl)/$($_.Name)"
+              }
+            displayName: Show expected uploaded URLs
             workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
 
           - ${{ if eq(parameters.publishSymbols, true) }}:
             - ${{ each builder in parameters.builders }}:
-              - download: current
-                artifact: Symbols ${{ builder.id }}
-                # Filter out manifests added by 1ES pipeline template.
-                patterns: '!_manifest/**'
-                displayName: 'Download: Symbols ${{ builder.id }}'
+              - ${{ if eq(parameters.publishExistingRunID, 'nil') }}:
+                - download: current
+                  artifact: Symbols ${{ builder.id }}
+                  # Filter out manifests added by 1ES pipeline template.
+                  patterns: '!_manifest/**'
+                  displayName: 'Download: Symbols ${{ builder.id }}'
+              - ${{ else }}:
+                - task: DownloadPipelineArtifact@2
+                  displayName: 'Download: Symbols ${{ builder.id }} (Specific)'
+                  inputs:
+                    buildType: specific
+                    project: $(System.TeamProject)
+                    definition: $(System.DefinitionId)
+                    runVersion: 'specific'
+                    runId: ${{ parameters.publishExistingRunID }}
+                    artifact: Symbols ${{ builder.id }}
+                    # Filter out manifests added by 1ES pipeline template.
+                    patterns: '!_manifest/**'
+                    targetPath: '$(Pipeline.Workspace)/Symbols ${{ builder.id }}'
 
-              - powershell: |
+              - pwsh: |
                   $flatDir = "$(Pipeline.Workspace)/Symbols"
                   New-Item $flatDir -ItemType Directory -ErrorAction Ignore
 
@@ -158,7 +200,7 @@ stages:
                     }
                     Copy-Item $_.FullName $flatDir
                   }
-                displayName: 'Copy to flat dir: ${{ builder.id }}'
+                displayName: 'Flatten: Symbols ${{ builder.id }}'
                 workingDirectory: '$(Pipeline.Workspace)'
             - task: PublishSymbols@2
               inputs:

--- a/eng/pipeline/stages/publish-stage.yml
+++ b/eng/pipeline/stages/publish-stage.yml
@@ -151,8 +151,8 @@ stages:
               displayName: Upload to blob storage
               inputs:
                 Destination: AzureBlob
-                azureSubscription: GoLang
-                storage: golangartifacts
+                azureSubscription: golang-pme-storage
+                storage: golangartifactsbackup
                 ContainerName: microsoft
                 SourcePath: '$(Pipeline.Workspace)/Binaries Signed/*'
                 BlobPrefix: $(blobPrefix)

--- a/eng/pipeline/stages/publish-stage.yml
+++ b/eng/pipeline/stages/publish-stage.yml
@@ -16,6 +16,12 @@ parameters:
     type: object
   - name: official
     type: boolean
+  - name: builders
+    type: object
+    default: []
+  - name: publishSymbols
+    type: boolean
+    default: false
 
 stages:
   - stage: Publish${{ parameters.public }}
@@ -60,6 +66,13 @@ stages:
                 artifact: BuildAssets
               ${{ else }}:
                 artifact: BuildAssetsInternal
+            - ${{ if parameters.publishSymbols }}:
+              - output: pipelineArtifact
+                path: $(Pipeline.Workspace)/Symbols
+                ${{ if parameters.public }}:
+                  artifact: Symbols
+                ${{ else }}:
+                  artifact: SymbolsInternal
 
         steps:
           - template: ../steps/checkout-unix-task.yml
@@ -124,3 +137,36 @@ stages:
               done
             displayName: Show uploaded URLs
             workingDirectory: '$(Pipeline.Workspace)/Binaries Signed/'
+
+          - ${{ if eq(parameters.publishSymbols, true) }}:
+            - ${{ each builder in parameters.builders }}:
+              - download: current
+                artifact: Symbols ${{ builder.id }}
+                # Filter out manifests added by 1ES pipeline template.
+                patterns: '!_manifest/**'
+                displayName: 'Download: Symbols ${{ builder.id }}'
+
+              - powershell: |
+                  $flatDir = "$(Pipeline.Workspace)/Symbols"
+                  New-Item $flatDir -ItemType Directory -ErrorAction Ignore
+
+                  Get-ChildItem -Recurse -File -Path @(
+                    'Symbols ${{ builder.id }}'
+                  ) | %{
+                    if (Test-Path "$flatDir\$($_.Name)") {
+                      throw "Duplicate filename, unable to flatten: $($_.FullName)"
+                    }
+                    Copy-Item $_.FullName $flatDir
+                  }
+                displayName: 'Copy to flat dir: ${{ builder.id }}'
+                workingDirectory: '$(Pipeline.Workspace)'
+            - task: PublishSymbols@2
+              inputs:
+                SymbolsFolder: $(Pipeline.Workspace)/Symbols
+                SearchPattern: '*.pdb'
+                SymbolServerType: TeamServices
+                # Source indexing doesn't work for us. It needs the source files to be available
+                # in the AzDO repo, but we pull them at build time using a git submodule.
+                # See https://github.com/microsoft/go-lab/issues/67.
+                IndexSources: false
+              displayName: Publish symbols

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -13,6 +13,10 @@ parameters:
     type: boolean
     default: false
 
+  - name: createSymbols
+    type: boolean
+    default: false
+
   - name: releaseVersion
     type: string
     default: 'nil'
@@ -64,6 +68,8 @@ stages:
 
         variables:
           - group: go-cmdscan-rules
+          - name: createPDB
+            value: ${{ and(eq(parameters.createSymbols, true), eq(parameters.builder.config, 'buildandpack'), eq(parameters.builder.os, 'windows')) }} # Only create PDBs on Windows
 
         ${{ if and(parameters.official, eq(parameters.builder.config, 'buildandpack')) }}:
           templateContext:
@@ -72,6 +78,9 @@ stages:
               - output: pipelineArtifact
                 path: eng/artifacts/bin
                 artifact: Binaries ${{ parameters.builder.id }}
+              - output: pipelineArtifact
+                path: eng/artifacts/symbols
+                artifact: Symbols ${{ parameters.builder.id }}
 
         steps:
           - ${{ if eq(parameters.builder.os, 'linux') }}:
@@ -88,6 +97,11 @@ stages:
 
             - template: ../steps/checkout-unix-task.yml
             - template: ../steps/init-pwsh-task.yml
+          
+          - pwsh: |
+              New-Item eng/artifacts/bin -ItemType Directory -ErrorAction Ignore
+              New-Item eng/artifacts/symbols -ItemType Directory -ErrorAction Ignore
+            displayName: Create artifact directories
 
           - ${{ if eq(parameters.builder.os, 'windows') }}:
             - template: ../steps/checkout-windows-task.yml
@@ -130,12 +144,18 @@ stages:
               - pwsh: Write-Host "##vso[task.setvariable variable=GOARM]6"
                 displayName: Set GOARM for cross-compile
 
+          - ${{ if eq(variables.createPDB, true) }}:
+            - template: ../steps/install-gopdb.yml
+
           # Use build script directly for "buildandpack". If we used run-builder, we would need to
           # download its external module dependencies.
           - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
             - pwsh: |
                 eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -- `
-                  pwsh eng/run.ps1 build -pack
+                  pwsh eng/run.ps1 build -pack $env:CREATE_PDB_ARG
+              env:
+                ${{ if eq(variables.createPDB, true) }}:
+                  CREATE_PDB_ARG: '-pdb'
               displayName: Build and Pack
 
           # Use run-builder for any configuration that includes tests. run-builder uses the "gotestsum"

--- a/eng/pipeline/steps/install-gopdb.yml
+++ b/eng/pipeline/steps/install-gopdb.yml
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# go-pdb is experimental and not available publicly.
+
+parameters:
+  - name: version
+    type: string
+    default: 0.2.1
+
+steps:
+  - pwsh: |
+      $pdbPath = "$(System.ArtifactsDirectory)/gopdb"
+      New-Item $pdbPath -ItemType Directory -ErrorAction Ignore
+      Write-Host "##vso[task.setvariable variable=pdbPath;]$pdbPath"
+      Write-Host "##vso[task.prependpath]$pdbPath"
+    displayName: Set up gopdb path
+
+  # Clone the go-pdb repo from the AzDO mirror, the bot doesn't have access to the GitHub repo.
+  # Use "git clone" instead of "go install", the later doesn't work because the module name points to GitHub, not AzDO.
+  - pwsh: |
+      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" `
+        clone --depth 1 --branch v${{ parameters.version }} https://dev.azure.com/dnceng/internal/_git/microsoft-go-pdb go-pdb
+    displayName: Clone gopdb
+
+  - pwsh: |
+      . eng/utilities.ps1
+      $gobin = Get-Stage0GoRoot # Make sure we have a Go toolchain available
+      cd go-pdb
+      & $gobin/bin/go.exe build -o $(pdbPath)/gopdb.exe ./cmd/gopdb
+    displayName: Install gopdb
+
+  - pwsh: |
+      Remove-Item -Path go-pdb -Force -Recurse
+    displayName: Cleanup gopdb

--- a/eng/utilities.ps1
+++ b/eng/utilities.ps1
@@ -24,17 +24,17 @@ function Get-Stage0GoRoot() {
   # pre-installed. This CI script installs a consistent, official version of Go to a directory in
   # $HOME to handle this. This also makes it easier to locally repro issues in CI that involve a
   # specific version of Go. The downloaded copy of Go is called the "stage 0" version.
-  $stage0_go_version = '1.18.7'
+  $stage0_go_version = '1.20.6'
 
   $proc_arch = ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture).ToString().ToLowerInvariant()
   if ($IsWindows) {
     switch ($proc_arch) {
       'x64' {
-        $stage0_go_sha256 = '8c23c6ae7777df883ccc2fd07a90c3ac7fab3eb7398c0e2f39c7cb27ee06517e'
+        $stage0_go_sha256 = 'b67dd7f2b4589701e53c98e348e1b4d9a7c3536dc316941172b2f0b60ae4ce5f'
         $stage0_go_suffix = 'windows-amd64.zip'
       }
       'arm64' {
-        $stage0_go_sha256 = '14a1f33da77bcecea3c1f9ad5ca2363e0835fb77e83b3b1e09b922fd91fb66e1'
+        $stage0_go_sha256 = '9027e52be386e779ef1a0c938994ee2361689496ac832100407238f5ed0fd82a'
         $stage0_go_suffix = 'windows-arm64.zip'
       }
       Default { throw "Unable to match Windows '$proc_arch' to an architecture supported by the Microsoft scripts to build Go." }
@@ -42,11 +42,11 @@ function Get-Stage0GoRoot() {
   } elseif ($IsLinux) {
     switch ($proc_arch) {
       'x64' {
-        $stage0_go_sha256 = '6c967efc22152ce3124fc35cdf50fc686870120c5fd2107234d05d450a6105d8'
+        $stage0_go_sha256 = 'b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1eb'
         $stage0_go_suffix = 'linux-amd64.tar.gz'
       }
       'arm64' {
-        $stage0_go_sha256 = 'dceea023a9f87dc7c3bf638874e34ff1b42b76e3f1e489510a0c5ffde0cad438'
+        $stage0_go_sha256 = '4e15ab37556e979181a1a1cc60f6d796932223a0f5351d7c83768b356f84429b'
         $stage0_go_suffix = 'linux-arm64.tar.gz'
       }
       Default { throw "Unable to match Linux '$proc_arch' to an architecture supported by the Microsoft scripts to build Go." }


### PR DESCRIPTION
* Port #1210
  * This establishes some publish refactoring that the later changes use. Reduces cherry-pick conflicts. Not a bad feature to have anyway.
* Port #1225
* Port #1243
* Port Go stage 0 update from https://github.com/microsoft/go/pull/988
  * A newer version of Go is needed to build the PDB tool.
  * 1.22 already has this change, 1.21 needs it.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2468905&view=results

Related: 1.22 ports: https://github.com/microsoft/go/pull/1245