### PR TITLE
Don't mark azurelinux3 as broken

### DIFF
--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -91,8 +91,8 @@ stages:
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: mariner2 }
           - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: mariner2, fips: true }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, broken: true }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true, broken: true }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test }
           - { experiment: boringcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: windows, arch: amd64, config: devscript }


### PR DESCRIPTION
Azure Linux 3 CI pipelines are no longer broken. We can promote it to first class so that failures in AZ3 block PRs.