### PR TITLE
[microsoft/release-branch.go1.23] Add an hour to all builder timeouts

### DIFF
--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -57,10 +57,12 @@ stages:
           # longtest has been seen to succeed after 53 minutes. Give around 3x headroom. In the future,
           # we should also give the tests a shorter timeout to make sure this doesn't balloon too far:
           # https://github.com/microsoft/go/issues/568
-          timeoutInMinutes: 180
-        ${{ if startsWith(parameters.builder.config, 'codeql') }}:
+          timeoutInMinutes: 240
+        ${{ elseif startsWith(parameters.builder.config, 'codeql') }}:
           # Allow CodeQL to take a while. https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#other-issues
-          timeoutInMinutes: 360
+          timeoutInMinutes: 420
+        ${{ else }}:
+          timeoutInMinutes: 120
 
         pool: ${{ parameters.pool }}
 


### PR DESCRIPTION
Clean cherry-pick of https://github.com/microsoft/go/pull/1299.

Should unblock release, which runs a round of innerloop tests that aren't currently completing in time.