### PR TITLE
Support SymCrypt in crypto/rsa

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -21,9 +21,9 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/hmac/hmac_test.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go  |  30 +++
  src/crypto/internal/backend/bbig/big.go      |  17 ++
- src/crypto/internal/backend/common.go        |  92 +++++++++
+ src/crypto/internal/backend/common.go        |  99 +++++++++
  src/crypto/internal/backend/isrequirefips.go |   9 +
- src/crypto/internal/backend/nobackend.go     | 193 +++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go     | 201 +++++++++++++++++++
  src/crypto/internal/backend/norequirefips.go |   9 +
  src/crypto/internal/backend/stub.s           |  10 +
  src/crypto/md5/md5.go                        |   7 +
@@ -51,13 +51,13 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/handshake_server.go           |  25 ++-
  src/crypto/tls/handshake_server_tls13.go     |  10 +
  src/crypto/tls/key_schedule.go               |  18 +-
- src/crypto/tls/prf.go                        |  77 +++++---
+ src/crypto/tls/prf.go                        |  77 ++++---
  src/crypto/tls/prf_test.go                   |  12 +-
  src/crypto/x509/boring_test.go               |   5 +
  src/go/build/deps_test.go                    |   4 +
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 53 files changed, 878 insertions(+), 106 deletions(-)
+ 53 files changed, 893 insertions(+), 106 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -539,10 +539,10 @@ index 00000000000000..85bd3ed083f5b2
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..bc595e91024f11
+index 00000000000000..183aedbf668e83
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,99 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -550,8 +550,8 @@ index 00000000000000..bc595e91024f11
 +package backend
 +
 +import (
++	"crypto"
 +	"crypto/internal/boring/sig"
-+	"internal/goexperiment"
 +	"runtime"
 +	"syscall"
 +)
@@ -623,17 +623,24 @@ index 00000000000000..bc595e91024f11
 +	}
 +}
 +
-+func IsRSAKeySupported(primes int) bool {
-+	if goexperiment.BoringCrypto {
-+		return true
-+	}
-+	// CNG only supports 2-prime RSA keys.
-+	// The built-in OpenSSL 3 providers and OpenSSL 1 do support n-prime RSA keys,
-+	// but the SymCrypt provider for OpenSSL only supports 2-prime RSA keys.
-+	// Only 2-prime RSA keys are FIPS compliant, other n having compatibility
-+	// and security issues. Even crypto/rsa deprecated rsa.GenerateMultiPrimeKey as of Go 1.21.
-+	// Given the above reasons, we only support 2-prime RSA keys.
-+	return primes == 2
++// SupportsRSAPrimes reports whether the number of primes is supported for RSA keys.
++func SupportsRSAPrimes(primes int) bool {
++	return supportsRSAPrimes(primes)
++}
++
++// SupportsPKCS1v15Hash reports whether the hash function is supported for use in PKCS#1 v1.5 signatures.
++func SupportsPKCS1v15Hash(h crypto.Hash) bool {
++	return supportsPKCS1v15Hash(h)
++}
++
++// SupportsRSAHash reports whether the hash function is supported for use in RSA signatures and encryption.
++func SupportsRSAHash(h crypto.Hash) bool {
++	return supportsRSAHash(h)
++}
++
++// SupportsSalt reports whether the salt length is supported.
++func SupportsSalt(salt int) bool {
++	return supportsSalt(salt)
 +}
 diff --git a/src/crypto/internal/backend/isrequirefips.go b/src/crypto/internal/backend/isrequirefips.go
 new file mode 100644
@@ -652,10 +659,10 @@ index 00000000000000..e5d7570d6d4363
 +const isRequireFIPS = true
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..08600a2c833ac7
+index 00000000000000..75b60e6d4bf70c
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,193 @@
+@@ -0,0 +1,201 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -701,8 +708,8 @@ index 00000000000000..08600a2c833ac7
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { panic("cryptobackend: not available") }
 +
-+func NewAESCipher(key []byte) (cipher.Block, error) { panic("cryptobackend: not available") }
-+func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) { panic("cryptobackend: not available") }
++func NewAESCipher(key []byte) (cipher.Block, error)   { panic("cryptobackend: not available") }
++func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { panic("cryptobackend: not available") }
 +func NewGCMTLS13(c cipher.Block) (cipher.AEAD, error) { panic("cryptobackend: not available") }
 +
 +type PublicKeyECDSA struct{ _ int }
