### PR TITLE
Remove test skip for non-default GOTOOLCHAIN: fixed upstream

### DIFF
--- a/patches/0008-Update-default-go.env.patch
+++ b/patches/0008-Update-default-go.env.patch
@@ -4,9 +4,8 @@ Date: Thu, 8 Jun 2023 14:17:13 +0200
 Subject: [PATCH] Update default go.env
 
 ---
- go.env                                     | 6 ++++--
- src/cmd/go/testdata/script/env_changed.txt | 3 +++
- 2 files changed, 7 insertions(+), 2 deletions(-)
+ go.env | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/go.env b/go.env
 index 6ff2b921d464bc..4aca2ff2c63dbc 100644
@@ -23,16 +22,3 @@ index 6ff2b921d464bc..4aca2ff2c63dbc 100644
  # See https://go.dev/doc/toolchain for details.
 -GOTOOLCHAIN=auto
 +GOTOOLCHAIN=local
-diff --git a/src/cmd/go/testdata/script/env_changed.txt b/src/cmd/go/testdata/script/env_changed.txt
-index 37d6571938cba6..204c39c5b18891 100644
---- a/src/cmd/go/testdata/script/env_changed.txt
-+++ b/src/cmd/go/testdata/script/env_changed.txt
-@@ -1,5 +1,8 @@
- # Test query for non-defaults in the env
- 
-+# See https://github.com/golang/go/issues/67793
-+skip 'test relies on the standard go.env file, but Microsoft Go has a modified go.env file'
-+
- env GOROOT=./a
- env GOTOOLCHAIN=local
- env GOSUMDB=nodefault


### PR DESCRIPTION
https://github.com/golang/go/issues/67793 is fixed upstream and we pulled in the commit with PR https://github.com/microsoft/go/pull/1247, so this test skip can be removed.