### PR TITLE
Upgrade golang-fips/openssl to latest

### DIFF
--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -714,32 +714,32 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index d7a4ef150410e3..c842df62ecee5b 100644
+index d7a4ef150410e3..7a6455fefb4bed 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.24
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.3
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072
  	golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0
  	golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd
  )
 diff --git a/src/go.sum b/src/go.sum
-index 8ff5ecd640f084..138066f5f84b68 100644
+index 8ff5ecd640f084..c502448cd5ec1b 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.3 h1:9+J2R0BQio6Jz8+dPZf/0ylISByl0gZWjTEKm+J+y7Y=
-+github.com/golang-fips/openssl/v2 v2.0.3/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072 h1:MiLLfnjVDjuOST8SQ7XgeBpWMWPpVb8VKDhL5Uvco7Q=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
  golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0 h1:wxHbFWyu21uEPJJnYaSDaHSWbvnZ9gLSSOPwnEc3lLM=
  golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
  golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd h1:pHzwejE8Zkb94bG4nA+fUeskKPFp1HPldrhv62dabro=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 26301398c5820c..26570cdadda16d 100644
+index ca6a512bf95c7e..e69c1f8901fe74 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -459,6 +459,8 @@ var depsRules = `
+@@ -460,6 +460,8 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -748,7 +748,7 @@ index 26301398c5820c..26570cdadda16d 100644
  	< crypto/internal/boring
  	< crypto/internal/backend
  	< crypto/boring;
-@@ -497,6 +499,7 @@ var depsRules = `
+@@ -498,6 +500,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -756,7 +756,7 @@ index 26301398c5820c..26570cdadda16d 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -796,7 +799,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -797,7 +800,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -765,7 +765,7 @@ index 26301398c5820c..26570cdadda16d 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -806,7 +809,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -807,7 +810,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1123,13 +1123,13 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index c842df62ecee5b..1e6b6b1324624a 100644
+index 7a6455fefb4bed..84460ce0490727 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.24
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.3
+ 	github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
  	golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0
  	golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd
@@ -1139,18 +1139,18 @@ index 138066f5f84b68..31b48ffe22c863 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.3 h1:9+J2R0BQio6Jz8+dPZf/0ylISByl0gZWjTEKm+J+y7Y=
- github.com/golang-fips/openssl/v2 v2.0.3/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
+ github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072 h1:MiLLfnjVDjuOST8SQ7XgeBpWMWPpVb8VKDhL5Uvco7Q=
+ github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103 h1:KQsPPal3pKvKzAPTaR7sEriaqrHmRWw0dWG/7E5FNNk=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0 h1:wxHbFWyu21uEPJJnYaSDaHSWbvnZ9gLSSOPwnEc3lLM=
  golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
  golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd h1:pHzwejE8Zkb94bG4nA+fUeskKPFp1HPldrhv62dabro=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 26570cdadda16d..b48078b3866fa1 100644
+index e69c1f8901fe74..eb0b0ea4eb4622 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -459,6 +459,10 @@ var depsRules = `
+@@ -460,6 +460,10 @@ var depsRules = `
  
  	crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1161,7 +1161,7 @@ index 26570cdadda16d..b48078b3866fa1 100644
  	< github.com/golang-fips/openssl/v2/internal/subtle
  	< github.com/golang-fips/openssl/v2
  	< crypto/internal/boring
