### PR TITLE
Test mariner2 an azl3 in FIPS mode

### DIFF
--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -83,7 +83,9 @@ stages:
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, fips: true }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: mariner2 }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: mariner2, fips: true }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, broken: true }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips:true, broken: true }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: windows, arch: amd64, config: devscript }

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -85,7 +85,7 @@ stages:
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: mariner2 }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: mariner2, fips: true }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, broken: true }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips:true, broken: true }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true, broken: true }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: windows, arch: amd64, config: devscript }


### PR DESCRIPTION
We should be testing Mariner and Azure Linux 3 in FIPS mode.