### PR TITLE
Add initial version of the Developer Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+Please read the [Developer Guide](eng/doc/DeveloperGuide.md) for more information about contributing to this project.
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 

--- a/eng/doc/DeveloperGuide.md
+++ b/eng/doc/DeveloperGuide.md
@@ -1,0 +1,80 @@
+# Developer Guide
+
+This document is a guide for developers who want to contribute to the Microsoft Go repository.
+It explains how to build the repository, how to work with the Go submodule, and how to use the different tools
+that help maintain the repository.
+
+## Setting up the repository
+
+### Step 0: Contributor License Agreement
+
+Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution.
+For details, visit https://cla.opensource.microsoft.com.
+
+### Step 1: Install a Go toolchain
+
+A preexisting Go toolchain is required to bootstrap the build process.
+You can use your system's package manager to install Go, or you can download it from the [official Go website](https://golang.org/dl/).
+The only requirement is that the Go version is high enough for the bootstrap process.
+If the version is too low, the bootstrap process will fail and ask you to install a newer version.
+
+### Step 2: Install the git-go-patch command
+
+The `git-go-patch` command is a tool that helps you manage the patches in the `go` submodule.
+
+To install the `git-go-patch` command, run the following command:
+
+```
+go install github.com/microsoft/go-infra/cmd/go-patch@latest
+```
+
+> [!NOTE]
+> Make sure `git-go-patch` is accessible in your shell's `PATH` variable.
+> You may need to add `$GOPATH/bin` to your `PATH`. Use `go env GOPATH` to locate it.
+
+Then, run the command to see the help documentation:
+
+```
+git go-patch -h
+```
+
+> [!NOTE]
+> `git` detects that our `git-go-patch` executable starts with `git-` and makes it available as `git go-patch`.
+> The program still works if you call it with its real name, but we think it's easier to remember and type something that looks like a `git` subcommand.
+
+### Step 2: Initialize the submodule and apply patches
+
+The repository uses a `go` submodule to store the Go source code.
+All the patches that modify the Go source code are stored in the `patches` directory.
+
+To initialize the submodule and apply the patches, run the following command:
+
+```
+git go-patch apply
+```
+
+### Step 3: Build the Go toolchain
+
+You now can edit the `go/src` directory as you would any other Go project.
+
+Note that the `go/src/go.mod` file uses a `go` directive with a version that is not available as a prebuilt binary.
+This is because that module contains the future version of Go, which is not yet released.
+In order to build the standard library packages located in `go/src` you will first need to build to Go toolchain from the `go/src` directory itself using the following command:
+
+```
+cd go/src
+./make.bash # or make.bat on Windows
+```
+
+After building the Go toolchain, you can use it to develop and test changes in the `go/src` directory.
+You will need to add the `go/bin` directory to your `PATH` to use the new Go toolchain.
+
+### Step 4: Test that your environment is set up correctly
+
+To test that your environment is set up correctly, run the following command:
+
+```
+cd go/src
+go version
+go test -short ./...
+```

