### PR TITLE
Remove `crypto/internal/boring/fipstls` dependency from `crypto/internal/backend`

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -26,13 +26,15 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/hmac/hmac_test.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go  |  30 +++
  src/crypto/internal/backend/bbig/big.go      |  17 ++
- src/crypto/internal/backend/common.go        |  92 ++++++++
- src/crypto/internal/backend/isrequirefips.go |   9 +
+ src/crypto/internal/backend/common.go        |  68 ++++++
+ .../backend/fips140/fips140.go               |  55 +++++
+ .../backend/fips140/isrequirefips.go         |   9 +
+ .../backend/fips140/norequirefips.go         |   9 +
+ .../backend/fips140/nosystemcrypto.go        |  11 +
  src/crypto/internal/backend/nobackend.go     | 223 +++++++++++++++++++
- src/crypto/internal/backend/norequirefips.go |   9 +
  src/crypto/internal/backend/stub.s           |  10 +
  src/crypto/internal/boring/fipstls/stub.s    |   2 +-
- src/crypto/internal/boring/fipstls/tls.go    |   2 +-
+ src/crypto/internal/boring/fipstls/tls.go    |   7 +-
  src/crypto/md5/md5.go                        |   7 +
  src/crypto/md5/md5_test.go                   |  14 ++
  src/crypto/purego_test.go                    |   2 +-
@@ -68,13 +70,13 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/x509/boring.go                    |   2 +-
  src/crypto/x509/boring_test.go               |   7 +-
  src/crypto/x509/notboring.go                 |   2 +-
- src/go/build/deps_test.go                    |   4 +
+ src/go/build/deps_test.go                    |  11 +-
  src/hash/boring_test.go                      |   9 +
  src/hash/marshal_test.go                     |   5 +
  src/hash/notboring_test.go                   |   9 +
  src/net/smtp/smtp_test.go                    |  72 +++---
  src/runtime/runtime_boring.go                |   5 +
- 70 files changed, 1125 insertions(+), 94 deletions(-)
+ 73 files changed, 1180 insertions(+), 95 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ed25519/boring.go
@@ -82,9 +84,11 @@ Subject: [PATCH] Add crypto backend foundation
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
  create mode 100644 src/crypto/internal/backend/common.go
- create mode 100644 src/crypto/internal/backend/isrequirefips.go
+ create mode 100644 src/crypto/internal/backend/fips140/fips140.go
+ create mode 100644 src/crypto/internal/backend/fips140/isrequirefips.go
+ create mode 100644 src/crypto/internal/backend/fips140/norequirefips.go
+ create mode 100644 src/crypto/internal/backend/fips140/nosystemcrypto.go
  create mode 100644 src/crypto/internal/backend/nobackend.go
- create mode 100644 src/crypto/internal/backend/norequirefips.go
  create mode 100644 src/crypto/internal/backend/stub.s
  create mode 100644 src/hash/boring_test.go
  create mode 100644 src/hash/notboring_test.go
@@ -879,10 +883,10 @@ index 00000000000000..20251a290dc2e0
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..bc595e91024f11
+index 00000000000000..07d965bf8b467c
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,68 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -890,45 +894,21 @@ index 00000000000000..bc595e91024f11
 +package backend
 +
 +import (
++	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
 +	"internal/goexperiment"
 +	"runtime"
-+	"syscall"
 +)
 +
 +func init() {
-+	if v, r, ok := envGoFIPS(); ok && v == "1" {
++	if fips140.Enabled() {
 +		if !Enabled {
 +			if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
-+				panic("FIPS mode requested (" + r + ") but no crypto backend is supported on " + runtime.GOOS)
++				panic("FIPS mode requested (" + fips140.Message + ") but no crypto backend is supported on " + runtime.GOOS)
 +			}
-+			panic("FIPS mode requested (" + r + ") but no supported crypto backend is enabled")
++			panic("FIPS mode requested (" + fips140.Message + ") but no supported crypto backend is enabled")
 +		}
 +	}
-+}
-+
-+func envGoFIPS() (value string, reason string, ok bool) {
-+	// TODO: Decide which environment variable to use.
-+	// See https://github.com/microsoft/go/issues/397.
-+	var varName string
-+	if value, ok = syscall.Getenv("GOFIPS"); ok {
-+		varName = "GOFIPS"
-+	} else if value, ok = syscall.Getenv("GOLANG_FIPS"); ok {
-+		varName = "GOLANG_FIPS"
-+	}
-+	if isRequireFIPS {
-+		if ok && value != "1" {
-+			panic("the 'requirefips' build tag is enabled, but it conflicts " +
-+				"with the detected env variable " +
-+				varName + "=" + value +
-+				" which would disable FIPS mode")
-+		}
-+		return "1", "requirefips tag set", true
-+	}
-+	if ok {
-+		return value, "environment variable " + varName + "=1", true
-+	}
-+	return "", "", false
 +}
 +
 +// Unreachable marks code that should be unreachable
