### PR TITLE
Consistently use systemcrypto as a build tag

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -2304,7 +2304,7 @@ index 3091f7a67acede..fead8cc4bec73a 100644
  
 diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
 new file mode 100644
-index 00000000000000..0f289915be6daa
+index 00000000000000..11dc691600b110
 --- /dev/null
 +++ b/src/hash/notboring_test.go
 @@ -0,0 +1,9 @@
@@ -2312,7 +2312,7 @@ index 00000000000000..0f289915be6daa
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !goexperiment.boringcrypto
++//go:build !goexperiment.systemcrypto
 +
 +package hash_test
 +

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -4,18 +4,20 @@ Date: Thu, 30 Jun 2022 10:03:03 +0200
 Subject: [PATCH] Add crypto backend foundation
 
 ---
+ src/cmd/api/boring_test.go                   |   2 +-
+ src/cmd/go/go_boring_test.go                 |   2 +-
  src/crypto/aes/cipher.go                     |   2 +-
  src/crypto/aes/cipher_asm.go                 |   2 +-
- src/crypto/boring/boring.go                  |   2 +-
+ src/crypto/boring/boring.go                  |   4 +-
  src/crypto/des/cipher.go                     |   7 +
  src/crypto/dsa/boring.go                     | 113 ++++++++++
  src/crypto/dsa/dsa.go                        |  88 ++++++++
  src/crypto/dsa/notboring.go                  |  16 ++
  src/crypto/ecdh/ecdh.go                      |   2 +-
  src/crypto/ecdh/nist.go                      |   2 +-
- src/crypto/ecdsa/boring.go                   |   4 +-
+ src/crypto/ecdsa/boring.go                   |   6 +-
  src/crypto/ecdsa/ecdsa.go                    |   4 +-
- src/crypto/ecdsa/notboring.go                |   2 +-
+ src/crypto/ecdsa/notboring.go                |   4 +-
  src/crypto/ed25519/boring.go                 |  71 ++++++
  src/crypto/ed25519/ed25519.go                |  75 ++++++-
  src/crypto/ed25519/ed25519_test.go           |   2 +-
@@ -29,14 +31,17 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/internal/backend/nobackend.go     | 223 +++++++++++++++++++
  src/crypto/internal/backend/norequirefips.go |   9 +
  src/crypto/internal/backend/stub.s           |  10 +
+ src/crypto/internal/boring/fipstls/stub.s    |   2 +-
+ src/crypto/internal/boring/fipstls/tls.go    |   2 +-
  src/crypto/md5/md5.go                        |   7 +
  src/crypto/md5/md5_test.go                   |  14 ++
  src/crypto/purego_test.go                    |   2 +-
  src/crypto/rand/rand.go                      |   2 +-
  src/crypto/rand/rand_test.go                 |   2 +-
  src/crypto/rc4/rc4.go                        |  18 ++
- src/crypto/rsa/boring.go                     |   4 +-
- src/crypto/rsa/notboring.go                  |   2 +-
+ src/crypto/rsa/boring.go                     |   6 +-
+ src/crypto/rsa/boring_test.go                |   2 +-
+ src/crypto/rsa/notboring.go                  |   4 +-
  src/crypto/rsa/pkcs1v15.go                   |  10 +-
  src/crypto/rsa/pkcs1v15_test.go              |   5 +
  src/crypto/rsa/pss.go                        |   8 +-
@@ -49,21 +54,27 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/sha256/sha256_test.go             |  20 +-
  src/crypto/sha512/sha512.go                  |   2 +-
  src/crypto/sha512/sha512_test.go             |  20 +-
- src/crypto/tls/boring_test.go                |   5 +
+ src/crypto/tls/boring.go                     |   2 +-
+ src/crypto/tls/boring_test.go                |   7 +-
  src/crypto/tls/cipher_suites.go              |   2 +-
+ src/crypto/tls/fipsonly/fipsonly.go          |   2 +-
+ src/crypto/tls/fipsonly/fipsonly_test.go     |   2 +-
  src/crypto/tls/handshake_client.go           |  10 +-
  src/crypto/tls/handshake_server.go           |  10 +-
  src/crypto/tls/handshake_server_tls13.go     |  10 +
  src/crypto/tls/key_schedule.go               |  23 +-
+ src/crypto/tls/notboring.go                  |   2 +-
  src/crypto/tls/prf.go                        |  40 ++++
- src/crypto/x509/boring_test.go               |   5 +
+ src/crypto/x509/boring.go                    |   2 +-
+ src/crypto/x509/boring_test.go               |   7 +-
+ src/crypto/x509/notboring.go                 |   2 +-
  src/go/build/deps_test.go                    |   4 +
  src/hash/boring_test.go                      |   9 +
  src/hash/marshal_test.go                     |   5 +
  src/hash/notboring_test.go                   |   9 +
  src/net/smtp/smtp_test.go                    |  72 +++---
  src/runtime/runtime_boring.go                |   5 +
