### PR TITLE
Update github.com/golang-fips/openssl/v2 to v2.0.3

### DIFF
--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -714,24 +714,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index b38dee7e6ddc28..46820be2075592 100644
+index b38dee7e6ddc28..097f35ca01aa5b 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.23
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.2
++	github.com/golang-fips/openssl/v2 v2.0.3
  	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
  	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
  )
 diff --git a/src/go.sum b/src/go.sum
-index c5eab7d4b2f93b..733bad46e50c77 100644
+index c5eab7d4b2f93b..fac8a0626146bc 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.2 h1:jWZLvtLF7PfFpSdG13bwBLt9DqPo5wN5SWwICrpwuGY=
-+github.com/golang-fips/openssl/v2 v2.0.2/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.3 h1:9+J2R0BQio6Jz8+dPZf/0ylISByl0gZWjTEKm+J+y7Y=
++github.com/golang-fips/openssl/v2 v2.0.3/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
  golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c h1:CR/7/SLUhIJw6g675eeoDiwggElO2MV9rGkNYjqi8GM=
@@ -829,7 +829,7 @@ index 777337d92d3c72..ef00871d619651 100644
  	// SystemCrypto enables the OpenSSL or CNG crypto experiment depending on
  	// which one is appropriate on the target GOOS.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index c749de99db69e1..3b405e621df529 100644
+index dbe59fea119e70..c3df1f9ac49b82 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
 @@ -14,6 +14,7 @@ import (

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1123,24 +1123,24 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 46820be2075592..68ae41a4cf5bc1 100644
+index 097f35ca01aa5b..fe0aa0cc92b35b 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.23
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.2
+ 	github.com/golang-fips/openssl/v2 v2.0.3
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
  	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
  	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
  )
 diff --git a/src/go.sum b/src/go.sum
-index 733bad46e50c77..04b9ef21ca2cc6 100644
+index fac8a0626146bc..43ae325dc538d2 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.2 h1:jWZLvtLF7PfFpSdG13bwBLt9DqPo5wN5SWwICrpwuGY=
- github.com/golang-fips/openssl/v2 v2.0.2/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
+ github.com/golang-fips/openssl/v2 v2.0.3 h1:9+J2R0BQio6Jz8+dPZf/0ylISByl0gZWjTEKm+J+y7Y=
+ github.com/golang-fips/openssl/v2 v2.0.3/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103 h1:KQsPPal3pKvKzAPTaR7sEriaqrHmRWw0dWG/7E5FNNk=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -11,7 +11,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../github.com/golang-fips/openssl/v2/aes.go  | 100 +++
  .../golang-fips/openssl/v2/bbig/big.go        |  37 +
  .../github.com/golang-fips/openssl/v2/big.go  |  11 +
- .../golang-fips/openssl/v2/cipher.go          | 582 +++++++++++++
+ .../golang-fips/openssl/v2/cipher.go          | 569 +++++++++++++
  .../github.com/golang-fips/openssl/v2/des.go  | 113 +++
  .../github.com/golang-fips/openssl/v2/ec.go   |  59 ++
  .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
@@ -61,7 +61,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 56 files changed, 9058 insertions(+)
+ 56 files changed, 9045 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -162,7 +162,7 @@ index 00000000000000..97e85154015761
 \ No newline at end of file
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/README.md b/src/vendor/github.com/golang-fips/openssl/v2/README.md
 new file mode 100644
-index 00000000000000..ba6289ecff86d0
+index 00000000000000..1bfbaf60f4dd58
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/README.md
 @@ -0,0 +1,66 @@
@@ -194,7 +194,7 @@ index 00000000000000..ba6289ecff86d0
 +
 +### Multiple OpenSSL versions supported
 +
-+The `openssl` package has support for multiple OpenSSL versions, namely 1.0.2, 1.1.0, 1.1.1 and 3.0.x.
++The `openssl` package has support for multiple OpenSSL versions, namely 1.0.2, 1.1.0, 1.1.1 and 3.x.
 +
 +All supported OpenSSL versions pass a small set of automatic tests that ensure they can be built and that there are no major regressions.
 +These tests do not validate the cryptographic correctness of the `openssl` package.