@@ -975,21 +955,117 @@ index 00000000000000..bc595e91024f11
 +	// Given the above reasons, we only support 2-prime RSA keys.
 +	return primes == 2
 +}
-diff --git a/src/crypto/internal/backend/isrequirefips.go b/src/crypto/internal/backend/isrequirefips.go
+diff --git a/src/crypto/internal/backend/fips140/fips140.go b/src/crypto/internal/backend/fips140/fips140.go
 new file mode 100644
-index 00000000000000..e5d7570d6d4363
+index 00000000000000..f54d39970319af
 --- /dev/null
-+++ b/src/crypto/internal/backend/isrequirefips.go
++++ b/src/crypto/internal/backend/fips140/fips140.go
+@@ -0,0 +1,55 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package fips140
++
++import "syscall"
++
++// Enabled reports whether FIPS 140 mode is enabled by using GOFIPS=1, GOLANG_FIPS=1,
++// the 'requirefips' build tag, or any other platform-specific mechanism.
++func Enabled() bool {
++	return enabled
++}
++
++var enabled bool
++
++// Disabled reports whether FIPS 140 mode is disabled by using GOFIPS=0 or GOLANG_FIPS=0.
++func Disabled() bool {
++	return disabled
++}
++
++var disabled bool
++
++// Message is a human-readable message about how [Enabled] was set.
++var Message string
++
++func init() {
++	// TODO: Decide which environment variable to use.
++	// See https://github.com/microsoft/go/issues/397.
++	var value string
++	var ok bool
++	if value, ok = syscall.Getenv("GOFIPS"); ok {
++		Message = "environment variable GOFIPS"
++	} else if value, ok = syscall.Getenv("GOLANG_FIPS"); ok {
++		Message = "environment variable GOLANG_FIPS"
++	} else if systemFIPSMode() {
++		Message = "system FIPS mode"
++		value = "1"
++	}
++	if value == "1" {
++		enabled = true
++	} else if value == "0" {
++		disabled = true
++	}
++	if isRequireFIPS {
++		if disabled {
++			panic("the 'requirefips' build tag is enabled, but it conflicts " +
++				"with the " + Message + "=" + value +
++				" which would disable FIPS mode")
++		}
++		Message = "requirefips tag set"
++		enabled = true
++		return
++	}
++}
+\ No newline at end of file
+diff --git a/src/crypto/internal/backend/fips140/isrequirefips.go b/src/crypto/internal/backend/fips140/isrequirefips.go
+new file mode 100644
+index 00000000000000..b33d08c84e2dae
+--- /dev/null
++++ b/src/crypto/internal/backend/fips140/isrequirefips.go
 @@ -0,0 +1,9 @@
-+// Copyright 2022 The Go Authors. All rights reserved.
++// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +//go:build requirefips
 +
-+package backend
++package fips140
 +
 +const isRequireFIPS = true
+\ No newline at end of file
+diff --git a/src/crypto/internal/backend/fips140/norequirefips.go b/src/crypto/internal/backend/fips140/norequirefips.go
+new file mode 100644
+index 00000000000000..6f01b9a3524dee
+--- /dev/null
++++ b/src/crypto/internal/backend/fips140/norequirefips.go
+@@ -0,0 +1,9 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !requirefips
++
++package fips140
++
++const isRequireFIPS = false
+\ No newline at end of file
+diff --git a/src/crypto/internal/backend/fips140/nosystemcrypto.go b/src/crypto/internal/backend/fips140/nosystemcrypto.go
+new file mode 100644
+index 00000000000000..83691d7dd42d51
+--- /dev/null
++++ b/src/crypto/internal/backend/fips140/nosystemcrypto.go
+@@ -0,0 +1,11 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !goexperiment.systemcrypto
++
++package fips140
++
++func systemFIPSMode() bool {
++	return false
++}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
 index 00000000000000..ffa8d38e5d490f
