### PR TITLE
[microsoft/release-branch.go1.22] Update golang-fips/openssl to db0a77fc6fcc

### DIFF
--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -107,7 +107,7 @@ index 4aaf46b5d0f0dc..6fe798cf4a94e9 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index eab74dc32864ed..d9a41aa26d8908 100644
+index 7af88869d2cfb7..9c11f263030be8 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
 @@ -1162,6 +1162,7 @@ var hostobj []Hostobj
@@ -713,24 +713,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 737d78da5d9b40..b6fbded5de38fa 100644
+index 737d78da5d9b40..ee090c82b7bc02 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.22
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240320212310-fde4397fc4ac
++	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc
  	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
  	golang.org/x/net v0.19.1-0.20240412193750-db050b07227e
  )
 diff --git a/src/go.sum b/src/go.sum
-index 86d173c9e6ff99..4ad0804f1afedf 100644
+index 86d173c9e6ff99..59c7eb17d79d99 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240320212310-fde4397fc4ac h1:YOH3Ko9Zh1TzJ4qqJ84EbkI06tN4HQlHx1dsAakLbms=
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240320212310-fde4397fc4ac/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc h1:hhEgfLgvtoZjh93TTHn3xLKkC4z5zl+XwUpcJzW0No0=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
  golang.org/x/net v0.19.1-0.20240412193750-db050b07227e h1:oDnvqaqHo3ho8OChMtkQbQAyp9eqnm3J7JRtt0+Cabc=
@@ -816,7 +816,7 @@ index 2f423aefd14076..e58baf9fa0ef4e 100644
  	// SystemCrypto enables the OpenSSL or CNG crypto experiment depending on
  	// which one is appropriate on the target GOOS.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index 71a00494ad3bbe..3255ed72385a4a 100644
+index fb03a6116ac87f..8f09166c510a61 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
 @@ -14,6 +14,7 @@ import (

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1097,24 +1097,24 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index b6fbded5de38fa..5f5f1a35cae19a 100644
+index ee090c82b7bc02..d30923c3317fd0 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240320212310-fde4397fc4ac
+ 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
  	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
  	golang.org/x/net v0.19.1-0.20240412193750-db050b07227e
  )
 diff --git a/src/go.sum b/src/go.sum
-index 4ad0804f1afedf..8ef67280c861ff 100644
+index 59c7eb17d79d99..1f5fbf7aa3b522 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240320212310-fde4397fc4ac h1:YOH3Ko9Zh1TzJ4qqJ84EbkI06tN4HQlHx1dsAakLbms=
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240320212310-fde4397fc4ac/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc h1:hhEgfLgvtoZjh93TTHn3xLKkC4z5zl+XwUpcJzW0No0=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103 h1:KQsPPal3pKvKzAPTaR7sEriaqrHmRWw0dWG/7E5FNNk=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -11,7 +11,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../github.com/golang-fips/openssl/v2/aes.go  | 100 +++
  .../golang-fips/openssl/v2/bbig/big.go        |  37 +
  .../github.com/golang-fips/openssl/v2/big.go  |  11 +
- .../golang-fips/openssl/v2/cipher.go          | 582 +++++++++++++
+ .../golang-fips/openssl/v2/cipher.go          | 569 +++++++++++++
  .../github.com/golang-fips/openssl/v2/des.go  | 113 +++
  .../github.com/golang-fips/openssl/v2/ec.go   |  59 ++
  .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
@@ -59,7 +59,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 54 files changed, 8912 insertions(+)
+ 54 files changed, 8899 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -396,16 +396,17 @@ index 00000000000000..6461f241f863fc
 +type BigInt []uint
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cipher.go b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
 new file mode 100644
-index 00000000000000..2b983c5411fc72
+index 00000000000000..72f7aebfc130e7
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
-@@ -0,0 +1,582 @@
+@@ -0,0 +1,569 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
 +// #include "goopenssl.h"
 +import "C"
