### PR TITLE
Add missing copyright headers

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -58,12 +58,12 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/prf_test.go                   |  12 +-
  src/crypto/x509/boring_test.go               |   5 +
  src/go/build/deps_test.go                    |   4 +
- src/hash/boring_test.go                      |   5 +
+ src/hash/boring_test.go                      |   9 +
  src/hash/marshal_test.go                     |   5 +
- src/hash/notboring_test.go                   |   5 +
+ src/hash/notboring_test.go                   |   9 +
  src/net/smtp/smtp_test.go                    |  72 +++---
  src/runtime/runtime_boring.go                |   5 +
- 59 files changed, 1141 insertions(+), 106 deletions(-)
+ 59 files changed, 1145 insertions(+), 106 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ed25519/boring.go
@@ -2277,10 +2277,14 @@ index c6a2518f62ff3a..578b4d6f68504c 100644
  	< crypto/ed25519
 diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
 new file mode 100644
-index 00000000000000..c90899062a9665
+index 00000000000000..b4cb21f3580737
 --- /dev/null
 +++ b/src/hash/boring_test.go
-@@ -0,0 +1,5 @@
+@@ -0,0 +1,9 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
 +//go:build goexperiment.boringcrypto
 +
 +package hash_test
@@ -2304,10 +2308,14 @@ index 3091f7a67acede..fead8cc4bec73a 100644
  
 diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
 new file mode 100644
-index 00000000000000..79f8c22f2b7416
+index 00000000000000..0f289915be6daa
 --- /dev/null
 +++ b/src/hash/notboring_test.go
-@@ -0,0 +1,5 @@
+@@ -0,0 +1,9 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
 +//go:build !goexperiment.boringcrypto
 +
 +package hash_test

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -843,20 +843,26 @@ index 7f6237ffd59c11..7c821ae4bc5727 100644
  
  // Verify that the vendor directories contain only packages matching the list above.
 diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
-index c90899062a9665..802c0f8b8987bf 100644
+index b4cb21f3580737..ff24d12966e22f 100644
 --- a/src/hash/boring_test.go
 +++ b/src/hash/boring_test.go
-@@ -1,4 +1,4 @@
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
 -//go:build goexperiment.boringcrypto
 +//go:build goexperiment.boringcrypto || goexperiment.opensslcrypto
  
  package hash_test
  
 diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
-index 79f8c22f2b7416..f3e8ed3e1cbf20 100644
+index 0f289915be6daa..bd935326bf7305 100644
 --- a/src/hash/notboring_test.go
 +++ b/src/hash/notboring_test.go
-@@ -1,4 +1,4 @@
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
 -//go:build !goexperiment.boringcrypto
 +//go:build !goexperiment.boringcrypto && !goexperiment.opensslcrypto
  

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -793,10 +793,13 @@ index 7c821ae4bc5727..1d0b9b20e9b1d4 100644
  
  // Verify that the vendor directories contain only packages matching the list above.
 diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
-index 802c0f8b8987bf..99e1933f84b52c 100644
+index ff24d12966e22f..a5242cca089049 100644
 --- a/src/hash/boring_test.go
 +++ b/src/hash/boring_test.go
-@@ -1,4 +1,4 @@
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
 -//go:build goexperiment.boringcrypto || goexperiment.opensslcrypto
 +//go:build goexperiment.boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
  
@@ -816,10 +819,13 @@ index f07b9aaa2c4898..2ff6c4827391c0 100644
  
  import (
 diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
-index f3e8ed3e1cbf20..a85fc430cfa655 100644
+index bd935326bf7305..40c84700690612 100644
 --- a/src/hash/notboring_test.go
 +++ b/src/hash/notboring_test.go
-@@ -1,4 +1,4 @@
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
 -//go:build !goexperiment.boringcrypto && !goexperiment.opensslcrypto
 +//go:build !goexperiment.boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
  

--- a/patches/0010-unset-GOFIPS-when-running-the-Go-toolchain.patch
+++ b/patches/0010-unset-GOFIPS-when-running-the-Go-toolchain.patch
@@ -4,17 +4,21 @@ Date: Wed, 14 Feb 2024 11:03:01 +0100
 Subject: [PATCH] unset GOFIPS when running the Go toolchain
 
 ---
- src/cmd/go/internal/gofips/gofips.go | 32 ++++++++++++++++++++++++++++
- src/cmd/go/main.go                   |  5 +++++
- 2 files changed, 37 insertions(+)
+ src/cmd/go/internal/gofips/gofips.go | 36 ++++++++++++++++++++++++++++
+ src/cmd/go/main.go                   |  5 ++++
+ 2 files changed, 41 insertions(+)
  create mode 100644 src/cmd/go/internal/gofips/gofips.go
 
 diff --git a/src/cmd/go/internal/gofips/gofips.go b/src/cmd/go/internal/gofips/gofips.go
 new file mode 100644
-index 00000000000000..009eece5b6c080
+index 00000000000000..1f3549cf1b4ab5
 --- /dev/null
 +++ b/src/cmd/go/internal/gofips/gofips.go
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,36 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
 +// gofips is a package that, when imported, unsets the GOFIPS environment variable
 +// and stores it for later use.
 +//
@@ -48,10 +52,10 @@ index 00000000000000..009eece5b6c080
 +	return gofips, gofipsSet
 +}
 diff --git a/src/cmd/go/main.go b/src/cmd/go/main.go