@@ -1219,21 +1295,6 @@ index 00000000000000..ffa8d38e5d490f
 +func VerifyDSA(pub *PublicKeyDSA, hashed []byte, r, s BigInt, encodeSignature func(r, s BigInt) ([]byte, error)) bool {
 +	panic("cryptobackend: not available")
 +}
-diff --git a/src/crypto/internal/backend/norequirefips.go b/src/crypto/internal/backend/norequirefips.go
-new file mode 100644
-index 00000000000000..26bfb5f6a643f3
---- /dev/null
-+++ b/src/crypto/internal/backend/norequirefips.go
-@@ -0,0 +1,9 @@
-+// Copyright 2022 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build !requirefips
-+
-+package backend
-+
-+const isRequireFIPS = false
 diff --git a/src/crypto/internal/backend/stub.s b/src/crypto/internal/backend/stub.s
 new file mode 100644
 index 00000000000000..5e4b436554d44d
@@ -1264,7 +1325,7 @@ index f2e5a503eaacb6..35cf7532625efb 100644
  // runtime_arg0 is declared in tls.go without a body.
  // It's provided by package runtime,
 diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
-index b51f142fde8311..0ea6593743349b 100644
+index b51f142fde8311..108b52d9d8fcb7 100644
 --- a/src/crypto/internal/boring/fipstls/tls.go
 +++ b/src/crypto/internal/boring/fipstls/tls.go
 @@ -2,7 +2,7 @@
@@ -1276,6 +1337,26 @@ index b51f142fde8311..0ea6593743349b 100644
  
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
  // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
+@@ -10,12 +10,19 @@
+ package fipstls
+ 
+ import (
++	"crypto/internal/backend/fips140"
+ 	"internal/stringslite"
+ 	"sync/atomic"
+ )
+ 
+ var required atomic.Bool
+ 
++func init() {
++	if fips140.Enabled() {
++		Force()
++	}
++}
++
+ // Force forces crypto/tls to restrict TLS configurations to FIPS-approved settings.
+ // By design, this call is impossible to undo (except in tests).
+ //
 diff --git a/src/crypto/md5/md5.go b/src/crypto/md5/md5.go
 index c984c3f4968598..229dd457f8d53c 100644
 --- a/src/crypto/md5/md5.go
@@ -2242,10 +2323,22 @@ index c83a7272c9f01f..7f6e574dc0c2dc 100644
  package x509
  
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index c6a2518f62ff3a..578b4d6f68504c 100644
+index c6a2518f62ff3a..6c7229b41c825e 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -464,7 +464,9 @@ var depsRules = `
+@@ -457,14 +457,20 @@ var depsRules = `
+ 	< crypto/internal/fips/hmac
+ 	< FIPS;
+ 
++	syscall < crypto/internal/backend/fips140;
++
+ 	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
+-	sync/atomic < crypto/internal/boring/bcache, crypto/internal/boring/fipstls;
++	sync/atomic,
++	crypto/internal/backend/fips140
++	< crypto/internal/boring/bcache, crypto/internal/boring/fipstls;
+ 	crypto/internal/boring/sig, crypto/internal/boring/fipstls < crypto/tls/fipsonly;
+ 
  	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
  	FIPS,
  	crypto/internal/boring/sig,
@@ -2255,15 +2348,17 @@ index c6a2518f62ff3a..578b4d6f68504c 100644
  	golang.org/x/sys/cpu,
  	hash, embed
  	< crypto
-@@ -475,6 +477,7 @@ var depsRules = `
+@@ -474,7 +480,9 @@ var depsRules = `
+ 
  	crypto/cipher,
  	crypto/internal/boring/bcache
++	crypto/internal/backend/fips140
  	< crypto/internal/boring
 +	< crypto/internal/backend
  	< crypto/boring;
  
  	crypto/internal/alias, math/rand/v2
