### PR TITLE
Fix blobContainer to log correct expected links

### DIFF
--- a/eng/pipeline/stages/publish-stage.yml
+++ b/eng/pipeline/stages/publish-stage.yml
@@ -42,11 +42,13 @@ stages:
         pool: ${{ parameters.pool }}
 
         variables:
+          - name: blobBackupAccount
+            value: golangartifactsbackup
           - name: blobContainer
             ${{ if parameters.public }}:
               value: 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft'
             ${{ else }}:
-              value: 'https://golangartifacts.blob.core.windows.net/microsoft'
+              value: 'https://$(blobBackupAccount).blob.core.windows.net/microsoft'
 
           - name: blobPrefix
             value: '$(PublishBranchAlias)/$(Build.BuildNumber)'
@@ -152,7 +154,7 @@ stages:
               inputs:
                 Destination: AzureBlob
                 azureSubscription: golang-pme-storage
-                storage: golangartifactsbackup
+                storage: $(blobBackupAccount)
                 ContainerName: microsoft
                 SourcePath: '$(Pipeline.Workspace)/Binaries Signed/*'
                 BlobPrefix: $(blobPrefix)


### PR DESCRIPTION
I looked at https://dev.azure.com/dnceng/internal/_build/results?buildId=2469633&view=results to see if the change to publish to `golangartifactsbackup` worked (https://github.com/microsoft/go/pull/1244), and I was surprised when `Show expected uploaded URLs` still showed `https://golangartifacts.blob.core.windows.net`.

It turns out this is just because the task that logs the expected URLs uses an older variable. Publishing does go to `golangartifactsbackup` as expected.

This PR is a quick fix to make this particular value shared by both the publish and `Show expected uploaded URLs` steps.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2470200&view=results