- 59 files changed, 1107 insertions(+), 76 deletions(-)
+ 70 files changed, 1125 insertions(+), 94 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ed25519/boring.go
@@ -78,6 +89,32 @@ Subject: [PATCH] Add crypto backend foundation
  create mode 100644 src/hash/boring_test.go
  create mode 100644 src/hash/notboring_test.go
 
+diff --git a/src/cmd/api/boring_test.go b/src/cmd/api/boring_test.go
+index f0e3575637c62a..9eab3b4e66e60b 100644
+--- a/src/cmd/api/boring_test.go
++++ b/src/cmd/api/boring_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ package main
+ 
+diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
+index ed0fbf3d53d75b..06478963f4be44 100644
+--- a/src/cmd/go/go_boring_test.go
++++ b/src/cmd/go/go_boring_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ package main_test
+ 
 diff --git a/src/crypto/aes/cipher.go b/src/crypto/aes/cipher.go
 index cde2e45d2ca559..cf47a4fc57d8e2 100644
 --- a/src/crypto/aes/cipher.go
@@ -105,9 +142,18 @@ index 3e5f589c2cdd0b..e9d3c0be11ef61 100644
  	"internal/goarch"
  )
 diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
-index 097c37e343fdb8..1cf43edba40359 100644
+index 097c37e343fdb8..a5d603896d3890 100644
 --- a/src/crypto/boring/boring.go
 +++ b/src/crypto/boring/boring.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ // Package boring exposes functions that are only available when building with
+ // Go+BoringCrypto. This package is available on all targets as long as the
 @@ -13,7 +13,7 @@
  // is satisfied, so that applications can tag files that use this package.
  package boring
@@ -151,7 +197,7 @@ index 04b73e7d3bf758..0891652a4566fb 100644
  	c.cipher1.generateSubkeys(key[:8])
 diff --git a/src/crypto/dsa/boring.go b/src/crypto/dsa/boring.go
 new file mode 100644
-index 00000000000000..3be888a0104809
+index 00000000000000..7ea0c8c423e9ee
 --- /dev/null
 +++ b/src/crypto/dsa/boring.go
 @@ -0,0 +1,113 @@
@@ -159,7 +205,7 @@ index 00000000000000..3be888a0104809
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
++//go:build goexperiment.systemcrypto
 +
 +package dsa
 +
@@ -402,7 +448,7 @@ index 4524bd492feba0..ff890b1d06aea2 100644
 +}
 diff --git a/src/crypto/dsa/notboring.go b/src/crypto/dsa/notboring.go
 new file mode 100644
-index 00000000000000..f8771d0189f990
+index 00000000000000..cd02ff5a00c3dc
 --- /dev/null
 +++ b/src/crypto/dsa/notboring.go
 @@ -0,0 +1,16 @@
@@ -410,7 +456,7 @@ index 00000000000000..f8771d0189f990
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
++//go:build !goexperiment.systemcrypto
 +
 +package dsa
 +
@@ -449,10 +495,16 @@ index b91e8f38a5a78e..2bb8f3486c8249 100644
  	"crypto/internal/randutil"
  	"errors"
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
-index 275c60b4de49eb..61e70f981db4eb 100644
+index 275c60b4de49eb..ff8bddf28c4545 100644
 --- a/src/crypto/ecdsa/boring.go
 +++ b/src/crypto/ecdsa/boring.go
-@@ -7,8 +7,8 @@
+@@ -2,13 +2,13 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
  package ecdsa
  
  import (
@@ -480,10 +532,15 @@ index 2179b01e8e3db5..9eb763cecfe687 100644
  	"crypto/internal/randutil"
  	"crypto/sha512"
 diff --git a/src/crypto/ecdsa/notboring.go b/src/crypto/ecdsa/notboring.go
-index 039bd82ed21f9f..19188518e85e65 100644
+index 039bd82ed21f9f..69a97d9bf250be 100644
 --- a/src/crypto/ecdsa/notboring.go
 +++ b/src/crypto/ecdsa/notboring.go
-@@ -6,7 +6,7 @@
+@@ -2,11 +2,11 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !boringcrypto
++//go:build !goexperiment.systemcrypto
  
  package ecdsa
  
@@ -799,7 +856,7 @@ index 00000000000000..c2c06d3bff8c74
 +}
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
 new file mode 100644
-index 00000000000000..85bd3ed083f5b2
+index 00000000000000..20251a290dc2e0
 --- /dev/null
 +++ b/src/crypto/internal/backend/bbig/big.go
 @@ -0,0 +1,17 @@
@@ -807,7 +864,7 @@ index 00000000000000..85bd3ed083f5b2
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !boringcrypto
++//go:build !goexperiment.systemcrypto
 +
 +package bbig
 +
@@ -1193,6 +1250,32 @@ index 00000000000000..5e4b436554d44d
 +// Having this assembly file keeps the go command
 +// from complaining about the missing body
 +// (because the implementation might be here).
+diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
+index f2e5a503eaacb6..35cf7532625efb 100644
+--- a/src/crypto/internal/boring/fipstls/stub.s
++++ b/src/crypto/internal/boring/fipstls/stub.s
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ // runtime_arg0 is declared in tls.go without a body.
+ // It's provided by package runtime,
+diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
+index b51f142fde8311..0ea6593743349b 100644
+--- a/src/crypto/internal/boring/fipstls/tls.go
++++ b/src/crypto/internal/boring/fipstls/tls.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
+ // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
 diff --git a/src/crypto/md5/md5.go b/src/crypto/md5/md5.go
 index c984c3f4968598..229dd457f8d53c 100644
 --- a/src/crypto/md5/md5.go
@@ -1368,10 +1451,16 @@ index 67452ec39f0fd4..47726d0ebe38d9 100644
  		return
  	}
 diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
-index b9f9d3154f2589..ecb43aaf264743 100644
+index b9f9d3154f2589..d52faddef45549 100644
 --- a/src/crypto/rsa/boring.go
 +++ b/src/crypto/rsa/boring.go
-@@ -7,8 +7,8 @@
+@@ -2,13 +2,13 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
  package rsa
  
  import (
@@ -1382,11 +1471,29 @@ index b9f9d3154f2589..ecb43aaf264743 100644
  	"crypto/internal/boring/bcache"
  	"math/big"
  )
+diff --git a/src/crypto/rsa/boring_test.go b/src/crypto/rsa/boring_test.go
+index 2234d079f0d9e7..94ce18b2338416 100644
+--- a/src/crypto/rsa/boring_test.go
++++ b/src/crypto/rsa/boring_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ // Note: Can run these tests against the non-BoringCrypto
+ // version of the code by using "CGO_ENABLED=0 go test".
 diff --git a/src/crypto/rsa/notboring.go b/src/crypto/rsa/notboring.go
-index 2abc0436405f8a..34c22c8fbba7da 100644
+index 2abc0436405f8a..3e4d6f3eef61e6 100644
 --- a/src/crypto/rsa/notboring.go
 +++ b/src/crypto/rsa/notboring.go
-@@ -6,7 +6,7 @@
+@@ -2,11 +2,11 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !boringcrypto
++//go:build !goexperiment.systemcrypto
  
  package rsa
  
@@ -1815,10 +1922,32 @@ index fdad37b1863ae8..cf6e4c395cd4fb 100644
  	for i, test := range largeUnmarshalTests {
  
  		h := New()
+diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
+index c44ae92f2528f3..ddfec0c438265e 100644
+--- a/src/crypto/tls/boring.go
++++ b/src/crypto/tls/boring.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ package tls
+ 
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 56050421985927..dcbd33167e4499 100644
+index 56050421985927..863ad8d1faf810 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ package tls
+ 
 @@ -25,6 +25,11 @@ import (
  	"time"
  )
@@ -1844,6 +1973,32 @@ index 917a1eff42d34f..f6f57130b64f41 100644
  	"crypto/rc4"
  	"crypto/sha1"
  	"crypto/sha256"
+diff --git a/src/crypto/tls/fipsonly/fipsonly.go b/src/crypto/tls/fipsonly/fipsonly.go
+index e5e47835e2f48d..7dccbc7c3d748a 100644
+--- a/src/crypto/tls/fipsonly/fipsonly.go
++++ b/src/crypto/tls/fipsonly/fipsonly.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ // Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+ //
+diff --git a/src/crypto/tls/fipsonly/fipsonly_test.go b/src/crypto/tls/fipsonly/fipsonly_test.go
+index f8485dc3ca1c29..d4915031340480 100644
+--- a/src/crypto/tls/fipsonly/fipsonly_test.go
++++ b/src/crypto/tls/fipsonly/fipsonly_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ package fipsonly
+ 
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
 index 760e827f467f15..393c59ba8f1183 100644
 --- a/src/crypto/tls/handshake_client.go
@@ -1955,6 +2110,19 @@ index 1636baf79e7288..747c3c0883230c 100644
  	return hkdf.Extract(c.hash.New, newSecret, currentSecret)
  }
  
+diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
+index bdbc32e05b35dd..3bfe4096471910 100644
+--- a/src/crypto/tls/notboring.go
++++ b/src/crypto/tls/notboring.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !boringcrypto
++//go:build !goexperiment.systemcrypto
+ 
+ package tls
+ 
 diff --git a/src/crypto/tls/prf.go b/src/crypto/tls/prf.go
 index a7fa3370e66c82..d34cd41f0891db 100644
 --- a/src/crypto/tls/prf.go
@@ -2022,10 +2190,32 @@ index a7fa3370e66c82..d34cd41f0891db 100644
  		labelAndSeed := make([]byte, len(label)+len(seed))
  		copy(labelAndSeed, label)
  		copy(labelAndSeed[len(label):], seed)
+diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
+index 095b58c31590d4..6b32417ea85657 100644
+--- a/src/crypto/x509/boring.go
++++ b/src/crypto/x509/boring.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ package x509
+ 
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index 319ac61f49c994..1b2454dbaab264 100644
+index 319ac61f49c994..b5f52252fb3e37 100644
 --- a/src/crypto/x509/boring_test.go
 +++ b/src/crypto/x509/boring_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
++//go:build goexperiment.systemcrypto
+ 
+ package x509
+ 
 @@ -26,6 +26,11 @@ const (
  	boringCertFIPSOK = 0x80
  )
@@ -2038,6 +2228,19 @@ index 319ac61f49c994..1b2454dbaab264 100644
  func boringRSAKey(t *testing.T, size int) *rsa.PrivateKey {
  	t.Helper()
  	k, err := rsa.GenerateKey(rand.Reader, size)
+diff --git a/src/crypto/x509/notboring.go b/src/crypto/x509/notboring.go
+index c83a7272c9f01f..7f6e574dc0c2dc 100644
+--- a/src/crypto/x509/notboring.go
++++ b/src/crypto/x509/notboring.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !boringcrypto
++//go:build !goexperiment.systemcrypto
+ 
+ package x509
+ 
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index c6a2518f62ff3a..578b4d6f68504c 100644
 --- a/src/go/build/deps_test.go
@@ -2070,7 +2273,7 @@ index c6a2518f62ff3a..578b4d6f68504c 100644
  	< crypto/ed25519
 diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
 new file mode 100644
-index 00000000000000..b4cb21f3580737
+index 00000000000000..52748c44698076
 --- /dev/null
 +++ b/src/hash/boring_test.go
 @@ -0,0 +1,9 @@
@@ -2078,7 +2281,7 @@ index 00000000000000..b4cb21f3580737
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.boringcrypto
++//go:build goexperiment.systemcrypto
 +
 +package hash_test
 +

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -15,12 +15,11 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/go.sum                                    |   2 +
  src/go/build/deps_test.go                     |   7 +-
  src/go/build/vendor_test.go                   |   1 +
- src/hash/notboring_test.go                    |   2 +-
  .../goexperiment/exp_opensslcrypto_off.go     |   9 +
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 16 files changed, 436 insertions(+), 5 deletions(-)
+ 15 files changed, 435 insertions(+), 4 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
@@ -569,19 +568,6 @@ index 7f6237ffd59c11..7c821ae4bc5727 100644
  }
  
  // Verify that the vendor directories contain only packages matching the list above.
-diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
-index 0f289915be6daa..bd935326bf7305 100644
---- a/src/hash/notboring_test.go
-+++ b/src/hash/notboring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !goexperiment.boringcrypto
-+//go:build !goexperiment.boringcrypto && !goexperiment.opensslcrypto
- 
- package hash_test
- 
 diff --git a/src/internal/goexperiment/exp_opensslcrypto_off.go b/src/internal/goexperiment/exp_opensslcrypto_off.go
 new file mode 100644
 index 00000000000000..62033547c6143a

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -4,61 +4,28 @@ Date: Thu, 30 Jun 2022 10:06:19 +0200
 Subject: [PATCH] Add OpenSSL crypto backend
 
 ---
- src/cmd/api/boring_test.go                    |   2 +-
  src/cmd/dist/test.go                          |   3 +-
- src/cmd/go/go_boring_test.go                  |   2 +-
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
- src/crypto/boring/boring.go                   |   2 +-
- src/crypto/ecdsa/boring.go                    |   2 +-
- src/crypto/ecdsa/notboring.go                 |   2 +-
- src/crypto/internal/backend/bbig/big.go       |   2 +-
  .../internal/backend/bbig/big_openssl.go      |  12 +
  src/crypto/internal/backend/openssl_linux.go  | 371 ++++++++++++++++++
- src/crypto/internal/boring/fipstls/stub.s     |   2 +-
- src/crypto/internal/boring/fipstls/tls.go     |   2 +-
- src/crypto/rsa/boring.go                      |   2 +-
- src/crypto/rsa/boring_test.go                 |   2 +-
- src/crypto/rsa/notboring.go                   |   2 +-
  src/crypto/rsa/rsa_test.go                    |   3 +
- src/crypto/tls/boring.go                      |   2 +-
- src/crypto/tls/boring_test.go                 |   2 +-
- src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
- src/crypto/tls/fipsonly/fipsonly_test.go      |   2 +-
  src/crypto/tls/key_schedule.go                |   1 +
- src/crypto/tls/notboring.go                   |   2 +-
- src/crypto/x509/boring.go                     |   2 +-
- src/crypto/x509/boring_test.go                |   2 +-
- src/crypto/x509/notboring.go                  |   2 +-
  src/go.mod                                    |   1 +
  src/go.sum                                    |   2 +
  src/go/build/deps_test.go                     |   7 +-
  src/go/build/vendor_test.go                   |   1 +
