### PR TITLE
[release-branch.go1.23] Support TLS 1.3 resumption with SymCrypt

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -48,6 +48,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/crypto/tls/handshake_client.go           |  25 ++-
  src/crypto/tls/handshake_server.go           |  25 ++-
+ src/crypto/tls/handshake_server_tls13.go     |   9 +
  src/crypto/tls/key_schedule.go               |  18 +-
  src/crypto/tls/prf.go                        |  77 +++++---
  src/crypto/tls/prf_test.go                   |  12 +-
@@ -55,7 +56,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/go/build/deps_test.go                    |   4 +
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 51 files changed, 764 insertions(+), 93 deletions(-)
+ 52 files changed, 773 insertions(+), 93 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -1338,6 +1339,26 @@ index ac3d915d1746d7..631db82b9ab3ae 100644
  	if _, err := hs.c.writeHandshakeRecord(finished, &hs.finishedHash); err != nil {
  		return err
  	}
+diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
+index 503a732e05765e..ad6585d8653cf5 100644
+--- a/src/crypto/tls/handshake_server_tls13.go
++++ b/src/crypto/tls/handshake_server_tls13.go
+@@ -435,6 +435,15 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
+ // interfaces implemented by standard library hashes to clone the state of in
+ // to a new instance of h. It returns nil if the operation fails.
+ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
++	if boring.Enabled {
++		// CNG and OpenSSL with SymCrypt hash functions do not implement the
++		// encoding.BinaryMarshaler interface, but they do implement the Clone method.
++		if cloner, ok := in.(interface{ Clone() (hash.Hash, error) }); ok {
++			if out, err := cloner.Clone(); err == nil {
++				return out
++			}
++		}
++	}
+ 	// Recreate the interface to avoid importing encoding.
+ 	type binaryMarshaler interface {
+ 		MarshalBinary() (data []byte, err error)
 diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
 index 1636baf79e7288..c9a5877d3d504f 100644
 --- a/src/crypto/tls/key_schedule.go

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -48,7 +48,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/crypto/tls/handshake_client.go           |  25 ++-
  src/crypto/tls/handshake_server.go           |  25 ++-
- src/crypto/tls/handshake_server_tls13.go     |   9 +
+ src/crypto/tls/handshake_server_tls13.go     |  10 +
  src/crypto/tls/key_schedule.go               |  18 +-
  src/crypto/tls/prf.go                        |  77 +++++---
  src/crypto/tls/prf_test.go                   |  12 +-
@@ -56,7 +56,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/go/build/deps_test.go                    |   4 +
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 52 files changed, 773 insertions(+), 93 deletions(-)
+ 52 files changed, 774 insertions(+), 93 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -1340,10 +1340,18 @@ index ac3d915d1746d7..631db82b9ab3ae 100644
  		return err
  	}
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index 503a732e05765e..ad6585d8653cf5 100644
+index 503a732e05765e..53dfce967b3c2a 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
-@@ -435,6 +435,15 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
+@@ -10,6 +10,7 @@ import (
+ 	"crypto"
+ 	"crypto/hmac"
+ 	"crypto/internal/mlkem768"
++	boring "crypto/internal/backend"
+ 	"crypto/rsa"
+ 	"errors"
+ 	"hash"
+@@ -435,6 +436,15 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
  // interfaces implemented by standard library hashes to clone the state of in
  // to a new instance of h. It returns nil if the operation fails.
  func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -35,7 +35,6 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/tls/boring_test.go                 |   2 +-
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
  src/crypto/tls/fipsonly/fipsonly_test.go      |   2 +-
- src/crypto/tls/handshake_server_tls13.go      |  10 +
  src/crypto/tls/notboring.go                   |   2 +-
  src/crypto/x509/boring.go                     |   2 +-
  src/crypto/x509/boring_test.go                |   2 +-
@@ -49,7 +48,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 45 files changed, 495 insertions(+), 40 deletions(-)
+ 44 files changed, 485 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -1042,34 +1041,6 @@ index 9c1d3d279c472f..0ca7a863b73690 100644
  
  package fipsonly
  
-diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index 503a732e05765e..db8919aaf9cbdd 100644
---- a/src/crypto/tls/handshake_server_tls13.go
-+++ b/src/crypto/tls/handshake_server_tls13.go
-@@ -14,6 +14,7 @@ import (
- 	"errors"
- 	"hash"
- 	"internal/byteorder"
-+	"internal/goexperiment"
- 	"io"
- 	"slices"
- 	"time"
-@@ -442,6 +443,15 @@ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
- 	}
- 	marshaler, ok := in.(binaryMarshaler)
- 	if !ok {
-+		if goexperiment.CNGCrypto {
-+			// CNGCrypto hashes do not implement the binaryMarshaler interface,
-+			// but do implement the Clone method.
-+			if cloner, ok := in.(interface{ Clone() (hash.Hash, error) }); ok {
-+				if out, err := cloner.Clone(); err == nil {
-+					return out
-+				}
-+			}
-+		}
- 		return nil
- 	}
- 	state, err := marshaler.MarshalBinary()
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
 index 36b4ceab0046c6..c87df4ad695f1b 100644
 --- a/src/crypto/tls/notboring.go


### PR DESCRIPTION
SCOSSL digest functions doesn't support the `binaryMarshaler` interface, which is necessary to implement TLS 1.3 resumption.

This PR generalizes the CNG patch (which doesn't support digest marshaling neither) to also affect the OpenSSL backend.