-@@ -512,6 +515,7 @@ var depsRules = `
+@@ -512,6 +520,7 @@ var depsRules = `
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
  	< crypto/internal/boring/bbig

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -6,9 +6,11 @@ Subject: [PATCH] Add BoringSSL crypto backend
 ---
  .../internal/backend/bbig/big_boring.go       |  12 +
  src/crypto/internal/backend/boring_linux.go   | 257 ++++++++++++++++++
- 2 files changed, 270 insertions(+)
+ src/crypto/internal/backend/fips140/boring.go |  11 +
+ 3 files changed, 281 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
+ create mode 100644 src/crypto/internal/backend/fips140/boring.go
 
 diff --git a/src/crypto/internal/backend/bbig/big_boring.go b/src/crypto/internal/backend/bbig/big_boring.go
 new file mode 100644
@@ -290,4 +292,21 @@ index 00000000000000..31e57a8dffd4c3
 +
 +func VerifyDSA(pub *PublicKeyDSA, hashed []byte, r, s boring.BigInt, encodeSignature func(r, s boring.BigInt) ([]byte, error)) bool {
 +	panic("cryptobackend: not available")
++}
+diff --git a/src/crypto/internal/backend/fips140/boring.go b/src/crypto/internal/backend/fips140/boring.go
+new file mode 100644
+index 00000000000000..3b583dc0eb0235
+--- /dev/null
++++ b/src/crypto/internal/backend/fips140/boring.go
+@@ -0,0 +1,11 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build goexperiment.boringcrypto
++
++package fips140
++
++func systemFIPSMode() bool {
++	return false
 +}

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -8,19 +8,20 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/openssl_linux.go  | 371 ++++++++++++++++++
- src/crypto/rsa/rsa_test.go                    |   3 +
+ .../internal/backend/fips140/openssl.go       |  41 +++
+ src/crypto/internal/backend/openssl_linux.go  | 323 ++++++++++++++++++
  src/crypto/tls/key_schedule.go                |   1 +
  src/go.mod                                    |   1 +
  src/go.sum                                    |   2 +
- src/go/build/deps_test.go                     |   7 +-
+ src/go/build/deps_test.go                     |   9 +-
  src/go/build/vendor_test.go                   |   1 +
  .../goexperiment/exp_opensslcrypto_off.go     |   9 +
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 15 files changed, 435 insertions(+), 4 deletions(-)
+ 16 files changed, 429 insertions(+), 5 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
+ create mode 100644 src/crypto/internal/backend/fips140/openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_on.go
@@ -92,12 +93,59 @@ index 00000000000000..e6695dd66b1d02
 +
 +var Enc = bbig.Enc
 +var Dec = bbig.Dec