--- a/eng/doc/DeveloperGuide.md
+++ b/eng/doc/DeveloperGuide.md
@@ -78,3 +78,7 @@ cd go/src
 go version
 go test -short ./...
 ```
+
+## Making changes to go/src
+
+TODO

--- a/eng/doc/DeveloperGuide.md
+++ b/eng/doc/DeveloperGuide.md
@@ -44,7 +44,7 @@ git go-patch -h
 
 ### Step 2: Initialize the submodule and apply patches
 
-The repository uses a `go` submodule to store the Go source code.
+The repository uses a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) named `go` to store the Go source code.
 All the patches that modify the Go source code are stored in the `patches` directory.
 
 To initialize the submodule and apply the patches, run the following command:
@@ -55,7 +55,8 @@ git go-patch apply
 
 ### Step 3: Build the Go toolchain
 
-You now can edit the `go/src` directory as you would any other Go project.
+You now can edit the `go/src` directory as you would the upstream Go project.
+[The upstream "Installing Go from source" instructions](https://go.dev/doc/install/source) apply to the `go` directory and can be used to build and test.
 
 Note that the `go/src/go.mod` file uses a `go` directive with a version that is not available as a prebuilt binary.
 This is because that module contains the future version of Go, which is not yet released.

--- a/eng/doc/DeveloperGuide.md
+++ b/eng/doc/DeveloperGuide.md
@@ -1,8 +1,9 @@
 # Developer Guide
 
 This document is a guide for developers who want to contribute to the Microsoft Go repository.
-It explains how to build the repository, how to work with the Go submodule, and how to use the different tools
-that help maintain the repository.
+It explains how to build the repository, how to work with the Go submodule, and how to use the different tools that help maintain the repository.
+
+This guide is primarily intended for developers working for the Go team at Microsoft, but it can also be useful for external contributors.
 
 ## Setting up the repository
 
@@ -18,9 +19,16 @@ You can use your system's package manager to install Go, or you can download it 
 The only requirement is that the Go version is high enough for the bootstrap process.
 If the version is too low, the bootstrap process will fail and ask you to install a newer version.
 
-### Step 2: Install the git-go-patch command
+This repository implements some scripts (provided by `eng/run.ps1`) to facilitate installing the correct bootstrapping Go version and also to build the Go toolchain from source, see the [`eng` Readme](../eng/README.md) for more information.
+It is recommended that you get familiar with both the upstream Go build process and the scripts provided in this repository.
 
-The `git-go-patch` command is a tool that helps you manage the patches in the `go` submodule.
+### Step 2: Install git and the git-go-patch command
+
+This repository heavily relies on advanced Git features to manage the Go submodule, so it is recommended to develop with a local clone of the repository rather than using the GitHub web interface.
+
+You will need to have Git installed on your system, either from your system's package manager or from the [official Git website](https://git-scm.com/downloads).
+
+The [`git-go-patch`](https://github.com/microsoft/go-infra/tree/main/cmd/git-go-patch) command is a tool that helps you manage the patches in the `go` submodule.
 
 To install the `git-go-patch` command, run the following command:
 
@@ -40,12 +48,11 @@ git go-patch -h
 
 > [!NOTE]
 > `git` detects that our `git-go-patch` executable starts with `git-` and makes it available as `git go-patch`.
-> The program still works if you call it with its real name, but we think it's easier to remember and type something that looks like a `git` subcommand.
 
 ### Step 2: Initialize the submodule and apply patches
 
 The repository uses a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) named `go` to store the Go source code.
-All the patches that modify the Go source code are stored in the `patches` directory.
+All the patches that modify the Go source code are stored in the [`patches`](../../patches) directory.
 
 To initialize the submodule and apply the patches, run the following command:
 
@@ -58,17 +65,22 @@ git go-patch apply
 You now can edit the `go/src` directory as you would the upstream Go project.
 [The upstream "Installing Go from source" instructions](https://go.dev/doc/install/source) apply to the `go` directory and can be used to build and test.
 
-Note that the `go/src/go.mod` file uses a `go` directive with a version that is not available as a prebuilt binary.
-This is because that module contains the future version of Go, which is not yet released.
-In order to build the standard library packages located in `go/src` you will first need to build to Go toolchain from the `go/src` directory itself using the following command:
+In order to make changes to the standard library packages located in `go/src` you will first need to build to Go toolchain from the `go/src` directory itself using the following command:
 
 ```
 cd go/src
 ./make.bash # or make.bat on Windows
 ```
 
-After building the Go toolchain, you can use it to develop and test changes in the `go/src` directory.
-You will need to add the `go/bin` directory to your `PATH` to use the new Go toolchain.
+> [!NOTE]
+> Rebuilding the Go toolchain from source is not necessary for changes in the Go standard library, they are immediately reflected in any future `go build`, `go test`, or `go run` commands.
+> However, if you are making changes to the Go toolchain itself (any package under `go/src/cmd`), you will need to rebuild the Go toolchain.
+
+The newly built Go toolchain will be available in the `go/bin` directory. From now one this guide will assume that any mention of the `go` command refers to the one in the `go/bin` directory.
+There are different ways to use the new Go toolchain:
+- Add `go/bin` to your `PATH`, although but it is not recommended because it will probably contain unstable features that may interfere with other Go projects.
+- You can use the full path to the `go` command in the `go/bin` directory.
+- You can instruct your IDE to use the `go` command in the `go/bin` directory (recommended approach). See the [IDE setup](#ide-setup) section for more information.
 
 ### Step 4: Test that your environment is set up correctly
 
@@ -79,6 +91,28 @@ cd go/src
 go version
 go test -short ./...
 ```