@@ -400,16 +400,17 @@ index 00000000000000..6461f241f863fc
 +type BigInt []uint
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cipher.go b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
 new file mode 100644
-index 00000000000000..2b983c5411fc72
+index 00000000000000..72f7aebfc130e7
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
-@@ -0,0 +1,582 @@
+@@ -0,0 +1,569 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
 +// #include "goopenssl.h"
 +import "C"
++
 +import (
 +	"crypto/cipher"
 +	"encoding/binary"
@@ -551,8 +552,6 @@ index 00000000000000..2b983c5411fc72
 +
 +type evpCipher struct {
 +	key       []byte
-+	enc_ctx   C.GO_EVP_CIPHER_CTX_PTR
-+	dec_ctx   C.GO_EVP_CIPHER_CTX_PTR
 +	kind      cipherKind
 +	blockSize int
 +}
@@ -565,17 +564,7 @@ index 00000000000000..2b983c5411fc72
 +	c := &evpCipher{key: make([]byte, len(key)), kind: kind}
 +	copy(c.key, key)
 +	c.blockSize = int(C.go_openssl_EVP_CIPHER_get_block_size(cipher))
-+	runtime.SetFinalizer(c, (*evpCipher).finalize)
 +	return c, nil
-+}
-+
-+func (c *evpCipher) finalize() {
-+	if c.enc_ctx != nil {
-+		C.go_openssl_EVP_CIPHER_CTX_free(c.enc_ctx)
-+	}
-+	if c.dec_ctx != nil {
-+		C.go_openssl_EVP_CIPHER_CTX_free(c.dec_ctx)
-+	}
 +}
 +
 +func (c *evpCipher) encrypt(dst, src []byte) error {
@@ -590,15 +579,13 @@ index 00000000000000..2b983c5411fc72
 +	if inexactOverlap(dst[:c.blockSize], src[:c.blockSize]) {
 +		return errors.New("invalid buffer overlap")
 +	}
-+	if c.enc_ctx == nil {
-+		var err error
-+		c.enc_ctx, err = newCipherCtx(c.kind, cipherModeECB, cipherOpEncrypt, c.key, nil)
-+		if err != nil {
-+			return err
-+		}
++	enc_ctx, err := newCipherCtx(c.kind, cipherModeECB, cipherOpEncrypt, c.key, nil)
++	if err != nil {
++		return err
 +	}
++	defer C.go_openssl_EVP_CIPHER_CTX_free(enc_ctx)
 +
-+	if C.go_openssl_EVP_EncryptUpdate_wrapper(c.enc_ctx, base(dst), base(src), C.int(c.blockSize)) != 1 {
++	if C.go_openssl_EVP_EncryptUpdate_wrapper(enc_ctx, base(dst), base(src), C.int(c.blockSize)) != 1 {
 +		return errors.New("EncryptUpdate failed")
 +	}
 +	runtime.KeepAlive(c)
@@ -617,18 +604,17 @@ index 00000000000000..2b983c5411fc72
 +	if inexactOverlap(dst[:c.blockSize], src[:c.blockSize]) {
 +		return errors.New("invalid buffer overlap")
 +	}
-+	if c.dec_ctx == nil {
-+		var err error
-+		c.dec_ctx, err = newCipherCtx(c.kind, cipherModeECB, cipherOpDecrypt, c.key, nil)
-+		if err != nil {
-+			return err
-+		}
-+		if C.go_openssl_EVP_CIPHER_CTX_set_padding(c.dec_ctx, 0) != 1 {
-+			return errors.New("could not disable cipher padding")
-+		}
++	dec_ctx, err := newCipherCtx(c.kind, cipherModeECB, cipherOpDecrypt, c.key, nil)
++	if err != nil {
++		return err
++	}
++	defer C.go_openssl_EVP_CIPHER_CTX_free(dec_ctx)
++
++	if C.go_openssl_EVP_CIPHER_CTX_set_padding(dec_ctx, 0) != 1 {
++		return errors.New("could not disable cipher padding")
 +	}
 +
-+	C.go_openssl_EVP_DecryptUpdate_wrapper(c.dec_ctx, base(dst), base(src), C.int(c.blockSize))
++	C.go_openssl_EVP_DecryptUpdate_wrapper(dec_ctx, base(dst), base(src), C.int(c.blockSize))
 +	runtime.KeepAlive(c)
 +	return nil
 +}
@@ -727,7 +713,7 @@ index 00000000000000..2b983c5411fc72
 +)
 +
 +type cipherGCM struct {
-+	ctx C.GO_EVP_CIPHER_CTX_PTR
++	c   *evpCipher
 +	tls cipherGCMTLS
 +	// minNextNonce is the minimum value that the next nonce can be, enforced by
 +	// all TLS modes.
@@ -785,17 +771,8 @@ index 00000000000000..2b983c5411fc72
 +}
 +
 +func (c *evpCipher) newGCM(tls cipherGCMTLS) (cipher.AEAD, error) {
-+	ctx, err := newCipherCtx(c.kind, cipherModeGCM, cipherOpNone, c.key, nil)
-+	if err != nil {
-+		return nil, err
-+	}
-+	g := &cipherGCM{ctx: ctx, tls: tls, blockSize: c.blockSize}
-+	runtime.SetFinalizer(g, (*cipherGCM).finalize)
++	g := &cipherGCM{c: c, tls: tls, blockSize: c.blockSize}
 +	return g, nil
-+}
-+
-+func (g *cipherGCM) finalize() {
-+	C.go_openssl_EVP_CIPHER_CTX_free(g.ctx)
 +}
 +
 +func (g *cipherGCM) NonceSize() int {
@@ -870,6 +847,11 @@ index 00000000000000..2b983c5411fc72
 +		panic("cipher: invalid buffer overlap")
 +	}
 +
++	ctx, err := newCipherCtx(g.c.kind, cipherModeGCM, cipherOpNone, g.c.key, nil)
++	if err != nil {
++		panic(err)
++	}
++	defer C.go_openssl_EVP_CIPHER_CTX_free(ctx)
 +	// Encrypt additional data.
 +	// When sealing a TLS payload, OpenSSL app sets the additional data using
 +	// 'EVP_CIPHER_CTX_ctrl(g.ctx, C.EVP_CTRL_AEAD_TLS1_AAD, C.EVP_AEAD_TLS1_AAD_LEN, base(additionalData))'.
@@ -877,7 +859,7 @@ index 00000000000000..2b983c5411fc72
 +	// relying in the explicit nonce being securely set externally,
 +	// and it also gives some interesting speed gains.
 +	// Unfortunately we can't use it because Go expects AEAD.Seal to honor the provided nonce.
-+	if C.go_openssl_EVP_CIPHER_CTX_seal_wrapper(g.ctx, base(out), base(nonce),
++	if C.go_openssl_EVP_CIPHER_CTX_seal_wrapper(ctx, base(out), base(nonce),
 +		base(plaintext), C.int(len(plaintext)),
 +		base(additionalData), C.int(len(additionalData))) != 1 {
 +
@@ -912,8 +894,13 @@ index 00000000000000..2b983c5411fc72
 +		panic("cipher: invalid buffer overlap")
 +	}
 +
++	ctx, err := newCipherCtx(g.c.kind, cipherModeGCM, cipherOpNone, g.c.key, nil)
++	if err != nil {
++		return nil, err
++	}
++	defer C.go_openssl_EVP_CIPHER_CTX_free(ctx)
 +	ok := C.go_openssl_EVP_CIPHER_CTX_open_wrapper(
-+		g.ctx, base(out), base(nonce),
++		ctx, base(out), base(nonce),
 +		base(ciphertext), C.int(len(ciphertext)),
 +		base(additionalData), C.int(len(additionalData)), base(tag))
 +	runtime.KeepAlive(g)
@@ -9498,11 +9485,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 2868749b894fb2..c91ea7f76a892a 100644
+index 2868749b894fb2..5b911da9df470b 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.2
++# github.com/golang-fips/openssl/v2 v2.0.3
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig


### PR DESCRIPTION
* Incorporate the fix for https://github.com/golang-fips/go/issues/187

I tested a local build before/after this change and it behaves as expected. Used https://github.com/golang-fips/go/issues/187#issuecomment-2145511252 as repro test.

Windows/CNG side is tracked by https://github.com/microsoft/go-crypto-winnative/issues/55.