### PR TITLE
Update to latest upstream `master`

### DIFF
--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -58,10 +58,10 @@ index f0e3575637c62a..0e9aceeb832d3b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index d7cbadf7b17aef..61685c5359bfde 100644
+index 0ffcabe4164af6..056f3ea5ae9beb 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -1238,12 +1238,11 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1225,12 +1225,11 @@ func (t *tester) registerCgoTests(heading string) {
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
@@ -108,7 +108,7 @@ index 4aaf46b5d0f0dc..6fe798cf4a94e9 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index 755c889585e729..bcb591a380b74c 100644
+index d66027387b97f8..8e4dfab49f6b6b 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
 @@ -1162,6 +1162,7 @@ var hostobj []Hostobj
@@ -714,29 +714,29 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index b38dee7e6ddc28..097f35ca01aa5b 100644
+index d7a4ef150410e3..c842df62ecee5b 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
- go 1.23
+ go 1.24
  
  require (
 +	github.com/golang-fips/openssl/v2 v2.0.3
- 	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
- 	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
+ 	golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0
+ 	golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd
  )
 diff --git a/src/go.sum b/src/go.sum
-index c5eab7d4b2f93b..fac8a0626146bc 100644
+index 8ff5ecd640f084..138066f5f84b68 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
 +github.com/golang-fips/openssl/v2 v2.0.3 h1:9+J2R0BQio6Jz8+dPZf/0ylISByl0gZWjTEKm+J+y7Y=
 +github.com/golang-fips/openssl/v2 v2.0.3/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
- golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=
- golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
- golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c h1:CR/7/SLUhIJw6g675eeoDiwggElO2MV9rGkNYjqi8GM=
+ golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0 h1:wxHbFWyu21uEPJJnYaSDaHSWbvnZ9gLSSOPwnEc3lLM=
+ golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
+ golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd h1:pHzwejE8Zkb94bG4nA+fUeskKPFp1HPldrhv62dabro=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 68d3b0578d18b1..15f4bb124b8528 100644
+index 26301398c5820c..26570cdadda16d 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -459,6 +459,8 @@ var depsRules = `
@@ -756,7 +756,7 @@ index 68d3b0578d18b1..15f4bb124b8528 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -793,7 +796,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -796,7 +799,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -765,7 +765,7 @@ index 68d3b0578d18b1..15f4bb124b8528 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -803,7 +806,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -806,7 +809,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}
@@ -829,7 +829,7 @@ index 777337d92d3c72..ef00871d619651 100644
  	// SystemCrypto enables the OpenSSL or CNG crypto experiment depending on
  	// which one is appropriate on the target GOOS.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index dbe59fea119e70..c3df1f9ac49b82 100644
+index a0bb89e203ddf1..2b4a2680dcdd7e 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
 @@ -14,6 +14,7 @@ import (

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -559,10 +559,10 @@ index f5b4827c688f3b..12df96069f6b83 100644
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
  // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
 diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
-index f9d1037c9b82b9..6b91d4388b73fe 100644
+index 7031d0abdaa13b..ada2d5be13f986 100644
 --- a/src/crypto/md5/md5_test.go
 +++ b/src/crypto/md5/md5_test.go
-@@ -11,6 +11,7 @@ import (
+@@ -12,6 +12,7 @@ import (
  	"encoding"
  	"fmt"
  	"hash"
@@ -570,7 +570,7 @@ index f9d1037c9b82b9..6b91d4388b73fe 100644
  	"io"
  	"testing"
  	"unsafe"
-@@ -88,6 +89,9 @@ func TestGolden(t *testing.T) {
+@@ -89,6 +90,9 @@ func TestGolden(t *testing.T) {
  }
  
  func TestGoldenMarshal(t *testing.T) {
@@ -580,7 +580,7 @@ index f9d1037c9b82b9..6b91d4388b73fe 100644
  	for _, g := range golden {
  		h := New()
  		h2 := New()
-@@ -195,6 +199,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+@@ -196,6 +200,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
  }
  
  func TestLargeHashes(t *testing.T) {
@@ -831,10 +831,10 @@ index dbcc1bec58bd46..b1e9d8e94c2c9e 100644
  	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
  	if err == ErrMessageTooLong {
 diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
-index bc169888786321..e0d6f4c5040d91 100644
+index d0a9b1b46727fa..10ea3e8eeb6efd 100644
 --- a/src/crypto/sha1/sha1_test.go
 +++ b/src/crypto/sha1/sha1_test.go
-@@ -13,6 +13,7 @@ import (
+@@ -14,6 +14,7 @@ import (
  	"encoding"
  	"fmt"
  	"hash"
@@ -842,7 +842,7 @@ index bc169888786321..e0d6f4c5040d91 100644
  	"io"
  	"testing"
  )
-@@ -96,6 +97,9 @@ func TestGolden(t *testing.T) {
+@@ -97,6 +98,9 @@ func TestGolden(t *testing.T) {
  }
  
  func TestGoldenMarshal(t *testing.T) {
@@ -852,7 +852,7 @@ index bc169888786321..e0d6f4c5040d91 100644
  	h := New()
  	h2 := New()
  	for _, g := range golden {
-@@ -197,6 +201,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+@@ -198,6 +202,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
  }
  
  func TestLargeHashes(t *testing.T) {
@@ -907,10 +907,10 @@ index 02c597d785ef68..268f1fdd49ecd3 100644
  	}
  	var d digest
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index 7437655badee23..95c8688904c088 100644
+index 755ed4d238ee5a..b7212e3f3c2175 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
-@@ -13,6 +13,7 @@ import (
+@@ -14,6 +14,7 @@ import (
  	"encoding"
  	"fmt"
  	"hash"
@@ -918,7 +918,7 @@ index 7437655badee23..95c8688904c088 100644
  	"io"
  	"testing"
  )
-@@ -139,6 +140,9 @@ func TestGolden(t *testing.T) {
+@@ -140,6 +141,9 @@ func TestGolden(t *testing.T) {
  }
  
  func TestGoldenMarshal(t *testing.T) {
@@ -928,7 +928,7 @@ index 7437655badee23..95c8688904c088 100644
  	tests := []struct {
  		name    string
  		newHash func() hash.Hash
-@@ -184,6 +188,9 @@ func TestGoldenMarshal(t *testing.T) {
+@@ -185,6 +189,9 @@ func TestGoldenMarshal(t *testing.T) {
  }
  
  func TestMarshalTypeMismatch(t *testing.T) {
@@ -938,7 +938,7 @@ index 7437655badee23..95c8688904c088 100644
  	h1 := New()
  	h2 := New224()
  
-@@ -273,6 +280,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+@@ -274,6 +281,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
  	return h.Sum(nil), nil
  }
  func TestLargeHashes(t *testing.T) {
@@ -949,10 +949,10 @@ index 7437655badee23..95c8688904c088 100644
  
  		h := New()
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index 2fef7ddae07480..979e4c69ab710c 100644
+index b63e3af59f3829..121cf04e54cd87 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
-@@ -14,6 +14,7 @@ import (
+@@ -15,6 +15,7 @@ import (
  	"encoding/hex"
  	"fmt"
  	"hash"
@@ -960,7 +960,7 @@ index 2fef7ddae07480..979e4c69ab710c 100644
  	"io"
  	"testing"
  )
-@@ -719,6 +720,9 @@ func TestGolden(t *testing.T) {
+@@ -720,6 +721,9 @@ func TestGolden(t *testing.T) {
  }
  
  func TestGoldenMarshal(t *testing.T) {
@@ -970,7 +970,7 @@ index 2fef7ddae07480..979e4c69ab710c 100644
  	tests := []struct {
  		name    string
  		newHash func() hash.Hash
-@@ -766,6 +770,9 @@ func TestGoldenMarshal(t *testing.T) {
+@@ -767,6 +771,9 @@ func TestGoldenMarshal(t *testing.T) {
  }
  
  func TestMarshalMismatch(t *testing.T) {
@@ -980,7 +980,7 @@ index 2fef7ddae07480..979e4c69ab710c 100644
  	h := []func() hash.Hash{
  		New,
  		New384,
-@@ -872,6 +879,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+@@ -873,6 +880,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
  }
  
  func TestLargeHashes(t *testing.T) {
@@ -1043,7 +1043,7 @@ index 9c1d3d279c472f..0ca7a863b73690 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index f24c2671acd435..f88fcad4e78f0d 100644
+index 503a732e05765e..db8919aaf9cbdd 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
 @@ -14,6 +14,7 @@ import (
@@ -1123,19 +1123,19 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 097f35ca01aa5b..fe0aa0cc92b35b 100644
+index c842df62ecee5b..1e6b6b1324624a 100644
 --- a/src/go.mod
 +++ b/src/go.mod
-@@ -4,6 +4,7 @@ go 1.23
+@@ -4,6 +4,7 @@ go 1.24
  
  require (
  	github.com/golang-fips/openssl/v2 v2.0.3
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
- 	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
- 	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
+ 	golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0
+ 	golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd
  )
 diff --git a/src/go.sum b/src/go.sum
-index fac8a0626146bc..43ae325dc538d2 100644
+index 138066f5f84b68..31b48ffe22c863 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
@@ -1143,11 +1143,11 @@ index fac8a0626146bc..43ae325dc538d2 100644
  github.com/golang-fips/openssl/v2 v2.0.3/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103 h1:KQsPPal3pKvKzAPTaR7sEriaqrHmRWw0dWG/7E5FNNk=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
- golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=
- golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
- golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c h1:CR/7/SLUhIJw6g675eeoDiwggElO2MV9rGkNYjqi8GM=
+ golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0 h1:wxHbFWyu21uEPJJnYaSDaHSWbvnZ9gLSSOPwnEc3lLM=
+ golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
+ golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd h1:pHzwejE8Zkb94bG4nA+fUeskKPFp1HPldrhv62dabro=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 15f4bb124b8528..82b38763d02d6c 100644
+index 26570cdadda16d..b48078b3866fa1 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -459,6 +459,10 @@ var depsRules = `

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -9485,7 +9485,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 2868749b894fb2..5b911da9df470b 100644
+index 7562f74b39ada6..95f7d5ee47b3c1 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
@@ -9500,6 +9500,6 @@ index 2868749b894fb2..5b911da9df470b 100644
 +github.com/microsoft/go-crypto-winnative/internal/bcrypt
 +github.com/microsoft/go-crypto-winnative/internal/subtle
 +github.com/microsoft/go-crypto-winnative/internal/sysdll
- # golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
- ## explicit; go 1.18
+ # golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0
+ ## explicit; go 1.20
  golang.org/x/crypto/chacha20


### PR DESCRIPTION
* Fixup for https://github.com/microsoft/go/pull/1280 that won't be overridden by automation.
* Ordinary patch conflict resolution: nearby version lines.