### PR TITLE
Skip SHA test that require marshaling

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -27,7 +27,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/internal/backend/norequirefips.go |   9 +
  src/crypto/internal/backend/stub.s           |  10 +
  src/crypto/md5/md5.go                        |   7 +
- src/crypto/md5/md5_test.go                   |   4 +
+ src/crypto/md5/md5_test.go                   |  14 ++
  src/crypto/purego_test.go                    |   2 +-
  src/crypto/rand/rand.go                      |   2 +-
  src/crypto/rand/rand_test.go                 |   2 +-
@@ -40,11 +40,11 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/rsa/rsa.go                        |  21 +-
  src/crypto/rsa/rsa_test.go                   |   2 +-
  src/crypto/sha1/sha1.go                      |   2 +-
- src/crypto/sha1/sha1_test.go                 |   2 +-
+ src/crypto/sha1/sha1_test.go                 |  12 +-
  src/crypto/sha256/sha256.go                  |   6 +-
- src/crypto/sha256/sha256_test.go             |   2 +-
+ src/crypto/sha256/sha256_test.go             |  20 +-
  src/crypto/sha512/sha512.go                  |   2 +-
- src/crypto/sha512/sha512_test.go             |   2 +-
+ src/crypto/sha512/sha512_test.go             |  20 +-
  src/crypto/tls/boring_test.go                |   5 +
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/crypto/tls/handshake_client.go           |  25 ++-
@@ -56,7 +56,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/go/build/deps_test.go                    |   4 +
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 52 files changed, 802 insertions(+), 106 deletions(-)
+ 52 files changed, 858 insertions(+), 106 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -912,7 +912,7 @@ index c984c3f4968598..229dd457f8d53c 100644
  	d.Reset()
  	d.Write(data)
 diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
-index 6a8258a67e860c..3a973eebd284a4 100644
+index 6a8258a67e860c..63dfe196da7a58 100644
 --- a/src/crypto/md5/md5_test.go
 +++ b/src/crypto/md5/md5_test.go
 @@ -6,6 +6,7 @@ package md5
@@ -923,7 +923,19 @@ index 6a8258a67e860c..3a973eebd284a4 100644
  	"crypto/internal/cryptotest"
  	"crypto/rand"
  	"encoding"