@@ -849,6 +856,14 @@ index 00000000000000..08600a2c833ac7
 +func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
 +	panic("cryptobackend: not available")
 +}
++
++func supportsRSAPrimes(primes int) bool { return false }
++
++func supportsPKCS1v15Hash(h crypto.Hash) bool { return false }
++
++func supportsRSAHash(h crypto.Hash) bool { return false }
++
++func supportsSalt(salt int) bool { return true }
 diff --git a/src/crypto/internal/backend/norequirefips.go b/src/crypto/internal/backend/norequirefips.go
 new file mode 100644
 index 00000000000000..26bfb5f6a643f3
@@ -1083,7 +1098,7 @@ index 2abc0436405f8a..34c22c8fbba7da 100644
  func boringPublicKey(*PublicKey) (*boring.PublicKeyRSA, error) {
  	panic("boringcrypto: not available")
 diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
-index 2f958022f98584..790d9cef5d3563 100644
+index 2f958022f98584..b5e9bb2b1f50d2 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
 @@ -7,7 +7,7 @@ package rsa
@@ -1100,7 +1115,7 @@ index 2f958022f98584..790d9cef5d3563 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.IsRSAKeySupported(len(priv.Primes)) {
++	if boring.Enabled && boring.SupportsRSAPrimes(len(priv.Primes)) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
@@ -1109,7 +1124,7 @@ index 2f958022f98584..790d9cef5d3563 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.IsRSAKeySupported(len(priv.Primes)) {
++	if boring.Enabled && boring.SupportsRSAPrimes(len(priv.Primes)) {
  		var bkey *boring.PrivateKeyRSA
  		bkey, err = boringPrivateKey(priv)
  		if err != nil {
@@ -1118,7 +1133,7 @@ index 2f958022f98584..790d9cef5d3563 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.IsRSAKeySupported(len(priv.Primes)) && (hash == 0 || boring.SupportsHash(hash)) {
++	if boring.Enabled && boring.SupportsRSAPrimes(len(priv.Primes)) && boring.SupportsPKCS1v15Hash(hash) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
@@ -1127,7 +1142,7 @@ index 2f958022f98584..790d9cef5d3563 100644
  // channels, or if an attacker has control of part of the inputs.
  func VerifyPKCS1v15(pub *PublicKey, hash crypto.Hash, hashed []byte, sig []byte) error {
 -	if boring.Enabled {
-+	if boring.Enabled && (hash == 0 || boring.SupportsHash(hash)) {
++	if boring.Enabled && boring.SupportsPKCS1v15Hash(hash) {
  		bkey, err := boringPublicKey(pub)
  		if err != nil {
  			return err
@@ -1155,7 +1170,7 @@ index dfa1eddc886ff3..849dafacf93d0f 100644
  	_, err := DecryptPKCS1v15(nil, rsaPrivateKey, ciphertext)
  	if err == nil {
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
-index 5716c464ca0a33..4aac87d7952081 100644
+index 5716c464ca0a33..c231073e3838cc 100644
 --- a/src/crypto/rsa/pss.go
 +++ b/src/crypto/rsa/pss.go
 @@ -9,7 +9,7 @@ package rsa
@@ -1172,7 +1187,7 @@ index 5716c464ca0a33..4aac87d7952081 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.IsRSAKeySupported(len(priv.Primes)) {
++	if boring.Enabled && boring.SupportsRSAPrimes(len(priv.Primes)) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
@@ -1181,7 +1196,7 @@ index 5716c464ca0a33..4aac87d7952081 100644
  	}
  
 -	if boring.Enabled && rand == boring.RandReader {
-+	if boring.Enabled && rand == boring.RandReader && boring.IsRSAKeySupported(len(priv.Primes)) && boring.SupportsHash(hash) {
++	if boring.Enabled && rand == boring.RandReader && boring.SupportsRSAPrimes(len(priv.Primes)) && boring.SupportsRSAHash(hash) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
@@ -1190,12 +1205,12 @@ index 5716c464ca0a33..4aac87d7952081 100644
  // channels, or if an attacker has control of part of the inputs.
  func VerifyPSS(pub *PublicKey, hash crypto.Hash, digest []byte, sig []byte, opts *PSSOptions) error {
 -	if boring.Enabled {
-+	if boring.Enabled && boring.SupportsHash(hash) {
++	if boring.Enabled && boring.SupportsSalt(opts.saltLength()) && boring.SupportsRSAHash(hash) {
  		bkey, err := boringPublicKey(pub)
  		if err != nil {
  			return err
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index 4d78d1eaaa6be0..a016c4f8362cf5 100644
+index 4d78d1eaaa6be0..a48e0543000c6c 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
 @@ -26,14 +26,15 @@ package rsa
@@ -1249,7 +1264,7 @@ index 4d78d1eaaa6be0..a016c4f8362cf5 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && hash == mgfHash && boring.IsRSAKeySupported(len(priv.Primes)) {
++	if boring.Enabled && hash == mgfHash && boring.SupportsRSAPrimes(len(priv.Primes)) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 +
- src/crypto/internal/backend/boring_linux.go   | 225 ++++++++++++++++++
- 2 files changed, 237 insertions(+)
+ src/crypto/internal/backend/boring_linux.go   | 241 ++++++++++++++++++
+ 2 files changed, 253 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
 
@@ -30,10 +30,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..7c5fbeea717618
+index 00000000000000..9923f5fd42d08e
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,225 @@
+@@ -0,0 +1,241 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -82,8 +82,8 @@ index 00000000000000..7c5fbeea717618
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return boring.NewHMAC(h, key) }
 +
-+func NewAESCipher(key []byte) (cipher.Block, error) { return boring.NewAESCipher(key) }
-+func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) { return boring.NewGCMTLS(c) }
++func NewAESCipher(key []byte) (cipher.Block, error)   { return boring.NewAESCipher(key) }
++func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return boring.NewGCMTLS(c) }
 +func NewGCMTLS13(c cipher.Block) (cipher.AEAD, error) { return boring.NewGCMTLS13(c) }
 +
 +type PublicKeyECDSA = boring.PublicKeyECDSA
@@ -258,4 +258,20 @@ index 00000000000000..7c5fbeea717618
 +
 +func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
 +	panic("cryptobackend: not available")
++}
++
++func supportsRSAPrimes(primes int) bool {
++	return true
++}
++
++func supportsPKCS1v15Hash(h crypto.Hash) bool {
++	return h == 0 || supportsRSAHash(h)
++}
++
++func supportsRSAHash(h crypto.Hash) bool {
++	return SupportsHash(h)
++}
++
++func supportsSalt(salt int) bool {
++	return true
 +}

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 323 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 358 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -38,7 +38,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 34 files changed, 406 insertions(+), 23 deletions(-)
+ 34 files changed, 441 insertions(+), 23 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -191,10 +191,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..69af0ffe2fcf80
+index 00000000000000..c57d4716a57f51
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,323 @@
+@@ -0,0 +1,358 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -518,6 +518,41 @@ index 00000000000000..69af0ffe2fcf80
 +func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
 +	return openssl.VerifyEd25519(pub, message, sig)
 +}
++
++func supportsRSAPrimes(primes int) bool {
++	// The built-in OpenSSL 3 providers and OpenSSL 1 do support n-prime RSA keys,
++	// but the SymCrypt provider for OpenSSL only supports 2-prime RSA keys.
++	// Only 2-prime RSA keys are FIPS compliant, other n having compatibility
++	// and security issues. Even crypto/rsa deprecated rsa.GenerateMultiPrimeKey as of Go 1.21.
++	// Given the above reasons, we only support 2-prime RSA keys.
++	return primes == 2
++}
++
++func supportsPKCS1v15Hash(h crypto.Hash) bool {
++	if h == 0 {
++		// The SymCrypt provider for OpenSSL does not support unpadded PKCS1v15 signatures,
++		// although the built-in OpenSSL providers do.
++		// Given that unpadded PKCS1v15 signatures are not widely used, do not support them.
++		return false
++	}
++	return supportsRSAHash(h)
++}
++
++func supportsRSAHash(h crypto.Hash) bool {
++	if !SupportsHash(h) {
++		return false
++	}
++	// The SymCrypt provider for OpenSSL only supports digest function provided by SymCrypt itself.
++	// It can happen that SupportsHash return true for a digest not provided by SymCrypt, but by another provider.
++	// The RSA operations will fail if that happens.
++	// To avoid this case we only support digest functions also supported by SymCrypt, which happens to be
++	// the most common ones.
++	return h == crypto.SHA1 || h == crypto.SHA256 || h == crypto.SHA384 || h == crypto.SHA512
++}
++
++func supportsSalt(salt int) bool {
++	return true
++}
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
 index f2e5a503eaacb6..1dc7116efdff2e 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
@@ -584,10 +619,10 @@ index 34c22c8fbba7da..933ac569e034a8 100644
  package rsa
  
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 86466e67e87eeb..dbcc1bec58bd46 100644
+index c6294694521c69..ab99b176ac9540 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
-@@ -690,6 +690,9 @@ func TestDecryptOAEP(t *testing.T) {
+@@ -700,6 +700,9 @@ func TestDecryptOAEP(t *testing.T) {
  }
  
  func Test2DecryptOAEP(t *testing.T) {
@@ -714,7 +749,7 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index df27f25e789f05..3e9514234e7125 100644
+index df27f25e789f05..12d8c8f4f97321 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -726,7 +761,7 @@ index df27f25e789f05..3e9514234e7125 100644
  	golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd
  )
 diff --git a/src/go.sum b/src/go.sum
-index b4efd6d3c50c11..d159c7d47bac3b 100644
+index b4efd6d3c50c11..4c3ca847c21cd2 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -14,7 +14,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 358 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 350 ++++++++++++++++++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
@@ -40,7 +40,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 36 files changed, 443 insertions(+), 25 deletions(-)
+ 36 files changed, 435 insertions(+), 25 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -193,10 +193,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..c57d4716a57f51
+index 00000000000000..38eadc5e93e115
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,358 @@
+@@ -0,0 +1,350 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -541,15 +541,7 @@ index 00000000000000..c57d4716a57f51
 +}
 +
 +func supportsRSAHash(h crypto.Hash) bool {
-+	if !SupportsHash(h) {
-+		return false
-+	}
-+	// The SymCrypt provider for OpenSSL only supports digest function provided by SymCrypt itself.
-+	// It can happen that SupportsHash return true for a digest not provided by SymCrypt, but by another provider.
-+	// The RSA operations will fail if that happens.
-+	// To avoid this case we only support digest functions also supported by SymCrypt, which happens to be
-+	// the most common ones.
-+	return h == crypto.SHA1 || h == crypto.SHA256 || h == crypto.SHA384 || h == crypto.SHA512
++	return SupportsHash(h)
 +}
 +
 +func supportsSalt(salt int) bool {

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -7,20 +7,19 @@ Subject: [PATCH] Add CNG crypto backend
  src/cmd/api/boring_test.go                    |   2 +-
  src/cmd/go/go_boring_test.go                  |   2 +-
  src/crypto/boring/boring.go                   |   2 +-
- src/crypto/ecdsa/badlinkname.go               |  17 ++
+ src/crypto/ecdsa/badlinkname.go               |  17 +
  src/crypto/ecdsa/boring.go                    |   2 +-
  src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 280 ++++++++++++++++++
- src/crypto/internal/backend/common.go         |  13 +-
+ src/crypto/internal/backend/cng_windows.go    | 300 ++++++++++++++++++
+ src/crypto/internal/backend/common.go         |   7 +-
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/boring.go                      |   2 +-
  src/crypto/rsa/boring_test.go                 |   2 +-
  src/crypto/rsa/notboring.go                   |   2 +-
- src/crypto/rsa/pss.go                         |   2 +-
  src/crypto/rsa/pss_test.go                    |   2 +-
  src/crypto/tls/boring.go                      |   2 +-
  src/crypto/tls/boring_test.go                 |   2 +-
@@ -39,7 +38,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 35 files changed, 377 insertions(+), 25 deletions(-)
+ 34 files changed, 390 insertions(+), 24 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -182,10 +181,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..3d3d13709de5ac
+index 00000000000000..53753b29b244be
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,280 @@
+@@ -0,0 +1,300 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -466,11 +465,39 @@ index 00000000000000..3d3d13709de5ac
 +func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
 +	panic("cryptobackend: not available")
 +}
++
++func supportsRSAPrimes(primes int) bool {
++	return primes == 2
++}
++
++func supportsPKCS1v15Hash(h crypto.Hash) bool {
++	if h == 0 {
++		// CNG does not support unpadded PKCS1v15 signatures.
++		return false
++	}
++	return supportsRSAHash(h)
++}
++
++func supportsRSAHash(h crypto.Hash) bool {
++	return SupportsHash(h)
++}
++
++func supportsSalt(salt int) bool {
++	return salt != 0 // rsa.PSSSaltLengthAuto
++}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
-index bc595e91024f11..7766d674f5cfaf 100644
+index 183aedbf668e83..1943cbd46ea4da 100644
 --- a/src/crypto/internal/backend/common.go
 +++ b/src/crypto/internal/backend/common.go
-@@ -68,7 +68,11 @@ func hasSuffix(s, t string) bool {
+@@ -7,6 +7,7 @@ package backend
+ import (
+ 	"crypto"
+ 	"crypto/internal/boring/sig"
++	"internal/goexperiment"
+ 	"runtime"
+ 	"syscall"
+ )
+@@ -68,7 +69,11 @@ func hasSuffix(s, t string) bool {
  // UnreachableExceptTests marks code that should be unreachable
  // when backend is in use. It panics.
  func UnreachableExceptTests() {
@@ -483,17 +510,6 @@ index bc595e91024f11..7766d674f5cfaf 100644
  		name := runtime_arg0()
  		// If ran on Windows we'd need to allow _test.exe and .test.exe as well.
  		if !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
-@@ -90,3 +94,10 @@ func IsRSAKeySupported(primes int) bool {
- 	// Given the above reasons, we only support 2-prime RSA keys.
- 	return primes == 2
- }
-+
-+func IsSaltSupported(salt int) bool {
-+	if goexperiment.CNGCrypto {
-+		return salt != 0 // rsa.PSSSaltLengthAuto
-+	}
-+	return true
-+}
 diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
 index 1dc7116efdff2e..b4c321d1d2babb 100644
 --- a/src/crypto/internal/boring/fipstls/stub.s
@@ -559,19 +575,6 @@ index 933ac569e034a8..0f152b210fdd84 100644
  
  package rsa
  
-diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
-index 4aac87d7952081..010ee1467501c3 100644
---- a/src/crypto/rsa/pss.go
-+++ b/src/crypto/rsa/pss.go
-@@ -342,7 +342,7 @@ func SignPSS(rand io.Reader, priv *PrivateKey, hash crypto.Hash, digest []byte,
- // The inputs are not considered confidential, and may leak through timing side
- // channels, or if an attacker has control of part of the inputs.
- func VerifyPSS(pub *PublicKey, hash crypto.Hash, digest []byte, sig []byte, opts *PSSOptions) error {
--	if boring.Enabled && boring.SupportsHash(hash) {
-+	if boring.Enabled && boring.IsSaltSupported(opts.saltLength()) && boring.SupportsHash(hash) {
- 		bkey, err := boringPublicKey(pub)
- 		if err != nil {
- 			return err
 diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
 index 637d07e18cff2e..21435b86b52dad 100644
 --- a/src/crypto/rsa/pss_test.go


### PR DESCRIPTION
The SymCrypt provider for OpenSSL only supports digest function provided by SymCrypt itself. Unfortunately, it can happen that `SupportsHash` return true for a digest not provided by SymCrypt, but by another provider. The RSA operations will fail if that happens, so we should detect this case and fallback to Go crypto.

This PR refactors the RSA code to only use the OpenSSL backend for digest functions that we know that are also support by SymCrypt.

It also contains some refactors to make it clearer what which RSA operations are supported by each backend.

⚠️ Don't merge until https://github.com/microsoft/go/pull/1386 has been merged. ⚠️