### PR TITLE
Add Azure Linux 3 to CI pipelines

### DIFF
--- a/eng/pipeline/pr-outerloop-pipeline.yml
+++ b/eng/pipeline/pr-outerloop-pipeline.yml
@@ -24,6 +24,8 @@ resources:
       image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
     - container: mariner1arm64
       image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
+    - container: azurelinux3
+      image: golangpublicimages.azurecr.io/infra-images:azurelinux-3.0-amd64-default
 
 stages:
   - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/pr-outerloop-pipeline.yml
+++ b/eng/pipeline/pr-outerloop-pipeline.yml
@@ -25,7 +25,7 @@ resources:
     - container: mariner1arm64
       image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
     - container: azurelinux3
-      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024101937-2ca0565
+      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024144202-a3a1203
 
 stages:
   - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/pr-outerloop-pipeline.yml
+++ b/eng/pipeline/pr-outerloop-pipeline.yml
@@ -25,7 +25,7 @@ resources:
     - container: mariner1arm64
       image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
     - container: azurelinux3
-      image: golangpublicimages.azurecr.io/infra-images:azurelinux-3.0-amd64-default
+      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024101937-2ca0565
 
 stages:
   - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -21,6 +21,8 @@ resources:
       image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
     - container: mariner1arm64
       image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
+    - container: azurelinux3
+      image: golangpublicimages.azurecr.io/infra-images:azurelinux-3.0-amd64-default
 
 stages:
   - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -22,7 +22,7 @@ resources:
     - container: mariner1arm64
       image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
     - container: azurelinux3
-      image: golangpublicimages.azurecr.io/infra-images:azurelinux-3.0-amd64-default
+      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024101937-2ca0565
 
 stages:
   - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -22,7 +22,7 @@ resources:
     - container: mariner1arm64
       image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
     - container: azurelinux3
-      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024101937-2ca0565
+      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024144202-a3a1203
 
 stages:
   - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -45,7 +45,7 @@ extends:
       mariner1arm64:
         image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
       azurelinux3:
-        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024101937-2ca0565
+        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024144202-a3a1203
 
     stages:
       - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -44,6 +44,8 @@ extends:
         image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
       mariner1arm64:
         image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
+      azurelinux3:
+        image: golangpublicimages.azurecr.io/infra-images:azurelinux-3.0-amd64-default
 
     stages:
       - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -45,7 +45,7 @@ extends:
       mariner1arm64:
         image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
       azurelinux3:
-        image: golangpublicimages.azurecr.io/infra-images:azurelinux-3.0-amd64-default
+        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024101937-2ca0565
 
     stages:
       - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/rolling-pipeline.yml
+++ b/eng/pipeline/rolling-pipeline.yml
@@ -38,7 +38,7 @@ extends:
       mariner1arm64:
         image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
       azurelinux3:
-        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024101937-2ca0565
+        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024144202-a3a1203
 
     stages:
       - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/rolling-pipeline.yml
+++ b/eng/pipeline/rolling-pipeline.yml
@@ -38,7 +38,7 @@ extends:
       mariner1arm64:
         image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
       azurelinux3:
-        image: golangpublicimages.azurecr.io/infra-images:azurelinux-3.0-amd64-default
+        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024101937-2ca0565
 
     stages:
       - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/rolling-pipeline.yml
+++ b/eng/pipeline/rolling-pipeline.yml
@@ -37,6 +37,8 @@ extends:
         image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22
       mariner1arm64:
         image: golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148
+      azurelinux3:
+        image: golangpublicimages.azurecr.io/infra-images:azurelinux-3.0-amd64-default
 
     stages:
       - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -5,7 +5,7 @@
 # This template expands a list of builders into a list of jobs.
 
 parameters:
-  # [] of { id, os, arch, hostarch, config, distro?, experiment? }
+  # [] of { id, os, arch, hostarch, config, distro?, experiment?, flaky? }
   builders: []
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.
   sign: false

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -5,7 +5,7 @@
 # This template expands a list of builders into a list of jobs.
 
 parameters:
-  # [] of { id, os, arch, hostarch, config, distro?, experiment?, flaky? }
+  # [] of { id, os, arch, hostarch, config, distro?, experiment?, broken? }
   builders: []
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.
   sign: false

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -81,7 +81,7 @@ stages:
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, fips: true }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, flaky: true }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, broken: true }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: windows, arch: amd64, config: devscript }

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -81,7 +81,7 @@ stages:
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, fips: true }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, flaky: true }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: windows, arch: amd64, config: devscript }

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -81,6 +81,7 @@ stages:
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, fips: true }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: windows, arch: amd64, config: devscript }

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -77,6 +77,7 @@ stages:
           - { os: linux, arch: amd64, config: devscript }
           - { os: linux, arch: amd64, config: test }
           - { os: linux, arch: amd64, config: test, distro: ubuntu }
+          - { os: linux, arch: amd64, config: test, distro: azurelinux3 }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, fips: true }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -280,7 +280,8 @@ stages:
                 condition: and(ne(variables['TEST_BUILDER_SUCCESSFUL'], 'true'), succeeded())
                 ${{ if ne(attempt, 'FINAL') }}:
                   ignoreLASTEXITCODE: true
