### PR TITLE
Support curve P-521 when TLS fipsonly mode is enabled

### DIFF
--- a/patches/0014-Support-curve-P-521-when-TLS-fipsonly-mode-is-enable.patch
+++ b/patches/0014-Support-curve-P-521-when-TLS-fipsonly-mode-is-enable.patch
@@ -10,14 +10,23 @@ Upstream follows the boringssl FIPS policy, which doesn't allow P-521.
 
 This change adds support for P-521 in TLS when fipsonly mode is enabled.
 ---
- src/crypto/tls/boring_test.go | 1 +
+ src/crypto/tls/boring_test.go | 3 ++-
  src/crypto/tls/defaults.go    | 3 ++-
- 2 files changed, 3 insertions(+), 1 deletion(-)
+ 2 files changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 3cdde9780352a4..7db181ab5b03a4 100644
+index 3cdde9780352a4..0682dfb162268c 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
+@@ -113,7 +113,7 @@ func isBoringCipherSuite(id uint16) bool {
+ 
+ func isBoringCurve(id CurveID) bool {
+ 	switch id {
+-	case CurveP256, CurveP384:
++	case CurveP256, CurveP384, CurveP521:
+ 		return true
+ 	}
+ 	return false
 @@ -137,6 +137,7 @@ func isBoringSignatureScheme(alg SignatureScheme) bool {
  		PKCS1WithSHA384,
  		ECDSAWithP384AndSHA384,

--- a/patches/0014-Support-curve-P-521-when-TLS-fipsonly-mode-is-enable.patch
+++ b/patches/0014-Support-curve-P-521-when-TLS-fipsonly-mode-is-enable.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: qmuntal <qmuntaldiaz@microsoft.com>
+Date: Mon, 30 Sep 2024 14:41:28 +0200
+Subject: [PATCH] Support curve P-521 when TLS fipsonly mode is enabled
+
+We have historically supported P-521 in TLS when fipsonly mode is
+enabled, as this aligns with CNG, OpenSSL and SymCrypt FIPs policies.
+
+Upstream follows the boringssl FIPS policy, which doesn't allow P-521.
+
+This change adds support for P-521 in TLS when fipsonly mode is enabled.
+---
+ src/crypto/tls/boring_test.go | 1 +
+ src/crypto/tls/defaults.go    | 3 ++-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
+index 3cdde9780352a4..7db181ab5b03a4 100644
+--- a/src/crypto/tls/boring_test.go
++++ b/src/crypto/tls/boring_test.go
+@@ -137,6 +137,7 @@ func isBoringSignatureScheme(alg SignatureScheme) bool {
+ 		PKCS1WithSHA384,
+ 		ECDSAWithP384AndSHA384,
+ 		PKCS1WithSHA512,
++		ECDSAWithP521AndSHA512,
+ 		PSSWithSHA256,
+ 		PSSWithSHA384,
+ 		PSSWithSHA512:
+diff --git a/src/crypto/tls/defaults.go b/src/crypto/tls/defaults.go
+index ad4070df4a8883..26b6602b841209 100644
+--- a/src/crypto/tls/defaults.go
++++ b/src/crypto/tls/defaults.go
+@@ -99,7 +99,7 @@ var defaultSupportedVersionsFIPS = []uint16{
+ 
+ // defaultCurvePreferencesFIPS are the FIPS-allowed curves,
+ // in preference order (most preferable first).
+-var defaultCurvePreferencesFIPS = []CurveID{CurveP256, CurveP384}
++var defaultCurvePreferencesFIPS = []CurveID{CurveP256, CurveP384, CurveP521}
+ 
+ // defaultSupportedSignatureAlgorithmsFIPS currently are a subset of
+ // defaultSupportedSignatureAlgorithms without Ed25519 and SHA-1.
+@@ -112,6 +112,7 @@ var defaultSupportedSignatureAlgorithmsFIPS = []SignatureScheme{
+ 	PKCS1WithSHA384,
+ 	ECDSAWithP384AndSHA384,
+ 	PKCS1WithSHA512,
++	ECDSAWithP521AndSHA512,
+ }
+ 
+ // defaultCipherSuitesFIPS are the FIPS-allowed cipher suites.


### PR DESCRIPTION
(See https://github.com/microsoft/go/pull/1285#issuecomment-2379018260 for more context)

We have historically supported P-521 in TLS when fipsonly mode is enabled, as this aligns with CNG, OpenSSL and SymCrypt FIPs policies.

Upstream follows the boringssl FIPS policy, which doesn't allow P-521.

This change adds support for P-521 in TLS when fipsonly mode is enabled.