### PR TITLE
workflow: add automerge job to approve PRs from microsoft-golang-bot

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,25 @@
+name: Pull Request auto-merge
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    # Only run for the microsoft-golang-bot
+    if: github.actor == 'microsoft-golang-bot'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Approve pull request
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          
+      - name: Enable auto-merge for pull request
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
We're investigating switching to GitHub workflows to handle this so we can restrict the token permissions on our GitHub bots

linked to https://github.com/microsoft/go-infra/pull/183