### PR TITLE
Fix testKeyBasics and testEverything

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -38,7 +38,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/rsa/pkcs1v15_test.go              |   5 +
  src/crypto/rsa/pss.go                        |   8 +-
  src/crypto/rsa/rsa.go                        |  21 +-
- src/crypto/rsa/rsa_test.go                   |   2 +-
+ src/crypto/rsa/rsa_test.go                   |  12 +-
  src/crypto/sha1/sha1.go                      |   2 +-
  src/crypto/sha1/sha1_test.go                 |  12 +-
  src/crypto/sha256/sha256.go                  |   6 +-
@@ -56,7 +56,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/go/build/deps_test.go                    |   4 +
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 52 files changed, 858 insertions(+), 106 deletions(-)
+ 52 files changed, 868 insertions(+), 106 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -912,7 +912,7 @@ index c984c3f4968598..229dd457f8d53c 100644
  	d.Reset()
  	d.Write(data)
 diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
-index 6a8258a67e860c..63dfe196da7a58 100644
+index 6a8258a67e860c..61ea6b5153f617 100644
 --- a/src/crypto/md5/md5_test.go
 +++ b/src/crypto/md5/md5_test.go
 @@ -6,6 +6,7 @@ package md5
@@ -1253,7 +1253,7 @@ index 4d78d1eaaa6be0..a016c4f8362cf5 100644
  		if err != nil {
  			return nil, err
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 2afa045a3a0bd2..86466e67e87eeb 100644
+index 2afa045a3a0bd2..c6294694521c69 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -8,7 +8,7 @@ import (
@@ -1265,6 +1265,30 @@ index 2afa045a3a0bd2..86466e67e87eeb 100644
  	"crypto/rand"
  	. "crypto/rsa"
  	"crypto/sha1"
+@@ -113,6 +113,11 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
+ 	if priv.D.Cmp(priv.N) > 0 {
+ 		t.Errorf("private exponent too large")
+ 	}
++	if boring.Enabled && priv.N.BitLen() < 512 {
++		// Some crypto backends (e.g. CNG and OpenSSL with SymCrypt) don't support key sizes
++		// lower than 512 and intentionally fail rather than fall back to Go crypto.
++		t.Skip("skipping allocations test with BoringCrypto")
++	}
+ 
+ 	msg := []byte("hi!")
+ 	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
+@@ -187,6 +192,11 @@ func testEverything(t *testing.T, priv *PrivateKey) {
+ 	if err := priv.Validate(); err != nil {
+ 		t.Errorf("Validate() failed: %s", err)
+ 	}
++	if boring.Enabled && priv.N.BitLen() < 512 {
++		// Some crypto backends (e.g. CNG and OpenSSL with SymCrypt) don't support key sizes
++		// lower than 512 and intentionally fail rather than fall back to Go crypto.
++		t.Skip("skipping allocations test with BoringCrypto")
++	}
+ 
+ 	msg := []byte("test")
+ 	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
 diff --git a/src/crypto/sha1/sha1.go b/src/crypto/sha1/sha1.go
 index 8189d1946d8ea5..8f5f7f27f26fea 100644
 --- a/src/crypto/sha1/sha1.go
@@ -1347,7 +1371,7 @@ index d87c689c9001ad..7584c380af0cec 100644
  	}
  	h := New224()
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index ffd16386515830..09f7046548bf8f 100644
+index ffd16386515830..58632c01dc6a7f 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -8,7 +8,7 @@ package sha256
@@ -1412,7 +1436,7 @@ index 0a12fde7bc060b..ca752598e4343a 100644
  	"hash"
  )
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index fdad37b1863ae8..78fa1f60a542b5 100644
+index fdad37b1863ae8..cf6e4c395cd4fb 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -8,7 +8,7 @@ package sha512

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -22,7 +22,6 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/rsa/notboring.go                   |   2 +-
  src/crypto/rsa/pss.go                         |   2 +-
  src/crypto/rsa/pss_test.go                    |   2 +-
- src/crypto/rsa/rsa_test.go                    |   8 +-
  src/crypto/tls/boring.go                      |   2 +-
  src/crypto/tls/boring_test.go                 |   2 +-
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
@@ -41,7 +40,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 37 files changed, 394 insertions(+), 26 deletions(-)
+ 36 files changed, 387 insertions(+), 25 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -587,39 +586,6 @@ index 637d07e18cff2e..21435b86b52dad 100644
  	if err != nil {
  		t.Fatal(err)
  	}
-diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index dbcc1bec58bd46..b1e9d8e94c2c9e 100644
---- a/src/crypto/rsa/rsa_test.go
-+++ b/src/crypto/rsa/rsa_test.go
-@@ -17,6 +17,7 @@ import (
- 	"encoding/pem"
- 	"flag"
- 	"fmt"
-+	"internal/goexperiment"
- 	"internal/testenv"
- 	"math/big"
- 	"strings"
-@@ -113,6 +114,9 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
- 	if priv.D.Cmp(priv.N) > 0 {
- 		t.Errorf("private exponent too large")
- 	}
-+	if goexperiment.CNGCrypto && priv.N.BitLen() < 512 {
-+		t.Skip("CNGCrypto does not support key sizes lower than 512 and intentionally fails rather than fall back to Go crypto")
-+	}
- 
- 	msg := []byte("hi!")
- 	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
-@@ -187,7 +191,9 @@ func testEverything(t *testing.T, priv *PrivateKey) {
- 	if err := priv.Validate(); err != nil {
- 		t.Errorf("Validate() failed: %s", err)
- 	}
--
-+	if goexperiment.CNGCrypto && priv.N.BitLen() < 512 {
-+		t.Skip("CNGCrypto does not support key sizes lower than 512 and intentionally fails rather than fall back to Go crypto")
-+	}
- 	msg := []byte("test")
- 	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
- 	if err == ErrMessageTooLong {
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
 index 698efc6751e12c..575d51b02298c8 100644
 --- a/src/crypto/tls/boring.go


### PR DESCRIPTION
Some crypto backends (e.g. CNG and OpenSSL with SymCrypt) fail to create RSA keys that are smaller than 512 bits. Some tests use keys lower than 512 bits, so we have to skip them. We were previously doing so for the CNG backend. This PR conditionally skips the failing tests when using any backend.

We lose a bit of coverage, as the OpenSSL backend do support small keys when using the built-in providers. There is no easy way to know which key sizes are supported by a given OpenSSL provider, and our implementation doesn't depend on the key size, so I think is makes sense to just skip the test rather than trying to be too clever.

⚠️ Don't merge until #1384 has been merged. ⚠️