++
 +import (
 +	"crypto/cipher"
 +	"encoding/binary"
@@ -547,8 +548,6 @@ index 00000000000000..2b983c5411fc72
 +
 +type evpCipher struct {
 +	key       []byte
-+	enc_ctx   C.GO_EVP_CIPHER_CTX_PTR
-+	dec_ctx   C.GO_EVP_CIPHER_CTX_PTR
 +	kind      cipherKind
 +	blockSize int
 +}
@@ -561,17 +560,7 @@ index 00000000000000..2b983c5411fc72
 +	c := &evpCipher{key: make([]byte, len(key)), kind: kind}
 +	copy(c.key, key)
 +	c.blockSize = int(C.go_openssl_EVP_CIPHER_get_block_size(cipher))
-+	runtime.SetFinalizer(c, (*evpCipher).finalize)
 +	return c, nil
-+}
-+
-+func (c *evpCipher) finalize() {
-+	if c.enc_ctx != nil {
-+		C.go_openssl_EVP_CIPHER_CTX_free(c.enc_ctx)
-+	}
-+	if c.dec_ctx != nil {
-+		C.go_openssl_EVP_CIPHER_CTX_free(c.dec_ctx)
-+	}
 +}
 +
 +func (c *evpCipher) encrypt(dst, src []byte) error {
@@ -586,15 +575,13 @@ index 00000000000000..2b983c5411fc72
 +	if inexactOverlap(dst[:c.blockSize], src[:c.blockSize]) {
 +		return errors.New("invalid buffer overlap")
 +	}
-+	if c.enc_ctx == nil {
-+		var err error
-+		c.enc_ctx, err = newCipherCtx(c.kind, cipherModeECB, cipherOpEncrypt, c.key, nil)
-+		if err != nil {
-+			return err
-+		}
++	enc_ctx, err := newCipherCtx(c.kind, cipherModeECB, cipherOpEncrypt, c.key, nil)
++	if err != nil {
++		return err
 +	}
++	defer C.go_openssl_EVP_CIPHER_CTX_free(enc_ctx)
 +
-+	if C.go_openssl_EVP_EncryptUpdate_wrapper(c.enc_ctx, base(dst), base(src), C.int(c.blockSize)) != 1 {
++	if C.go_openssl_EVP_EncryptUpdate_wrapper(enc_ctx, base(dst), base(src), C.int(c.blockSize)) != 1 {
 +		return errors.New("EncryptUpdate failed")
 +	}
 +	runtime.KeepAlive(c)
@@ -613,18 +600,17 @@ index 00000000000000..2b983c5411fc72
 +	if inexactOverlap(dst[:c.blockSize], src[:c.blockSize]) {
 +		return errors.New("invalid buffer overlap")
 +	}
-+	if c.dec_ctx == nil {
-+		var err error
-+		c.dec_ctx, err = newCipherCtx(c.kind, cipherModeECB, cipherOpDecrypt, c.key, nil)
-+		if err != nil {
-+			return err
-+		}
-+		if C.go_openssl_EVP_CIPHER_CTX_set_padding(c.dec_ctx, 0) != 1 {
-+			return errors.New("could not disable cipher padding")
-+		}
++	dec_ctx, err := newCipherCtx(c.kind, cipherModeECB, cipherOpDecrypt, c.key, nil)
++	if err != nil {
++		return err
++	}
++	defer C.go_openssl_EVP_CIPHER_CTX_free(dec_ctx)
++
++	if C.go_openssl_EVP_CIPHER_CTX_set_padding(dec_ctx, 0) != 1 {
++		return errors.New("could not disable cipher padding")
 +	}
 +
-+	C.go_openssl_EVP_DecryptUpdate_wrapper(c.dec_ctx, base(dst), base(src), C.int(c.blockSize))
++	C.go_openssl_EVP_DecryptUpdate_wrapper(dec_ctx, base(dst), base(src), C.int(c.blockSize))
 +	runtime.KeepAlive(c)
 +	return nil
 +}
@@ -723,7 +709,7 @@ index 00000000000000..2b983c5411fc72
 +)
 +
 +type cipherGCM struct {
-+	ctx C.GO_EVP_CIPHER_CTX_PTR
++	c   *evpCipher
 +	tls cipherGCMTLS
 +	// minNextNonce is the minimum value that the next nonce can be, enforced by
 +	// all TLS modes.
@@ -781,17 +767,8 @@ index 00000000000000..2b983c5411fc72
 +}
 +
 +func (c *evpCipher) newGCM(tls cipherGCMTLS) (cipher.AEAD, error) {
-+	ctx, err := newCipherCtx(c.kind, cipherModeGCM, cipherOpNone, c.key, nil)
-+	if err != nil {
-+		return nil, err
-+	}
-+	g := &cipherGCM{ctx: ctx, tls: tls, blockSize: c.blockSize}
-+	runtime.SetFinalizer(g, (*cipherGCM).finalize)
++	g := &cipherGCM{c: c, tls: tls, blockSize: c.blockSize}
 +	return g, nil
-+}
-+
-+func (g *cipherGCM) finalize() {
-+	C.go_openssl_EVP_CIPHER_CTX_free(g.ctx)
 +}
 +
 +func (g *cipherGCM) NonceSize() int {
@@ -866,6 +843,11 @@ index 00000000000000..2b983c5411fc72
 +		panic("cipher: invalid buffer overlap")
 +	}
 +
++	ctx, err := newCipherCtx(g.c.kind, cipherModeGCM, cipherOpNone, g.c.key, nil)
++	if err != nil {
++		panic(err)
++	}
++	defer C.go_openssl_EVP_CIPHER_CTX_free(ctx)
 +	// Encrypt additional data.
 +	// When sealing a TLS payload, OpenSSL app sets the additional data using
 +	// 'EVP_CIPHER_CTX_ctrl(g.ctx, C.EVP_CTRL_AEAD_TLS1_AAD, C.EVP_AEAD_TLS1_AAD_LEN, base(additionalData))'.
@@ -873,7 +855,7 @@ index 00000000000000..2b983c5411fc72
 +	// relying in the explicit nonce being securely set externally,
 +	// and it also gives some interesting speed gains.
 +	// Unfortunately we can't use it because Go expects AEAD.Seal to honor the provided nonce.
-+	if C.go_openssl_EVP_CIPHER_CTX_seal_wrapper(g.ctx, base(out), base(nonce),
++	if C.go_openssl_EVP_CIPHER_CTX_seal_wrapper(ctx, base(out), base(nonce),
 +		base(plaintext), C.int(len(plaintext)),
 +		base(additionalData), C.int(len(additionalData))) != 1 {
 +
@@ -908,8 +890,13 @@ index 00000000000000..2b983c5411fc72
 +		panic("cipher: invalid buffer overlap")
 +	}
 +
++	ctx, err := newCipherCtx(g.c.kind, cipherModeGCM, cipherOpNone, g.c.key, nil)
++	if err != nil {
++		return nil, err
++	}
++	defer C.go_openssl_EVP_CIPHER_CTX_free(ctx)
 +	ok := C.go_openssl_EVP_CIPHER_CTX_open_wrapper(
-+		g.ctx, base(out), base(nonce),
++		ctx, base(out), base(nonce),
 +		base(ciphertext), C.int(len(ciphertext)),
 +		base(additionalData), C.int(len(additionalData)), base(tag))
 +	runtime.KeepAlive(g)
@@ -9336,11 +9323,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 338c496bf95ad7..4eea9772658fad 100644
+index 9a234e59b10c8c..68dd94319b5db5 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240320212310-fde4397fc4ac
++# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig


### PR DESCRIPTION
* Incorporate cherry-picked fix: https://github.com/golang-fips/openssl/pull/157

Update to use https://github.com/golang-fips/openssl/commit/db0a77fc6fcca38dcf8df0ab2e28b778d2d21551, mod tidy, mod vendor, and conflict resolution for neighboring lines.

I did notice that trying to update the go.mod/go.sum/vendor with Microsoft Go 1.23.0 and upstream Go 1.23.0 yielded different results than using Go 1.22.6 (and different from each other!). The changes in this PR use 1.22.6 and look normal. I'll open issues for what I saw to figure out if this is something we should/can do something about. I *generally* expect that you can work on a Go module using any greater version of Go.