### PR TITLE
Fix official build dependency on Get-Stage0GoRoot

### DIFF
--- a/eng/pipeline/steps/install-gopdb.yml
+++ b/eng/pipeline/steps/install-gopdb.yml
@@ -26,9 +26,9 @@ steps:
 
   - pwsh: |
       . eng/utilities.ps1
-      $gobin = Get-Stage0GoRoot # Make sure we have a Go toolchain available
+      Download-Stage0 # Make sure we have a Go toolchain available
       cd go-pdb
-      & $gobin/bin/go.exe build -o $(pdbPath)/gopdb.exe ./cmd/gopdb
+      & go build -o $(pdbPath)/gopdb.exe ./cmd/gopdb
     displayName: Install gopdb
 
   - pwsh: |


### PR DESCRIPTION
* https://github.com/microsoft/go/pull/1400 replaced `Get-Stage0GoRoot` with `Download-Stage0`, which works differently. I missed this usage in `eng/pipeline/steps/install-gopdb.yml`, causing the internal build to break.

Example failure: https://dev.azure.com/dnceng/internal/_build/results?buildId=2584173&view=logs&j=307c05fb-395e-5cff-ceb4-9869362bab1d&t=ef5e75da-3c36-5b4c-4186-618017808ff2

This step succeeded in a test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2584393&view=logs&j=307c05fb-395e-5cff-ceb4-9869362bab1d&t=ef5e75da-3c36-5b4c-4186-618017808ff2