-@@ -157,6 +158,9 @@ func TestLarge(t *testing.T) {
+@@ -88,6 +89,11 @@ func TestGolden(t *testing.T) {
+ }
+ 
+ func TestGoldenMarshal(t *testing.T) {
++	if boring.Enabled {
++		if _, ok := New().(encoding.BinaryMarshaler); !ok {
++			t.Skip("BinaryMarshaler not implemented")
++		}
++	}
+ 	for _, g := range golden {
+ 		h := New()
+ 		h2 := New()
+@@ -157,6 +163,9 @@ func TestLarge(t *testing.T) {
  
  // Tests that blockGeneric (pure Go) and block (in assembly for amd64, 386, arm) match.
  func TestBlockGeneric(t *testing.T) {
@@ -933,6 +945,18 @@ index 6a8258a67e860c..3a973eebd284a4 100644
  	gen, asm := New().(*digest), New().(*digest)
  	buf := make([]byte, BlockSize*20) // arbitrary factor
  	rand.Read(buf)
+@@ -204,6 +213,11 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+ }
+ 
+ func TestLargeHashes(t *testing.T) {
++	if boring.Enabled {
++		if _, ok := New().(encoding.BinaryUnmarshaler); !ok {
++			t.Skip("BinaryMarshaler not implemented")
++		}
++	}
+ 	for i, test := range largeUnmarshalTests {
+ 
+ 		h := New()
 diff --git a/src/crypto/purego_test.go b/src/crypto/purego_test.go
 index 62be347e0c6822..d284b5cf7814a6 100644
 --- a/src/crypto/purego_test.go
@@ -1255,7 +1279,7 @@ index 8189d1946d8ea5..8f5f7f27f26fea 100644
  	"hash"
  	"internal/byteorder"
 diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
-index d03892c57d4e61..d44f70b92661b4 100644
+index d03892c57d4e61..f848659c6e4aa3 100644
 --- a/src/crypto/sha1/sha1_test.go
 +++ b/src/crypto/sha1/sha1_test.go
 @@ -8,7 +8,7 @@ package sha1
@@ -1267,6 +1291,30 @@ index d03892c57d4e61..d44f70b92661b4 100644
  	"crypto/internal/cryptotest"
  	"crypto/rand"
  	"encoding"
+@@ -97,6 +97,11 @@ func TestGolden(t *testing.T) {
+ }
+ 
+ func TestGoldenMarshal(t *testing.T) {
++	if boring.Enabled {
++		if _, ok := New().(encoding.BinaryMarshaler); !ok {
++			t.Skip("BinaryMarshaler not implemented")
++		}
++	}
+ 	h := New()
+ 	h2 := New()
+ 	for _, g := range golden {
+@@ -210,6 +215,11 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+ }
+ 
+ func TestLargeHashes(t *testing.T) {
++	if boring.Enabled {
++		if _, ok := New().(encoding.BinaryMarshaler); !ok {
++			t.Skip("BinaryMarshaler not implemented")
++		}
++	}
+ 	for i, test := range largeUnmarshalTests {
+ 
+ 		h := New()
 diff --git a/src/crypto/sha256/sha256.go b/src/crypto/sha256/sha256.go
 index d87c689c9001ad..7584c380af0cec 100644
 --- a/src/crypto/sha256/sha256.go
@@ -1299,7 +1347,7 @@ index d87c689c9001ad..7584c380af0cec 100644
  	}
  	h := New224()
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index ffd16386515830..d2fa4369d068bf 100644
+index ffd16386515830..09f7046548bf8f 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -8,7 +8,7 @@ package sha256
@@ -1311,6 +1359,45 @@ index ffd16386515830..d2fa4369d068bf 100644
  	"crypto/internal/cryptotest"
  	"encoding"
  	"fmt"
+@@ -157,6 +157,11 @@ func testGoldenMarshal(t *testing.T) {
+ 
+ 	for _, tt := range tests {
+ 		t.Run(tt.name, func(t *testing.T) {
++			if boring.Enabled {
++				if _, ok := tt.newHash().(encoding.BinaryMarshaler); !ok {
++					t.Skip("BinaryMarshaler not implemented")
++				}
++			}
+ 			for _, g := range tt.gold {
+ 				h := tt.newHash()
+ 				h2 := tt.newHash()
+@@ -206,6 +211,14 @@ func TestMarshalTypeMismatch(t *testing.T) {
+ 	h1 := New()
+ 	h2 := New224()
+ 
++	if boring.Enabled {
++		_, ok1 := h1.(encoding.BinaryMarshaler)
++		_, ok2 := h2.(encoding.BinaryUnmarshaler)
++		if !ok1 || !ok2 {
++			t.Skip("BinaryMarshaler not implemented")
++		}
++	}
++
+ 	state1, err := h1.(encoding.BinaryMarshaler).MarshalBinary()
+ 	if err != nil {
+ 		t.Errorf("could not marshal: %v", err)
+@@ -277,6 +290,11 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+ 	return h.Sum(nil), nil
+ }
+ func TestLargeHashes(t *testing.T) {
++	if boring.Enabled {
++		if _, ok := New().(encoding.BinaryUnmarshaler); !ok {
++			t.Skip("BinaryMarshaler not implemented")
++		}
++	}
+ 	for i, test := range largeUnmarshalTests {
+ 
+ 		h := New()
 diff --git a/src/crypto/sha512/sha512.go b/src/crypto/sha512/sha512.go
 index 0a12fde7bc060b..ca752598e4343a 100644
 --- a/src/crypto/sha512/sha512.go
@@ -1325,7 +1412,7 @@ index 0a12fde7bc060b..ca752598e4343a 100644
  	"hash"
  )
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index fdad37b1863ae8..736504b8fc85a5 100644
+index fdad37b1863ae8..78fa1f60a542b5 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -8,7 +8,7 @@ package sha512
@@ -1337,6 +1424,45 @@ index fdad37b1863ae8..736504b8fc85a5 100644
  	"crypto/internal/cryptotest"
  	"encoding"
  	"encoding/hex"
+@@ -746,6 +746,11 @@ func testGoldenMarshal(t *testing.T) {
+ 	for _, tt := range tests {
+ 		t.Run(tt.name, func(t *testing.T) {
+ 			for _, test := range tt.golden {
++				if boring.Enabled {
++					if _, ok := tt.newHash().(encoding.BinaryMarshaler); !ok {
++						t.Skip("BinaryMarshaler not implemented")
++					}
++				}
+ 				h := tt.newHash()
+ 				h2 := tt.newHash()
+ 
+@@ -807,6 +812,14 @@ func TestMarshalMismatch(t *testing.T) {
+ 			h1 := fn1()
+ 			h2 := fn2()
+ 
++			if boring.Enabled {
++				_, ok1 := h1.(encoding.BinaryMarshaler)
++				_, ok2 := h2.(encoding.BinaryUnmarshaler)
++				if !ok1 || !ok2 {
++					t.Skip("BinaryMarshaler not implemented")
++				}
++			}
++
+ 			state, err := h1.(encoding.BinaryMarshaler).MarshalBinary()
+ 			if err != nil {
+ 				t.Errorf("i=%d: could not marshal: %v", i, err)
+@@ -882,6 +895,11 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+ }
+ 
+ func TestLargeHashes(t *testing.T) {
++	if boring.Enabled {
++		if _, ok := New().(encoding.BinaryUnmarshaler); !ok {
++			t.Skip("BinaryMarshaler not implemented")
++		}
++	}
+ 	for i, test := range largeUnmarshalTests {
+ 
+ 		h := New()
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
 index 56050421985927..dcbd33167e4499 100644
 --- a/src/crypto/tls/boring_test.go

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -951,7 +951,7 @@ index 6a8258a67e860c..63dfe196da7a58 100644
  func TestLargeHashes(t *testing.T) {
 +	if boring.Enabled {
 +		if _, ok := New().(encoding.BinaryUnmarshaler); !ok {
-+			t.Skip("BinaryMarshaler not implemented")
++			t.Skip("BinaryUnmarshaler not implemented")
 +		}
 +	}
  	for i, test := range largeUnmarshalTests {
@@ -1392,7 +1392,7 @@ index ffd16386515830..09f7046548bf8f 100644
  func TestLargeHashes(t *testing.T) {
 +	if boring.Enabled {
 +		if _, ok := New().(encoding.BinaryUnmarshaler); !ok {
-+			t.Skip("BinaryMarshaler not implemented")
++			t.Skip("BinaryUnmarshaler not implemented")
 +		}
 +	}
  	for i, test := range largeUnmarshalTests {
@@ -1457,7 +1457,7 @@ index fdad37b1863ae8..78fa1f60a542b5 100644
  func TestLargeHashes(t *testing.T) {
 +	if boring.Enabled {
 +		if _, ok := New().(encoding.BinaryUnmarshaler); !ok {
-+			t.Skip("BinaryMarshaler not implemented")
++			t.Skip("BinaryUnmarshaler not implemented")
 +		}
 +	}
  	for i, test := range largeUnmarshalTests {

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -1915,11 +1915,11 @@ index c6a2518f62ff3a..578b4d6f68504c 100644
  	< crypto/ed25519
 diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
 new file mode 100644
-index 00000000000000..cd07ee1c00d379
+index 00000000000000..c90899062a9665
 --- /dev/null
 +++ b/src/hash/boring_test.go
 @@ -0,0 +1,5 @@
-+//go:build systemcrypto
++//go:build goexperiment.boringcrypto
 +
 +package hash_test
 +
@@ -1942,11 +1942,11 @@ index 3091f7a67acede..fead8cc4bec73a 100644
  
 diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
 new file mode 100644
-index 00000000000000..e1874086d3f315
+index 00000000000000..79f8c22f2b7416
 --- /dev/null
 +++ b/src/hash/notboring_test.go
 @@ -0,0 +1,5 @@
-+//go:build !systemcrypto
++//go:build !goexperiment.boringcrypto
 +
 +package hash_test
 +

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -54,10 +54,12 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/prf_test.go                   |  12 +-
  src/crypto/x509/boring_test.go               |   5 +
  src/go/build/deps_test.go                    |   4 +
- src/hash/marshal_test.go                     |   3 +
+ src/hash/boring_test.go                      |   5 +
+ src/hash/marshal_test.go                     |   5 +
+ src/hash/notboring_test.go                   |   5 +
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 53 files changed, 861 insertions(+), 106 deletions(-)
+ 55 files changed, 873 insertions(+), 106 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -67,6 +69,8 @@ Subject: [PATCH] Add crypto backend foundation
  create mode 100644 src/crypto/internal/backend/nobackend.go
  create mode 100644 src/crypto/internal/backend/norequirefips.go
  create mode 100644 src/crypto/internal/backend/stub.s
+ create mode 100644 src/hash/boring_test.go
+ create mode 100644 src/hash/notboring_test.go
 
 diff --git a/src/crypto/aes/cipher.go b/src/crypto/aes/cipher.go
 index cde2e45d2ca559..cf47a4fc57d8e2 100644
@@ -1909,20 +1913,44 @@ index c6a2518f62ff3a..578b4d6f68504c 100644
  	< crypto/rand
  	< crypto/internal/mlkem768
  	< crypto/ed25519
+diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
+new file mode 100644
+index 00000000000000..cd07ee1c00d379
+--- /dev/null
++++ b/src/hash/boring_test.go
+@@ -0,0 +1,5 @@
++//go:build systemcrypto
++
++package hash_test
++
++const boringEnabled = true
 diff --git a/src/hash/marshal_test.go b/src/hash/marshal_test.go
-index 3091f7a67acede..b066f8281c5265 100644
+index 3091f7a67acede..fead8cc4bec73a 100644
 --- a/src/hash/marshal_test.go
 +++ b/src/hash/marshal_test.go
-@@ -65,6 +65,9 @@ func TestMarshalHash(t *testing.T) {
+@@ -65,6 +65,11 @@ func TestMarshalHash(t *testing.T) {
  			}
  
  			h := tt.new()
-+			if _, ok := h.(encoding.BinaryMarshaler); !ok {
-+				t.Skip("BinaryMarshaler not implemented")
++			if boringEnabled {
++				if _, ok := h.(encoding.BinaryMarshaler); !ok {
++					t.Skip("BinaryMarshaler not implemented")
++				}
 +			}
  			h.Write(buf[:256])
  			sum := h.Sum(nil)
  
+diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
+new file mode 100644
+index 00000000000000..e1874086d3f315
+--- /dev/null
++++ b/src/hash/notboring_test.go
+@@ -0,0 +1,5 @@
++//go:build !systemcrypto
++
++package hash_test
++
++const boringEnabled = false
 diff --git a/src/net/smtp/smtp_test.go b/src/net/smtp/smtp_test.go
 index 389eda9ad54b99..110d60beb0e70c 100644
 --- a/src/net/smtp/smtp_test.go

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -54,9 +54,10 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/prf_test.go                   |  12 +-
  src/crypto/x509/boring_test.go               |   5 +
  src/go/build/deps_test.go                    |   4 +
+ src/hash/marshal_test.go                     |   3 +
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 52 files changed, 858 insertions(+), 106 deletions(-)
+ 53 files changed, 861 insertions(+), 106 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -912,7 +913,7 @@ index c984c3f4968598..229dd457f8d53c 100644
  	d.Reset()
  	d.Write(data)
 diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
-index 6a8258a67e860c..63dfe196da7a58 100644
+index 6a8258a67e860c..61ea6b5153f617 100644
 --- a/src/crypto/md5/md5_test.go
 +++ b/src/crypto/md5/md5_test.go
 @@ -6,6 +6,7 @@ package md5
@@ -1347,7 +1348,7 @@ index d87c689c9001ad..7584c380af0cec 100644
  	}
  	h := New224()
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index ffd16386515830..09f7046548bf8f 100644
+index ffd16386515830..58632c01dc6a7f 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -8,7 +8,7 @@ package sha256
@@ -1412,7 +1413,7 @@ index 0a12fde7bc060b..ca752598e4343a 100644
  	"hash"
  )
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index fdad37b1863ae8..78fa1f60a542b5 100644
+index fdad37b1863ae8..cf6e4c395cd4fb 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -8,7 +8,7 @@ package sha512
@@ -1908,6 +1909,20 @@ index c6a2518f62ff3a..578b4d6f68504c 100644
  	< crypto/rand
  	< crypto/internal/mlkem768
  	< crypto/ed25519
+diff --git a/src/hash/marshal_test.go b/src/hash/marshal_test.go
+index 3091f7a67acede..b066f8281c5265 100644
+--- a/src/hash/marshal_test.go
++++ b/src/hash/marshal_test.go
+@@ -65,6 +65,9 @@ func TestMarshalHash(t *testing.T) {
+ 			}
+ 
+ 			h := tt.new()
++			if _, ok := h.(encoding.BinaryMarshaler); !ok {
++				t.Skip("BinaryMarshaler not implemented")
++			}
+ 			h.Write(buf[:256])
+ 			sum := h.Sum(nil)
+ 
 diff --git a/src/net/smtp/smtp_test.go b/src/net/smtp/smtp_test.go
 index 389eda9ad54b99..110d60beb0e70c 100644
 --- a/src/net/smtp/smtp_test.go

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -34,11 +34,13 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/go.sum                                    |   2 +
  src/go/build/deps_test.go                     |   7 +-
  src/go/build/vendor_test.go                   |   1 +
+ src/hash/boring_test.go                       |   2 +-
+ src/hash/notboring_test.go                    |   2 +-
  .../goexperiment/exp_opensslcrypto_off.go     |   9 +
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 34 files changed, 406 insertions(+), 23 deletions(-)
+ 36 files changed, 408 insertions(+), 25 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -714,7 +716,7 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index df27f25e789f05..3e9514234e7125 100644
+index df27f25e789f05..12d8c8f4f97321 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -726,7 +728,7 @@ index df27f25e789f05..3e9514234e7125 100644
  	golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd
  )
 diff --git a/src/go.sum b/src/go.sum
-index b4efd6d3c50c11..d159c7d47bac3b 100644
+index b4efd6d3c50c11..4c3ca847c21cd2 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
@@ -786,6 +788,26 @@ index 7f6237ffd59c11..7c821ae4bc5727 100644
  }
  
  // Verify that the vendor directories contain only packages matching the list above.
+diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
+index c90899062a9665..802c0f8b8987bf 100644
+--- a/src/hash/boring_test.go
++++ b/src/hash/boring_test.go
+@@ -1,4 +1,4 @@
+-//go:build goexperiment.boringcrypto
++//go:build goexperiment.boringcrypto || goexperiment.opensslcrypto
+ 
+ package hash_test
+ 
+diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
+index 79f8c22f2b7416..f3e8ed3e1cbf20 100644
+--- a/src/hash/notboring_test.go
++++ b/src/hash/notboring_test.go
+@@ -1,4 +1,4 @@
+-//go:build !goexperiment.boringcrypto
++//go:build !goexperiment.boringcrypto && !goexperiment.opensslcrypto
+ 
+ package hash_test
+ 
 diff --git a/src/internal/goexperiment/exp_opensslcrypto_off.go b/src/internal/goexperiment/exp_opensslcrypto_off.go
 new file mode 100644
 index 00000000000000..62033547c6143a

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -37,11 +37,10 @@ Subject: [PATCH] Add CNG crypto backend
  src/go/build/deps_test.go                     |   5 +
  src/go/build/vendor_test.go                   |   1 +
  src/hash/example_test.go                      |   2 +
- src/hash/marshal_test.go                      |   4 +
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 37 files changed, 394 insertions(+), 26 deletions(-)
+ 36 files changed, 390 insertions(+), 26 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -824,28 +823,6 @@ index f07b9aaa2c4898..2ff6c4827391c0 100644
  package hash_test
  
  import (
-diff --git a/src/hash/marshal_test.go b/src/hash/marshal_test.go
-index 3091f7a67acede..824be4a90fd4db 100644
---- a/src/hash/marshal_test.go
-+++ b/src/hash/marshal_test.go
-@@ -21,6 +21,7 @@ import (
- 	"hash/crc32"
- 	"hash/crc64"
- 	"hash/fnv"
-+	"internal/goexperiment"
- 	"testing"
- )
- 
-@@ -76,6 +77,9 @@ func TestMarshalHash(t *testing.T) {
- 			}
- 			h2m, ok := h2.(encoding.BinaryMarshaler)
- 			if !ok {
-+				if goexperiment.CNGCrypto {
-+					t.Skip("CNGCrypto does not hash marshaling")
-+				}
- 				t.Fatalf("Hash does not implement MarshalBinary")
- 			}
- 			enc, err := h2m.MarshalBinary()
 diff --git a/src/internal/goexperiment/exp_cngcrypto_off.go b/src/internal/goexperiment/exp_cngcrypto_off.go
 new file mode 100644
 index 00000000000000..831460053281e2

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -36,11 +36,13 @@ Subject: [PATCH] Add CNG crypto backend
  src/go.sum                                    |   2 +
  src/go/build/deps_test.go                     |   5 +
  src/go/build/vendor_test.go                   |   1 +
+ src/hash/boring_test.go                       |   2 +-
  src/hash/example_test.go                      |   2 +
+ src/hash/notboring_test.go                    |   2 +-
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 36 files changed, 390 insertions(+), 26 deletions(-)
+ 38 files changed, 392 insertions(+), 28 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -810,6 +812,16 @@ index 7c821ae4bc5727..1d0b9b20e9b1d4 100644
  }
  
  // Verify that the vendor directories contain only packages matching the list above.
+diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
+index 802c0f8b8987bf..99e1933f84b52c 100644
+--- a/src/hash/boring_test.go
++++ b/src/hash/boring_test.go
+@@ -1,4 +1,4 @@
+-//go:build goexperiment.boringcrypto || goexperiment.opensslcrypto
++//go:build goexperiment.boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
+ 
+ package hash_test
+ 
 diff --git a/src/hash/example_test.go b/src/hash/example_test.go
 index f07b9aaa2c4898..2ff6c4827391c0 100644
 --- a/src/hash/example_test.go
@@ -823,6 +835,16 @@ index f07b9aaa2c4898..2ff6c4827391c0 100644
  package hash_test
  
  import (
+diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
+index f3e8ed3e1cbf20..a85fc430cfa655 100644
+--- a/src/hash/notboring_test.go
++++ b/src/hash/notboring_test.go
+@@ -1,4 +1,4 @@
+-//go:build !goexperiment.boringcrypto && !goexperiment.opensslcrypto
++//go:build !goexperiment.boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
+ 
+ package hash_test
+ 
 diff --git a/src/internal/goexperiment/exp_cngcrypto_off.go b/src/internal/goexperiment/exp_cngcrypto_off.go
 new file mode 100644
 index 00000000000000..831460053281e2

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -17,16 +17,12 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/common.go         |  13 +-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
- src/crypto/md5/md5_test.go                    |   7 +
  src/crypto/rsa/boring.go                      |   2 +-
  src/crypto/rsa/boring_test.go                 |   2 +-
  src/crypto/rsa/notboring.go                   |   2 +-
  src/crypto/rsa/pss.go                         |   2 +-
  src/crypto/rsa/pss_test.go                    |   2 +-
  src/crypto/rsa/rsa_test.go                    |   8 +-
- src/crypto/sha1/sha1_test.go                  |   7 +
- src/crypto/sha256/sha256_test.go              |  10 +
- src/crypto/sha512/sha512_test.go              |  10 +
  src/crypto/tls/boring.go                      |   2 +-
  src/crypto/tls/boring_test.go                 |   2 +-
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
@@ -45,7 +41,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 41 files changed, 428 insertions(+), 26 deletions(-)
+ 37 files changed, 394 insertions(+), 26 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -526,38 +522,6 @@ index f5b4827c688f3b..12df96069f6b83 100644
  
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
  // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
-diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
-index 3a973eebd284a4..5e24e07e2787e2 100644
---- a/src/crypto/md5/md5_test.go
-+++ b/src/crypto/md5/md5_test.go
-@@ -12,6 +12,7 @@ import (
- 	"encoding"
- 	"fmt"
- 	"hash"
-+	"internal/goexperiment"
- 	"io"
- 	"testing"
- 	"unsafe"
-@@ -89,6 +90,9 @@ func TestGolden(t *testing.T) {
- }
- 
- func TestGoldenMarshal(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshalling")
-+	}
- 	for _, g := range golden {
- 		h := New()
- 		h2 := New()
-@@ -208,6 +212,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
- }
- 
- func TestLargeHashes(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshalling")
-+	}
- 	for i, test := range largeUnmarshalTests {
- 
- 		h := New()
 diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
 index 220f8c05c3d94b..dd20b4af2e0472 100644
 --- a/src/crypto/rsa/boring.go
@@ -656,122 +620,6 @@ index dbcc1bec58bd46..b1e9d8e94c2c9e 100644
  	msg := []byte("test")
  	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
  	if err == ErrMessageTooLong {
-diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
-index d44f70b92661b4..76726556f80fbd 100644
---- a/src/crypto/sha1/sha1_test.go
-+++ b/src/crypto/sha1/sha1_test.go
-@@ -14,6 +14,7 @@ import (
- 	"encoding"
- 	"fmt"
- 	"hash"
-+	"internal/goexperiment"
- 	"io"
- 	"testing"
- )
-@@ -97,6 +98,9 @@ func TestGolden(t *testing.T) {
- }
- 
- func TestGoldenMarshal(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshalling")
-+	}
- 	h := New()
- 	h2 := New()
- 	for _, g := range golden {
-@@ -210,6 +214,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
- }
- 
- func TestLargeHashes(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshalling")
-+	}
- 	for i, test := range largeUnmarshalTests {
- 
- 		h := New()
-diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index d2fa4369d068bf..027b705e96113f 100644
---- a/src/crypto/sha256/sha256_test.go
-+++ b/src/crypto/sha256/sha256_test.go
-@@ -13,6 +13,7 @@ import (
- 	"encoding"
- 	"fmt"
- 	"hash"
-+	"internal/goexperiment"
- 	"internal/testenv"
- 	"io"
- 	"testing"
-@@ -142,6 +143,9 @@ func testGolden(t *testing.T) {
- }
- 
- func TestGoldenMarshal(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshalling")
-+	}
- 	cryptotest.TestAllImplementations(t, "crypto/sha256", testGoldenMarshal)
- }
- 
-@@ -203,6 +207,9 @@ func testGoldenMarshal(t *testing.T) {
- }
- 
- func TestMarshalTypeMismatch(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshalling")
-+	}
- 	h1 := New()
- 	h2 := New224()
- 
-@@ -277,6 +284,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
- 	return h.Sum(nil), nil
- }
- func TestLargeHashes(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshalling")
-+	}
- 	for i, test := range largeUnmarshalTests {
- 
- 		h := New()
-diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index 736504b8fc85a5..582ed2ae870e23 100644
---- a/src/crypto/sha512/sha512_test.go
-+++ b/src/crypto/sha512/sha512_test.go
-@@ -14,6 +14,7 @@ import (
- 	"encoding/hex"
- 	"fmt"
- 	"hash"
-+	"internal/goexperiment"
- 	"internal/testenv"
- 	"io"
- 	"testing"
-@@ -726,6 +727,9 @@ func testGolden(t *testing.T) {
- }
- 
- func TestGoldenMarshal(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshalling")
-+	}
- 	cryptotest.TestAllImplementations(t, "crypto/sha512", func(t *testing.T) {
- 		testGoldenMarshal(t)
- 	})
-@@ -791,6 +795,9 @@ func testGoldenMarshal(t *testing.T) {
- }
- 
- func TestMarshalMismatch(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshaling")
-+	}
- 	h := []func() hash.Hash{
- 		New,
- 		New384,
-@@ -882,6 +889,9 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
- }
- 
- func TestLargeHashes(t *testing.T) {
-+	if goexperiment.CNGCrypto {
-+		t.Skip("CNGCrypto does not support hash marshalling")
-+	}
- 	for i, test := range largeUnmarshalTests {
- 
- 		h := New()
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
 index 698efc6751e12c..575d51b02298c8 100644
 --- a/src/crypto/tls/boring.go
@@ -905,7 +753,7 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 3e9514234e7125..611e053ec8c2a0 100644
+index 12d8c8f4f97321..39d84e4165d654 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.24
@@ -917,7 +765,7 @@ index 3e9514234e7125..611e053ec8c2a0 100644
  	golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd
  )
 diff --git a/src/go.sum b/src/go.sum
-index d159c7d47bac3b..e2ae52f398320a 100644
+index 4c3ca847c21cd2..116a769b257e34 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@


### PR DESCRIPTION
Some OpenSSL providers (looking at you SymCrypt) don't support marshaling the internal state of the hash function. There are some tests that require that functionality to succeed. We were previously skipping those tests when using the CNG backend, which doesn't implement digest marshaling. This PR generalizes the way we detect that a given digest doesn't support marshaling so it also works for OpenSSL.