### PR TITLE
[microsoft/release-branch.go1.22] Update openssl to ms-go1.22-support, 889cd907e03c

### DIFF
--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -713,24 +713,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 737d78da5d9b40..ee090c82b7bc02 100644
+index 737d78da5d9b40..b4d80d9215e9ef 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.22
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc
++	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c
  	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
  	golang.org/x/net v0.19.1-0.20240412193750-db050b07227e
  )
 diff --git a/src/go.sum b/src/go.sum
-index 86d173c9e6ff99..59c7eb17d79d99 100644
+index 86d173c9e6ff99..1c33d55236f035 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc h1:hhEgfLgvtoZjh93TTHn3xLKkC4z5zl+XwUpcJzW0No0=
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c h1:qieSrBDSfZmyVe+ThvHkwrJpROCielrlEa9g8B3Fpek=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
  golang.org/x/net v0.19.1-0.20240412193750-db050b07227e h1:oDnvqaqHo3ho8OChMtkQbQAyp9eqnm3J7JRtt0+Cabc=

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1097,24 +1097,24 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index ee090c82b7bc02..d30923c3317fd0 100644
+index b4d80d9215e9ef..3d65a947d22a9b 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc
+ 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
  	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
  	golang.org/x/net v0.19.1-0.20240412193750-db050b07227e
  )
 diff --git a/src/go.sum b/src/go.sum
-index 59c7eb17d79d99..1f5fbf7aa3b522 100644
+index 1c33d55236f035..cf76c92e3de793 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc h1:hhEgfLgvtoZjh93TTHn3xLKkC4z5zl+XwUpcJzW0No0=
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c h1:qieSrBDSfZmyVe+ThvHkwrJpROCielrlEa9g8B3Fpek=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103 h1:KQsPPal3pKvKzAPTaR7sEriaqrHmRWw0dWG/7E5FNNk=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -12,7 +12,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../golang-fips/openssl/v2/bbig/big.go        |  37 +
  .../github.com/golang-fips/openssl/v2/big.go  |  11 +
  .../golang-fips/openssl/v2/cipher.go          | 569 +++++++++++++
- .../github.com/golang-fips/openssl/v2/des.go  | 113 +++
+ .../github.com/golang-fips/openssl/v2/des.go  | 114 +++
  .../github.com/golang-fips/openssl/v2/ec.go   |  59 ++
  .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
  .../golang-fips/openssl/v2/ecdsa.go           | 217 +++++
@@ -59,7 +59,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 54 files changed, 8899 insertions(+)
+ 54 files changed, 8900 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -971,10 +971,10 @@ index 00000000000000..72f7aebfc130e7
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/des.go b/src/vendor/github.com/golang-fips/openssl/v2/des.go
 new file mode 100644
-index 00000000000000..71b13333a28513
+index 00000000000000..c98a276ec33fb0
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/des.go
-@@ -0,0 +1,113 @@
+@@ -0,0 +1,114 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1010,27 +1010,22 @@ index 00000000000000..71b13333a28513
 +	if len(key) != 8 {
 +		return nil, errors.New("crypto/des: invalid key size")
 +	}
-+	c, err := newEVPCipher(key, cipherDES)
-+	if err != nil {
-+		return nil, err
-+	}
-+	// Should always be true for stock OpenSSL.
-+	if loadCipher(cipherDES, cipherModeCBC) == nil {
-+		return &desCipherWithoutCBC{c}, nil
-+	}
-+	return &desCipher{c}, nil
++	return newDESCipher(key, cipherDES)
 +}
 +
 +func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 +	if len(key) != 24 {
 +		return nil, errors.New("crypto/des: invalid key size")
 +	}
-+	c, err := newEVPCipher(key, cipherDES3)
++	return newDESCipher(key, cipherDES3)
++}
++
++func newDESCipher(key []byte, kind cipherKind) (cipher.Block, error) {
++	c, err := newEVPCipher(key, kind)
 +	if err != nil {
 +		return nil, err
 +	}
-+	// Should always be true for stock OpenSSL.
-+	if loadCipher(cipherDES, cipherModeCBC) != nil {
++	if loadCipher(kind, cipherModeCBC) == nil {
 +		return &desCipherWithoutCBC{c}, nil
 +	}
 +	return &desCipher{c}, nil
@@ -1082,11 +1077,17 @@ index 00000000000000..71b13333a28513
 +}
 +
 +func (c *desCipherWithoutCBC) Encrypt(dst, src []byte) {
-+	c.encrypt(dst, src)
++	if err := c.encrypt(dst, src); err != nil {
++		// crypto/des expects that the panic message starts with "crypto/des: ".
++		panic("crypto/des: " + err.Error())
++	}
 +}
 +
 +func (c *desCipherWithoutCBC) Decrypt(dst, src []byte) {
-+	c.decrypt(dst, src)
++	if err := c.decrypt(dst, src); err != nil {
++		// crypto/des expects that the panic message starts with "crypto/des: ".
++		panic("crypto/des: " + err.Error())
++	}
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ec.go b/src/vendor/github.com/golang-fips/openssl/v2/ec.go
 new file mode 100644
@@ -9323,11 +9324,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 9a234e59b10c8c..68dd94319b5db5 100644
+index 9a234e59b10c8c..02d2c809a26f73 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240903170240-db0a77fc6fcc
++# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig


### PR DESCRIPTION
* Ports fix for issue detected in main: https://github.com/microsoft/go/issues/1290