### PR TITLE
[release-branch.go1.22] Update CNG backend to ms-go1.22-support b29b5cde7fdd

### DIFF
--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1097,26 +1097,26 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index b4d80d9215e9ef..3d65a947d22a9b 100644
+index b4d80d9215e9ef..878294b3ec7d76 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
  	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
++	github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
  	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
  	golang.org/x/net v0.19.1-0.20240412193750-db050b07227e
  )
 diff --git a/src/go.sum b/src/go.sum
-index 1c33d55236f035..cf76c92e3de793 100644
+index 1c33d55236f035..bde9f93c810156 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c h1:qieSrBDSfZmyVe+ThvHkwrJpROCielrlEa9g8B3Fpek=
  github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103 h1:KQsPPal3pKvKzAPTaR7sEriaqrHmRWw0dWG/7E5FNNk=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd h1:2ziav5Bdjyv0VYCCftEExmA+QQZ193w8BvSgoEZ+qAY=
++github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
  golang.org/x/net v0.19.1-0.20240412193750-db050b07227e h1:oDnvqaqHo3ho8OChMtkQbQAyp9eqnm3J7JRtt0+Cabc=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -6586,7 +6586,7 @@ index 00000000000000..844c087287cabe
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/des.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/des.go
 new file mode 100644
-index 00000000000000..2172f03e860418
+index 00000000000000..b0784affba0aa4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/des.go
 @@ -0,0 +1,107 @@
@@ -6615,7 +6615,7 @@ index 00000000000000..2172f03e860418
 +}
 +
 +func NewDESCipher(key []byte) (cipher.Block, error) {
-+	kh, err := newCipherHandle(bcrypt.DES_ALGORITHM, "", key)
++	kh, err := newCipherHandle(bcrypt.DES_ALGORITHM, bcrypt.CHAIN_MODE_ECB, key)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -6626,7 +6626,7 @@ index 00000000000000..2172f03e860418
 +}
 +
 +func NewTripleDESCipher(key []byte) (cipher.Block, error) {
-+	kh, err := newCipherHandle(bcrypt.DES3_ALGORITHM, "", key)
++	kh, err := newCipherHandle(bcrypt.DES3_ALGORITHM, bcrypt.CHAIN_MODE_ECB, key)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -9324,7 +9324,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 9a234e59b10c8c..02d2c809a26f73 100644
+index 9a234e59b10c8c..88b9a1ee44c25f 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
@@ -9332,7 +9332,7 @@ index 9a234e59b10c8c..02d2c809a26f73 100644
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
++# github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
* Get https://github.com/microsoft/go-crypto-winnative/pull/59