### PR TITLE
Upgrade AZL3 images

### DIFF
--- a/eng/pipeline/pr-outerloop-pipeline.yml
+++ b/eng/pipeline/pr-outerloop-pipeline.yml
@@ -29,7 +29,7 @@ resources:
     - container: mariner2arm64
       image: mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-arm64-default-20241029143304-6049f85
     - container: azurelinux3
-      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024144202-a3a1203
+      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241210101540-a3a1203
 
 stages:
   - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -26,7 +26,7 @@ resources:
     - container: mariner2arm64
       image: mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-arm64-default-20241029143304-6049f85
     - container: azurelinux3
-      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024144202-a3a1203
+      image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241210101540-a3a1203
 
 stages:
   - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -49,7 +49,7 @@ extends:
       mariner2arm64:
         image: mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-arm64-default-20241029143304-6049f85
       azurelinux3:
-        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024144202-a3a1203
+        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241210101540-a3a1203
 
     stages:
       - template: stages/go-builder-matrix-stages.yml

--- a/eng/pipeline/rolling-pipeline.yml
+++ b/eng/pipeline/rolling-pipeline.yml
@@ -42,7 +42,7 @@ extends:
       mariner2arm64:
         image: mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-arm64-default-20241029143304-6049f85
       azurelinux3:
-        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241024144202-a3a1203
+        image: mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default-20241210101540-a3a1203
 
     stages:
       - template: stages/go-builder-matrix-stages.yml


### PR DESCRIPTION
The latest AZL3 image build contains the upgraded SymCrypt and SCOSSL packages. These are necessary to fix some tests that are  failing in the upstream sync PR.

For #1416.
For #1383.