### PR TITLE
[microsoft/release-branch.go1.23] Update openssl to ms-go1.23-support, 0a2f211a8f95

### DIFF
--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -714,24 +714,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 789f5aaa1d3e26..2f397cf20abb0a 100644
+index 789f5aaa1d3e26..14ced0e416fde8 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.23
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20240905155948-17d05d3f692c
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95
  	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
  	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
  )
 diff --git a/src/go.sum b/src/go.sum
-index a75ea98c7312df..7729cca493647c 100644
+index a75ea98c7312df..9fad90e123a9f6 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20240905155948-17d05d3f692c h1:q7tCgQctS2aXmDVWjTV0951iRioF7Svx/hSQxymkZYo=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20240905155948-17d05d3f692c/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95 h1:e+JGYwsNT8K58Z9JysRNadrPzxNlGf+0wQXcdlHiv5M=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
  golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c h1:CR/7/SLUhIJw6g675eeoDiwggElO2MV9rGkNYjqi8GM=

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1123,24 +1123,24 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 2f397cf20abb0a..3340fe1de869ab 100644
+index 14ced0e416fde8..b2e1fa24bcda18 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.23
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.4-0.20240905155948-17d05d3f692c
+ 	github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
  	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
  	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
  )
 diff --git a/src/go.sum b/src/go.sum
-index 7729cca493647c..3f8f33aa3fba93 100644
+index 9fad90e123a9f6..6bd576f5fbb07e 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.4-0.20240905155948-17d05d3f692c h1:q7tCgQctS2aXmDVWjTV0951iRioF7Svx/hSQxymkZYo=
- github.com/golang-fips/openssl/v2 v2.0.4-0.20240905155948-17d05d3f692c/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
+ github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95 h1:e+JGYwsNT8K58Z9JysRNadrPzxNlGf+0wQXcdlHiv5M=
+ github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103 h1:KQsPPal3pKvKzAPTaR7sEriaqrHmRWw0dWG/7E5FNNk=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -12,7 +12,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../golang-fips/openssl/v2/bbig/big.go        |  37 +
  .../github.com/golang-fips/openssl/v2/big.go  |  11 +
  .../golang-fips/openssl/v2/cipher.go          | 569 +++++++++++++
- .../github.com/golang-fips/openssl/v2/des.go  | 113 +++
+ .../github.com/golang-fips/openssl/v2/des.go  | 114 +++
  .../github.com/golang-fips/openssl/v2/ec.go   |  59 ++
  .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
  .../golang-fips/openssl/v2/ecdsa.go           | 217 +++++
@@ -61,7 +61,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 56 files changed, 9048 insertions(+)
+ 56 files changed, 9049 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -975,10 +975,10 @@ index 00000000000000..72f7aebfc130e7
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/des.go b/src/vendor/github.com/golang-fips/openssl/v2/des.go
 new file mode 100644
-index 00000000000000..71b13333a28513
+index 00000000000000..c98a276ec33fb0
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/des.go
-@@ -0,0 +1,113 @@
+@@ -0,0 +1,114 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1014,27 +1014,22 @@ index 00000000000000..71b13333a28513
 +	if len(key) != 8 {
 +		return nil, errors.New("crypto/des: invalid key size")
 +	}
-+	c, err := newEVPCipher(key, cipherDES)
-+	if err != nil {
-+		return nil, err
-+	}
-+	// Should always be true for stock OpenSSL.
-+	if loadCipher(cipherDES, cipherModeCBC) == nil {
-+		return &desCipherWithoutCBC{c}, nil
-+	}
-+	return &desCipher{c}, nil
++	return newDESCipher(key, cipherDES)
 +}
 +
 +func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 +	if len(key) != 24 {
 +		return nil, errors.New("crypto/des: invalid key size")
 +	}
-+	c, err := newEVPCipher(key, cipherDES3)
++	return newDESCipher(key, cipherDES3)
++}
++
++func newDESCipher(key []byte, kind cipherKind) (cipher.Block, error) {
++	c, err := newEVPCipher(key, kind)
 +	if err != nil {
 +		return nil, err
 +	}
-+	// Should always be true for stock OpenSSL.
-+	if loadCipher(cipherDES, cipherModeCBC) != nil {
++	if loadCipher(kind, cipherModeCBC) == nil {
 +		return &desCipherWithoutCBC{c}, nil
 +	}
 +	return &desCipher{c}, nil
@@ -1086,11 +1081,17 @@ index 00000000000000..71b13333a28513
 +}
 +
 +func (c *desCipherWithoutCBC) Encrypt(dst, src []byte) {
-+	c.encrypt(dst, src)
++	if err := c.encrypt(dst, src); err != nil {
++		// crypto/des expects that the panic message starts with "crypto/des: ".
++		panic("crypto/des: " + err.Error())
++	}
 +}
 +
 +func (c *desCipherWithoutCBC) Decrypt(dst, src []byte) {
-+	c.decrypt(dst, src)
++	if err := c.decrypt(dst, src); err != nil {
++		// crypto/des expects that the panic message starts with "crypto/des: ".
++		panic("crypto/des: " + err.Error())
++	}
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ec.go b/src/vendor/github.com/golang-fips/openssl/v2/ec.go
 new file mode 100644
@@ -9488,11 +9489,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b8a0b84a282a32..d6dcd31f88c56b 100644
+index b8a0b84a282a32..69417c384eb8c0 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20240905155948-17d05d3f692c
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig


### PR DESCRIPTION
* Ports fix for issue detected in main: https://github.com/microsoft/go/issues/1290