-index d380aae489436f..fe619a8aadd2ae 100644
+index f2e4d890d3d61b..fd1f733f7018a1 100644
 --- a/src/cmd/go/main.go
 +++ b/src/cmd/go/main.go
-@@ -29,6 +29,7 @@ import (
+@@ -27,6 +27,7 @@ import (
  	"cmd/go/internal/fix"
  	"cmd/go/internal/fmtcmd"
  	"cmd/go/internal/generate"
@@ -59,7 +63,7 @@ index d380aae489436f..fe619a8aadd2ae 100644
  	"cmd/go/internal/help"
  	"cmd/go/internal/list"
  	"cmd/go/internal/modcmd"
-@@ -223,6 +224,10 @@ func invoke(cmd *base.Command, args []string) {
+@@ -301,6 +302,10 @@ func invoke(cmd *base.Command, args []string) {
  	// but in practice there might be skew
  	// This makes sure we all agree.
  	cfg.OrigEnv = toolchain.FilterEnv(os.Environ())

--- a/patches/0011-add-support-for-logging-used-Windows-APIs.patch
+++ b/patches/0011-add-support-for-logging-used-Windows-APIs.patch
@@ -6,21 +6,21 @@ Subject: [PATCH] add support for logging used Windows APIs
 ---
  src/runtime/os_windows.go                    |   1 +
  src/runtime/syscall_windows.go               |   1 +
- src/runtime/syscalltrace_generate_windows.go |  46 +++++++
- src/runtime/syscalltrace_windows.go          | 127 +++++++++++++++++++
- src/runtime/syscalltrace_windows_test.go     |  77 +++++++++++
+ src/runtime/syscalltrace_generate_windows.go |  50 +++++++
+ src/runtime/syscalltrace_windows.go          | 131 +++++++++++++++++++
+ src/runtime/syscalltrace_windows_test.go     |  81 ++++++++++++
  src/runtime/zsyscalltrace_windows.go         |  60 +++++++++
- 6 files changed, 312 insertions(+)
+ 6 files changed, 324 insertions(+)
  create mode 100644 src/runtime/syscalltrace_generate_windows.go
  create mode 100644 src/runtime/syscalltrace_windows.go
  create mode 100644 src/runtime/syscalltrace_windows_test.go
  create mode 100644 src/runtime/zsyscalltrace_windows.go
 
 diff --git a/src/runtime/os_windows.go b/src/runtime/os_windows.go
-index 4aabc29644e6f9..fc7296f28ab12f 100644
+index 7183e79f7df093..2b382202bf7e49 100644
 --- a/src/runtime/os_windows.go
 +++ b/src/runtime/os_windows.go
-@@ -222,6 +222,7 @@ func windowsFindfunc(lib uintptr, name []byte) stdFunction {
+@@ -223,6 +223,7 @@ func windowsFindfunc(lib uintptr, name []byte) stdFunction {
  	if name[len(name)-1] != 0 {
  		throw("usage")
  	}
@@ -29,7 +29,7 @@ index 4aabc29644e6f9..fc7296f28ab12f 100644
  	return stdFunction(unsafe.Pointer(f))
  }
 diff --git a/src/runtime/syscall_windows.go b/src/runtime/syscall_windows.go
-index 69d720a395c48d..2772c019a15af2 100644
+index 85b1b8c9024a73..384be25350726e 100644
 --- a/src/runtime/syscall_windows.go
 +++ b/src/runtime/syscall_windows.go
 @@ -443,6 +443,7 @@ func syscall_loadlibrary(filename *uint16) (handle, err uintptr) {
@@ -42,10 +42,14 @@ index 69d720a395c48d..2772c019a15af2 100644
  	if outhandle != 0 {
 diff --git a/src/runtime/syscalltrace_generate_windows.go b/src/runtime/syscalltrace_generate_windows.go
 new file mode 100644
-index 00000000000000..e3bbe376f43ce9
+index 00000000000000..17fb696be88776
 --- /dev/null
 +++ b/src/runtime/syscalltrace_generate_windows.go
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,50 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
 +//go:build ignore
 +
 +package main
@@ -94,10 +98,14 @@ index 00000000000000..e3bbe376f43ce9
 +}
 diff --git a/src/runtime/syscalltrace_windows.go b/src/runtime/syscalltrace_windows.go
 new file mode 100644
-index 00000000000000..15245e4414c0b8
+index 00000000000000..ed9161b797c4f9
 --- /dev/null
 +++ b/src/runtime/syscalltrace_windows.go
-@@ -0,0 +1,127 @@
+@@ -0,0 +1,131 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
 +//go:generate go run syscalltrace_generate_windows.go -output zsyscalltrace_windows.go os_windows syscalltrace_windows
 +
 +package runtime
@@ -227,10 +235,14 @@ index 00000000000000..15245e4414c0b8
 +}
 diff --git a/src/runtime/syscalltrace_windows_test.go b/src/runtime/syscalltrace_windows_test.go
 new file mode 100644
-index 00000000000000..31d1fc18bb8640
+index 00000000000000..626c5e98f7eae4
 --- /dev/null
 +++ b/src/runtime/syscalltrace_windows_test.go
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,81 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
 +package runtime_test
 +
 +import (


### PR DESCRIPTION
Upstream recently added a tets that checks all files have a copyright header. The upstream PR is failing in part because some of our files don't have the corresponding header. Fix it.

For https://github.com/microsoft/go/issues/1416.
For https://github.com/microsoft/go/pull/1383.