### PR TITLE
Run GitHub codeql workflow only for eng/_utils

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@294a9d92911152fe08befb9ec03e240add280cb3 # v3.26.8
         with:
           languages: go
 
@@ -33,6 +33,6 @@ jobs:
           working-directory: eng/_util
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@294a9d92911152fe08befb9ec03e240add280cb3 # v3.26.8
         with:
           category: /language:go

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,13 +18,6 @@ jobs:
     permissions:
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language:
-          - 'cpp'
-          - 'go'
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,13 +25,14 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: ${{ matrix.language }}
-          build-mode: manual
+          languages: go
 
-      - run: pwsh eng/run.ps1 submodule-refresh -shallow
-      - run: pwsh eng/run.ps1 build
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+        with:
+          working-directory: eng/_util
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
-          category: /language:${{matrix.language}}
+          category: /language:go

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@294a9d92911152fe08befb9ec03e240add280cb3 # v3.26.8

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@294a9d92911152fe08befb9ec03e240add280cb3 # v3.26.8
         with:
           working-directory: eng/_util
 


### PR DESCRIPTION
`github/codeql-action` doesn't work well if the `go` binary is replaced during the build command, and that's exactly what happens when building the Go toolchain. See https://github.com/github/codeql/issues/17526 for more info.

This PR reduces the scope of the GitHub codeql workflow to only run for `eng/_utils` to avoid the issue. This folder contains all the code that is really not part of the Microsoft Go toolchain but is used to build the toolchain itself. The Go toolchain will still be analyzed when running the CI in Azure Pipelines, as 1ES is tightly integrated with CodeQL.

In fact, the GitHub CodeQL workflow was not doing that much. This is the report from its last successful run:

![image](https://github.com/user-attachments/assets/6e186ee5-2a24-4b62-9f1f-9525367ea7df)

It only analyzed 3 files from the thousands of files that take part in the Go toolchain compilation, and all of them where from `eng/_utils`.