### PR TITLE
Upgrade github.com/microsoft/go-crypto-winnative to fde8545

### DIFF
--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1019,7 +1019,7 @@ index 7a6455fefb4bed..ac91a5201b6581 100644
  
  require (
  	github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20240925150332-fdc07bead050
++	github.com/microsoft/go-crypto-winnative v0.0.0-20240927070024-fde854564ffb
  	golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0
  	golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd
  )
@@ -1030,8 +1030,8 @@ index b8e460e0a13c1c..19b381f6211587 100644
 @@ -1,5 +1,7 @@
  github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072 h1:MiLLfnjVDjuOST8SQ7XgeBpWMWPpVb8VKDhL5Uvco7Q=
  github.com/golang-fips/openssl/v2 v2.0.4-0.20240917142644-14fd57070072/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240925150332-fdc07bead050 h1:DYP8AiC/xuYDxOkvZQy9QVnFee4rBUCmzN54Iit5pkQ=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240925150332-fdc07bead050/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20240927070024-fde854564ffb h1:b8TGHZrQVCwpRzl9gFJLf3/1IgkdbEc7C8MBatQTgMA=
++github.com/microsoft/go-crypto-winnative v0.0.0-20240927070024-fde854564ffb/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
  golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0 h1:wxHbFWyu21uEPJJnYaSDaHSWbvnZ9gLSSOPwnEc3lLM=
  golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
  golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd h1:pHzwejE8Zkb94bG4nA+fUeskKPFp1HPldrhv62dabro=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -56,7 +56,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../microsoft/go-crypto-winnative/cng/keys.go |  220 ++++
  .../go-crypto-winnative/cng/pbkdf2.go         |   74 ++
  .../microsoft/go-crypto-winnative/cng/rand.go |   28 +
- .../microsoft/go-crypto-winnative/cng/rc4.go  |   61 +
+ .../microsoft/go-crypto-winnative/cng/rc4.go  |   65 +
  .../microsoft/go-crypto-winnative/cng/rsa.go  |  374 ++++++
  .../go-crypto-winnative/cng/tls1prf.go        |   92 ++
  .../internal/bcrypt/bcrypt_windows.go         |  359 ++++++
@@ -64,7 +64,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   11 +
- 59 files changed, 10418 insertions(+)
+ 59 files changed, 10422 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -7351,7 +7351,7 @@ index 00000000000000..36f0e0c6e278bc
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cipher.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cipher.go
 new file mode 100644
-index 00000000000000..61f5dc878d6c56
+index 00000000000000..b6f25a1a64794a
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/cipher.go
 @@ -0,0 +1,56 @@
@@ -7391,7 +7391,7 @@ index 00000000000000..61f5dc878d6c56
 +		return cipherAlgorithm{h, lengths}, nil
 +	})
 +	if err != nil {
-+		return cipherAlgorithm{}, nil
++		return cipherAlgorithm{}, err
 +	}
 +	return v.(cipherAlgorithm), nil
 +}
@@ -9480,10 +9480,10 @@ index 00000000000000..cdd845ab5bea98
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rc4.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rc4.go
 new file mode 100644
-index 00000000000000..e0d45070f26723
+index 00000000000000..f484a3e2211e04
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rc4.go
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,65 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -9533,6 +9533,10 @@ index 00000000000000..e0d45070f26723
 +	if c.kh == 0 || len(src) == 0 {
 +		return
 +	}
++	// rc4.Cipher.XORKeyStream throws an out of bounds panic if
++	// dst is smaller than src. Replicate the same behavior here.
++	_ = dst[len(src)-1]
++
 +	if subtle.InexactOverlap(dst[:len(src)], src) {
 +		panic("crypto/rc4: invalid buffer overlap")
 +	}
@@ -10883,7 +10887,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 7562f74b39ada6..d4e66e028cbf17 100644
+index 7562f74b39ada6..4a5212f108557c 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
@@ -10891,8 +10895,8 @@ index 7562f74b39ada6..d4e66e028cbf17 100644
 +## explicit; go 1.22
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20240925150332-fdc07bead050
-+## explicit; go 1.17
++# github.com/microsoft/go-crypto-winnative v0.0.0-20240927070024-fde854564ffb
++## explicit; go 1.22
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig
 +github.com/microsoft/go-crypto-winnative/internal/bcrypt


### PR DESCRIPTION
This PR upgrades go-crypto-winnative to [fde8545](https://github.com/microsoft/go-crypto-winnative/commit/fde854564ffbcb8f854f613a1b124e911a4537c8).

It pulls the following fixes into `main`:

* https://github.com/microsoft/go-crypto-winnative/pull/60
* https://github.com/microsoft/go-crypto-winnative/pull/62

This will help unblocking https://github.com/microsoft/go/pull/1289.