### PR TITLE
[release-branch.go1.22] Upgrade golang-fips/openssl to 65495925c2cb

### DIFF
--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -713,24 +713,24 @@ index c83a7272c9f01f..a0548a7f9179c5 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 737d78da5d9b40..b4d80d9215e9ef 100644
+index 737d78da5d9b40..24f9cc8784b7b6 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.22
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c
++	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241107084111-65495925c2cb
  	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
  	golang.org/x/net v0.19.1-0.20240412193750-db050b07227e
  )
 diff --git a/src/go.sum b/src/go.sum
-index 86d173c9e6ff99..1c33d55236f035 100644
+index 86d173c9e6ff99..ba3a28d8663c8e 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c h1:qieSrBDSfZmyVe+ThvHkwrJpROCielrlEa9g8B3Fpek=
-+github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241107084111-65495925c2cb h1:WREd0P9qUQIDt8n5eA7i7lHKyrwbKOAm14F3ncWEbLA=
++github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241107084111-65495925c2cb/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
  golang.org/x/net v0.19.1-0.20240412193750-db050b07227e h1:oDnvqaqHo3ho8OChMtkQbQAyp9eqnm3J7JRtt0+Cabc=

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1097,24 +1097,24 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index b4d80d9215e9ef..878294b3ec7d76 100644
+index 24f9cc8784b7b6..9ea762a2ab8cd2 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c
+ 	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241107084111-65495925c2cb
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
  	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
  	golang.org/x/net v0.19.1-0.20240412193750-db050b07227e
  )
 diff --git a/src/go.sum b/src/go.sum
-index 1c33d55236f035..bde9f93c810156 100644
+index ba3a28d8663c8e..e5a25a2b3fe3b7 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c h1:qieSrBDSfZmyVe+ThvHkwrJpROCielrlEa9g8B3Fpek=
- github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241107084111-65495925c2cb h1:WREd0P9qUQIDt8n5eA7i7lHKyrwbKOAm14F3ncWEbLA=
+ github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241107084111-65495925c2cb/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd h1:2ziav5Bdjyv0VYCCftEExmA+QQZ193w8BvSgoEZ+qAY=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -17,7 +17,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../github.com/golang-fips/openssl/v2/ecdh.go | 323 +++++++
  .../golang-fips/openssl/v2/ecdsa.go           | 217 +++++
  .../golang-fips/openssl/v2/ed25519.go         | 218 +++++
- .../github.com/golang-fips/openssl/v2/evp.go  | 471 +++++++++++
+ .../github.com/golang-fips/openssl/v2/evp.go  | 483 +++++++++++
  .../golang-fips/openssl/v2/goopenssl.c        | 218 +++++
  .../golang-fips/openssl/v2/goopenssl.h        | 201 +++++
  .../github.com/golang-fips/openssl/v2/hash.go | 793 ++++++++++++++++++
@@ -59,7 +59,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 54 files changed, 8900 insertions(+)
+ 54 files changed, 8912 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -1932,10 +1932,10 @@ index 00000000000000..f66a2a1deb3ce6
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/evp.go b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 new file mode 100644
-index 00000000000000..a9237a6a0ce9aa
+index 00000000000000..ff07f5f55bf974
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
-@@ -0,0 +1,471 @@
+@@ -0,0 +1,483 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1989,12 +1989,28 @@ index 00000000000000..a9237a6a0ce9aa
 +		return v.(C.GO_EVP_MD_PTR)
 +	}
 +	defer func() {
-+		if md != nil && vMajor == 3 {
-+			// On OpenSSL 3, directly operating on a EVP_MD object
-+			// not created by EVP_MD_fetch has negative performance
-+			// implications, as digest operations will have
-+			// to fetch it on every call. Better to just fetch it once here.
-+			md = C.go_openssl_EVP_MD_fetch(nil, C.go_openssl_EVP_MD_get0_name(md), nil)
++		if md != nil {
++			switch vMajor {
++			case 1:
++				// On OpenSSL 1 EVP_MD objects can be not-nil even
++				// when they are not supported. We need to pass the md
++				// to a EVP_MD_CTX to really know if they can be used.
++				ctx := C.go_openssl_EVP_MD_CTX_new()
++				if ctx != nil {
++					if C.go_openssl_EVP_DigestInit_ex(ctx, md, nil) != 1 {
++						md = nil
++					}
++					C.go_openssl_EVP_MD_CTX_free(ctx)
++				}
++			case 3:
++				// On OpenSSL 3, directly operating on a EVP_MD object
++				// not created by EVP_MD_fetch has negative performance
++				// implications, as digest operations will have
++				// to fetch it on every call. Better to just fetch it once here.
++				md = C.go_openssl_EVP_MD_fetch(nil, C.go_openssl_EVP_MD_get0_name(md), nil)
++			default:
++				panic(errUnsupportedVersion())
++			}
 +		}
 +		cacheMD.Store(ch, md)
 +	}()
@@ -2010,13 +2026,9 @@ index 00000000000000..a9237a6a0ce9aa
 +	}
 +	switch ch {
 +	case crypto.MD4:
-+		if versionAtOrAbove(1, 1, 0) || !FIPS() {
-+			return C.go_openssl_EVP_md4()
-+		}
++		return C.go_openssl_EVP_md4()
 +	case crypto.MD5:
-+		if versionAtOrAbove(1, 1, 0) || !FIPS() {
-+			return C.go_openssl_EVP_md5()
-+		}
++		return C.go_openssl_EVP_md5()
 +	case crypto.SHA1:
 +		return C.go_openssl_EVP_sha1()
 +	case crypto.SHA224:
@@ -9324,11 +9336,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 9a234e59b10c8c..88b9a1ee44c25f 100644
+index 9a234e59b10c8c..7d5a2c63b4ec56 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
-+# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20240909165543-889cd907e03c
++# github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241107084111-65495925c2cb
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig


### PR DESCRIPTION
This upgrade contains the following fix: https://github.com/golang-fips/openssl/pull/216.