- src/hash/boring_test.go                       |   2 +-
  src/hash/notboring_test.go                    |   2 +-
  .../goexperiment/exp_opensslcrypto_off.go     |   9 +
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 36 files changed, 456 insertions(+), 25 deletions(-)
+ 16 files changed, 436 insertions(+), 5 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_on.go
 
-diff --git a/src/cmd/api/boring_test.go b/src/cmd/api/boring_test.go
-index f0e3575637c62a..0e9aceeb832d3b 100644
---- a/src/cmd/api/boring_test.go
-+++ b/src/cmd/api/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- package main
- 
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
 index 0facfb579cb196..223472e20d24a5 100644
 --- a/src/cmd/dist/test.go
@@ -77,19 +44,6 @@ index 0facfb579cb196..223472e20d24a5 100644
  			// Static linking tests
  			if goos != "android" && p != "netbsd/arm" {
  				// TODO(#56629): Why does this fail on netbsd-arm?
-diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
-index ed0fbf3d53d75b..5376227f74cfaa 100644
---- a/src/cmd/go/go_boring_test.go
-+++ b/src/cmd/go/go_boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- package main_test
- 
 diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
 index 4aaf46b5d0f0dc..6fe798cf4a94e9 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
@@ -121,58 +75,6 @@ index 0c37a1dc1f8c15..faf8a1874d5f28 100644
  	"crypto/internal/boring",
  	"crypto/internal/boring/syso",
  	"crypto/x509",
-diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
-index 1cf43edba40359..7b04f14ebdd618 100644
---- a/src/crypto/boring/boring.go
-+++ b/src/crypto/boring/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- // Package boring exposes functions that are only available when building with
- // Go+BoringCrypto. This package is available on all targets as long as the
-diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
-index 61e70f981db4eb..602cb894e20d39 100644
---- a/src/crypto/ecdsa/boring.go
-+++ b/src/crypto/ecdsa/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- package ecdsa
- 
-diff --git a/src/crypto/ecdsa/notboring.go b/src/crypto/ecdsa/notboring.go
-index 19188518e85e65..3cc16ecab567a0 100644
---- a/src/crypto/ecdsa/notboring.go
-+++ b/src/crypto/ecdsa/notboring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto
- 
- package ecdsa
- 
-diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
-index 85bd3ed083f5b2..51bc3c68048d51 100644
---- a/src/crypto/internal/backend/bbig/big.go
-+++ b/src/crypto/internal/backend/bbig/big.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto
- 
- package bbig
- 
 diff --git a/src/crypto/internal/backend/bbig/big_openssl.go b/src/crypto/internal/backend/bbig/big_openssl.go
 new file mode 100644
 index 00000000000000..e6695dd66b1d02
@@ -568,71 +470,6 @@ index 00000000000000..57af729e1458f5
 +
 +	return openssl.VerifyDSA(pub, hashed, sig)
 +}
-diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
-index f2e5a503eaacb6..1dc7116efdff2e 100644
---- a/src/crypto/internal/boring/fipstls/stub.s
-+++ b/src/crypto/internal/boring/fipstls/stub.s
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- // runtime_arg0 is declared in tls.go without a body.
- // It's provided by package runtime,
-diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
-index b51f142fde8311..f5b4827c688f3b 100644
---- a/src/crypto/internal/boring/fipstls/tls.go
-+++ b/src/crypto/internal/boring/fipstls/tls.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
- // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
-diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
-index ecb43aaf264743..220f8c05c3d94b 100644
---- a/src/crypto/rsa/boring.go
-+++ b/src/crypto/rsa/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- package rsa
- 
-diff --git a/src/crypto/rsa/boring_test.go b/src/crypto/rsa/boring_test.go
-index 2234d079f0d9e7..82a9d220e139af 100644
---- a/src/crypto/rsa/boring_test.go
-+++ b/src/crypto/rsa/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- // Note: Can run these tests against the non-BoringCrypto
- // version of the code by using "CGO_ENABLED=0 go test".
-diff --git a/src/crypto/rsa/notboring.go b/src/crypto/rsa/notboring.go
-index 34c22c8fbba7da..933ac569e034a8 100644
---- a/src/crypto/rsa/notboring.go
-+++ b/src/crypto/rsa/notboring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto
- 
- package rsa
- 
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
 index c6294694521c69..ab99b176ac9540 100644
 --- a/src/crypto/rsa/rsa_test.go
@@ -647,58 +484,6 @@ index c6294694521c69..ab99b176ac9540 100644
  	random := rand.Reader
  
  	msg := []byte{0xed, 0x36, 0x90, 0x8d, 0xbe, 0xfc, 0x35, 0x40, 0x70, 0x4f, 0xf5, 0x9d, 0x6e, 0xc2, 0xeb, 0xf5, 0x27, 0xae, 0x65, 0xb0, 0x59, 0x29, 0x45, 0x25, 0x8c, 0xc1, 0x91, 0x22}
-diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index c44ae92f2528f3..698efc6751e12c 100644
---- a/src/crypto/tls/boring.go
-+++ b/src/crypto/tls/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- package tls
- 
-diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index dcbd33167e4499..1f577fd1d4d9ec 100644
---- a/src/crypto/tls/boring_test.go
-+++ b/src/crypto/tls/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- package tls
- 
-diff --git a/src/crypto/tls/fipsonly/fipsonly.go b/src/crypto/tls/fipsonly/fipsonly.go
-index e5e47835e2f48d..1a94656dfee6dd 100644
---- a/src/crypto/tls/fipsonly/fipsonly.go
-+++ b/src/crypto/tls/fipsonly/fipsonly.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- // Package fipsonly restricts all TLS configuration to FIPS-approved settings.
- //
-diff --git a/src/crypto/tls/fipsonly/fipsonly_test.go b/src/crypto/tls/fipsonly/fipsonly_test.go
-index f8485dc3ca1c29..9c1d3d279c472f 100644
---- a/src/crypto/tls/fipsonly/fipsonly_test.go
-+++ b/src/crypto/tls/fipsonly/fipsonly_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- package fipsonly
- 
 diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
 index 747c3c0883230c..ee9274bb63b9b4 100644
 --- a/src/crypto/tls/key_schedule.go
@@ -711,58 +496,6 @@ index 747c3c0883230c..ee9274bb63b9b4 100644
  	"crypto/internal/mlkem768"
  	"errors"
  	"fmt"
-diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index bdbc32e05b35dd..36b4ceab0046c6 100644
---- a/src/crypto/tls/notboring.go
-+++ b/src/crypto/tls/notboring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto
- 
- package tls
- 
-diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
-index 095b58c31590d4..9aec21dbcd3bff 100644
---- a/src/crypto/x509/boring.go
-+++ b/src/crypto/x509/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- package x509
- 
-diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index 1b2454dbaab264..8cfc61049d0a08 100644
---- a/src/crypto/x509/boring_test.go
-+++ b/src/crypto/x509/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto
- 
- package x509
- 
-diff --git a/src/crypto/x509/notboring.go b/src/crypto/x509/notboring.go
-index c83a7272c9f01f..a0548a7f9179c5 100644
---- a/src/crypto/x509/notboring.go
-+++ b/src/crypto/x509/notboring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto
- 
- package x509
- 
 diff --git a/src/go.mod b/src/go.mod
 index df27f25e789f05..30e45951c763fa 100644
 --- a/src/go.mod
@@ -836,19 +569,6 @@ index 7f6237ffd59c11..7c821ae4bc5727 100644
  }
  
  // Verify that the vendor directories contain only packages matching the list above.
-diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
-index b4cb21f3580737..ff24d12966e22f 100644
---- a/src/hash/boring_test.go
-+++ b/src/hash/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build goexperiment.boringcrypto
-+//go:build goexperiment.boringcrypto || goexperiment.opensslcrypto
- 
- package hash_test
- 
 diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
 index 0f289915be6daa..bd935326bf7305 100644
 --- a/src/hash/notboring_test.go

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -16,11 +16,10 @@ Subject: [PATCH] Add CNG crypto backend
  src/go/build/deps_test.go                     |   5 +
  src/go/build/vendor_test.go                   |   1 +
  src/hash/example_test.go                      |   2 +
