### PR TITLE
Support SymCrypt in TLS 1.3 handshakes

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -49,6 +49,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/crypto/tls/handshake_client.go           |  25 ++-
  src/crypto/tls/handshake_server.go           |  25 ++-
+ src/crypto/tls/handshake_server_tls13.go     |  10 +
  src/crypto/tls/key_schedule.go               |  18 +-
  src/crypto/tls/prf.go                        |  77 +++++---
  src/crypto/tls/prf_test.go                   |  12 +-
@@ -56,7 +57,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/go/build/deps_test.go                    |   4 +
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 52 files changed, 868 insertions(+), 106 deletions(-)
+ 53 files changed, 878 insertions(+), 106 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -1640,6 +1641,34 @@ index bc4e51ba364cf1..8b4fc36e49fdf8 100644
  	if _, err := hs.c.writeHandshakeRecord(finished, &hs.finishedHash); err != nil {
  		return err
  	}
+diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
+index b8cf4c3fa50b24..bc5d32a29c50c4 100644
+--- a/src/crypto/tls/handshake_server_tls13.go
++++ b/src/crypto/tls/handshake_server_tls13.go
+@@ -9,6 +9,7 @@ import (
+ 	"context"
+ 	"crypto"
+ 	"crypto/hmac"
++	boring "crypto/internal/backend"
+ 	"crypto/internal/mlkem768"
+ 	"crypto/rsa"
+ 	"errors"
+@@ -441,6 +442,15 @@ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
+ 	}
+ 	marshaler, ok := in.(binaryMarshaler)
+ 	if !ok {
++		if boring.Enabled {
++			// CNG and OpenSSL with SymCrypt hash functions do not implement the
++			// encoding.BinaryMarshaler interface, but they do implement the Clone method.
++			if cloner, ok := in.(interface{ Clone() (hash.Hash, error) }); ok {
++				if out, err := cloner.Clone(); err == nil {
++					return out
++				}
++			}
++		}
+ 		return nil
+ 	}
+ 	state, err := marshaler.MarshalBinary()
 diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
 index 1636baf79e7288..c9a5877d3d504f 100644
 --- a/src/crypto/tls/key_schedule.go

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -26,7 +26,6 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/tls/boring_test.go                 |   2 +-
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
  src/crypto/tls/fipsonly/fipsonly_test.go      |   2 +-
- src/crypto/tls/handshake_server_tls13.go      |  10 +
  src/crypto/tls/notboring.go                   |   2 +-
  src/crypto/x509/boring.go                     |   2 +-
  src/crypto/x509/boring_test.go                |   2 +-
@@ -40,7 +39,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 36 files changed, 387 insertions(+), 25 deletions(-)
+ 35 files changed, 377 insertions(+), 25 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -638,34 +637,6 @@ index 9c1d3d279c472f..0ca7a863b73690 100644
  
  package fipsonly
  
-diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index b8cf4c3fa50b24..dd2c36ab1bef0b 100644
---- a/src/crypto/tls/handshake_server_tls13.go
-+++ b/src/crypto/tls/handshake_server_tls13.go
-@@ -14,6 +14,7 @@ import (
- 	"errors"
- 	"hash"
- 	"internal/byteorder"
-+	"internal/goexperiment"
- 	"io"
- 	"slices"
- 	"time"
-@@ -441,6 +442,15 @@ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
- 	}
- 	marshaler, ok := in.(binaryMarshaler)
- 	if !ok {
-+		if goexperiment.CNGCrypto {
-+			// CNGCrypto hashes do not implement the binaryMarshaler interface,
-+			// but do implement the Clone method.
-+			if cloner, ok := in.(interface{ Clone() (hash.Hash, error) }); ok {
-+				if out, err := cloner.Clone(); err == nil {
-+					return out
-+				}
-+			}
-+		}
- 		return nil
- 	}
- 	state, err := marshaler.MarshalBinary()
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
 index 36b4ceab0046c6..c87df4ad695f1b 100644
 --- a/src/crypto/tls/notboring.go


### PR DESCRIPTION
TLS 1.3 handshakes use the `eencoding.BinaryMarshaler` interface to clone the hash. The SymCrypt provider for OpenSSL doesn't support that interface. Apply the same workaround as we were already doing for CNG.

⚠️ Don't merge until https://github.com/microsoft/go/pull/1385 has been merged. ⚠️