-@@ -499,6 +503,7 @@ var depsRules = `
+@@ -500,6 +504,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -5,63 +5,65 @@ Subject: [PATCH] Vendor crypto backends
 
 To reproduce, run 'go mod vendor' in 'go/src'.
 ---
- .../golang-fips/openssl/v2/.gitleaks.toml     |   9 +
- .../github.com/golang-fips/openssl/v2/LICENSE |  20 +
- .../golang-fips/openssl/v2/README.md          |  66 ++
- .../github.com/golang-fips/openssl/v2/aes.go  | 100 +++
- .../golang-fips/openssl/v2/bbig/big.go        |  37 +
- .../github.com/golang-fips/openssl/v2/big.go  |  11 +
- .../golang-fips/openssl/v2/cipher.go          | 569 +++++++++++++
- .../github.com/golang-fips/openssl/v2/des.go  | 113 +++
- .../github.com/golang-fips/openssl/v2/ec.go   |  59 ++
- .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
- .../golang-fips/openssl/v2/ecdsa.go           | 217 +++++
- .../golang-fips/openssl/v2/ed25519.go         | 218 +++++
- .../github.com/golang-fips/openssl/v2/evp.go  | 471 +++++++++++
- .../golang-fips/openssl/v2/goopenssl.c        | 218 +++++
- .../golang-fips/openssl/v2/goopenssl.h        | 255 ++++++
- .../github.com/golang-fips/openssl/v2/hash.go | 793 ++++++++++++++++++
- .../github.com/golang-fips/openssl/v2/hkdf.go | 174 ++++
- .../github.com/golang-fips/openssl/v2/hmac.go | 238 ++++++
- .../github.com/golang-fips/openssl/v2/init.go |  64 ++
- .../golang-fips/openssl/v2/init_unix.go       |  31 +
- .../golang-fips/openssl/v2/init_windows.go    |  36 +
- .../golang-fips/openssl/v2/openssl.go         | 419 +++++++++
- .../golang-fips/openssl/v2/pbkdf2.go          |  28 +
- .../openssl/v2/port_evp_md5_sha1.c            | 126 +++
- .../github.com/golang-fips/openssl/v2/rand.go |  20 +
- .../github.com/golang-fips/openssl/v2/rc4.go  |  66 ++
- .../github.com/golang-fips/openssl/v2/rsa.go  | 435 ++++++++++
- .../github.com/golang-fips/openssl/v2/shims.h | 371 ++++++++
- .../golang-fips/openssl/v2/thread_setup.go    |  14 +
- .../golang-fips/openssl/v2/thread_setup.h     |   4 +
- .../openssl/v2/thread_setup_unix.c            |  61 ++
- .../openssl/v2/thread_setup_windows.c         |  64 ++
- .../golang-fips/openssl/v2/tls1prf.go         | 104 +++
- .../microsoft/go-crypto-winnative/LICENSE     |  21 +
- .../microsoft/go-crypto-winnative/cng/aes.go  | 389 +++++++++
- .../go-crypto-winnative/cng/bbig/big.go       |  31 +
- .../microsoft/go-crypto-winnative/cng/big.go  |  30 +
- .../go-crypto-winnative/cng/cipher.go         |  56 ++
- .../microsoft/go-crypto-winnative/cng/cng.go  | 130 +++
- .../microsoft/go-crypto-winnative/cng/des.go  | 107 +++
- .../microsoft/go-crypto-winnative/cng/ecdh.go | 260 ++++++
- .../go-crypto-winnative/cng/ecdsa.go          | 175 ++++
- .../microsoft/go-crypto-winnative/cng/hash.go | 320 +++++++
- .../microsoft/go-crypto-winnative/cng/hkdf.go | 179 ++++
- .../microsoft/go-crypto-winnative/cng/hmac.go |  35 +
- .../microsoft/go-crypto-winnative/cng/keys.go | 178 ++++
- .../go-crypto-winnative/cng/pbkdf2.go         |  74 ++
- .../microsoft/go-crypto-winnative/cng/rand.go |  28 +
- .../microsoft/go-crypto-winnative/cng/rc4.go  |  61 ++
- .../microsoft/go-crypto-winnative/cng/rsa.go  | 374 +++++++++
- .../go-crypto-winnative/cng/tls1prf.go        |  92 ++
- .../internal/bcrypt/bcrypt_windows.go         | 284 +++++++
- .../internal/bcrypt/zsyscall_windows.go       | 389 +++++++++
- .../internal/subtle/aliasing.go               |  32 +
- .../internal/sysdll/sys_windows.go            |  55 ++
- src/vendor/modules.txt                        |  11 +
- 56 files changed, 9045 insertions(+)
+ .../golang-fips/openssl/v2/.gitleaks.toml     |    9 +
+ .../github.com/golang-fips/openssl/v2/LICENSE |   20 +
+ .../golang-fips/openssl/v2/README.md          |   66 ++
+ .../github.com/golang-fips/openssl/v2/aes.go  |  100 ++
+ .../golang-fips/openssl/v2/bbig/big.go        |   37 +
+ .../github.com/golang-fips/openssl/v2/big.go  |   11 +
+ .../golang-fips/openssl/v2/cipher.go          |  569 +++++++++
+ .../github.com/golang-fips/openssl/v2/des.go  |  114 ++
+ .../github.com/golang-fips/openssl/v2/dsa.go  |  348 ++++++
+ .../github.com/golang-fips/openssl/v2/ec.go   |   59 +
+ .../github.com/golang-fips/openssl/v2/ecdh.go |  321 +++++
+ .../golang-fips/openssl/v2/ecdsa.go           |  215 ++++
+ .../golang-fips/openssl/v2/ed25519.go         |  218 ++++
+ .../github.com/golang-fips/openssl/v2/evp.go  |  471 ++++++++
+ .../golang-fips/openssl/v2/goopenssl.c        |  218 ++++
+ .../golang-fips/openssl/v2/goopenssl.h        |  259 ++++
+ .../github.com/golang-fips/openssl/v2/hash.go | 1041 +++++++++++++++++
+ .../github.com/golang-fips/openssl/v2/hkdf.go |  190 +++
+ .../github.com/golang-fips/openssl/v2/hmac.go |  276 +++++
+ .../github.com/golang-fips/openssl/v2/init.go |   64 +
+ .../golang-fips/openssl/v2/init_unix.go       |   31 +
+ .../golang-fips/openssl/v2/init_windows.go    |   36 +
+ .../golang-fips/openssl/v2/openssl.go         |  434 +++++++
+ .../golang-fips/openssl/v2/pbkdf2.go          |   28 +
+ .../golang-fips/openssl/v2/port_dsa.c         |   85 ++
+ .../openssl/v2/port_evp_md5_sha1.c            |  126 ++
+ .../github.com/golang-fips/openssl/v2/rand.go |   20 +
+ .../github.com/golang-fips/openssl/v2/rc4.go  |   66 ++
+ .../github.com/golang-fips/openssl/v2/rsa.go  |  443 +++++++
+ .../github.com/golang-fips/openssl/v2/shims.h |  392 +++++++
+ .../golang-fips/openssl/v2/thread_setup.go    |   14 +
+ .../golang-fips/openssl/v2/thread_setup.h     |    4 +
+ .../openssl/v2/thread_setup_unix.c            |   64 +
+ .../openssl/v2/thread_setup_windows.c         |   64 +
+ .../golang-fips/openssl/v2/tls1prf.go         |  104 ++
+ .../microsoft/go-crypto-winnative/LICENSE     |   21 +
+ .../microsoft/go-crypto-winnative/cng/aes.go  |  389 ++++++
+ .../go-crypto-winnative/cng/bbig/big.go       |   31 +
+ .../microsoft/go-crypto-winnative/cng/big.go  |   30 +
+ .../go-crypto-winnative/cng/cipher.go         |   56 +
+ .../microsoft/go-crypto-winnative/cng/cng.go  |  130 ++
+ .../microsoft/go-crypto-winnative/cng/des.go  |  107 ++
+ .../microsoft/go-crypto-winnative/cng/ecdh.go |  260 ++++
+ .../go-crypto-winnative/cng/ecdsa.go          |  175 +++
+ .../microsoft/go-crypto-winnative/cng/hash.go |  320 +++++
+ .../microsoft/go-crypto-winnative/cng/hkdf.go |  179 +++
+ .../microsoft/go-crypto-winnative/cng/hmac.go |   35 +
+ .../microsoft/go-crypto-winnative/cng/keys.go |  178 +++
+ .../go-crypto-winnative/cng/pbkdf2.go         |   74 ++
+ .../microsoft/go-crypto-winnative/cng/rand.go |   28 +
+ .../microsoft/go-crypto-winnative/cng/rc4.go  |   61 +
+ .../microsoft/go-crypto-winnative/cng/rsa.go  |  374 ++++++
+ .../go-crypto-winnative/cng/tls1prf.go        |   92 ++
+ .../internal/bcrypt/bcrypt_windows.go         |  284 +++++
+ .../internal/bcrypt/zsyscall_windows.go       |  389 ++++++
+ .../internal/subtle/aliasing.go               |   32 +
+ .../internal/sysdll/sys_windows.go            |   55 +
+ src/vendor/modules.txt                        |   11 +
+ 58 files changed, 9828 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -70,6 +72,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/big.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/cipher.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/des.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/dsa.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/ec.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/ecdh.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go
@@ -85,6 +88,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/init_windows.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/openssl.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/pbkdf2.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/port_dsa.c
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/port_evp_md5_sha1.c
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/rand.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/rc4.go
@@ -975,10 +979,10 @@ index 00000000000000..72f7aebfc130e7
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/des.go b/src/vendor/github.com/golang-fips/openssl/v2/des.go
 new file mode 100644
-index 00000000000000..71b13333a28513
+index 00000000000000..c98a276ec33fb0
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/des.go
-@@ -0,0 +1,113 @@
+@@ -0,0 +1,114 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1014,27 +1018,22 @@ index 00000000000000..71b13333a28513
 +	if len(key) != 8 {
 +		return nil, errors.New("crypto/des: invalid key size")
 +	}
-+	c, err := newEVPCipher(key, cipherDES)
-+	if err != nil {
-+		return nil, err
-+	}
-+	// Should always be true for stock OpenSSL.
-+	if loadCipher(cipherDES, cipherModeCBC) == nil {
-+		return &desCipherWithoutCBC{c}, nil
-+	}
-+	return &desCipher{c}, nil
++	return newDESCipher(key, cipherDES)
 +}
 +
 +func NewTripleDESCipher(key []byte) (cipher.Block, error) {
 +	if len(key) != 24 {
 +		return nil, errors.New("crypto/des: invalid key size")
 +	}
-+	c, err := newEVPCipher(key, cipherDES3)
++	return newDESCipher(key, cipherDES3)
++}
++
++func newDESCipher(key []byte, kind cipherKind) (cipher.Block, error) {
++	c, err := newEVPCipher(key, kind)
 +	if err != nil {
 +		return nil, err
 +	}
-+	// Should always be true for stock OpenSSL.
-+	if loadCipher(cipherDES, cipherModeCBC) != nil {
++	if loadCipher(kind, cipherModeCBC) == nil {
 +		return &desCipherWithoutCBC{c}, nil
 +	}
 +	return &desCipher{c}, nil
@@ -1086,15 +1085,375 @@ index 00000000000000..71b13333a28513
 +}
 +
 +func (c *desCipherWithoutCBC) Encrypt(dst, src []byte) {
-+	c.encrypt(dst, src)
++	if err := c.encrypt(dst, src); err != nil {
++		// crypto/des expects that the panic message starts with "crypto/des: ".
++		panic("crypto/des: " + err.Error())
++	}
 +}
 +
 +func (c *desCipherWithoutCBC) Decrypt(dst, src []byte) {
-+	c.decrypt(dst, src)
++	if err := c.decrypt(dst, src); err != nil {
++		// crypto/des expects that the panic message starts with "crypto/des: ".
++		panic("crypto/des: " + err.Error())
++	}
++}
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/dsa.go b/src/vendor/github.com/golang-fips/openssl/v2/dsa.go
+new file mode 100644
+index 00000000000000..875533a50fbac5
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/dsa.go
+@@ -0,0 +1,348 @@
++//go:build !cmd_go_bootstrap
++
++package openssl
++
++// #include "goopenssl.h"
++import "C"
++import (
++	"runtime"
++	"unsafe"
++)
++
++var (
++	OSSL_PKEY_PARAM_FFC_PBITS = C.CString("pbits")
++	OSSL_PKEY_PARAM_FFC_QBITS = C.CString("qbits")
++	OSSL_PKEY_PARAM_FFC_P     = C.CString("p")
++	OSSL_PKEY_PARAM_FFC_Q     = C.CString("q")
++	OSSL_PKEY_PARAM_FFC_G     = C.CString("g")
++)
++
++// SupportsDSA returns true if the OpenSSL library supports DSA.
++func SupportsDSA() bool {
++	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_DSA, nil)
++	if ctx == nil {
++		return false
++	}
++	C.go_openssl_EVP_PKEY_CTX_free(ctx)
++	return true
++}
++
++// DSAParameters contains the DSA parameters.
++type DSAParameters struct {
++	P, Q, G BigInt
++}
++
++// PrivateKeyDSA represents a DSA private key.
++type PrivateKeyDSA struct {
++	DSAParameters
++	X, Y BigInt
++
++	// _pkey MUST NOT be accessed directly. Instead, use the withKey method.
++	_pkey C.GO_EVP_PKEY_PTR
++}
++
++func (k *PrivateKeyDSA) finalize() {
++	C.go_openssl_EVP_PKEY_free(k._pkey)
++}
++
++func (k *PrivateKeyDSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
++	defer runtime.KeepAlive(k)
++	return f(k._pkey)
++}
++
++// PublicKeyDSA represents a DSA public key.
++type PublicKeyDSA struct {
++	DSAParameters
++	Y BigInt
++
++	// _pkey MUST NOT be accessed directly. Instead, use the withKey method.
++	_pkey C.GO_EVP_PKEY_PTR
++}
++
++func (k *PublicKeyDSA) finalize() {
++	C.go_openssl_EVP_PKEY_free(k._pkey)
++}
++
++func (k *PublicKeyDSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
++	defer runtime.KeepAlive(k)
++	return f(k._pkey)
++}
++
++// GenerateDSAParameters generates a set of DSA parameters.
++func GenerateDSAParameters(l, n int) (DSAParameters, error) {
++	// The DSA parameters are generated by creating a new DSA key and
++	// extracting the domain parameters from it.
++
++	// Generate a new DSA key context and set the known parameters.
++	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_DSA, nil)
++	if ctx == nil {
++		return DSAParameters{}, newOpenSSLError("EVP_PKEY_CTX_new_id failed")
++	}
++	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
++	if C.go_openssl_EVP_PKEY_paramgen_init(ctx) != 1 {
++		return DSAParameters{}, newOpenSSLError("EVP_PKEY_paramgen_init failed")
++	}
++	if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_DSA, -1, C.GO_EVP_PKEY_CTRL_DSA_PARAMGEN_BITS, C.int(l), nil) != 1 {
++		return DSAParameters{}, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
++	}
++	if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_DSA, -1, C.GO_EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS, C.int(n), nil) != 1 {
++		return DSAParameters{}, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
++	}
++	var pkey C.GO_EVP_PKEY_PTR
++	if C.go_openssl_EVP_PKEY_paramgen(ctx, &pkey) != 1 {
++		return DSAParameters{}, newOpenSSLError("EVP_PKEY_paramgen failed")
++	}
++	defer C.go_openssl_EVP_PKEY_free(pkey)
++
++	// Extract the domain parameters from the generated key.
++	var p, q, g C.GO_BIGNUM_PTR
++	switch vMajor {
++	case 1:
++		dsa := getDSA(pkey)
++		if vMinor == 0 {
++			C.go_openssl_DSA_get0_pqg_backport(dsa, &p, &q, &g)
++		} else {
++			C.go_openssl_DSA_get0_pqg(dsa, &p, &q, &g)
++		}
++	case 3:
++		defer func() {
++			C.go_openssl_BN_free(p)
++			C.go_openssl_BN_free(q)
++			C.go_openssl_BN_free(g)
++		}()
++		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_FFC_P, &p) != 1 ||
++			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_FFC_Q, &q) != 1 ||
++			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_FFC_G, &g) != 1 {
++			return DSAParameters{}, newOpenSSLError("EVP_PKEY_get_bn_param")
++		}
++	default:
++		panic(errUnsupportedVersion())
++	}
++
++	return DSAParameters{
++		P: bnToBig(p),
++		Q: bnToBig(q),
++		G: bnToBig(g),
++	}, nil
++}
++
++// NewPrivateKeyDSA creates a new DSA private key from the given parameters.
++func NewPrivateKeyDSA(params DSAParameters, x, y BigInt) (*PrivateKeyDSA, error) {
++	if x == nil || y == nil {
++		panic("x and y must not be nil")
++	}
++	pkey, err := newDSA(params, x, y)
++	if err != nil {
++		return nil, err
++	}
++	k := &PrivateKeyDSA{params, x, y, pkey}
++	runtime.SetFinalizer(k, (*PrivateKeyDSA).finalize)
++	return k, nil
++}
++
++// NewPublicKeyDSA creates a new DSA public key from the given parameters.
++func NewPublicKeyDSA(params DSAParameters, y BigInt) (*PublicKeyDSA, error) {
++	if y == nil {
++		panic("y must not be nil")
++	}
++	pkey, err := newDSA(params, nil, y)
++	if err != nil {
++		return nil, err
++	}
++	k := &PublicKeyDSA{params, y, pkey}
++	runtime.SetFinalizer(k, (*PublicKeyDSA).finalize)
++	return k, nil
++}
++
++// GenerateKeyDSA generates a new private DSA key using the given parameters.
++func GenerateKeyDSA(params DSAParameters) (*PrivateKeyDSA, error) {
++	pkey, err := newDSA(params, nil, nil)
++	if err != nil {
++		return nil, err
++	}
++	var x, y C.GO_BIGNUM_PTR
++	switch vMajor {
++	case 1:
++		dsa := getDSA(pkey)
++		if vMinor == 0 {
++			C.go_openssl_DSA_get0_key_backport(dsa, &y, &x)
++		} else {
++			C.go_openssl_DSA_get0_key(dsa, &y, &x)
++		}
++	case 3:
++		defer func() {
++			C.go_openssl_BN_clear_free(x)
++			C.go_openssl_BN_free(y)
++		}()
++		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PUB_KEY, &y) != 1 ||
++			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &x) != 1 {
++			return nil, newOpenSSLError("EVP_PKEY_get_bn_param")
++		}
++	default:
++		panic(errUnsupportedVersion())
++	}
++	k := &PrivateKeyDSA{params, bnToBig(x), bnToBig(y), pkey}
++	runtime.SetFinalizer(k, (*PrivateKeyDSA).finalize)
++	return k, nil
++}
++
++// SignDSA signs a hash (which should be the result of hashing a larger message).
++func SignDSA(priv *PrivateKeyDSA, hash []byte) ([]byte, error) {
++	return evpSign(priv.withKey, 0, 0, 0, hash)
++}
++
++// VerifyDSA verifiessig using the public key, pub.
++func VerifyDSA(pub *PublicKeyDSA, hash []byte, sig []byte) bool {
++	return evpVerify(pub.withKey, 0, 0, 0, sig, hash) == nil
++}
++
++func newDSA(params DSAParameters, x, y BigInt) (C.GO_EVP_PKEY_PTR, error) {
++	switch vMajor {
++	case 1:
++		return newDSA1(params, x, y)
++	case 3:
++		return newDSA3(params, x, y)
++	default:
++		panic(errUnsupportedVersion())
++	}
++}
++
++func newDSA1(params DSAParameters, x, y BigInt) (pkey C.GO_EVP_PKEY_PTR, err error) {
++	checkMajorVersion(1)
++
++	dsa := C.go_openssl_DSA_new()
++	if dsa == nil {
++		return nil, newOpenSSLError("DSA_new failed")
++	}
++	defer func() {
++		if pkey == nil {
++			C.go_openssl_DSA_free(dsa)
++		}
++	}()
++
++	p, q, g := bigToBN(params.P), bigToBN(params.Q), bigToBN(params.G)
++	var ret C.int
++	if vMinor == 0 {
++		ret = C.go_openssl_DSA_set0_pqg_backport(dsa, p, q, g)
++	} else {
++		ret = C.go_openssl_DSA_set0_pqg(dsa, p, q, g)
++	}
++	if ret != 1 {
++		C.go_openssl_BN_free(p)
++		C.go_openssl_BN_free(q)
++		C.go_openssl_BN_free(g)
++		return nil, newOpenSSLError("DSA_set0_pqg failed")
++	}
++	if y != nil {
++		pub, priv := bigToBN(y), bigToBN(x)
++		if vMinor == 0 {
++			ret = C.go_openssl_DSA_set0_key_backport(dsa, pub, priv)
++		} else {
++			ret = C.go_openssl_DSA_set0_key(dsa, pub, priv)
++		}
++		if ret != 1 {
++			C.go_openssl_BN_free(pub)
++			C.go_openssl_BN_clear_free(priv)
++			return nil, newOpenSSLError("DSA_set0_key failed")
++		}
++	} else {
++		if C.go_openssl_DSA_generate_key(dsa) != 1 {
++			return nil, newOpenSSLError("DSA_generate_key failed")
++		}
++	}
++	pkey = C.go_openssl_EVP_PKEY_new()
++	if pkey == nil {
++		return nil, newOpenSSLError("EVP_PKEY_new failed")
++	}
++	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_DSA, unsafe.Pointer(dsa)) != 1 {
++		C.go_openssl_EVP_PKEY_free(pkey)
++		return nil, newOpenSSLError("EVP_PKEY_assign failed")
++	}
++	return pkey, nil
++}
++
++func newDSA3(params DSAParameters, x, y BigInt) (C.GO_EVP_PKEY_PTR, error) {
++	checkMajorVersion(3)
++
++	bld := C.go_openssl_OSSL_PARAM_BLD_new()
++	if bld == nil {
++		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
++	}
++	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
++	p, q, g := bigToBN(params.P), bigToBN(params.Q), bigToBN(params.G)
++	defer func() {
++		C.go_openssl_BN_free(p)
++		C.go_openssl_BN_free(q)
++		C.go_openssl_BN_free(g)
++	}()
++	if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_P, p) != 1 ||
++		C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_Q, q) != 1 ||
++		C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_G, g) != 1 {
++
++		return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
++	}
++	selection := C.int(C.GO_EVP_PKEY_KEYPAIR)
++	if y != nil {
++		pub := bigToBN(y)
++		defer C.go_openssl_BN_free(pub)
++		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PUB_KEY, pub) != 1 {
++			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
++		}
++		if x == nil {
++			selection = C.int(C.GO_EVP_PKEY_PUBLIC_KEY)
++		}
++	}
++	if x != nil {
++		priv := bigToBN(x)
++		defer C.go_openssl_BN_clear_free(priv)
++		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, priv) != 1 {
++			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
++		}
++	}
++	bldparams := C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
++	if bldparams == nil {
++		return nil, newOpenSSLError("OSSL_PARAM_BLD_to_param")
++	}
++	defer C.go_openssl_OSSL_PARAM_free(bldparams)
++	pkey, err := newEvpFromParams(C.GO_EVP_PKEY_DSA, selection, bldparams)
++	if err != nil {
++		return nil, err
++	}
++	if y != nil {
++		return pkey, nil
++	}
++	// pkey doesn't contain the public component, but the crypto/dsa package
++	// expects it to be always there. Generate a new key using pkey as domain
++	// parameters placeholder.
++	defer C.go_openssl_EVP_PKEY_free(pkey)
++	ctx := C.go_openssl_EVP_PKEY_CTX_new_from_pkey(nil, pkey, nil)
++	if ctx == nil {
++		return nil, newOpenSSLError("EVP_PKEY_CTX_new_from_pkey")
++	}
++	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
++	if C.go_openssl_EVP_PKEY_keygen_init(ctx) != 1 {
++		return nil, newOpenSSLError("EVP_PKEY_keygen_init")
++	}
++	var gkey C.GO_EVP_PKEY_PTR
++	if C.go_openssl_EVP_PKEY_keygen(ctx, &gkey) != 1 {
++		return nil, newOpenSSLError("EVP_PKEY_keygen")
++	}
++	return gkey, nil
++}
++
++// getDSA returns the DSA from pkey.
++// If pkey does not contain an DSA it panics.
++// The returned key should not be freed.
++func getDSA(pkey C.GO_EVP_PKEY_PTR) (key C.GO_DSA_PTR) {
++	if vMajor == 1 && vMinor == 0 {
++		if key0 := C.go_openssl_EVP_PKEY_get0(pkey); key0 != nil {
++			key = C.GO_DSA_PTR(key0)
++		}
++	} else {
++		key = C.go_openssl_EVP_PKEY_get0_DSA(pkey)
++	}
++	if key == nil {
++		panic("pkey does not contain an DSA")
++	}
++	return key
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ec.go b/src/vendor/github.com/golang-fips/openssl/v2/ec.go
 new file mode 100644
-index 00000000000000..eac2f8bbee303c
+index 00000000000000..5c253f7eec5358
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ec.go
 @@ -0,0 +1,59 @@
@@ -1106,11 +1465,11 @@ index 00000000000000..eac2f8bbee303c
 +import "C"
 +
 +var (
-+	paramPubKey  = C.CString("pub")
-+	paramPrivKey = C.CString("priv")
-+	paramGroup   = C.CString("group")
-+	paramECPubX  = C.CString("qx")
-+	paramECPubY  = C.CString("qy")
++	OSSL_PKEY_PARAM_PUB_KEY    = C.CString("pub")
++	OSSL_PKEY_PARAM_PRIV_KEY   = C.CString("priv")
++	OSSL_PKEY_PARAM_GROUP_NAME = C.CString("group")
++	OSSL_PKEY_PARAM_EC_PUB_X   = C.CString("qx")
++	OSSL_PKEY_PARAM_EC_PUB_Y   = C.CString("qy")
 +)
 +
 +func curveNID(curve string) (C.int, error) {
@@ -1159,10 +1518,10 @@ index 00000000000000..eac2f8bbee303c
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ecdh.go b/src/vendor/github.com/golang-fips/openssl/v2/ecdh.go
 new file mode 100644
-index 00000000000000..a1e627eff44699
+index 00000000000000..de5f712f22158f
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ecdh.go
-@@ -0,0 +1,323 @@
+@@ -0,0 +1,321 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1292,9 +1651,8 @@ index 00000000000000..a1e627eff44699
 +}
 +
 +func newECDHPkey1(nid C.int, bytes []byte, isPrivate bool) (pkey C.GO_EVP_PKEY_PTR, err error) {
-+	if vMajor != 1 {
-+		panic("incorrect vMajor version")
-+	}
++	checkMajorVersion(1)
++
 +	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
 +	if key == nil {
 +		return nil, newOpenSSLError("EC_KEY_new_by_curve_name")
@@ -1331,15 +1689,14 @@ index 00000000000000..a1e627eff44699
 +}
 +
 +func newECDHPkey3(nid C.int, bytes []byte, isPrivate bool) (C.GO_EVP_PKEY_PTR, error) {
-+	if vMajor != 3 {
-+		panic("incorrect vMajor version")
-+	}
++	checkMajorVersion(3)
++
 +	bld := C.go_openssl_OSSL_PARAM_BLD_new()
 +	if bld == nil {
 +		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
 +	}
 +	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-+	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, paramGroup, C.go_openssl_OBJ_nid2sn(nid), 0)
++	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, C.go_openssl_OBJ_nid2sn(nid), 0)
 +	var selection C.int
 +	if isPrivate {
 +		priv := C.go_openssl_BN_bin2bn(base(bytes), C.int(len(bytes)), nil)
@@ -1347,14 +1704,14 @@ index 00000000000000..a1e627eff44699
 +			return nil, newOpenSSLError("BN_bin2bn")
 +		}
 +		defer C.go_openssl_BN_clear_free(priv)
-+		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, paramPrivKey, priv) != 1 {
++		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, priv) != 1 {
 +			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
 +		}
 +		selection = C.GO_EVP_PKEY_KEYPAIR
 +	} else {
 +		cbytes := C.CBytes(bytes)
 +		defer C.free(cbytes)
-+		C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, paramPubKey, cbytes, C.size_t(len(bytes)))
++		C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY, cbytes, C.size_t(len(bytes)))
 +		selection = C.GO_EVP_PKEY_PUBLIC_KEY
 +	}
 +	params := C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
@@ -1400,7 +1757,7 @@ index 00000000000000..a1e627eff44699
 +		}
 +	case 3:
 +		var priv C.GO_BIGNUM_PTR
-+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &priv) != 1 {
++		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &priv) != 1 {
 +			return newOpenSSLError("EVP_PKEY_get_bn_param")
 +		}
 +		defer C.go_openssl_BN_clear_free(priv)
@@ -1465,7 +1822,7 @@ index 00000000000000..a1e627eff44699
 +			return nil, nil, newOpenSSLError("EC_KEY_get0_private_key")
 +		}
 +	case 3:
-+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &priv) != 1 {
++		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &priv) != 1 {
 +			return nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
 +		}
 +		defer C.go_openssl_BN_clear_free(priv)
@@ -1488,10 +1845,10 @@ index 00000000000000..a1e627eff44699
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go b/src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go
 new file mode 100644
-index 00000000000000..46b16abf483e65
+index 00000000000000..be7e9455f49d47
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go
-@@ -0,0 +1,217 @@
+@@ -0,0 +1,215 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1534,8 +1891,8 @@ index 00000000000000..46b16abf483e65
 +
 +var errUnknownCurve = errors.New("openssl: unknown elliptic curve")
 +
-+func NewPublicKeyECDSA(curve string, X, Y BigInt) (*PublicKeyECDSA, error) {
-+	pkey, err := newECDSAKey(curve, X, Y, nil)
++func NewPublicKeyECDSA(curve string, x, y BigInt) (*PublicKeyECDSA, error) {
++	pkey, err := newECDSAKey(curve, x, y, nil)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -1544,8 +1901,8 @@ index 00000000000000..46b16abf483e65
 +	return k, nil
 +}
 +
-+func NewPrivateKeyECDSA(curve string, X, Y, D BigInt) (*PrivateKeyECDSA, error) {
-+	pkey, err := newECDSAKey(curve, X, Y, D)
++func NewPrivateKeyECDSA(curve string, x, y, d BigInt) (*PrivateKeyECDSA, error) {
++	pkey, err := newECDSAKey(curve, x, y, d)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -1554,7 +1911,7 @@ index 00000000000000..46b16abf483e65
 +	return k, nil
 +}
 +
-+func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
++func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 +	// Generate the private key.
 +	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_EC, 0, curve)
 +	if err != nil {
@@ -1585,9 +1942,9 @@ index 00000000000000..46b16abf483e65
 +		// Get Z. We don't need to free it, get0 does not increase the reference count.
 +		bd = C.go_openssl_EC_KEY_get0_private_key(key)
 +	case 3:
-+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramECPubX, &bx) != 1 ||
-+			C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramECPubY, &by) != 1 ||
-+			C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &bd) != 1 {
++		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_EC_PUB_X, &bx) != 1 ||
++			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_EC_PUB_Y, &by) != 1 ||
++			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &bd) != 1 {
 +			return nil, nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
 +		}
 +		defer C.go_openssl_BN_clear_free(bd)
@@ -1615,7 +1972,7 @@ index 00000000000000..46b16abf483e65
 +	return evpHashVerify(pub.withKey, h, msg, sig) == nil
 +}
 +
-+func newECDSAKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
++func newECDSAKey(curve string, x, y, d BigInt) (C.GO_EVP_PKEY_PTR, error) {
 +	nid, err := curveNID(curve)
 +	if err != nil {
 +		return nil, err
@@ -1626,10 +1983,10 @@ index 00000000000000..46b16abf483e65
 +		C.go_openssl_BN_free(by)
 +		C.go_openssl_BN_clear_free(bd)
 +	}()
-+	bx = bigToBN(X)
-+	by = bigToBN(Y)
-+	bd = bigToBN(D)
-+	if bx == nil || by == nil || (D != nil && bd == nil) {
++	bx = bigToBN(x)
++	by = bigToBN(y)
++	bd = bigToBN(d)
++	if bx == nil || by == nil || (d != nil && bd == nil) {
 +		return nil, newOpenSSLError("BN_lebin2bn failed")
 +	}
 +	switch vMajor {
@@ -1643,9 +2000,8 @@ index 00000000000000..46b16abf483e65
 +}
 +
 +func newECDSAKey1(nid C.int, bx, by, bd C.GO_BIGNUM_PTR) (pkey C.GO_EVP_PKEY_PTR, err error) {
-+	if vMajor != 1 {
-+		panic("incorrect vMajor version")
-+	}
++	checkMajorVersion(1)
++
 +	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
 +	if key == nil {
 +		return nil, newOpenSSLError("EC_KEY_new_by_curve_name failed")
@@ -1665,9 +2021,8 @@ index 00000000000000..46b16abf483e65
 +}
 +
 +func newECDSAKey3(nid C.int, bx, by, bd C.GO_BIGNUM_PTR) (C.GO_EVP_PKEY_PTR, error) {
-+	if vMajor != 3 {
-+		panic("incorrect vMajor version")
-+	}
++	checkMajorVersion(3)
++
 +	// Create the encoded public key public key from bx and by.
 +	pubBytes, err := generateAndEncodeEcPublicKey(nid, func(group C.GO_EC_GROUP_PTR) (C.GO_EC_POINT_PTR, error) {
 +		pt := C.go_openssl_EC_POINT_new(group)
@@ -1689,13 +2044,13 @@ index 00000000000000..46b16abf483e65
 +		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
 +	}
 +	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-+	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, paramGroup, C.go_openssl_OBJ_nid2sn(nid), 0)
++	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, C.go_openssl_OBJ_nid2sn(nid), 0)
 +	cbytes := C.CBytes(pubBytes)
 +	defer C.free(cbytes)
-+	C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, paramPubKey, cbytes, C.size_t(len(pubBytes)))
++	C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY, cbytes, C.size_t(len(pubBytes)))
 +	var selection C.int
 +	if bd != nil {
-+		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, paramPrivKey, bd) != 1 {
++		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, bd) != 1 {
 +			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
 +		}
 +		selection = C.GO_EVP_PKEY_KEYPAIR
@@ -1935,7 +2290,7 @@ index 00000000000000..f74bd8f8d7a993
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/evp.go b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 new file mode 100644
-index 00000000000000..a9237a6a0ce9aa
+index 00000000000000..fa557d86be71c5
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 @@ -0,0 +1,471 @@
@@ -1961,15 +2316,15 @@ index 00000000000000..a9237a6a0ce9aa
 +func hashToMD(h hash.Hash) C.GO_EVP_MD_PTR {
 +	var ch crypto.Hash
 +	switch h.(type) {
-+	case *sha1Hash:
++	case *sha1Hash, *sha1Marshal:
 +		ch = crypto.SHA1
-+	case *sha224Hash:
++	case *sha224Hash, *sha224Marshal:
 +		ch = crypto.SHA224
-+	case *sha256Hash:
++	case *sha256Hash, *sha256Marshal:
 +		ch = crypto.SHA256
-+	case *sha384Hash:
++	case *sha384Hash, *sha384Marshal:
 +		ch = crypto.SHA384
-+	case *sha512Hash:
++	case *sha512Hash, *sha512Marshal:
 +		ch = crypto.SHA512
 +	case *sha3_224Hash:
 +		ch = crypto.SHA3_224
@@ -2636,10 +2991,10 @@ index 00000000000000..1e428d5269f997
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/goopenssl.h b/src/vendor/github.com/golang-fips/openssl/v2/goopenssl.h
 new file mode 100644
-index 00000000000000..e488bf20142010
+index 00000000000000..a50caa3d82312c
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/goopenssl.h
-@@ -0,0 +1,255 @@
+@@ -0,0 +1,259 @@
 +// This header file describes the OpenSSL ABI as built for use in Go.
 +
 +#include <stdlib.h> // size_t
@@ -2670,6 +3025,10 @@ index 00000000000000..e488bf20142010
 +int go_openssl_thread_setup(void);
 +void go_openssl_load_functions(void* handle, unsigned int major, unsigned int minor, unsigned int patch);
 +const GO_EVP_MD_PTR go_openssl_EVP_md5_sha1_backport(void);
++void go_openssl_DSA_get0_pqg_backport(const GO_DSA_PTR d, GO_BIGNUM_PTR *p, GO_BIGNUM_PTR *q, GO_BIGNUM_PTR *g);
++int go_openssl_DSA_set0_pqg_backport(GO_DSA_PTR d, GO_BIGNUM_PTR p, GO_BIGNUM_PTR q, GO_BIGNUM_PTR g);
++void go_openssl_DSA_get0_key_backport(const GO_DSA_PTR d, GO_BIGNUM_PTR *pub_key, GO_BIGNUM_PTR *priv_key);
++int go_openssl_DSA_set0_key_backport(GO_DSA_PTR d, GO_BIGNUM_PTR pub_key, GO_BIGNUM_PTR priv_key);
 +
 +// Define pointers to all the used OpenSSL functions.
 +// Calling C function pointers from Go is currently not supported.
@@ -2898,10 +3257,10 @@ index 00000000000000..e488bf20142010
 \ No newline at end of file
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hash.go b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
 new file mode 100644
-index 00000000000000..646b4ce295896c
+index 00000000000000..6fd3a518906004
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
-@@ -0,0 +1,793 @@
+@@ -0,0 +1,1041 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -2914,6 +3273,7 @@ index 00000000000000..646b4ce295896c
 +	"hash"
 +	"runtime"
 +	"strconv"
++	"sync"
 +	"unsafe"
 +)
 +
@@ -3014,18 +3374,50 @@ index 00000000000000..646b4ce295896c
 +	return
 +}
 +
++var isMarshallableCache sync.Map
++
++// isHashMarshallable returns true if the memory layout of cb
++// is known by this library and can therefore be marshalled.
++func isHashMarshallable(ch crypto.Hash) bool {
++	if vMajor == 1 {
++		return true
++	}
++	if v, ok := isMarshallableCache.Load(ch); ok {
++		return v.(bool)
++	}
++	md := cryptoHashToMD(ch)
++	if md == nil {
++		return false
++	}
++	prov := C.go_openssl_EVP_MD_get0_provider(md)
++	if prov == nil {
++		return false
++	}
++	cname := C.go_openssl_OSSL_PROVIDER_get0_name(prov)
++	if cname == nil {
++		return false
++	}
++	name := C.GoString(cname)
++	// We only know the memory layout of the built-in providers.
++	// See evpHash.hashState for more details.
++	marshallable := name == "default" || name == "fips"
++	isMarshallableCache.Store(ch, marshallable)
++	return marshallable
++}
++
 +// evpHash implements generic hash methods.
 +type evpHash struct {
 +	ctx C.GO_EVP_MD_CTX_PTR
 +	// ctx2 is used in evpHash.sum to avoid changing
 +	// the state of ctx. Having it here allows reusing the
 +	// same allocated object multiple times.
-+	ctx2      C.GO_EVP_MD_CTX_PTR
-+	size      int
-+	blockSize int
++	ctx2         C.GO_EVP_MD_CTX_PTR
++	size         int
++	blockSize    int
++	marshallable bool
 +}
 +
-+func newEvpHash(ch crypto.Hash, size, blockSize int) *evpHash {
++func newEvpHash(ch crypto.Hash) *evpHash {
 +	md := cryptoHashToMD(ch)
 +	if md == nil {
 +		panic("openssl: unsupported hash function: " + strconv.Itoa(int(ch)))
@@ -3036,11 +3428,13 @@ index 00000000000000..646b4ce295896c
 +		panic(newOpenSSLError("EVP_DigestInit_ex"))
 +	}
 +	ctx2 := C.go_openssl_EVP_MD_CTX_new()
++	blockSize := int(C.go_openssl_EVP_MD_get_block_size(md))
 +	h := &evpHash{
-+		ctx:       ctx,
-+		ctx2:      ctx2,
-+		size:      size,
-+		blockSize: blockSize,
++		ctx:          ctx,
++		ctx2:         ctx2,
++		size:         ch.Size(),
++		blockSize:    blockSize,
++		marshallable: isHashMarshallable(ch),
 +	}
 +	runtime.SetFinalizer(h, (*evpHash).finalize)
 +	return h
@@ -3099,11 +3493,42 @@ index 00000000000000..646b4ce295896c
 +	runtime.KeepAlive(h)
 +}
 +
++// clone returns a new evpHash object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *evpHash) clone() (*evpHash, error) {
++	ctx := C.go_openssl_EVP_MD_CTX_new()
++	if ctx == nil {
++		return nil, newOpenSSLError("EVP_MD_CTX_new")
++	}
++	if C.go_openssl_EVP_MD_CTX_copy_ex(ctx, h.ctx) != 1 {
++		C.go_openssl_EVP_MD_CTX_free(ctx)
++		return nil, newOpenSSLError("EVP_MD_CTX_copy")
++	}
++	ctx2 := C.go_openssl_EVP_MD_CTX_new()
++	if ctx2 == nil {
++		C.go_openssl_EVP_MD_CTX_free(ctx)
++		return nil, newOpenSSLError("EVP_MD_CTX_new")
++	}
++	cloned := &evpHash{
++		ctx:          ctx,
++		ctx2:         ctx2,
++		size:         h.size,
++		blockSize:    h.blockSize,
++		marshallable: h.marshallable,
++	}
++	runtime.SetFinalizer(cloned, (*evpHash).finalize)
++	return cloned, nil
++}
++
 +// hashState returns a pointer to the internal hash structure.
 +//
 +// The EVP_MD_CTX memory layout has changed in OpenSSL 3
 +// and the property holding the internal structure is no longer md_data but algctx.
 +func (h *evpHash) hashState() unsafe.Pointer {
++	if !h.marshallable {
++		panic("openssl: hash state is not marshallable")
++	}
 +	switch vMajor {
 +	case 1:
 +		// https://github.com/openssl/openssl/blob/0418e993c717a6863f206feaa40673a261de7395/crypto/evp/evp_local.h#L12.
@@ -3132,7 +3557,7 @@ index 00000000000000..646b4ce295896c
 +// encoding.BinaryUnmarshaler.
 +func NewMD4() hash.Hash {
 +	return &md4Hash{
-+		evpHash: newEvpHash(crypto.MD4, 16, 64),
++		evpHash: newEvpHash(crypto.MD4),
 +	}
 +}
 +
@@ -3146,11 +3571,24 @@ index 00000000000000..646b4ce295896c
 +	return append(in, h.out[:]...)
 +}
 +
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *md4Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &md4Hash{evpHash: c}, nil
++}
++
 +// NewMD5 returns a new MD5 hash.
 +func NewMD5() hash.Hash {
-+	return &md5Hash{
-+		evpHash: newEvpHash(crypto.MD5, 16, 64),
++	h := md5Hash{evpHash: newEvpHash(crypto.MD5)}
++	if h.marshallable {
++		return &md5Marshal{h}
 +	}
++	return &h
 +}
 +
 +// md5State layout is taken from
@@ -3172,29 +3610,32 @@ index 00000000000000..646b4ce295896c
 +	return append(in, h.out[:]...)
 +}
 +
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *md5Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &md5Hash{evpHash: c}, nil
++}
++
 +const (
 +	md5Magic         = "md5\x01"
 +	md5MarshaledSize = len(md5Magic) + 4*4 + 64 + 8
 +)
 +
-+func (h *md5Hash) MarshalBinary() ([]byte, error) {
-+	d := (*md5State)(h.hashState())
-+	if d == nil {
-+		return nil, errors.New("crypto/md5: can't retrieve hash state")
-+	}
-+	b := make([]byte, 0, md5MarshaledSize)
-+	b = append(b, md5Magic...)
-+	b = appendUint32(b, d.h[0])
-+	b = appendUint32(b, d.h[1])
-+	b = appendUint32(b, d.h[2])
-+	b = appendUint32(b, d.h[3])
-+	b = append(b, d.x[:d.nx]...)
-+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
-+	return b, nil
++type md5Marshal struct {
++	md5Hash
 +}
 +
-+func (h *md5Hash) UnmarshalBinary(b []byte) error {
++func (h *md5Marshal) MarshalBinary() ([]byte, error) {
++	buf := make([]byte, 0, md5MarshaledSize)
++	return h.AppendBinary(buf)
++}
++
++func (h *md5Marshal) UnmarshalBinary(b []byte) error {
 +	if len(b) < len(md5Magic) || string(b[:len(md5Magic)]) != md5Magic {
 +		return errors.New("crypto/md5: invalid hash state identifier")
 +	}
@@ -3218,11 +3659,30 @@ index 00000000000000..646b4ce295896c
 +	return nil
 +}
 +
++func (h *md5Marshal) AppendBinary(buf []byte) ([]byte, error) {
++	d := (*md5State)(h.hashState())
++	if d == nil {
++		return nil, errors.New("crypto/md5: can't retrieve hash state")
++	}
++
++	buf = append(buf, md5Magic...)
++	buf = appendUint32(buf, d.h[0])
++	buf = appendUint32(buf, d.h[1])
++	buf = appendUint32(buf, d.h[2])
++	buf = appendUint32(buf, d.h[3])
++	buf = append(buf, d.x[:d.nx]...)
++	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
++	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
++	return buf, nil
++}
++
 +// NewSHA1 returns a new SHA1 hash.
 +func NewSHA1() hash.Hash {
-+	return &sha1Hash{
-+		evpHash: newEvpHash(crypto.SHA1, 20, 64),
++	h := sha1Hash{evpHash: newEvpHash(crypto.SHA1)}
++	if h.marshallable {
++		return &sha1Marshal{h}
 +	}
++	return &h
 +}
 +
 +type sha1Hash struct {
@@ -3233,6 +3693,17 @@ index 00000000000000..646b4ce295896c
 +func (h *sha1Hash) Sum(in []byte) []byte {
 +	h.sum(h.out[:])
 +	return append(in, h.out[:]...)
++}
++
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *sha1Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &sha1Hash{evpHash: c}, nil
 +}
 +
 +// sha1State layout is taken from
@@ -3249,25 +3720,16 @@ index 00000000000000..646b4ce295896c
 +	sha1MarshaledSize = len(sha1Magic) + 5*4 + 64 + 8
 +)
 +
-+func (h *sha1Hash) MarshalBinary() ([]byte, error) {
-+	d := (*sha1State)(h.hashState())
-+	if d == nil {
-+		return nil, errors.New("crypto/sha1: can't retrieve hash state")
-+	}
-+	b := make([]byte, 0, sha1MarshaledSize)
-+	b = append(b, sha1Magic...)
-+	b = appendUint32(b, d.h[0])
-+	b = appendUint32(b, d.h[1])
-+	b = appendUint32(b, d.h[2])
-+	b = appendUint32(b, d.h[3])
-+	b = appendUint32(b, d.h[4])
-+	b = append(b, d.x[:d.nx]...)
-+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
-+	return b, nil
++type sha1Marshal struct {
++	sha1Hash
 +}
 +
-+func (h *sha1Hash) UnmarshalBinary(b []byte) error {
++func (h *sha1Marshal) MarshalBinary() ([]byte, error) {
++	buf := make([]byte, 0, sha1MarshaledSize)
++	return h.AppendBinary(buf)
++}
++
++func (h *sha1Marshal) UnmarshalBinary(b []byte) error {
 +	if len(b) < len(sha1Magic) || string(b[:len(sha1Magic)]) != sha1Magic {
 +		return errors.New("crypto/sha1: invalid hash state identifier")
 +	}
@@ -3292,11 +3754,30 @@ index 00000000000000..646b4ce295896c
 +	return nil
 +}
 +
++func (h *sha1Marshal) AppendBinary(buf []byte) ([]byte, error) {
++	d := (*sha1State)(h.hashState())
++	if d == nil {
++		return nil, errors.New("crypto/sha1: can't retrieve hash state")
++	}
++	buf = append(buf, sha1Magic...)
++	buf = appendUint32(buf, d.h[0])
++	buf = appendUint32(buf, d.h[1])
++	buf = appendUint32(buf, d.h[2])
++	buf = appendUint32(buf, d.h[3])
++	buf = appendUint32(buf, d.h[4])
++	buf = append(buf, d.x[:d.nx]...)
++	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
++	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
++	return buf, nil
++}
++
 +// NewSHA224 returns a new SHA224 hash.
 +func NewSHA224() hash.Hash {
-+	return &sha224Hash{
-+		evpHash: newEvpHash(crypto.SHA224, 224/8, 64),
++	h := sha224Hash{evpHash: newEvpHash(crypto.SHA224)}
++	if h.marshallable {
++		return &sha224Marshal{h}
 +	}
++	return &h
 +}
 +
 +type sha224Hash struct {
@@ -3309,11 +3790,24 @@ index 00000000000000..646b4ce295896c
 +	return append(in, h.out[:]...)
 +}
 +
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *sha224Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &sha224Hash{evpHash: c}, nil
++}
++
 +// NewSHA256 returns a new SHA256 hash.
 +func NewSHA256() hash.Hash {
-+	return &sha256Hash{
-+		evpHash: newEvpHash(crypto.SHA256, 256/8, 64),
++	h := sha256Hash{evpHash: newEvpHash(crypto.SHA256)}
++	if h.marshallable {
++		return &sha256Marshal{h}
 +	}
++	return &h
 +}
 +
 +type sha256Hash struct {
@@ -3324,6 +3818,17 @@ index 00000000000000..646b4ce295896c
 +func (h *sha256Hash) Sum(in []byte) []byte {
 +	h.sum(h.out[:])
 +	return append(in, h.out[:]...)
++}
++
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *sha256Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &sha256Hash{evpHash: c}, nil
 +}
 +
 +const (
@@ -3341,49 +3846,25 @@ index 00000000000000..646b4ce295896c
 +	nx     uint32
 +}
 +
-+func (h *sha224Hash) MarshalBinary() ([]byte, error) {
-+	d := (*sha256State)(h.hashState())
-+	if d == nil {
-+		return nil, errors.New("crypto/sha256: can't retrieve hash state")
-+	}
-+	b := make([]byte, 0, marshaledSize256)
-+	b = append(b, magic224...)
-+	b = appendUint32(b, d.h[0])
-+	b = appendUint32(b, d.h[1])
-+	b = appendUint32(b, d.h[2])
-+	b = appendUint32(b, d.h[3])
-+	b = appendUint32(b, d.h[4])
-+	b = appendUint32(b, d.h[5])
-+	b = appendUint32(b, d.h[6])
-+	b = appendUint32(b, d.h[7])
-+	b = append(b, d.x[:d.nx]...)
-+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
-+	return b, nil
++type sha224Marshal struct {
++	sha224Hash
 +}
 +
-+func (h *sha256Hash) MarshalBinary() ([]byte, error) {
-+	d := (*sha256State)(h.hashState())
-+	if d == nil {
-+		return nil, errors.New("crypto/sha256: can't retrieve hash state")
-+	}
-+	b := make([]byte, 0, marshaledSize256)
-+	b = append(b, magic256...)
-+	b = appendUint32(b, d.h[0])
-+	b = appendUint32(b, d.h[1])
-+	b = appendUint32(b, d.h[2])
-+	b = appendUint32(b, d.h[3])
-+	b = appendUint32(b, d.h[4])
-+	b = appendUint32(b, d.h[5])
-+	b = appendUint32(b, d.h[6])
-+	b = appendUint32(b, d.h[7])
-+	b = append(b, d.x[:d.nx]...)
-+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
-+	return b, nil
++type sha256Marshal struct {
++	sha256Hash
 +}
 +
-+func (h *sha224Hash) UnmarshalBinary(b []byte) error {
++func (h *sha224Marshal) MarshalBinary() ([]byte, error) {
++	buf := make([]byte, 0, marshaledSize256)
++	return h.AppendBinary(buf)
++}
++
++func (h *sha256Marshal) MarshalBinary() ([]byte, error) {
++	buf := make([]byte, 0, marshaledSize256)
++	return h.AppendBinary(buf)
++}
++
++func (h *sha224Marshal) UnmarshalBinary(b []byte) error {
 +	if len(b) < len(magic224) || string(b[:len(magic224)]) != magic224 {
 +		return errors.New("crypto/sha256: invalid hash state identifier")
 +	}
@@ -3411,7 +3892,7 @@ index 00000000000000..646b4ce295896c
 +	return nil
 +}
 +
-+func (h *sha256Hash) UnmarshalBinary(b []byte) error {
++func (h *sha256Marshal) UnmarshalBinary(b []byte) error {
 +	if len(b) < len(magic256) || string(b[:len(magic256)]) != magic256 {
 +		return errors.New("crypto/sha256: invalid hash state identifier")
 +	}
@@ -3439,11 +3920,53 @@ index 00000000000000..646b4ce295896c
 +	return nil
 +}
 +
++func (h *sha224Marshal) AppendBinary(buf []byte) ([]byte, error) {
++	d := (*sha256State)(h.hashState())
++	if d == nil {
++		return nil, errors.New("crypto/sha256: can't retrieve hash state")
++	}
++	buf = append(buf, magic224...)
++	buf = appendUint32(buf, d.h[0])
++	buf = appendUint32(buf, d.h[1])
++	buf = appendUint32(buf, d.h[2])
++	buf = appendUint32(buf, d.h[3])
++	buf = appendUint32(buf, d.h[4])
++	buf = appendUint32(buf, d.h[5])
++	buf = appendUint32(buf, d.h[6])
++	buf = appendUint32(buf, d.h[7])
++	buf = append(buf, d.x[:d.nx]...)
++	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
++	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
++	return buf, nil
++}
++
++func (h *sha256Marshal) AppendBinary(buf []byte) ([]byte, error) {
++	d := (*sha256State)(h.hashState())
++	if d == nil {
++		return nil, errors.New("crypto/sha256: can't retrieve hash state")
++	}
++	buf = append(buf, magic256...)
++	buf = appendUint32(buf, d.h[0])
++	buf = appendUint32(buf, d.h[1])
++	buf = appendUint32(buf, d.h[2])
++	buf = appendUint32(buf, d.h[3])
++	buf = appendUint32(buf, d.h[4])
++	buf = appendUint32(buf, d.h[5])
++	buf = appendUint32(buf, d.h[6])
++	buf = appendUint32(buf, d.h[7])
++	buf = append(buf, d.x[:d.nx]...)
++	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
++	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
++	return buf, nil
++}
++
 +// NewSHA384 returns a new SHA384 hash.
 +func NewSHA384() hash.Hash {
-+	return &sha384Hash{
-+		evpHash: newEvpHash(crypto.SHA384, 384/8, 128),
++	h := sha384Hash{evpHash: newEvpHash(crypto.SHA384)}
++	if h.marshallable {
++		return &sha384Marshal{h}
 +	}
++	return &h
 +}
 +
 +type sha384Hash struct {
@@ -3456,11 +3979,24 @@ index 00000000000000..646b4ce295896c
 +	return append(in, h.out[:]...)
 +}
 +
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *sha384Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &sha384Hash{evpHash: c}, nil
++}
++
 +// NewSHA512 returns a new SHA512 hash.
 +func NewSHA512() hash.Hash {
-+	return &sha512Hash{
-+		evpHash: newEvpHash(crypto.SHA512, 512/8, 128),
++	h := sha512Hash{evpHash: newEvpHash(crypto.SHA512)}
++	if h.marshallable {
++		return &sha512Marshal{h}
 +	}
++	return &h
 +}
 +
 +type sha512Hash struct {
@@ -3471,6 +4007,17 @@ index 00000000000000..646b4ce295896c
 +func (h *sha512Hash) Sum(in []byte) []byte {
 +	h.sum(h.out[:])
 +	return append(in, h.out[:]...)
++}
++
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *sha512Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &sha512Hash{evpHash: c}, nil
 +}
 +
 +// sha512State layout is taken from
@@ -3490,49 +4037,25 @@ index 00000000000000..646b4ce295896c
 +	marshaledSize512 = len(magic512) + 8*8 + 128 + 8
 +)
 +
-+func (h *sha384Hash) MarshalBinary() ([]byte, error) {
-+	d := (*sha512State)(h.hashState())
-+	if d == nil {
-+		return nil, errors.New("crypto/sha512: can't retrieve hash state")
-+	}
-+	b := make([]byte, 0, marshaledSize512)
-+	b = append(b, magic384...)
-+	b = appendUint64(b, d.h[0])
-+	b = appendUint64(b, d.h[1])
-+	b = appendUint64(b, d.h[2])
-+	b = appendUint64(b, d.h[3])
-+	b = appendUint64(b, d.h[4])
-+	b = appendUint64(b, d.h[5])
-+	b = appendUint64(b, d.h[6])
-+	b = appendUint64(b, d.h[7])
-+	b = append(b, d.x[:d.nx]...)
-+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-+	b = appendUint64(b, d.nl>>3|d.nh<<61)
-+	return b, nil
++type sha384Marshal struct {
++	sha384Hash
 +}
 +
-+func (h *sha512Hash) MarshalBinary() ([]byte, error) {
-+	d := (*sha512State)(h.hashState())
-+	if d == nil {
-+		return nil, errors.New("crypto/sha512: can't retrieve hash state")
-+	}
-+	b := make([]byte, 0, marshaledSize512)
-+	b = append(b, magic512...)
-+	b = appendUint64(b, d.h[0])
-+	b = appendUint64(b, d.h[1])
-+	b = appendUint64(b, d.h[2])
-+	b = appendUint64(b, d.h[3])
-+	b = appendUint64(b, d.h[4])
-+	b = appendUint64(b, d.h[5])
-+	b = appendUint64(b, d.h[6])
-+	b = appendUint64(b, d.h[7])
-+	b = append(b, d.x[:d.nx]...)
-+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-+	b = appendUint64(b, d.nl>>3|d.nh<<61)
-+	return b, nil
++type sha512Marshal struct {
++	sha512Hash
 +}
 +
-+func (h *sha384Hash) UnmarshalBinary(b []byte) error {
++func (h *sha384Marshal) MarshalBinary() ([]byte, error) {
++	buf := make([]byte, 0, marshaledSize512)
++	return h.AppendBinary(buf)
++}
++
++func (h *sha512Marshal) MarshalBinary() ([]byte, error) {
++	buf := make([]byte, 0, marshaledSize512)
++	return h.AppendBinary(buf)
++}
++
++func (h *sha384Marshal) UnmarshalBinary(b []byte) error {
 +	if len(b) < len(magic512) {
 +		return errors.New("crypto/sha512: invalid hash state identifier")
 +	}
@@ -3563,7 +4086,7 @@ index 00000000000000..646b4ce295896c
 +	return nil
 +}
 +
-+func (h *sha512Hash) UnmarshalBinary(b []byte) error {
++func (h *sha512Marshal) UnmarshalBinary(b []byte) error {
 +	if len(b) < len(magic512) {
 +		return errors.New("crypto/sha512: invalid hash state identifier")
 +	}
@@ -3594,10 +4117,50 @@ index 00000000000000..646b4ce295896c
 +	return nil
 +}
 +
++func (h *sha384Marshal) AppendBinary(buf []byte) ([]byte, error) {
++	d := (*sha512State)(h.hashState())
++	if d == nil {
++		return nil, errors.New("crypto/sha512: can't retrieve hash state")
++	}
++	buf = append(buf, magic384...)
++	buf = appendUint64(buf, d.h[0])
++	buf = appendUint64(buf, d.h[1])
++	buf = appendUint64(buf, d.h[2])
++	buf = appendUint64(buf, d.h[3])
++	buf = appendUint64(buf, d.h[4])
++	buf = appendUint64(buf, d.h[5])
++	buf = appendUint64(buf, d.h[6])
++	buf = appendUint64(buf, d.h[7])
++	buf = append(buf, d.x[:d.nx]...)
++	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
++	buf = appendUint64(buf, d.nl>>3|d.nh<<61)
++	return buf, nil
++}
++
++func (h *sha512Marshal) AppendBinary(buf []byte) ([]byte, error) {
++	d := (*sha512State)(h.hashState())
++	if d == nil {
++		return nil, errors.New("crypto/sha512: can't retrieve hash state")
++	}
++	buf = append(buf, magic512...)
++	buf = appendUint64(buf, d.h[0])
++	buf = appendUint64(buf, d.h[1])
++	buf = appendUint64(buf, d.h[2])
++	buf = appendUint64(buf, d.h[3])
++	buf = appendUint64(buf, d.h[4])
++	buf = appendUint64(buf, d.h[5])
++	buf = appendUint64(buf, d.h[6])
++	buf = appendUint64(buf, d.h[7])
++	buf = append(buf, d.x[:d.nx]...)
++	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
++	buf = appendUint64(buf, d.nl>>3|d.nh<<61)
++	return buf, nil
++}
++
 +// NewSHA3_224 returns a new SHA3-224 hash.
 +func NewSHA3_224() hash.Hash {
 +	return &sha3_224Hash{
-+		evpHash: newEvpHash(crypto.SHA3_224, 224/8, 64),
++		evpHash: newEvpHash(crypto.SHA3_224),
 +	}
 +}
 +
@@ -3611,10 +4174,21 @@ index 00000000000000..646b4ce295896c
 +	return append(in, h.out[:]...)
 +}
 +
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *sha3_224Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &sha3_224Hash{evpHash: c}, nil
++}
++
 +// NewSHA3_256 returns a new SHA3-256 hash.
 +func NewSHA3_256() hash.Hash {
 +	return &sha3_256Hash{
-+		evpHash: newEvpHash(crypto.SHA3_256, 256/8, 64),
++		evpHash: newEvpHash(crypto.SHA3_256),
 +	}
 +}
 +
@@ -3628,10 +4202,21 @@ index 00000000000000..646b4ce295896c
 +	return append(in, h.out[:]...)
 +}
 +
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *sha3_256Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &sha3_256Hash{evpHash: c}, nil
++}
++
 +// NewSHA3_384 returns a new SHA3-384 hash.
 +func NewSHA3_384() hash.Hash {
 +	return &sha3_384Hash{
-+		evpHash: newEvpHash(crypto.SHA3_384, 384/8, 128),
++		evpHash: newEvpHash(crypto.SHA3_384),
 +	}
 +}
 +
@@ -3645,10 +4230,21 @@ index 00000000000000..646b4ce295896c
 +	return append(in, h.out[:]...)
 +}
 +
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *sha3_384Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &sha3_384Hash{evpHash: c}, nil
++}
++
 +// NewSHA3_512 returns a new SHA3-512 hash.
 +func NewSHA3_512() hash.Hash {
 +	return &sha3_512Hash{
-+		evpHash: newEvpHash(crypto.SHA3_512, 512/8, 128),
++		evpHash: newEvpHash(crypto.SHA3_512),
 +	}
 +}
 +
@@ -3660,6 +4256,17 @@ index 00000000000000..646b4ce295896c
 +func (h *sha3_512Hash) Sum(in []byte) []byte {
 +	h.sum(h.out[:])
 +	return append(in, h.out[:]...)
++}
++
++// Clone returns a new [hash.Hash] object that is a deep clone of itself.
++// The duplicate object contains all state and data contained in the
++// original object at the point of duplication.
++func (h *sha3_512Hash) Clone() (hash.Hash, error) {
++	c, err := h.clone()
++	if err != nil {
++		return nil, err
++	}
++	return &sha3_512Hash{evpHash: c}, nil
 +}
 +
 +// appendUint64 appends x into b as a big endian byte sequence.
@@ -3697,10 +4304,10 @@ index 00000000000000..646b4ce295896c
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
 new file mode 100644
-index 00000000000000..61cf483fed2cf4
+index 00000000000000..2e4323cc247a78
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
-@@ -0,0 +1,174 @@
+@@ -0,0 +1,190 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -3715,8 +4322,24 @@ index 00000000000000..61cf483fed2cf4
 +	"unsafe"
 +)
 +
++// SupprtHKDF reports whether the current OpenSSL version supports HKDF.
 +func SupportsHKDF() bool {
-+	return versionAtOrAbove(1, 1, 1)
++	switch vMajor {
++	case 1:
++		return versionAtOrAbove(1, 1, 1)
++	case 3:
++		// Some OpenSSL 3 providers don't support HKDF or don't support it via
++		// the EVP_PKEY API, which is the one we use.
++		// See https://github.com/golang-fips/openssl/issues/189.
++		ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_HKDF, nil)
++		if ctx == nil {
++			return false
++		}
++		C.go_openssl_EVP_PKEY_CTX_free(ctx)
++		return true
++	default:
++		panic(errUnsupportedVersion())
++	}
 +}
 +
 +func newHKDF(h func() hash.Hash, mode C.int) (*hkdf, error) {
@@ -3877,10 +4500,10 @@ index 00000000000000..61cf483fed2cf4
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hmac.go b/src/vendor/github.com/golang-fips/openssl/v2/hmac.go
 new file mode 100644
-index 00000000000000..ef8116ce666bd6
+index 00000000000000..02d0d3732b9b61
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hmac.go
-@@ -0,0 +1,238 @@
+@@ -0,0 +1,276 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -3894,12 +4517,7 @@ index 00000000000000..ef8116ce666bd6
 +	"unsafe"
 +)
 +
-+var paramDigest = C.CString("digest")
-+
-+var (
-+	fetchHMACOnce sync.Once
-+	evpHMAC       C.GO_EVP_MAC_PTR
-+)
++var OSSL_MAC_PARAM_DIGEST = C.CString("digest")
 +
 +// NewHMAC returns a new HMAC using OpenSSL.
 +// The function h must return a hash implemented by
@@ -3921,14 +4539,29 @@ index 00000000000000..ef8116ce666bd6
 +		key = make([]byte, C.GO_EVP_MAX_MD_SIZE)
 +	}
 +
++	hmac := &opensslHMAC{
++		size:      ch.Size(),
++		blockSize: ch.BlockSize(),
++	}
++
 +	switch vMajor {
 +	case 1:
-+		return newHMAC1(key, ch, md)
++		ctx := newHMAC1(key, md)
++		if ctx.ctx == nil {
++			return nil
++		}
++		hmac.ctx1 = ctx
 +	case 3:
-+		return newHMAC3(key, ch, md)
++		ctx := newHMAC3(key, md)
++		if ctx.ctx == nil {
++			return nil
++		}
++		hmac.ctx3 = ctx
 +	default:
 +		panic(errUnsupportedVersion())
 +	}
++	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
++	return hmac
 +}
 +
 +// hmacCtx3 is used for OpenSSL 1.
@@ -3950,7 +4583,7 @@ index 00000000000000..ef8116ce666bd6
 +	sum       []byte
 +}
 +
-+func newHMAC1(key []byte, h hash.Hash, md C.GO_EVP_MD_PTR) *opensslHMAC {
++func newHMAC1(key []byte, md C.GO_EVP_MD_PTR) hmacCtx1 {
 +	ctx := hmacCtxNew()
 +	if ctx == nil {
 +		panic("openssl: EVP_MAC_CTX_new failed")
@@ -3958,42 +4591,76 @@ index 00000000000000..ef8116ce666bd6
 +	if C.go_openssl_HMAC_Init_ex(ctx, unsafe.Pointer(&key[0]), C.int(len(key)), md, nil) == 0 {
 +		panic(newOpenSSLError("HMAC_Init_ex failed"))
 +	}
-+	hmac := &opensslHMAC{
-+		size:      h.Size(),
-+		blockSize: h.BlockSize(),
-+		ctx1:      hmacCtx1{ctx},
-+	}
-+	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
-+	return hmac
++	return hmacCtx1{ctx}
 +}
 +
-+func newHMAC3(key []byte, h hash.Hash, md C.GO_EVP_MD_PTR) *opensslHMAC {
-+	fetchHMACOnce.Do(func() {
-+		name := C.CString("HMAC")
-+		evpHMAC = C.go_openssl_EVP_MAC_fetch(nil, name, nil)
-+		C.free(unsafe.Pointer(name))
-+	})
-+	if evpHMAC == nil {
++var hmacDigestsSupported sync.Map
++var fetchHMAC3 = sync.OnceValue(func() C.GO_EVP_MAC_PTR {
++	name := C.CString("HMAC")
++	mac := C.go_openssl_EVP_MAC_fetch(nil, name, nil)
++	C.free(unsafe.Pointer(name))
++	if mac == nil {
 +		panic("openssl: HMAC not supported")
 +	}
-+	ctx := C.go_openssl_EVP_MAC_CTX_new(evpHMAC)
-+	if ctx == nil {
-+		panic("openssl: EVP_MAC_CTX_new failed")
-+	}
-+	digest := C.go_openssl_EVP_MD_get0_name(md)
++	return mac
++})
++
++func buildHMAC3Params(digest *C.char) C.GO_OSSL_PARAM_PTR {
 +	bld := C.go_openssl_OSSL_PARAM_BLD_new()
 +	if bld == nil {
 +		panic(newOpenSSLError("OSSL_PARAM_BLD_new"))
 +	}
 +	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-+	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, paramDigest, digest, 0)
-+	params := C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
++	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_MAC_PARAM_DIGEST, digest, 0)
++	return C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
++}
++
++func isHMAC3DigestSupported(digest string) bool {
++	if v, ok := hmacDigestsSupported.Load(digest); ok {
++		return v.(bool)
++	}
++	ctx := C.go_openssl_EVP_MAC_CTX_new(fetchHMAC3())
++	if ctx == nil {
++		panic(newOpenSSLError("EVP_MAC_CTX_new"))
++	}
++	defer C.go_openssl_EVP_MAC_CTX_free(ctx)
++
++	cdigest := C.CString(digest)
++	defer C.free(unsafe.Pointer(cdigest))
++	params := buildHMAC3Params(cdigest)
 +	if params == nil {
 +		panic(newOpenSSLError("OSSL_PARAM_BLD_to_param"))
 +	}
 +	defer C.go_openssl_OSSL_PARAM_free(params)
++
++	supported := C.go_openssl_EVP_MAC_CTX_set_params(ctx, params) != 0
++	hmacDigestsSupported.Store(digest, supported)
++	return supported
++}
++
++func newHMAC3(key []byte, md C.GO_EVP_MD_PTR) hmacCtx3 {
++	digest := C.go_openssl_EVP_MD_get0_name(md)
++	if !isHMAC3DigestSupported(C.GoString(digest)) {
++		// The digest is not supported by the HMAC provider.
++		// Don't panic here so the Go standard library to
++		// fall back to the Go implementation.
++		// See https://github.com/golang-fips/openssl/issues/153.
++		return hmacCtx3{}
++	}
++	params := buildHMAC3Params(digest)
++	if params == nil {
++		panic(newOpenSSLError("OSSL_PARAM_BLD_to_param"))
++	}
++	defer C.go_openssl_OSSL_PARAM_free(params)
++
++	ctx := C.go_openssl_EVP_MAC_CTX_new(fetchHMAC3())
++	if ctx == nil {
++		panic(newOpenSSLError("EVP_MAC_CTX_new"))
++	}
++
 +	if C.go_openssl_EVP_MAC_init(ctx, base(key), C.size_t(len(key)), params) == 0 {
-+		panic(newOpenSSLError("EVP_MAC_init failed"))
++		C.go_openssl_EVP_MAC_CTX_free(ctx)
++		panic(newOpenSSLError("EVP_MAC_init"))
 +	}
 +	var hkey []byte
 +	if vMinor == 0 && vPatch <= 2 {
@@ -4005,13 +4672,7 @@ index 00000000000000..ef8116ce666bd6
 +		hkey = make([]byte, len(key))
 +		copy(hkey, key)
 +	}
-+	hmac := &opensslHMAC{
-+		size:      h.Size(),
-+		blockSize: h.BlockSize(),
-+		ctx3:      hmacCtx3{ctx, hkey},
-+	}
-+	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
-+	return hmac
++	return hmacCtx3{ctx, hkey}
 +}
 +
 +func (h *opensslHMAC) Reset() {
@@ -4270,10 +4931,10 @@ index 00000000000000..3778e21227abb9
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/openssl.go b/src/vendor/github.com/golang-fips/openssl/v2/openssl.go
 new file mode 100644
-index 00000000000000..691bb16f728c9d
+index 00000000000000..1562cee2685bc8
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/openssl.go
-@@ -0,0 +1,419 @@
+@@ -0,0 +1,434 @@
 +//go:build !cmd_go_bootstrap
 +
 +// Package openssl provides access to OpenSSL cryptographic functions.
@@ -4353,6 +5014,13 @@ index 00000000000000..691bb16f728c9d
 +	return errors.New("openssl: OpenSSL version: " + utoa(vMajor) + "." + utoa(vMinor) + "." + utoa(vPatch))
 +}
 +
++// checkMajorVersion panics if the current major version is not expected.
++func checkMajorVersion(expected uint) {
++	if vMajor != expected {
++		panic("openssl: incorrect major version (" + strconv.Itoa(int(vMajor)) + "), expected " + strconv.Itoa(int(expected)))
++	}
++}
++
 +type fail string
 +
 +func (e fail) Error() string { return "openssl: " + string(e) + " failed" }
@@ -4385,6 +5053,14 @@ index 00000000000000..691bb16f728c9d
 +	default:
 +		panic(errUnsupportedVersion())
 +	}
++}
++
++// isProviderAvailable checks if the provider with the given name is available.
++// This function is used in export_test.go, but must be defined here as test files can't access C functions.
++func isProviderAvailable(name string) bool {
++	providerName := C.CString(name)
++	defer C.free(unsafe.Pointer(providerName))
++	return C.go_openssl_OSSL_PROVIDER_available(nil, providerName) == 1
 +}
 +
 +// SetFIPS enables or disables FIPS mode.
@@ -4566,7 +5242,7 @@ index 00000000000000..691bb16f728c9d
 +func (z BigInt) byteSwap() {
 +	for i, d := range z {
 +		var n uint = 0
-+		for j := 0; j < wordBytes; j++ {
++		for j := range wordBytes {
 +			n |= uint(byte(d)) << (8 * (wordBytes - j - 1))
 +			d >>= 8
 +		}
@@ -4668,7 +5344,7 @@ index 00000000000000..691bb16f728c9d
 +		if pad < 0 {
 +			return errors.New("openssl: destination buffer too small")
 +		}
-+		for i := 0; i < pad; i++ {
++		for i := range pad {
 +			to[i] = 0
 +		}
 +		if int(C.go_openssl_BN_bn2bin(bn, base(to[pad:]))) != n {
@@ -4727,6 +5403,98 @@ index 00000000000000..a895eab2d54767
 +	}
 +	return out, nil
 +}
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/port_dsa.c b/src/vendor/github.com/golang-fips/openssl/v2/port_dsa.c
+new file mode 100644
+index 00000000000000..5a948eafdbc6a7
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/port_dsa.c
+@@ -0,0 +1,85 @@
++// The following is a partial backport of crypto/dsa/dsa_lockl.h
++// and crypto/dsa/dsa_lib.c, commit cbc8a839959418d8a2c2e3ec6bdf394852c9501e
++// on the OpenSSL_1_1_0-stable branch. Only pqg and key getters/setters
++// are backported.
++
++#include "goopenssl.h"
++
++struct dsa_st
++{
++    int _ignored0;
++    long _ignored1;
++    int _ignored2;
++    GO_BIGNUM_PTR p;
++    GO_BIGNUM_PTR q;
++    GO_BIGNUM_PTR g;
++    GO_BIGNUM_PTR pub_key;
++    GO_BIGNUM_PTR priv_key;
++    // The following members are not used by our backport,
++    // so we don't define them here.
++};
++
++void go_openssl_DSA_get0_pqg_backport(const GO_DSA_PTR dsa,
++                  GO_BIGNUM_PTR *p, GO_BIGNUM_PTR *q, GO_BIGNUM_PTR *g)
++{
++    const struct dsa_st *d = dsa;
++    if (p != NULL)
++        *p = d->p;
++    if (q != NULL)
++        *q = d->q;
++    if (g != NULL)
++        *g = d->g;
++}
++
++int go_openssl_DSA_set0_pqg_backport(GO_DSA_PTR dsa,
++                  GO_BIGNUM_PTR p, GO_BIGNUM_PTR q, GO_BIGNUM_PTR g)
++{
++    struct dsa_st *d = dsa;
++    if ((d->p == NULL && p == NULL)
++        || (d->q == NULL && q == NULL)
++        || (d->g == NULL && g == NULL))
++        return 0;
++
++    if (p != NULL) {
++        go_openssl_BN_free(d->p);
++        d->p = p;
++    }
++    if (q != NULL) {
++        go_openssl_BN_free(d->q);
++        d->q = q;
++    }
++    if (g != NULL) {
++        go_openssl_BN_free(d->g);
++        d->g = g;
++    }
++
++    return 1;
++}
++
++void go_openssl_DSA_get0_key_backport(const GO_DSA_PTR dsa,
++                  GO_BIGNUM_PTR *pub_key, GO_BIGNUM_PTR *priv_key)
++{
++    const struct dsa_st *d = dsa;
++    if (pub_key != NULL)
++        *pub_key = d->pub_key;
++    if (priv_key != NULL)
++        *priv_key = d->priv_key;
++}
++
++int go_openssl_DSA_set0_key_backport(GO_DSA_PTR dsa, GO_BIGNUM_PTR pub_key, GO_BIGNUM_PTR priv_key)
++{
++    struct dsa_st *d = dsa;
++    if (d->pub_key == NULL && pub_key == NULL)
++        return 0;
++
++    if (pub_key != NULL) {
++        go_openssl_BN_free(d->pub_key);
++        d->pub_key = pub_key;
++    }
++    if (priv_key != NULL) {
++        go_openssl_BN_free(d->priv_key);
++        d->priv_key = priv_key;
++    }
++
++    return 1;
++}
+\ No newline at end of file
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/port_evp_md5_sha1.c b/src/vendor/github.com/golang-fips/openssl/v2/port_evp_md5_sha1.c
 new file mode 100644
 index 00000000000000..50d49b1f103351
@@ -4959,10 +5727,10 @@ index 00000000000000..f88150591eceb6
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rsa.go b/src/vendor/github.com/golang-fips/openssl/v2/rsa.go
 new file mode 100644
-index 00000000000000..f28d323adcbb3a
+index 00000000000000..4e45b02d88afc0
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/rsa.go
-@@ -0,0 +1,435 @@
+@@ -0,0 +1,443 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -4979,14 +5747,14 @@ index 00000000000000..f28d323adcbb3a
 +)
 +
 +var (
-+	paramRSA_N    = C.CString("n")
-+	paramRSA_E    = C.CString("e")
-+	paramRSA_D    = C.CString("d")
-+	paramRSA_P    = C.CString("rsa-factor1")
-+	paramRSA_Q    = C.CString("rsa-factor2")
-+	paramRSA_Dp   = C.CString("rsa-exponent1")
-+	paramRSA_Dq   = C.CString("rsa-exponent2")
-+	paramRSA_Qinv = C.CString("rsa-coefficient1")
++	OSSL_PKEY_PARAM_RSA_N            = C.CString("n")
++	OSSL_PKEY_PARAM_RSA_E            = C.CString("e")
++	OSSL_PKEY_PARAM_RSA_D            = C.CString("d")
++	OSSL_PKEY_PARAM_RSA_FACTOR1      = C.CString("rsa-factor1")
++	OSSL_PKEY_PARAM_RSA_FACTOR2      = C.CString("rsa-factor2")
++	OSSL_PKEY_PARAM_RSA_EXPONENT1    = C.CString("rsa-exponent1")
++	OSSL_PKEY_PARAM_RSA_EXPONENT2    = C.CString("rsa-exponent2")
++	OSSL_PKEY_PARAM_RSA_COEFFICIENT1 = C.CString("rsa-coefficient1")
 +)
 +
 +func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
@@ -5038,14 +5806,14 @@ index 00000000000000..f28d323adcbb3a
 +			C.go_openssl_BN_clear(tmp)
 +			return true
 +		}
-+		if !(setBigInt(&N, paramRSA_N) &&
-+			setBigInt(&E, paramRSA_E) &&
-+			setBigInt(&D, paramRSA_D) &&
-+			setBigInt(&P, paramRSA_P) &&
-+			setBigInt(&Q, paramRSA_Q) &&
-+			setBigInt(&Dp, paramRSA_Dp) &&
-+			setBigInt(&Dq, paramRSA_Dq) &&
-+			setBigInt(&Qinv, paramRSA_Qinv)) {
++		if !(setBigInt(&N, OSSL_PKEY_PARAM_RSA_N) &&
++			setBigInt(&E, OSSL_PKEY_PARAM_RSA_E) &&
++			setBigInt(&D, OSSL_PKEY_PARAM_RSA_D) &&
++			setBigInt(&P, OSSL_PKEY_PARAM_RSA_FACTOR1) &&
++			setBigInt(&Q, OSSL_PKEY_PARAM_RSA_FACTOR2) &&
++			setBigInt(&Dp, OSSL_PKEY_PARAM_RSA_EXPONENT1) &&
++			setBigInt(&Dq, OSSL_PKEY_PARAM_RSA_EXPONENT2) &&
++			setBigInt(&Qinv, OSSL_PKEY_PARAM_RSA_COEFFICIENT1)) {
 +			return bad(err)
 +		}
 +	default:
@@ -5059,7 +5827,7 @@ index 00000000000000..f28d323adcbb3a
 +	_pkey C.GO_EVP_PKEY_PTR
 +}
 +
-+func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) {
++func NewPublicKeyRSA(n, e BigInt) (*PublicKeyRSA, error) {
 +	var pkey C.GO_EVP_PKEY_PTR
 +	switch vMajor {
 +	case 1:
@@ -5067,7 +5835,7 @@ index 00000000000000..f28d323adcbb3a
 +		if key == nil {
 +			return nil, newOpenSSLError("RSA_new failed")
 +		}
-+		if !rsaSetKey(key, N, E, nil) {
++		if !rsaSetKey(key, n, e, nil) {
 +			return nil, fail("RSA_set0_key")
 +		}
 +		pkey = C.go_openssl_EVP_PKEY_new()
@@ -5082,7 +5850,7 @@ index 00000000000000..f28d323adcbb3a
 +		}
 +	case 3:
 +		var err error
-+		if pkey, err = newRSAKey3(false, N, E, nil, nil, nil, nil, nil, nil); err != nil {
++		if pkey, err = newRSAKey3(false, n, e, nil, nil, nil, nil, nil, nil); err != nil {
 +			return nil, err
 +		}
 +	default:
@@ -5110,7 +5878,7 @@ index 00000000000000..f28d323adcbb3a
 +	_pkey C.GO_EVP_PKEY_PTR
 +}
 +
-+func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv BigInt) (*PrivateKeyRSA, error) {
++func NewPrivateKeyRSA(n, e, d, p, q, dp, dq, qinv BigInt) (*PrivateKeyRSA, error) {
 +	var pkey C.GO_EVP_PKEY_PTR
 +	switch vMajor {
 +	case 1:
@@ -5118,16 +5886,16 @@ index 00000000000000..f28d323adcbb3a
 +		if key == nil {
 +			return nil, newOpenSSLError("RSA_new failed")
 +		}
-+		if !rsaSetKey(key, N, E, D) {
++		if !rsaSetKey(key, n, e, d) {
 +			return nil, fail("RSA_set0_key")
 +		}
-+		if P != nil && Q != nil {
-+			if !rsaSetFactors(key, P, Q) {
++		if p != nil && q != nil {
++			if !rsaSetFactors(key, p, q) {
 +				return nil, fail("RSA_set0_factors")
 +			}
 +		}
-+		if Dp != nil && Dq != nil && Qinv != nil {
-+			if !rsaSetCRTParams(key, Dp, Dq, Qinv) {
++		if dp != nil && dq != nil && qinv != nil {
++			if !rsaSetCRTParams(key, dp, dq, qinv) {
 +				return nil, fail("RSA_set0_crt_params")
 +			}
 +		}
@@ -5143,7 +5911,7 @@ index 00000000000000..f28d323adcbb3a
 +		}
 +	case 3:
 +		var err error
-+		if pkey, err = newRSAKey3(true, N, E, D, P, Q, Dp, Dq, Qinv); err != nil {
++		if pkey, err = newRSAKey3(true, n, e, d, p, q, dp, dq, qinv); err != nil {
 +			return nil, err
 +		}
 +	default:
@@ -5299,7 +6067,7 @@ index 00000000000000..f28d323adcbb3a
 +func rsaSetKey(key C.GO_RSA_PTR, n, e, d BigInt) bool {
 +	if vMajor == 1 && vMinor == 0 {
 +		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
-+		//r.d and d will be nil for public keys.
++		// r.d and d will be nil for public keys.
 +		if (r.n == nil && n == nil) ||
 +			(r.e == nil && e == nil) {
 +			return false
@@ -5341,8 +6109,7 @@ index 00000000000000..f28d323adcbb3a
 +	}
 +	return C.go_openssl_RSA_set0_crt_params(key, bigToBN(dmp1), bigToBN(dmq1), bigToBN(iqmp)) == 1
 +}
-+
-+func newRSAKey3(isPriv bool, N, E, D, P, Q, Dp, Dq, Qinv BigInt) (C.GO_EVP_PKEY_PTR, error) {
++func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (C.GO_EVP_PKEY_PTR, error) {
 +	// Construct the parameters.
 +	bld := C.go_openssl_OSSL_PARAM_BLD_new()
 +	if bld == nil {
@@ -5350,7 +6117,7 @@ index 00000000000000..f28d323adcbb3a
 +	}
 +	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
 +
-+	type bigIntParam struct{
++	type bigIntParam struct {
 +		name *C.char
 +		num  BigInt
 +	}
@@ -5358,19 +6125,28 @@ index 00000000000000..f28d323adcbb3a
 +	comps := make([]bigIntParam, 0, 8)
 +
 +	required := [...]bigIntParam{
-+		{paramRSA_N, N}, {paramRSA_E, E}, {paramRSA_D, D},
++		{OSSL_PKEY_PARAM_RSA_N, n}, {OSSL_PKEY_PARAM_RSA_E, e}, {OSSL_PKEY_PARAM_RSA_D, d},
 +	}
 +	comps = append(comps, required[:]...)
 +
-+	// OpenSSL 3.0 and 3.1 required all the precomputed values if
-+	// P and Q are present. See:
-+	// https://github.com/openssl/openssl/pull/22334
-+	if P != nil && Q != nil && Dp != nil && Dq != nil && Qinv != nil {
-+		precomputed := [...]bigIntParam{
-+			{paramRSA_P, P}, {paramRSA_Q, Q},
-+			{paramRSA_Dp, Dp}, {paramRSA_Dq, Dq}, {paramRSA_Qinv, Qinv},
++	if p != nil && q != nil {
++		allPrecomputedExists := dp != nil && dq != nil && qinv != nil
++		// The precomputed values should only be passed if P and Q are present
++		// and every precomputed value is present. (If any precomputed value is
++		// missing, don't pass any of them.)
++		//
++		// In OpenSSL 3.0 and 3.1, we must also omit P and Q if any precomputed
++		// value is missing. See https://github.com/openssl/openssl/pull/22334
++		if vMinor >= 2 || allPrecomputedExists {
++			comps = append(comps, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR1, p}, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR2, q})
 +		}
-+		comps = append(comps, precomputed[:]...)
++		if allPrecomputedExists {
++			comps = append(comps,
++				bigIntParam{OSSL_PKEY_PARAM_RSA_EXPONENT1, dp},
++				bigIntParam{OSSL_PKEY_PARAM_RSA_EXPONENT2, dq},
++				bigIntParam{OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv},
++			)
++		}
 +	}
 +
 +	for _, comp := range comps {
@@ -5400,10 +6176,10 @@ index 00000000000000..f28d323adcbb3a
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/shims.h b/src/vendor/github.com/golang-fips/openssl/v2/shims.h
 new file mode 100644
-index 00000000000000..99656f0cf20a36
+index 00000000000000..2370b6cc128f5e
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/shims.h
-@@ -0,0 +1,371 @@
+@@ -0,0 +1,392 @@
 +#include <stdlib.h> // size_t
 +#include <stdint.h> // uint64_t
 +
@@ -5425,9 +6201,10 @@ index 00000000000000..99656f0cf20a36
 +    GO_EVP_PKEY_TLS1_PRF = 1021,
 +    GO_EVP_PKEY_HKDF = 1036,
 +    GO_EVP_PKEY_ED25519 = 1087,
++    GO_EVP_PKEY_DSA = 116,
 +    /* This is defined differently in OpenSSL 3 (1 << 11), but in our
 +     * code it is only used in OpenSSL 1.
-+    */
++     */
 +    GO1_EVP_PKEY_OP_DERIVE = (1 << 10),
 +    GO_EVP_MAX_MD_SIZE = 64,
 +
@@ -5482,7 +6259,9 @@ index 00000000000000..99656f0cf20a36
 +    GO_EVP_PKEY_CTRL_RSA_KEYGEN_BITS = 0x1003,
 +    GO_EVP_PKEY_CTRL_RSA_MGF1_MD = 0x1005,
 +    GO_EVP_PKEY_CTRL_RSA_OAEP_MD = 0x1009,
-+    GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL = 0x100A
++    GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL = 0x100A,
++    GO_EVP_PKEY_CTRL_DSA_PARAMGEN_BITS = 0x1001,
++    GO_EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS = 0x1002
 +};
 +
 +typedef void* GO_OPENSSL_INIT_SETTINGS_PTR;
@@ -5508,6 +6287,7 @@ index 00000000000000..99656f0cf20a36
 +typedef void* GO_OSSL_PARAM_PTR;
 +typedef void* GO_CRYPTO_THREADID_PTR;
 +typedef void* GO_EVP_SIGNATURE_PTR;
++typedef void* GO_DSA_PTR;
 +
 +// #include <openssl/md5.h>
 +typedef void* GO_MD5_CTX_PTR;
@@ -5564,6 +6344,7 @@ index 00000000000000..99656f0cf20a36
 +// #include <openssl/ec.h>
 +// #include <openssl/rand.h>
 +// #include <openssl/evp.h>
++// #include <openssl/dsa.h>
 +// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 +// #include <openssl/provider.h>
 +// #include <openssl/param_build.h>
@@ -5596,13 +6377,17 @@ index 00000000000000..99656f0cf20a36
 +DEFINEFUNC_3_0(int, EVP_default_properties_enable_fips, (GO_OSSL_LIB_CTX_PTR libctx, int enable), (libctx, enable)) \
 +DEFINEFUNC_3_0(int, OSSL_PROVIDER_available, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 +DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
++DEFINEFUNC_3_0(const char *, OSSL_PROVIDER_get0_name, (const GO_OSSL_PROVIDER_PTR prov), (prov)) \
 +DEFINEFUNC_3_0(GO_EVP_MD_PTR, EVP_MD_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 +DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \
 +DEFINEFUNC_3_0(const char *, EVP_MD_get0_name, (const GO_EVP_MD_PTR md), (md)) \
++DEFINEFUNC_3_0(const GO_OSSL_PROVIDER_PTR, EVP_MD_get0_provider, (const GO_EVP_MD_PTR md), (md)) \
++DEFINEFUNC_RENAMED_3_0(int, EVP_MD_get_block_size, EVP_MD_block_size, (const GO_EVP_MD_PTR md), (md)) \
 +DEFINEFUNC(int, RAND_bytes, (unsigned char *arg0, int arg1), (arg0, arg1)) \
 +DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (void), ()) \
 +DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 +DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
++DEFINEFUNC(int, EVP_MD_CTX_copy_ex, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
 +DEFINEFUNC(int, EVP_Digest, (const void *data, size_t count, unsigned char *md, unsigned int *size, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (data, count, md, size, type, impl)) \
 +DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
 +DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \
@@ -5686,6 +6471,9 @@ index 00000000000000..99656f0cf20a36
 +DEFINEFUNC(int, EVP_PKEY_verify, (GO_EVP_PKEY_CTX_PTR ctx, const unsigned char *sig, size_t siglen, const unsigned char *tbs, size_t tbslen), (ctx, sig, siglen, tbs, tbslen)) \
 +DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new, (GO_EVP_PKEY_PTR arg0, GO_ENGINE_PTR arg1), (arg0, arg1)) \
 +DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new_id, (int id, GO_ENGINE_PTR e), (id, e)) \
++DEFINEFUNC_3_0(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new_from_pkey, (GO_OSSL_LIB_CTX_PTR libctx, GO_EVP_PKEY_PTR pkey, const char *propquery), (libctx, pkey, propquery)) \
++DEFINEFUNC(int, EVP_PKEY_paramgen_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
++DEFINEFUNC(int, EVP_PKEY_paramgen, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR *ppkey), (ctx, ppkey)) \
 +DEFINEFUNC(int, EVP_PKEY_keygen_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
 +DEFINEFUNC(int, EVP_PKEY_keygen, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR *ppkey), (ctx, ppkey)) \
 +DEFINEFUNC(void, EVP_PKEY_CTX_free, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
@@ -5702,6 +6490,7 @@ index 00000000000000..99656f0cf20a36
 +DEFINEFUNC(int, EVP_PKEY_derive, (GO_EVP_PKEY_CTX_PTR ctx, unsigned char *key, size_t *keylen), (ctx, key, keylen)) \
 +DEFINEFUNC_LEGACY_1_0(void*, EVP_PKEY_get0, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 +DEFINEFUNC_LEGACY_1_1(GO_EC_KEY_PTR, EVP_PKEY_get0_EC_KEY, (GO_EVP_PKEY_PTR pkey), (pkey)) \
++DEFINEFUNC_LEGACY_1_1(GO_DSA_PTR, EVP_PKEY_get0_DSA, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 +DEFINEFUNC_3_0(int, EVP_PKEY_fromdata_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
 +DEFINEFUNC_3_0(int, EVP_PKEY_fromdata, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR *pkey, int selection, GO_OSSL_PARAM_PTR params), (ctx, pkey, selection, params)) \
 +DEFINEFUNC_3_0(int, EVP_PKEY_set1_encoded_public_key, (GO_EVP_PKEY_PTR pkey, const unsigned char *pub, size_t publen), (pkey, pub, publen)) \
@@ -5746,6 +6535,7 @@ index 00000000000000..99656f0cf20a36
 +DEFINEFUNC(void, EC_GROUP_free, (GO_EC_GROUP_PTR group), (group)) \
 +DEFINEFUNC_3_0(GO_EVP_MAC_PTR, EVP_MAC_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 +DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_new, (GO_EVP_MAC_PTR arg0), (arg0)) \
++DEFINEFUNC_3_0(int, EVP_MAC_CTX_set_params, (GO_EVP_MAC_CTX_PTR ctx, const GO_OSSL_PARAM_PTR params), (ctx, params)) \
 +DEFINEFUNC_3_0(void, EVP_MAC_CTX_free, (GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
 +DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_dup, (const GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
 +DEFINEFUNC_3_0(int, EVP_MAC_init, (GO_EVP_MAC_CTX_PTR ctx, const unsigned char *key, size_t keylen, const GO_OSSL_PARAM_PTR params), (ctx, key, keylen, params)) \
@@ -5774,6 +6564,13 @@ index 00000000000000..99656f0cf20a36
 +DEFINEFUNC_1_1_1(int, EVP_PKEY_get_raw_private_key, (const GO_EVP_PKEY_PTR pkey, unsigned char *priv, size_t *len), (pkey, priv, len)) \
 +DEFINEFUNC_3_0(GO_EVP_SIGNATURE_PTR, EVP_SIGNATURE_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 +DEFINEFUNC_3_0(void, EVP_SIGNATURE_free, (GO_EVP_SIGNATURE_PTR signature), (signature)) \
++DEFINEFUNC_LEGACY_1(GO_DSA_PTR, DSA_new, (void), ()) \
++DEFINEFUNC_LEGACY_1(void, DSA_free, (GO_DSA_PTR r), (r)) \
++DEFINEFUNC_LEGACY_1(int, DSA_generate_key, (GO_DSA_PTR a), (a)) \
++DEFINEFUNC_LEGACY_1_1(void, DSA_get0_pqg, (const GO_DSA_PTR d, const GO_BIGNUM_PTR *p, const GO_BIGNUM_PTR *q, const GO_BIGNUM_PTR *g), (d, p, q, g)) \
++DEFINEFUNC_LEGACY_1_1(int, DSA_set0_pqg, (GO_DSA_PTR d, GO_BIGNUM_PTR p, GO_BIGNUM_PTR q, GO_BIGNUM_PTR g), (d, p, q, g)) \
++DEFINEFUNC_LEGACY_1_1(void, DSA_get0_key, (const GO_DSA_PTR d, const GO_BIGNUM_PTR *pub_key, const GO_BIGNUM_PTR *priv_key), (d, pub_key, priv_key)) \
++DEFINEFUNC_LEGACY_1_1(int, DSA_set0_key, (GO_DSA_PTR d, GO_BIGNUM_PTR pub_key, GO_BIGNUM_PTR priv_key), (d, pub_key, priv_key)) \
 +
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/thread_setup.go b/src/vendor/github.com/golang-fips/openssl/v2/thread_setup.go
 new file mode 100644
@@ -5807,10 +6604,10 @@ index 00000000000000..98d12f82a27c37
 +extern volatile unsigned int go_openssl_threads_cleaned_up;
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/thread_setup_unix.c b/src/vendor/github.com/golang-fips/openssl/v2/thread_setup_unix.c
 new file mode 100644
-index 00000000000000..53ea9d03d7d54c
+index 00000000000000..c837f9cb4dd7a3
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/thread_setup_unix.c
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,64 @@
 +//go:build unix
 +
 +#include "goopenssl.h"
@@ -5841,8 +6638,11 @@ index 00000000000000..53ea9d03d7d54c
 +    // per-thread error state, so this function is guaranteed to be executed at
 +    // least once on any thread with associated error state. The thread-local
 +    // variable needs to be set to a non-NULL value so that the destructor will
-+    // be called when the thread exits. The actual value does not matter.
-+    (void) pthread_setspecific(destructor_key, (void*)1);
++    // be called when the thread exits.
++    // The actual value does not matter, but should be a pointer with a valid size.
++    // See https://github.com/golang-fips/openssl/pull/162
++    static char stub;
++    (void) pthread_setspecific(destructor_key, &stub);
 +}
 +
 +static void cleanup_thread_state(void *ignored)
@@ -9485,12 +10285,12 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 7562f74b39ada6..95f7d5ee47b3c1 100644
+index 7562f74b39ada6..6e996fecefb628 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.3
-+## explicit; go 1.20
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072
++## explicit; go 1.22
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
 +# github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103


### PR DESCRIPTION
The `github.com/golang-fips/openssl/v2` module needs to be upgraded to get the following fixes and improvements:
- https://github.com/golang-fips/openssl/pull/169
- https://github.com/golang-fips/openssl/pull/170
- https://github.com/golang-fips/openssl/pull/135

I've upgraded to the latest commit instead of creating a new release. That module is going through a lot of development to get SymCrypt support and wouldn't make sense to create a release now.

Will help unblock #1285 and #1108.