- src/hash/notboring_test.go                    |   2 +-
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 16 files changed, 392 insertions(+), 7 deletions(-)
+ 15 files changed, 391 insertions(+), 6 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -532,19 +531,6 @@ index f07b9aaa2c4898..2ff6c4827391c0 100644
  package hash_test
  
  import (
-diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
-index bd935326bf7305..40c84700690612 100644
---- a/src/hash/notboring_test.go
-+++ b/src/hash/notboring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !goexperiment.boringcrypto && !goexperiment.opensslcrypto
-+//go:build !goexperiment.boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
- 
- package hash_test
- 
 diff --git a/src/internal/goexperiment/exp_cngcrypto_off.go b/src/internal/goexperiment/exp_cngcrypto_off.go
 new file mode 100644
 index 00000000000000..831460053281e2

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -4,88 +4,29 @@ Date: Tue, 19 Jul 2022 15:58:02 +0200
 Subject: [PATCH] Add CNG crypto backend
 
 ---
- src/cmd/api/boring_test.go                    |   2 +-
- src/cmd/go/go_boring_test.go                  |   2 +-
- src/crypto/boring/boring.go                   |   2 +-
  src/crypto/ecdsa/badlinkname.go               |  17 +
- src/crypto/ecdsa/boring.go                    |   2 +-
- src/crypto/ecdsa/notboring.go                 |   2 +-
  src/crypto/internal/backend/backend_test.go   |   4 +-
- src/crypto/internal/backend/bbig/big.go       |   2 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  src/crypto/internal/backend/cng_windows.go    | 317 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  13 +-
- src/crypto/internal/boring/fipstls/stub.s     |   2 +-
- src/crypto/internal/boring/fipstls/tls.go     |   2 +-
- src/crypto/rsa/boring.go                      |   2 +-
- src/crypto/rsa/boring_test.go                 |   2 +-
- src/crypto/rsa/notboring.go                   |   2 +-
  src/crypto/rsa/pss.go                         |   2 +-
  src/crypto/rsa/pss_test.go                    |   2 +-
- src/crypto/tls/boring.go                      |   2 +-
- src/crypto/tls/boring_test.go                 |   2 +-
- src/crypto/tls/fipsonly/fipsonly.go           |   2 +-
- src/crypto/tls/fipsonly/fipsonly_test.go      |   2 +-
- src/crypto/tls/notboring.go                   |   2 +-
- src/crypto/x509/boring.go                     |   2 +-
- src/crypto/x509/boring_test.go                |   2 +-
- src/crypto/x509/notboring.go                  |   2 +-
  src/go.mod                                    |   1 +
  src/go.sum                                    |   2 +
  src/go/build/deps_test.go                     |   5 +
  src/go/build/vendor_test.go                   |   1 +
- src/hash/boring_test.go                       |   2 +-
  src/hash/example_test.go                      |   2 +
  src/hash/notboring_test.go                    |   2 +-
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 36 files changed, 412 insertions(+), 27 deletions(-)
+ 16 files changed, 392 insertions(+), 7 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_on.go
 
-diff --git a/src/cmd/api/boring_test.go b/src/cmd/api/boring_test.go
-index 0e9aceeb832d3b..aecf81b09c8ad3 100644
---- a/src/cmd/api/boring_test.go
-+++ b/src/cmd/api/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package main
- 
-diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
-index 5376227f74cfaa..492ccf79d66b45 100644
---- a/src/cmd/go/go_boring_test.go
-+++ b/src/cmd/go/go_boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package main_test
- 
-diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
-index 7b04f14ebdd618..8bdafb72f2c51a 100644
---- a/src/crypto/boring/boring.go
-+++ b/src/crypto/boring/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- // Package boring exposes functions that are only available when building with
- // Go+BoringCrypto. This package is available on all targets as long as the
 diff --git a/src/crypto/ecdsa/badlinkname.go b/src/crypto/ecdsa/badlinkname.go
 new file mode 100644
 index 00000000000000..0d00b7bb3a7fc8
@@ -109,32 +50,6 @@ index 00000000000000..0d00b7bb3a7fc8
 +// This supplements other linknames that are already added by
 +// https://github.com/golang/go/commit/41aab30bd260297ad8ddad47e98fdf8390a9a67e
 +// See that commit for more information.
-diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
-index 602cb894e20d39..bf9e77e06599f0 100644
---- a/src/crypto/ecdsa/boring.go
-+++ b/src/crypto/ecdsa/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package ecdsa
- 
-diff --git a/src/crypto/ecdsa/notboring.go b/src/crypto/ecdsa/notboring.go
-index 3cc16ecab567a0..dbbc6e3897e153 100644
---- a/src/crypto/ecdsa/notboring.go
-+++ b/src/crypto/ecdsa/notboring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto && !goexperiment.opensslcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
- 
- package ecdsa
- 
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 index c2c06d3bff8c74..837cff477e257e 100644
 --- a/src/crypto/internal/backend/backend_test.go
@@ -150,19 +65,6 @@ index c2c06d3bff8c74..837cff477e257e 100644
  
  // Test that Unreachable panics.
  func TestUnreachable(t *testing.T) {
-diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
-index 51bc3c68048d51..15f9833c9fcd20 100644
---- a/src/crypto/internal/backend/bbig/big.go
-+++ b/src/crypto/internal/backend/bbig/big.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto && !goexperiment.opensslcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
- 
- package bbig
- 
 diff --git a/src/crypto/internal/backend/bbig/big_cng.go b/src/crypto/internal/backend/bbig/big_cng.go
 new file mode 100644
 index 00000000000000..92623031fd87d0
@@ -532,71 +434,6 @@ index bc595e91024f11..7766d674f5cfaf 100644
 +	}
 +	return true
 +}
