### PR TITLE
[release-branch.go1.23] Update CNG backend to ms-go1.22-support b29b5cde7fdd

### DIFF
--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1123,26 +1123,26 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 14ced0e416fde8..b2e1fa24bcda18 100644
+index 14ced0e416fde8..41ff48ef919672 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.23
  
  require (
  	github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
++	github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
  	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
  	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
  )
 diff --git a/src/go.sum b/src/go.sum
-index 9fad90e123a9f6..6bd576f5fbb07e 100644
+index 9fad90e123a9f6..acdcbd6cd5bcb2 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95 h1:e+JGYwsNT8K58Z9JysRNadrPzxNlGf+0wQXcdlHiv5M=
  github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103 h1:KQsPPal3pKvKzAPTaR7sEriaqrHmRWw0dWG/7E5FNNk=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd h1:2ziav5Bdjyv0VYCCftEExmA+QQZ193w8BvSgoEZ+qAY=
++github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
  golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c h1:CR/7/SLUhIJw6g675eeoDiwggElO2MV9rGkNYjqi8GM=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -6751,7 +6751,7 @@ index 00000000000000..844c087287cabe
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/des.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/des.go
 new file mode 100644
-index 00000000000000..2172f03e860418
+index 00000000000000..b0784affba0aa4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/des.go
 @@ -0,0 +1,107 @@
@@ -6780,7 +6780,7 @@ index 00000000000000..2172f03e860418
 +}
 +
 +func NewDESCipher(key []byte) (cipher.Block, error) {
-+	kh, err := newCipherHandle(bcrypt.DES_ALGORITHM, "", key)
++	kh, err := newCipherHandle(bcrypt.DES_ALGORITHM, bcrypt.CHAIN_MODE_ECB, key)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -6791,7 +6791,7 @@ index 00000000000000..2172f03e860418
 +}
 +
 +func NewTripleDESCipher(key []byte) (cipher.Block, error) {
-+	kh, err := newCipherHandle(bcrypt.DES3_ALGORITHM, "", key)
++	kh, err := newCipherHandle(bcrypt.DES3_ALGORITHM, bcrypt.CHAIN_MODE_ECB, key)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -9489,7 +9489,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b8a0b84a282a32..69417c384eb8c0 100644
+index b8a0b84a282a32..3677388dc80929 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
@@ -9497,7 +9497,7 @@ index b8a0b84a282a32..69417c384eb8c0 100644
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20240109184443-a968e40d3103
++# github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
* Get https://github.com/microsoft/go-crypto-winnative/pull/59