### PR TITLE
[release-branch.go1.22] Support TLS 1.3 resumption with SymCrypt

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -46,6 +46,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/cipher_suites.go              |   2 +-
  src/crypto/tls/handshake_client.go           |  25 ++-
  src/crypto/tls/handshake_server.go           |  25 ++-
+ src/crypto/tls/handshake_server_tls13.go     |  10 +
  src/crypto/tls/key_schedule.go               |  18 +-
  src/crypto/tls/prf.go                        |  77 +++++---
  src/crypto/tls/prf_test.go                   |  12 +-
@@ -54,7 +55,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/net/http/client_test.go                  |   6 +-
  src/net/smtp/smtp_test.go                    |  72 ++++---
  src/runtime/runtime_boring.go                |   5 +
- 50 files changed, 761 insertions(+), 94 deletions(-)
+ 51 files changed, 771 insertions(+), 94 deletions(-)
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -1178,7 +1179,7 @@ index 6f5bc37197a4f4..9079b5a2e3d50d 100644
  	"crypto/sha1"
  	"crypto/sha256"
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
-index f016e01b4b5182..e685339c29780a 100644
+index 08a2d47974c20e..a6a9a88bbd312a 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
 @@ -657,12 +657,16 @@ func (hs *clientHandshakeState) doFullHandshake() error {
@@ -1240,7 +1241,7 @@ index f016e01b4b5182..e685339c29780a 100644
  		return err
  	}
 diff --git a/src/crypto/tls/handshake_server.go b/src/crypto/tls/handshake_server.go
-index 8129e9c6164af9..816d316a7d5329 100644
+index 4e84aa9d8f0a1d..524456dc3264b8 100644
 --- a/src/crypto/tls/handshake_server.go
 +++ b/src/crypto/tls/handshake_server.go
 @@ -676,12 +676,16 @@ func (hs *serverHandshakeState) doFullHandshake() error {
@@ -1301,6 +1302,34 @@ index 8129e9c6164af9..816d316a7d5329 100644
  	if _, err := hs.c.writeHandshakeRecord(finished, &hs.finishedHash); err != nil {
  		return err
  	}
+diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
+index 21d798de37db0a..f67c6aa63f7acf 100644
+--- a/src/crypto/tls/handshake_server_tls13.go
++++ b/src/crypto/tls/handshake_server_tls13.go
+@@ -9,6 +9,7 @@ import (
+ 	"context"
+ 	"crypto"
+ 	"crypto/hmac"
++	boring "crypto/internal/backend"
+ 	"crypto/rsa"
+ 	"encoding/binary"
+ 	"errors"
+@@ -402,6 +403,15 @@ func (hs *serverHandshakeStateTLS13) checkForResumption() error {
+ // interfaces implemented by standard library hashes to clone the state of in
+ // to a new instance of h. It returns nil if the operation fails.
+ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
++	if boring.Enabled {
++		// CNG and OpenSSL with SymCrypt hash functions do not implement the
++		// encoding.BinaryMarshaler interface, but they do implement the Clone method.
++		if cloner, ok := in.(interface{ Clone() (hash.Hash, error) }); ok {
++			if out, err := cloner.Clone(); err == nil {
++				return out
++			}
++		}
++	}
+ 	// Recreate the interface to avoid importing encoding.
+ 	type binaryMarshaler interface {
+ 		MarshalBinary() (data []byte, err error)
 diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
 index d7f082c9ee1e04..14a85fbf1bd465 100644
 --- a/src/crypto/tls/key_schedule.go
@@ -1564,7 +1593,7 @@ index 33fd0ed52b1ff6..ffc3eeca9dbf95 100644
  	k, err := rsa.GenerateKey(rand.Reader, size)
  	if err != nil {
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 47a0f3a0b409d4..05b15b6dc022ef 100644
+index 7ce8d346b406ae..2362c4fa0cdfcb 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -427,6 +427,7 @@ var depsRules = `
@@ -1592,7 +1621,7 @@ index 47a0f3a0b409d4..05b15b6dc022ef 100644
  	< crypto/ed25519
  	< encoding/asn1
 diff --git a/src/net/http/client_test.go b/src/net/http/client_test.go
-index 7459b9cb6ed1df..e0ca4f7cedad8a 100644
+index e2a1cbbdea10da..d9a087a1249e88 100644
 --- a/src/net/http/client_test.go
 +++ b/src/net/http/client_test.go
 @@ -946,7 +946,9 @@ func testResponseSetsTLSConnectionState(t *testing.T, mode testMode) {

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -34,7 +34,6 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/tls/boring_test.go                 |   2 +-
  src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
  src/crypto/tls/fipsonly/fipsonly_test.go      |   2 +-
- src/crypto/tls/handshake_server_tls13.go      |  10 +
  src/crypto/tls/notboring.go                   |   2 +-
  src/crypto/x509/boring.go                     |   2 +-
  src/crypto/x509/boring_test.go                |   2 +-
@@ -47,7 +46,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 43 files changed, 477 insertions(+), 40 deletions(-)
+ 42 files changed, 467 insertions(+), 40 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
@@ -1016,34 +1015,6 @@ index 9c1d3d279c472f..0ca7a863b73690 100644
  
  package fipsonly
  
-diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index 21d798de37db0a..6c65da0ab04f9f 100644
---- a/src/crypto/tls/handshake_server_tls13.go
-+++ b/src/crypto/tls/handshake_server_tls13.go
-@@ -13,6 +13,7 @@ import (
- 	"encoding/binary"
- 	"errors"
- 	"hash"
-+	"internal/goexperiment"
- 	"io"
- 	"time"
- )
-@@ -409,6 +410,15 @@ func cloneHash(in hash.Hash, h crypto.Hash) hash.Hash {
- 	}
- 	marshaler, ok := in.(binaryMarshaler)
- 	if !ok {
-+		if goexperiment.CNGCrypto {
-+			// CNGCrypto hashes do not implement the binaryMarshaler interface,
-+			// but do implement the Clone method.
-+			if cloner, ok := in.(interface{ Clone() (hash.Hash, error) }); ok {
-+				if out, err := cloner.Clone(); err == nil {
-+					return out
-+				}
-+			}
-+		}
- 		return nil
- 	}
- 	state, err := marshaler.MarshalBinary()
 diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
 index 1aaabd5ef486aa..5a133c9b2f94c7 100644
 --- a/src/crypto/tls/notboring.go


### PR DESCRIPTION
SCOSSL digest functions doesn't support the `binaryMarshaler` interface, which is necessary to implement TLS 1.3 resumption.

This PR generalizes the CNG patch (which doesn't support digest marshaling neither) to also affect the OpenSSL backend.