### PR TITLE
Update .gdnsuppress

### DIFF
--- a/.config/guardian/.gdnsuppress
+++ b/.config/guardian/.gdnsuppress
@@ -8,184 +8,18 @@
   "suppressionSets": {
     "default": {
       "name": "default",
-      "createdDate": "2024-03-05 03:01:57Z",
-      "lastUpdatedDate": "2024-03-05 03:01:57Z"
+      "createdDate": "2024-06-10 09:31:52Z",
+      "lastUpdatedDate": "2024-06-10 09:31:52Z"
     }
   },
   "results": {
-    "31128318971be3d77cbd3aaf7b6a06d65b1874334a143ee500c7fccb5aa89427": {
-      "signature": "31128318971be3d77cbd3aaf7b6a06d65b1874334a143ee500c7fccb5aa89427",
-      "alternativeSignatures": [
-        "9106dc3b9a335702dc4feeeed54285f07d8a06494f38fc23167f6158793928dc"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "992b26983b997813a410dfc25048f3b218c6fc02fc14a5c2ad431ec8e022ac79": {
-      "signature": "992b26983b997813a410dfc25048f3b218c6fc02fc14a5c2ad431ec8e022ac79",
-      "alternativeSignatures": [
-        "23e97da32b7142c282727c96d07fd5ce6aefd6ef26f02e91cb471eb7863542f8"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "53b10a5fb6059b0b229ad32c6278123a5603386f65d9e1c5684a2333f2e1dc62": {
-      "signature": "53b10a5fb6059b0b229ad32c6278123a5603386f65d9e1c5684a2333f2e1dc62",
-      "alternativeSignatures": [
-        "cd7b0b0937cfa32a98962a528bd99ede0181ae41a609df430f35fd30763166c4"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "dd76b3defecd301787000102e3ce76506d45147b98fc4accb410b87097b2f0dd": {
-      "signature": "dd76b3defecd301787000102e3ce76506d45147b98fc4accb410b87097b2f0dd",
+    "d5ce1218657b3f7da8e9a6ac55d72833387257e76e39d837edfd5c62781b9b97": {
+      "signature": "d5ce1218657b3f7da8e9a6ac55d72833387257e76e39d837edfd5c62781b9b97",
       "alternativeSignatures": [],
       "memberOf": [
         "default"
       ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "6b250bd6def22ac84e477b4d22ec0b12cb69721002a7fe0fccf23ff5a7dfa688": {
-      "signature": "6b250bd6def22ac84e477b4d22ec0b12cb69721002a7fe0fccf23ff5a7dfa688",
-      "alternativeSignatures": [],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "877868030fa2e6114057d685aea3f4ec90d3190dcfe0e0ae1d86a3a4094fad87": {
-      "signature": "877868030fa2e6114057d685aea3f4ec90d3190dcfe0e0ae1d86a3a4094fad87",
-      "alternativeSignatures": [],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "3f72337007e55d003a9f252112dbaead6ddf0f89bac847d528b44c263ddce0e1": {
-      "signature": "3f72337007e55d003a9f252112dbaead6ddf0f89bac847d528b44c263ddce0e1",
-      "alternativeSignatures": [],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "1ebc50c2b5fecaf320705d05137b2d29a3851823251d6224fc6223ca653b7c02": {
-      "signature": "1ebc50c2b5fecaf320705d05137b2d29a3851823251d6224fc6223ca653b7c02",
-      "alternativeSignatures": [],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "3d4c2bb9f6a10eec92970320f48c0ee107981491a38c0869e054c54f156aafa1": {
-      "signature": "3d4c2bb9f6a10eec92970320f48c0ee107981491a38c0869e054c54f156aafa1",
-      "alternativeSignatures": [],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "ebf235ebc38c8301d92931d07d3ba98a286fc46d53f24467f7d804c7d907a88b": {
-      "signature": "ebf235ebc38c8301d92931d07d3ba98a286fc46d53f24467f7d804c7d907a88b",
-      "alternativeSignatures": [],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "d00714f4abdecfa0f2b96d616a8631088ace81abf5f0688c05937dcf9cc4bb5e": {
-      "signature": "d00714f4abdecfa0f2b96d616a8631088ace81abf5f0688c05937dcf9cc4bb5e",
-      "alternativeSignatures": [],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "a23a3b38776a5d5339458e6c750f3adcd464114001fc9e235cfdf2f59ea55e34": {
-      "signature": "a23a3b38776a5d5339458e6c750f3adcd464114001fc9e235cfdf2f59ea55e34",
-      "alternativeSignatures": [
-        "7212b237f04bb422b5d47898f2b7823f62b210d3cd78561fed00aa0b28774d69"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "f94f7b0a9cdab58aa6d63df82711a887bb505c358071b130e3b19914feeacfaf": {
-      "signature": "f94f7b0a9cdab58aa6d63df82711a887bb505c358071b130e3b19914feeacfaf",
-      "alternativeSignatures": [
-        "3b757c28bc24c86ab16f5dd06b2ad0c5744750d8aaab437ddf7363c7249777dc"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "1f0629c2e65089829a5483233e59009bb33bbcf91f9f521ec2fdd40e7a2e85f1": {
-      "signature": "1f0629c2e65089829a5483233e59009bb33bbcf91f9f521ec2fdd40e7a2e85f1",
-      "alternativeSignatures": [
-        "84059991bbd859b14d73cad923d081ddfd1a42ce610b17c4416ae047604771d5"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "eb224e8bc8c893c5ca8802276fcb3c24e094667695f567ad58d96628239d41f6": {
-      "signature": "eb224e8bc8c893c5ca8802276fcb3c24e094667695f567ad58d96628239d41f6",
-      "alternativeSignatures": [
-        "87300a609fdf2a1bbe8cc60aff2f4240faeecbbf7721645a0b121d6a11ed3c9f"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "0c5ca4e90739d04146a9337843e032e7dd692fdfa1e02a1268affcc517824205": {
-      "signature": "0c5ca4e90739d04146a9337843e032e7dd692fdfa1e02a1268affcc517824205",
-      "alternativeSignatures": [
-        "3a86dddfdf0a4c0a5649171b3f9132c9baed90260126bf2be968e38330504f8c"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "cb567c0478e945c60fd5facf19280855e9096ce89ffe5185e8f7627d436a2916": {
-      "signature": "cb567c0478e945c60fd5facf19280855e9096ce89ffe5185e8f7627d436a2916",
-      "alternativeSignatures": [
-        "c28198d0651933cea99d7eb621272150f5dcf87423db0a48ea9327c126e04717"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "b8d28916dfa6f72225a21f39bed70ddde006252999e17a333745dce16e1fae8b": {
-      "signature": "b8d28916dfa6f72225a21f39bed70ddde006252999e17a333745dce16e1fae8b",
-      "alternativeSignatures": [
-        "85e5597f45ce0b4a2e305a09b93ee2785a99b2c6631471bb65bc143f656d9fd3"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
-    },
-    "d08e23864e80404b7c10269dd557a04cadd2294df3b446aac581ab3628117abd": {
-      "signature": "d08e23864e80404b7c10269dd557a04cadd2294df3b446aac581ab3628117abd",
-      "alternativeSignatures": [
-        "033abb2372b916fea90f6236f2713cc1b31d755b49eaeb87874112f02a286109"
-      ],
-      "memberOf": [
-        "default"
-      ],
-      "createdDate": "2024-03-05 03:01:57Z"
+      "createdDate": "2024-06-10 09:31:52Z"
     }
   }
 }


### PR DESCRIPTION
`microsoft/main` is [failing due to CredScan](https://dev.azure.com/dnceng/internal/_build/results?buildId=2469776&view=results), but we haven't received a task from TSA (yet?) so we can't suppress it the usual way. To generate this PR I:

1. Grabbed guardian from https://aka.ms/gdn/nuget
2. Ran `guardian.cmd init`
3. Copied the build artifact `drop_sdl_sources/SDL Sources Analysis (self)/.gdnsuppress` to `.config\guardian\.gdnsuppress`
4. Ran `guardian.cmd dehydrate -s C:\git\go\.config\guardian\.gdnsuppress` (full path: guardian working dir is `.gdn`!)
5. Ran `guardian.cmd deinit --confirm`

I suspect that the old suppressions aren't showing up because we've addressed them in TSA work items.

Test build with this update: https://dev.azure.com/dnceng/internal/_build/results?buildId=2470349&view=results