+
+## IDE setup
+
+### Visual Studio Code
+
+Visual Studio Code (VS Code from now on) is a popular IDE for Go development. We recommend using the official Go extension for VS Code.
+Please refer to the [Go extension documentation](https://code.visualstudio.com/docs/languages/go) for more information on how to set up VS Code for Go development.
+
+#### Using the Go toolchain from the `go` submodule
+
+You can use the Go toolchain from the `go` submodule in VS Code by following these steps:
+
+1. In VS Code, open `Command Palette's Help` > `Show All Commands`. Or use the keyboard shortcut (`Ctrl+Shift+P`).
+1. Search for `Preferences: Open Workspace Settings (JSON)` then run the command from the pallet.
+1. Add the following setting to the JSON file that opens (replacing `{/path/to/microsoft-go}` with the path to the root of the Microsoft Go repository):
+
+```json
+{
+    "go.toolsGopath": "{/path/to/microsoft-go}/go/bin"
+}
+``` 
+1. Save the file and restart VS Code.
 
 ## Making changes to go/src
 

--- a/eng/doc/DeveloperGuide.md
+++ b/eng/doc/DeveloperGuide.md
@@ -7,12 +7,12 @@ This guide is primarily intended for developers working for the Go team at Micro
 
 ## Setting up the repository
 
-### Step 0: Contributor License Agreement
+### Contributor License Agreement
 
 Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution.
 For details, visit https://cla.opensource.microsoft.com.
 
-### Step 1: Install a Go toolchain
+### Install a Go toolchain
 
 A preexisting Go toolchain is required to bootstrap the build process.
 You can use your system's package manager to install Go, or you can download it from the [official Go website](https://golang.org/dl/).
@@ -22,7 +22,7 @@ If the version is too low, the bootstrap process will fail and ask you to instal
 This repository implements some scripts (provided by `eng/run.ps1`) to facilitate installing the correct bootstrapping Go version and also to build the Go toolchain from source, see the [`eng` Readme](../eng/README.md) for more information.
 It is recommended that you get familiar with both the upstream Go build process and the scripts provided in this repository.
 
-### Step 2: Install git and the git-go-patch command
+### Install git and the git-go-patch command
 
 This repository heavily relies on advanced Git features to manage the Go submodule, so it is recommended to develop with a local clone of the repository rather than using the GitHub web interface.
 
@@ -49,7 +49,7 @@ git go-patch -h
 > [!NOTE]
 > `git` detects that our `git-go-patch` executable starts with `git-` and makes it available as `git go-patch`.
 
-### Step 2: Initialize the submodule and apply patches
+### Initialize the submodule and apply patches
 
 The repository uses a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) named `go` to store the Go source code.
 All the patches that modify the Go source code are stored in the [`patches`](../../patches) directory.
@@ -60,7 +60,7 @@ To initialize the submodule and apply the patches, run the following command:
 git go-patch apply
 ```
 
-### Step 3: Build the Go toolchain
+### Build the Go toolchain
 
 You now can edit the `go/src` directory as you would the upstream Go project.
 [The upstream "Installing Go from source" instructions](https://go.dev/doc/install/source) apply to the `go` directory and can be used to build and test.
@@ -82,7 +82,7 @@ There are different ways to use the new Go toolchain:
 - You can use the full path to the `go` command in the `go/bin` directory.
 - You can instruct your IDE to use the `go` command in the `go/bin` directory (recommended approach). See the [IDE setup](#ide-setup) section for more information.
 
-### Step 4: Test that your environment is set up correctly
+### Test that your environment is set up correctly
 
 To test that your environment is set up correctly, run the following command:
 
@@ -104,14 +104,9 @@ Please refer to the [Go extension documentation](https://code.visualstudio.com/d
 You can use the Go toolchain from the `go` submodule in VS Code by following these steps:
 
 1. In VS Code, open `Command Palette's Help` > `Show All Commands`. Or use the keyboard shortcut (`Ctrl+Shift+P`).
-1. Search for `Preferences: Open Workspace Settings (JSON)` then run the command from the pallet.
-1. Add the following setting to the JSON file that opens (replacing `{/path/to/microsoft-go}` with the path to the root of the Microsoft Go repository):
-
-```json
-{
-    "go.toolsGopath": "{/path/to/microsoft-go}/go/bin"
-}
-``` 
+1. Search for `Go: Choose Go environment` then run the command from the pallet.
+1. Select `Choose from file browser`.
+1. Select the `go` command in the `go/bin` directory.
 1. Save the file and restart VS Code.
 
 ## Making changes to go/src

--- a/eng/doc/README.md
+++ b/eng/doc/README.md
@@ -2,7 +2,7 @@ This directory, `/eng/doc`, contains documents describing the Microsoft
 infrastructure used to build Go, in particular any designs that are not obvious
 by reading the infrastructure code itself.
 
-For dev scenario documentation, see [eng/README.md](/eng/README.md).
+For dev scenario documentation, see the [DeveloperGuide.md](DeveloperGuide.md) doc.
 
 The [Downloads.md](Downloads.md) doc contains a table of links to the latest assets for each supported Go release branch.
 The [release-branch-links.json](release-branch-links.json) file contains the same data in JSON format suitable for parsing.


### PR DESCRIPTION
We don't have a centralized guide about how to contribute to the Microsoft Go repository. This PR fixes that.