### PR TITLE
[release-branch.go1.23] Upgrade golang-fips/openssl to 4bcac10661a9

### DIFF
--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -721,7 +721,7 @@ index 789f5aaa1d3e26..14ced0e416fde8 100644
  go 1.23
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20241106131105-4bcac10661a9
  	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
  	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
  )
@@ -730,8 +730,8 @@ index a75ea98c7312df..9fad90e123a9f6 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95 h1:e+JGYwsNT8K58Z9JysRNadrPzxNlGf+0wQXcdlHiv5M=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20241106131105-4bcac10661a9 h1:LSalTbQ1mC7dgzyVZTvgVBV3RY503kOtn5iIvIXTBvY=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20241106131105-4bcac10661a9/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
  golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c h1:CR/7/SLUhIJw6g675eeoDiwggElO2MV9rGkNYjqi8GM=

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1129,7 +1129,7 @@ index 14ced0e416fde8..41ff48ef919672 100644
 @@ -4,6 +4,7 @@ go 1.23
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95
+ 	github.com/golang-fips/openssl/v2 v2.0.4-0.20241106131105-4bcac10661a9
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
  	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
  	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
@@ -1139,8 +1139,8 @@ index 9fad90e123a9f6..acdcbd6cd5bcb2 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95 h1:e+JGYwsNT8K58Z9JysRNadrPzxNlGf+0wQXcdlHiv5M=
- github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
+ github.com/golang-fips/openssl/v2 v2.0.4-0.20241106131105-4bcac10661a9 h1:LSalTbQ1mC7dgzyVZTvgVBV3RY503kOtn5iIvIXTBvY=
+ github.com/golang-fips/openssl/v2 v2.0.4-0.20241106131105-4bcac10661a9/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd h1:2ziav5Bdjyv0VYCCftEExmA+QQZ193w8BvSgoEZ+qAY=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -17,7 +17,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
  .../golang-fips/openssl/v2/ecdsa.go           | 217 +++++
  .../golang-fips/openssl/v2/ed25519.go         | 218 +++++
- .../github.com/golang-fips/openssl/v2/evp.go  | 471 +++++++++++
+ .../github.com/golang-fips/openssl/v2/evp.go  | 483 +++++++++++
  .../golang-fips/openssl/v2/goopenssl.c        | 218 +++++
  .../golang-fips/openssl/v2/goopenssl.h        | 255 ++++++
  .../github.com/golang-fips/openssl/v2/hash.go | 793 ++++++++++++++++++
@@ -61,7 +61,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 56 files changed, 9049 insertions(+)
+ 56 files changed, 9061 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -1936,10 +1936,10 @@ index 00000000000000..f74bd8f8d7a993
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/evp.go b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 new file mode 100644
-index 00000000000000..a9237a6a0ce9aa
+index 00000000000000..ff07f5f55bf974
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
-@@ -0,0 +1,471 @@
+@@ -0,0 +1,483 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1993,12 +1993,28 @@ index 00000000000000..a9237a6a0ce9aa
 +		return v.(C.GO_EVP_MD_PTR)
 +	}
 +	defer func() {
-+		if md != nil && vMajor == 3 {
-+			// On OpenSSL 3, directly operating on a EVP_MD object
-+			// not created by EVP_MD_fetch has negative performance
-+			// implications, as digest operations will have
-+			// to fetch it on every call. Better to just fetch it once here.
-+			md = C.go_openssl_EVP_MD_fetch(nil, C.go_openssl_EVP_MD_get0_name(md), nil)
++		if md != nil {
++			switch vMajor {
++			case 1:
++				// On OpenSSL 1 EVP_MD objects can be not-nil even
++				// when they are not supported. We need to pass the md
++				// to a EVP_MD_CTX to really know if they can be used.
++				ctx := C.go_openssl_EVP_MD_CTX_new()
++				if ctx != nil {
++					if C.go_openssl_EVP_DigestInit_ex(ctx, md, nil) != 1 {
++						md = nil
++					}
++					C.go_openssl_EVP_MD_CTX_free(ctx)
++				}
++			case 3:
++				// On OpenSSL 3, directly operating on a EVP_MD object
++				// not created by EVP_MD_fetch has negative performance
++				// implications, as digest operations will have
++				// to fetch it on every call. Better to just fetch it once here.
++				md = C.go_openssl_EVP_MD_fetch(nil, C.go_openssl_EVP_MD_get0_name(md), nil)
++			default:
++				panic(errUnsupportedVersion())
++			}
 +		}
 +		cacheMD.Store(ch, md)
 +	}()
@@ -2014,13 +2030,9 @@ index 00000000000000..a9237a6a0ce9aa
 +	}
 +	switch ch {
 +	case crypto.MD4:
-+		if versionAtOrAbove(1, 1, 0) || !FIPS() {
-+			return C.go_openssl_EVP_md4()
-+		}
++		return C.go_openssl_EVP_md4()
 +	case crypto.MD5:
-+		if versionAtOrAbove(1, 1, 0) || !FIPS() {
-+			return C.go_openssl_EVP_md5()
-+		}
++		return C.go_openssl_EVP_md5()
 +	case crypto.SHA1:
 +		return C.go_openssl_EVP_sha1()
 +	case crypto.SHA224:
@@ -9489,11 +9501,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b8a0b84a282a32..3677388dc80929 100644
+index b8a0b84a282a32..fa72eda0979db6 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20240909165545-0a2f211a8f95
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20241106131105-4bcac10661a9
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig


### PR DESCRIPTION
This upgrade contains the following fix: https://github.com/golang-fips/openssl/pull/215.