+diff --git a/src/crypto/internal/backend/fips140/openssl.go b/src/crypto/internal/backend/fips140/openssl.go
+new file mode 100644
+index 00000000000000..118efa3a492a7d
+--- /dev/null
++++ b/src/crypto/internal/backend/fips140/openssl.go
+@@ -0,0 +1,41 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build goexperiment.opensslcrypto
++
++package fips140
++
++import "syscall"
++
++func systemFIPSMode() bool {
++	var fd int
++	for {
++		var err error
++		fd, err = syscall.Open("/proc/sys/crypto/fips_enabled", syscall.O_RDONLY, 0)
++		if err == nil {
++			break
++		}
++		switch err {
++		case syscall.EINTR:
++			continue
++		case syscall.ENOENT:
++			return false
++		default:
++			// If there is an error reading we could either panic or assume FIPS is not enabled.
++			// Panicking would be too disruptive for apps that don't require FIPS.
++			// If an app wants to be 100% sure that is running in FIPS mode
++			// it should use boring.Enabled() or GOFIPS=1.
++			return false
++		}
++	}
++	defer syscall.Close(fd)
++	var tmp [1]byte
++	n, err := syscall.Read(fd, tmp[:])
++	if n != 1 || err != nil {
++		// We return false instead of panicing for the same reason as before.
++		return false
++	}
++	// fips_enabled can be either '0' or '1'.
++	return tmp[0] == '1'
++}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..57af729e1458f5
+index 00000000000000..bccf529a4bcfac
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,371 @@
+@@ -0,0 +1,323 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -112,7 +160,7 @@ index 00000000000000..57af729e1458f5
 +import (
 +	"crypto"
 +	"crypto/cipher"
-+	"crypto/internal/boring/fipstls"
++	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
 +	"hash"
 +	"syscall"
@@ -163,68 +211,20 @@ index 00000000000000..57af729e1458f5
 +	if err := openssl.Init(lcrypto); err != nil {
 +		panic("opensslcrypto: can't initialize OpenSSL " + lcrypto + ": " + err.Error())
 +	}
-+	// 0: FIPS opt-out: abort the process if it is enabled and can't be disabled.
-+	// 1: FIPS required: abort the process if it is not enabled and can't be enabled.
-+	// other values: do not override OpenSSL configured FIPS mode.
-+	var fips string
-+	if v, _, ok := envGoFIPS(); ok {
-+		fips = v
-+	} else if systemFIPSMode() {
-+		// System configuration can only force FIPS mode.
-+		fips = "1"
-+	}
-+	switch fips {
-+	case "0":
-+		if openssl.FIPS() {
-+			if err := openssl.SetFIPS(false); err != nil {
-+				panic("opensslcrypto: can't disable FIPS mode for " + openssl.VersionText() + ": " + err.Error())
-+			}
-+		}
-+	case "1":
++	if fips140.Enabled() {
 +		if !openssl.FIPS() {
 +			if err := openssl.SetFIPS(true); err != nil {
 +				panic("opensslcrypto: can't enable FIPS mode for " + openssl.VersionText() + ": " + err.Error())
 +			}
 +		}
-+	}
-+	if openssl.FIPS() {
-+		// FIPS mode is enabled,
-+		// so force FIPS mode for crypto/tls and crypto/x509.
-+		fipstls.Force()
++	} else if fips140.Disabled() {
++		if openssl.FIPS() {
++			if err := openssl.SetFIPS(false); err != nil {
++				panic("opensslcrypto: can't disable FIPS mode for " + openssl.VersionText() + ": " + err.Error())
++			}
++		}
 +	}
 +	sig.BoringCrypto()
-+}
-+
-+func systemFIPSMode() bool {
-+	var fd int
-+	for {
-+		var err error
-+		fd, err = syscall.Open("/proc/sys/crypto/fips_enabled", syscall.O_RDONLY, 0)
-+		if err == nil {
-+			break
-+		}
-+		switch err {
-+		case syscall.EINTR:
-+			continue
-+		case syscall.ENOENT:
-+			return false
-+		default:
-+			// If there is an error reading we could either panic or assume FIPS is not enabled.
-+			// Panicking would be too disruptive for apps that don't require FIPS.
-+			// If an app wants to be 100% sure that is running in FIPS mode
-+			// it should use boring.Enabled() or GOFIPS=1.
-+			return false
-+		}
-+	}
-+	defer syscall.Close(fd)
-+	var tmp [1]byte
-+	n, err := syscall.Read(fd, tmp[:])
-+	if n != 1 || err != nil {
-+		// We return false instead of panicing for the same reason as before.
-+		return false
-+	}
-+	// fips_enabled can be either '0' or '1'.
-+	return tmp[0] == '1'
 +}
 +
 +const RandReader = openssl.RandReader
@@ -518,19 +518,22 @@ index b4efd6d3c50c11..fd8881e46df76e 100644
  golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
  golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd h1:pHzwejE8Zkb94bG4nA+fUeskKPFp1HPldrhv62dabro=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 578b4d6f68504c..80a14d54739524 100644
+index 6c7229b41c825e..6504a23ce5d51f 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -476,6 +476,8 @@ var depsRules = `
+@@ -479,8 +479,10 @@ var depsRules = `
+ 	< crypto/cipher;
  
  	crypto/cipher,
- 	crypto/internal/boring/bcache
+-	crypto/internal/boring/bcache
++	crypto/internal/boring/bcache,
+ 	crypto/internal/backend/fips140
 +	< github.com/golang-fips/openssl/v2/internal/subtle
 +	< github.com/golang-fips/openssl/v2
  	< crypto/internal/boring
  	< crypto/internal/backend
  	< crypto/boring;
-@@ -514,6 +516,7 @@ var depsRules = `
+@@ -519,6 +521,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
@@ -538,7 +541,7 @@ index 578b4d6f68504c..80a14d54739524 100644
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
  	< crypto/rand
-@@ -812,7 +815,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -817,7 +820,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -547,7 +550,7 @@ index 578b4d6f68504c..80a14d54739524 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -822,7 +825,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -827,7 +830,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  src/crypto/internal/backend/cng_windows.go    | 310 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  13 +-
- src/crypto/internal/backend/fips140/cng.go    |  30 ++
+ src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/internal/boring/fipstls/stub.s     |   2 +-
  src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/pss.go                         |   2 +-
@@ -22,7 +22,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 16 files changed, 417 insertions(+), 6 deletions(-)
+ 17 files changed, 417 insertions(+), 6 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -88,7 +88,7 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..7fb68218e56e9f
+index 00000000000000..2d7a18eaec2e23
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,310 @@
@@ -432,10 +432,10 @@ index 07d965bf8b467c..91223c0ef0f810 100644
 +}
 diff --git a/src/crypto/internal/backend/fips140/cng.go b/src/crypto/internal/backend/fips140/cng.go
 new file mode 100644
-index 00000000000000..22e4197bbb3ba5
+index 00000000000000..f769d15f94ab05
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/cng.go
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,33 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -463,7 +463,10 @@ index 00000000000000..22e4197bbb3ba5
 +
 +func systemFIPSMode() bool {
 +	var enabled uint32
-+	bcryptGetFipsAlgorithmMode.Call(uintptr(unsafe.Pointer(&enabled)))
++	ret, _, _ := bcryptGetFipsAlgorithmMode.Call(uintptr(unsafe.Pointer(&enabled)))
++	if ret != 0 {
++		return false
++	}
 +	return enabled != 0
 +}
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -7,8 +7,11 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/ecdsa/badlinkname.go               |  17 +
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 317 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 310 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  13 +-
+ src/crypto/internal/backend/fips140/cng.go    |  30 ++
+ src/crypto/internal/boring/fipstls/stub.s     |   2 +-
+ src/crypto/internal/boring/fipstls/tls.go     |   2 +-
  src/crypto/rsa/pss.go                         |   2 +-
  src/crypto/rsa/pss_test.go                    |   2 +-
  src/go.mod                                    |   1 +
@@ -19,10 +22,11 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 15 files changed, 391 insertions(+), 6 deletions(-)
+ 16 files changed, 417 insertions(+), 6 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
+ create mode 100644 src/crypto/internal/backend/fips140/cng.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_on.go
 
@@ -84,10 +88,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..543b5ed1b5d15c
+index 00000000000000..7fb68218e56e9f
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,317 @@
+@@ -0,0 +1,310 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -102,7 +106,7 @@ index 00000000000000..543b5ed1b5d15c
 +import (
 +	"crypto"
 +	"crypto/cipher"
-+	"crypto/internal/boring/fipstls"
++	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
 +	"hash"
 +	_ "unsafe"
@@ -116,9 +120,7 @@ index 00000000000000..543b5ed1b5d15c
 +type BigInt = cng.BigInt
 +
 +func init() {
-+	// 1: FIPS required: abort the process if the system is not in FIPS mode.
-+	// other values: continue regardless of system-configured FIPS mode.
-+	if v, _, ok := envGoFIPS(); ok && v == "1" {
++	if fips140.Enabled() {
 +		enabled, err := cng.FIPS()
 +		if err != nil {
 +			panic("cngcrypto: unknown FIPS mode: " + err.Error())
@@ -126,11 +128,6 @@ index 00000000000000..543b5ed1b5d15c
 +		if !enabled {
 +			panic("cngcrypto: not in FIPS mode")
 +		}
-+	}
-+	if enabled, _ := cng.FIPS(); enabled {
-+		// FIPS mode is enabled,
-+		// so force FIPS mode for crypto/tls and crypto/x509.
-+		fipstls.Force()
 +	}
 +	sig.BoringCrypto()
 +}
@@ -406,10 +403,10 @@ index 00000000000000..543b5ed1b5d15c
 +	return cng.VerifyDSA(pub, hashed, r, s)
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
-index bc595e91024f11..7766d674f5cfaf 100644
+index 07d965bf8b467c..91223c0ef0f810 100644
 --- a/src/crypto/internal/backend/common.go
 +++ b/src/crypto/internal/backend/common.go
-@@ -68,7 +68,11 @@ func hasSuffix(s, t string) bool {
+@@ -44,7 +44,11 @@ func hasSuffix(s, t string) bool {
  // UnreachableExceptTests marks code that should be unreachable
  // when backend is in use. It panics.
  func UnreachableExceptTests() {
@@ -422,7 +419,7 @@ index bc595e91024f11..7766d674f5cfaf 100644
  		name := runtime_arg0()
  		// If ran on Windows we'd need to allow _test.exe and .test.exe as well.
  		if !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
-@@ -90,3 +94,10 @@ func IsRSAKeySupported(primes int) bool {
+@@ -66,3 +70,10 @@ func IsRSAKeySupported(primes int) bool {
  	// Given the above reasons, we only support 2-prime RSA keys.
  	return primes == 2
  }
@@ -432,6 +429,42 @@ index bc595e91024f11..7766d674f5cfaf 100644
 +		return salt != 0 // rsa.PSSSaltLengthAuto
 +	}
 +	return true
++}
+diff --git a/src/crypto/internal/backend/fips140/cng.go b/src/crypto/internal/backend/fips140/cng.go
+new file mode 100644
+index 00000000000000..22e4197bbb3ba5
+--- /dev/null
++++ b/src/crypto/internal/backend/fips140/cng.go
+@@ -0,0 +1,30 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build goexperiment.cngcrypto
++
++package fips140
++
++import (
++	"internal/syscall/windows/sysdll"
++	"syscall"
++	"unsafe"
++)
++
++// Don't use github.com/microsoft/go-crypto-winnative here.
++// The fips140 package should have minimal dependencies.
++// Also, don't directly query the system FIPS mode from the registry,
++// there are some no-longer documented legacy entries that can enable FIPS mode,
++// and BCryptGetFipsAlgorithmMode supports them all.
++var (
++	bcrypt = syscall.MustLoadDLL(sysdll.Add("bcrypt.dll"))
++
++	bcryptGetFipsAlgorithmMode = bcrypt.MustFindProc("BCryptGetFipsAlgorithmMode")
++)
++
++func systemFIPSMode() bool {
++	var enabled uint32
++	bcryptGetFipsAlgorithmMode.Call(uintptr(unsafe.Pointer(&enabled)))
++	return enabled != 0
 +}
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
 index 4aac87d7952081..010ee1467501c3 100644
@@ -484,13 +517,13 @@ index fd8881e46df76e..1d0d5a1b7845bb 100644
  golang.org/x/crypto v0.25.1-0.20240722173533-bb80217080b0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
  golang.org/x/net v0.27.1-0.20240722181819-765c7e89b3bd h1:pHzwejE8Zkb94bG4nA+fUeskKPFp1HPldrhv62dabro=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 80a14d54739524..74e0606b0ac903 100644
+index 6504a23ce5d51f..3b30b0dc249a94 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -476,6 +476,10 @@ var depsRules = `
- 
+@@ -481,6 +481,10 @@ var depsRules = `
  	crypto/cipher,
- 	crypto/internal/boring/bcache
+ 	crypto/internal/boring/bcache,
+ 	crypto/internal/backend/fips140
 +	< github.com/microsoft/go-crypto-winnative/internal/subtle
 +	< github.com/microsoft/go-crypto-winnative/internal/sysdll
 +	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
@@ -498,7 +531,7 @@ index 80a14d54739524..74e0606b0ac903 100644
  	< github.com/golang-fips/openssl/v2/internal/subtle
  	< github.com/golang-fips/openssl/v2
  	< crypto/internal/boring
-@@ -516,6 +520,7 @@ var depsRules = `
+@@ -521,6 +525,7 @@ var depsRules = `
  
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big


### PR DESCRIPTION
(Review ignoring whitespaces)

Upstream refactored the fipstls logic to support the new built-in FIPS module. This is causing many conflicts in the upstream sync PR.

This PR moved the logic that detects whether FIPS mode is required or not (e.g. setting the `GOFIPS` env var) to its own package that only depends on `syscall`. This way we can easily import it elsewhere, for example in `crypto/internal/boring/fipstls` and make `crypto/internal/backend` not depend on the former. Doing so will greatly simplify reconciling the conflicts in the upstream sync PR.

The refactor shouldn't change any behavior.

For https://github.com/microsoft/go/issues/1416.
For https://github.com/microsoft/go/pull/1383.