-diff --git a/src/crypto/internal/boring/fipstls/stub.s b/src/crypto/internal/boring/fipstls/stub.s
-index 1dc7116efdff2e..b4c321d1d2babb 100644
---- a/src/crypto/internal/boring/fipstls/stub.s
-+++ b/src/crypto/internal/boring/fipstls/stub.s
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- // runtime_arg0 is declared in tls.go without a body.
- // It's provided by package runtime,
-diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
-index f5b4827c688f3b..12df96069f6b83 100644
---- a/src/crypto/internal/boring/fipstls/tls.go
-+++ b/src/crypto/internal/boring/fipstls/tls.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
- // This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
-diff --git a/src/crypto/rsa/boring.go b/src/crypto/rsa/boring.go
-index 220f8c05c3d94b..dd20b4af2e0472 100644
---- a/src/crypto/rsa/boring.go
-+++ b/src/crypto/rsa/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package rsa
- 
-diff --git a/src/crypto/rsa/boring_test.go b/src/crypto/rsa/boring_test.go
-index 82a9d220e139af..c3860f8d698bc3 100644
---- a/src/crypto/rsa/boring_test.go
-+++ b/src/crypto/rsa/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- // Note: Can run these tests against the non-BoringCrypto
- // version of the code by using "CGO_ENABLED=0 go test".
-diff --git a/src/crypto/rsa/notboring.go b/src/crypto/rsa/notboring.go
-index 933ac569e034a8..0f152b210fdd84 100644
---- a/src/crypto/rsa/notboring.go
-+++ b/src/crypto/rsa/notboring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto && !goexperiment.opensslcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
- 
- package rsa
- 
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
 index 4aac87d7952081..010ee1467501c3 100644
 --- a/src/crypto/rsa/pss.go
@@ -623,110 +460,6 @@ index 2c82f50adf38b8..33630f14dcc8d4 100644
  	if err != nil {
  		t.Fatal(err)
  	}
-diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 698efc6751e12c..575d51b02298c8 100644
---- a/src/crypto/tls/boring.go
-+++ b/src/crypto/tls/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package tls
- 
-diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 1f577fd1d4d9ec..3cdde9780352a4 100644
---- a/src/crypto/tls/boring_test.go
-+++ b/src/crypto/tls/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package tls
- 
-diff --git a/src/crypto/tls/fipsonly/fipsonly.go b/src/crypto/tls/fipsonly/fipsonly.go
-index 1a94656dfee6dd..d7d1441ed319be 100644
---- a/src/crypto/tls/fipsonly/fipsonly.go
-+++ b/src/crypto/tls/fipsonly/fipsonly.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- // Package fipsonly restricts all TLS configuration to FIPS-approved settings.
- //
-diff --git a/src/crypto/tls/fipsonly/fipsonly_test.go b/src/crypto/tls/fipsonly/fipsonly_test.go
-index 9c1d3d279c472f..0ca7a863b73690 100644
---- a/src/crypto/tls/fipsonly/fipsonly_test.go
-+++ b/src/crypto/tls/fipsonly/fipsonly_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package fipsonly
- 
-diff --git a/src/crypto/tls/notboring.go b/src/crypto/tls/notboring.go
-index 36b4ceab0046c6..c87df4ad695f1b 100644
---- a/src/crypto/tls/notboring.go
-+++ b/src/crypto/tls/notboring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto && !goexperiment.opensslcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
- 
- package tls
- 
-diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
-index 9aec21dbcd3bff..05324f731bedc4 100644
---- a/src/crypto/x509/boring.go
-+++ b/src/crypto/x509/boring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package x509
- 
-diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index 8cfc61049d0a08..8948d51dfabd20 100644
---- a/src/crypto/x509/boring_test.go
-+++ b/src/crypto/x509/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build boringcrypto || goexperiment.opensslcrypto
-+//go:build boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package x509
- 
-diff --git a/src/crypto/x509/notboring.go b/src/crypto/x509/notboring.go
-index a0548a7f9179c5..ae6117a1554b7f 100644
---- a/src/crypto/x509/notboring.go
-+++ b/src/crypto/x509/notboring.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build !boringcrypto && !goexperiment.opensslcrypto
-+//go:build !boringcrypto && !goexperiment.opensslcrypto && !goexperiment.cngcrypto
- 
- package x509
- 
 diff --git a/src/go.mod b/src/go.mod
 index 30e45951c763fa..0209eeb6b8642c 100644
 --- a/src/go.mod
@@ -786,19 +519,6 @@ index 7c821ae4bc5727..1d0b9b20e9b1d4 100644
  }
  
  // Verify that the vendor directories contain only packages matching the list above.
-diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
-index ff24d12966e22f..a5242cca089049 100644
---- a/src/hash/boring_test.go
-+++ b/src/hash/boring_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--//go:build goexperiment.boringcrypto || goexperiment.opensslcrypto
-+//go:build goexperiment.boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto
- 
- package hash_test
- 
 diff --git a/src/hash/example_test.go b/src/hash/example_test.go
 index f07b9aaa2c4898..2ff6c4827391c0 100644
 --- a/src/hash/example_test.go


### PR DESCRIPTION
Using `goexperiment.systemcrypto` as a replacement for `goexperiment.boringcrypto || goexperiment.opensslcrypto || goexperiment.cngcrypto` is a neat win. It reduces the size of of patch files and simplifies patching new algorithms and adding new backends (this is for you @gdams). It will also help merging the upstream sync PR.

For https://github.com/microsoft/go/issues/1416.
For https://github.com/microsoft/go/pull/1383.