-                ${{ if eq(parameters.builder.broken, true) }}:
+                ${{ elseif eq(parameters.builder.broken, true) }}:
+                  # Don't fail the job if we are at the last retry and the builder is marked as broken.
                   continueOnError: true
 
           # - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -5,7 +5,7 @@
 # This job runs a builder for any OS.
 
 parameters:
-  # { id, os, arch, hostArch, config, distro?, experiment?, fips? }
+  # { id, os, arch, hostArch, config, distro?, experiment?, fips?, flaky? }
   - name: builder
     type: object
 
@@ -280,6 +280,8 @@ stages:
                 condition: and(ne(variables['TEST_BUILDER_SUCCESSFUL'], 'true'), succeeded())
                 ${{ if ne(attempt, 'FINAL') }}:
                   ignoreLASTEXITCODE: true
+                ${{ if eq(parameters.builder.flaky, true) }}:
+                  continueOnError: true
 
           # - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
           #   - ${{ if ne(parameters.releaseVersion, 'nil') }}:

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -5,7 +5,7 @@
 # This job runs a builder for any OS.
 
 parameters:
-  # { id, os, arch, hostArch, config, distro?, experiment?, fips?, flaky? }
+  # { id, os, arch, hostArch, config, distro?, experiment?, fips?, broken? }
   - name: builder
     type: object
 
@@ -280,7 +280,7 @@ stages:
                 condition: and(ne(variables['TEST_BUILDER_SUCCESSFUL'], 'true'), succeeded())
                 ${{ if ne(attempt, 'FINAL') }}:
                   ignoreLASTEXITCODE: true
-                ${{ if eq(parameters.builder.flaky, true) }}:
+                ${{ if eq(parameters.builder.broken, true) }}:
                   continueOnError: true
 
           # - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -71,6 +71,8 @@ stages:
             ${{ if eq(parameters.builder.hostArch, 'amd64') }}:
               ${{ if eq(parameters.builder.distro, 'ubuntu') }}:
                 container: ubuntu2204
+              ${{ elseif eq(parameters.builder.distro, 'azurelinux3') }}:
+                container: azurelinux3
               ${{ else }}:
                 container: mariner1
             ${{ elseif eq(parameters.builder.hostArch, 'arm64') }}:

--- a/eng/pipeline/stages/shorthand-builders-to-builders.yml
+++ b/eng/pipeline/stages/shorthand-builders-to-builders.yml
@@ -11,13 +11,13 @@
 # to be used by template expressions, as of writing.
 
 parameters:
-  # [] of { os, arch, hostArch, config, distro?, experiment? }
+  # [] of { os, arch, hostArch, config, distro?, experiment?, flaky? }
   # If hostArch is not defined, defaults to the arch value.
   # The job ID is generated based on these values.
   shorthandBuilders: []
   # The inner jobs template to pass the filed-out builders into.
   #
-  # It should accept parameter "builders", [] of { id, os, arch, hostArch, config, distro?, fips? }
+  # It should accept parameter "builders", [] of { id, os, arch, hostArch, config, distro?, fips?, flaky? }
   jobsTemplate: ""
   jobsParameters: {}
 

--- a/eng/pipeline/stages/shorthand-builders-to-builders.yml
+++ b/eng/pipeline/stages/shorthand-builders-to-builders.yml
@@ -11,13 +11,13 @@
 # to be used by template expressions, as of writing.
 
 parameters:
-  # [] of { os, arch, hostArch, config, distro?, experiment?, flaky? }
+  # [] of { os, arch, hostArch, config, distro?, experiment?, broken? }
   # If hostArch is not defined, defaults to the arch value.
   # The job ID is generated based on these values.
   shorthandBuilders: []
   # The inner jobs template to pass the filed-out builders into.
   #
-  # It should accept parameter "builders", [] of { id, os, arch, hostArch, config, distro?, fips?, flaky? }
+  # It should accept parameter "builders", [] of { id, os, arch, hostArch, config, distro?, fips?, broken? }
   jobsTemplate: ""
   jobsParameters: {}
 

--- a/eng/pipeline/stages/sign-stage.yml
+++ b/eng/pipeline/stages/sign-stage.yml
@@ -6,7 +6,7 @@
 # publishes the signed files and signatures into a consolidated pipeline artifact.
 
 parameters:
-  # [] of { id, os, arch, config, distro?, experiment? }
+  # [] of { id, os, arch, config, distro?, experiment?, flaky? }
   builders: []
 
 stages:

--- a/eng/pipeline/stages/sign-stage.yml
+++ b/eng/pipeline/stages/sign-stage.yml
@@ -6,7 +6,7 @@
 # publishes the signed files and signatures into a consolidated pipeline artifact.
 
 parameters:
-  # [] of { id, os, arch, config, distro?, experiment?, flaky? }
+  # [] of { id, os, arch, config, distro?, experiment?, broken? }
   builders: []
 
 stages:


### PR DESCRIPTION
This PR adds Azure Linux 3 (AZL3) to our CI test matrix.

AZL3 jobs are currently failing because we still haven't upgraded the OpenSSL backend to the latest version, which contains fixes for most of the issues. I'll do that in a follow-up PR.