### PR TITLE
Add SHA512-224 and SHA512-256 support for OpenSSL backend and implement its methods in other backends

### DIFF
--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -34,7 +34,7 @@ Subject: [PATCH] Add crypto backend foundation
  .../internal/backend/fips140/isrequirefips.go |   9 +
  .../internal/backend/fips140/norequirefips.go |   9 +
  .../backend/fips140/nosystemcrypto.go         |  11 +
- src/crypto/internal/backend/nobackend.go      | 229 ++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go      | 233 ++++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/crypto/internal/cryptotest/allocations.go |   2 +-
  .../internal/cryptotest/implementations.go    |   2 +-
@@ -68,7 +68,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/tls/handshake_server.go            |  10 +-
  src/crypto/tls/handshake_server_tls13.go      |  25 +-
  src/crypto/tls/internal/fips140tls/fipstls.go |   3 +-
- src/crypto/tls/prf.go                         |  41 ++++
+ src/crypto/tls/prf.go                         |  41 +++
  src/go/build/deps_test.go                     |   8 +-
  src/hash/boring_test.go                       |   9 +
  src/hash/example_test.go                      |   2 +
@@ -76,7 +76,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/hash/notboring_test.go                    |   9 +
  src/net/smtp/smtp_test.go                     |  72 ++++--
  src/runtime/runtime_boring.go                 |   5 +
- 72 files changed, 1217 insertions(+), 89 deletions(-)
+ 72 files changed, 1221 insertions(+), 89 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ed25519/boring.go
@@ -1148,10 +1148,10 @@ index 00000000000000..83691d7dd42d51
 +}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..2ad15a0d1e370e
+index 00000000000000..3ebb6d5e4b4bb5
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,229 @@
+@@ -0,0 +1,233 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1180,19 +1180,23 @@ index 00000000000000..2ad15a0d1e370e
 +
 +func SupportsHash(h crypto.Hash) bool { panic("cryptobackend: not available") }
 +
-+func NewMD5() hash.Hash    { panic("cryptobackend: not available") }
-+func NewSHA1() hash.Hash   { panic("cryptobackend: not available") }
-+func NewSHA224() hash.Hash { panic("cryptobackend: not available") }
-+func NewSHA256() hash.Hash { panic("cryptobackend: not available") }
-+func NewSHA384() hash.Hash { panic("cryptobackend: not available") }
-+func NewSHA512() hash.Hash { panic("cryptobackend: not available") }
++func NewMD5() hash.Hash        { panic("cryptobackend: not available") }
++func NewSHA1() hash.Hash       { panic("cryptobackend: not available") }
++func NewSHA224() hash.Hash     { panic("cryptobackend: not available") }
++func NewSHA256() hash.Hash     { panic("cryptobackend: not available") }
++func NewSHA384() hash.Hash     { panic("cryptobackend: not available") }
++func NewSHA512() hash.Hash     { panic("cryptobackend: not available") }
++func NewSHA512_224() hash.Hash { panic("cryptobackend: not available") }
++func NewSHA512_256() hash.Hash { panic("cryptobackend: not available") }
 +
-+func MD5(p []byte) (sum [16]byte)    { panic("cryptobackend: not available") }
-+func SHA1(p []byte) (sum [20]byte)   { panic("cryptobackend: not available") }
-+func SHA224(p []byte) (sum [28]byte) { panic("cryptobackend: not available") }
-+func SHA256(p []byte) (sum [32]byte) { panic("cryptobackend: not available") }
-+func SHA384(p []byte) (sum [48]byte) { panic("cryptobackend: not available") }
-+func SHA512(p []byte) (sum [64]byte) { panic("cryptobackend: not available") }
++func MD5(p []byte) (sum [16]byte)        { panic("cryptobackend: not available") }
++func SHA1(p []byte) (sum [20]byte)       { panic("cryptobackend: not available") }
++func SHA224(p []byte) (sum [28]byte)     { panic("cryptobackend: not available") }
++func SHA256(p []byte) (sum [32]byte)     { panic("cryptobackend: not available") }
++func SHA384(p []byte) (sum [48]byte)     { panic("cryptobackend: not available") }
++func SHA512(p []byte) (sum [64]byte)     { panic("cryptobackend: not available") }
++func SHA512_224(p []byte) (sum [28]byte) { panic("cryptobackend: not available") }
++func SHA512_256(p []byte) (sum [32]byte) { panic("cryptobackend: not available") }
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { panic("cryptobackend: not available") }
 +

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -556,10 +556,10 @@ index 275c60b4de49eb..ff8bddf28c4545 100644
  	"math/big"
  )
 diff --git a/src/crypto/ecdsa/ecdsa.go b/src/crypto/ecdsa/ecdsa.go
-index 0f9749975ffba9..41ac17df22d7d7 100644
+index f682e6b1c6cfa6..049da55bd70f2c 100644
 --- a/src/crypto/ecdsa/ecdsa.go
 +++ b/src/crypto/ecdsa/ecdsa.go
-@@ -18,8 +18,8 @@ import (
+@@ -20,8 +20,8 @@ import (
  	"crypto"
  	"crypto/ecdh"
  	"crypto/elliptic"
@@ -590,7 +590,7 @@ index 039bd82ed21f9f..69a97d9bf250be 100644
  	panic("boringcrypto: not available")
 diff --git a/src/crypto/ed25519/boring.go b/src/crypto/ed25519/boring.go
 new file mode 100644
-index 00000000000000..3a7d7b76c8d8d7
+index 00000000000000..cce33e4d6cc927
 --- /dev/null
 +++ b/src/crypto/ed25519/boring.go
 @@ -0,0 +1,71 @@
@@ -633,7 +633,7 @@ index 00000000000000..3a7d7b76c8d8d7
 +
 +	b = new(boringPub)
 +	copy(b.orig[:], pub)
-+	key, err := boring.NewPublicKeyEd25119(b.orig[:])
++	key, err := boring.NewPublicKeyEd25519(b.orig[:])
 +	if err != nil {
 +		return nil, err
 +	}
@@ -657,7 +657,7 @@ index 00000000000000..3a7d7b76c8d8d7
 +
 +	b = new(boringPriv)
 +	copy(b.orig[:], priv)
-+	key, err := boring.NewPrivateKeyEd25119(b.orig[:])
++	key, err := boring.NewPrivateKeyEd25519(b.orig[:])
 +	if err != nil {
 +		return nil, err
 +	}
@@ -666,7 +666,7 @@ index 00000000000000..3a7d7b76c8d8d7
 +	return key, nil
 +}
 diff --git a/src/crypto/ed25519/ed25519.go b/src/crypto/ed25519/ed25519.go
-index c1f8ff784e4a5c..308d814ff6302b 100644
+index c1f8ff784e4a5c..6476bfbe896d6c 100644
 --- a/src/crypto/ed25519/ed25519.go
 +++ b/src/crypto/ed25519/ed25519.go
 @@ -17,6 +17,7 @@ package ed25519
@@ -767,7 +767,7 @@ index c1f8ff784e4a5c..308d814ff6302b 100644
 +		0x22, 0xab, 0xbe, 0xe6, 0x85, 0xfd, 0xa4, 0x42, 0x0f, 0x88, 0x34,
 +		0xb1, 0x08, 0xc3, 0xbd, 0xae, 0x36, 0x9e, 0xf5, 0x49, 0xfa,
 +	}
-+	pub, err := boring.NewPublicKeyEd25119(pkey)
++	pub, err := boring.NewPublicKeyEd25519(pkey)
 +	if err != nil {
 +		return false
 +	}
@@ -1148,7 +1148,7 @@ index 00000000000000..83691d7dd42d51
 +}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..71e0ec9dc25a02
+index 00000000000000..2ad15a0d1e370e
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -0,0 +1,229 @@
@@ -1331,11 +1331,11 @@ index 00000000000000..71e0ec9dc25a02
 +	panic("cryptobackend: not available")
 +}
 +
-+func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
++func NewPrivateKeyEd25519(priv []byte) (*PrivateKeyEd25519, error) {
 +	panic("cryptobackend: not available")
 +}
 +
-+func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
++func NewPublicKeyEd25519(pub []byte) (*PublicKeyEd25519, error) {
 +	panic("cryptobackend: not available")
 +}
 +
@@ -2430,7 +2430,7 @@ index e7369542a73270..ff52175e4ac636 100644
  	}
  }
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index d9d985dca4ade4..de88160bcf3a1c 100644
+index a62a5173b9c6bc..b39db00839ab43 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -493,6 +493,8 @@ var depsRules = `

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,9 +5,9 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 +
- src/crypto/internal/backend/boring_linux.go   | 263 ++++++++++++++++++
+ src/crypto/internal/backend/boring_linux.go   | 265 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
- 3 files changed, 286 insertions(+)
+ 3 files changed, 288 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
  create mode 100644 src/crypto/internal/backend/fips140/boring.go
@@ -32,10 +32,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..b1bd6d5ba756d7
+index 00000000000000..e1ebc95a1db0e9
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,263 @@
+@@ -0,0 +1,265 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -76,12 +76,14 @@ index 00000000000000..b1bd6d5ba756d7
 +func NewSHA384() hash.Hash { return boring.NewSHA384() }
 +func NewSHA512() hash.Hash { return boring.NewSHA512() }
 +
-+func MD5(p []byte) (sum [16]byte)    { panic("cryptobackend: not available") }
-+func SHA1(p []byte) (sum [20]byte)   { return boring.SHA1(p) }
-+func SHA224(p []byte) (sum [28]byte) { return boring.SHA224(p) }
-+func SHA256(p []byte) (sum [32]byte) { return boring.SHA256(p) }
-+func SHA384(p []byte) (sum [48]byte) { return boring.SHA384(p) }
-+func SHA512(p []byte) (sum [64]byte) { return boring.SHA512(p) }
++func MD5(p []byte) (sum [16]byte)        { panic("cryptobackend: not available") }
++func SHA1(p []byte) (sum [20]byte)       { return boring.SHA1(p) }
++func SHA224(p []byte) (sum [28]byte)     { return boring.SHA224(p) }
++func SHA256(p []byte) (sum [32]byte)     { return boring.SHA256(p) }
++func SHA384(p []byte) (sum [48]byte)     { return boring.SHA384(p) }
++func SHA512(p []byte) (sum [64]byte)     { return boring.SHA512(p) }
++func SHA512_224(p []byte) (sum [28]byte) { panic("cryptobackend: not available") }
++func SHA512_256(p []byte) (sum [32]byte) { panic("cryptobackend: not available") }
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return boring.NewHMAC(h, key) }
 +
@@ -249,11 +251,11 @@ index 00000000000000..b1bd6d5ba756d7
 +	panic("cryptobackend: not available")
 +}
 +
-+func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
++func NewPrivateKeyEd25519(priv []byte) (*PrivateKeyEd25519, error) {
 +	panic("cryptobackend: not available")
 +}
 +
-+func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
++func NewPublicKeyEd25519(pub []byte) (*PublicKeyEd25519, error) {
 +	panic("cryptobackend: not available")
 +}
 +

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -5,9 +5,9 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 +
- src/crypto/internal/backend/boring_linux.go   | 265 ++++++++++++++++++
+ src/crypto/internal/backend/boring_linux.go   | 267 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
- 3 files changed, 288 insertions(+)
+ 3 files changed, 290 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
  create mode 100644 src/crypto/internal/backend/fips140/boring.go
@@ -32,10 +32,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..e1ebc95a1db0e9
+index 00000000000000..94bc444f10eb2b
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,265 @@
+@@ -0,0 +1,267 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -69,12 +69,14 @@ index 00000000000000..e1ebc95a1db0e9
 +	}
 +}
 +
-+func NewMD5() hash.Hash    { panic("cryptobackend: not available") }
-+func NewSHA1() hash.Hash   { return boring.NewSHA1() }
-+func NewSHA224() hash.Hash { return boring.NewSHA224() }
-+func NewSHA256() hash.Hash { return boring.NewSHA256() }
-+func NewSHA384() hash.Hash { return boring.NewSHA384() }
-+func NewSHA512() hash.Hash { return boring.NewSHA512() }
++func NewMD5() hash.Hash        { panic("cryptobackend: not available") }
++func NewSHA1() hash.Hash       { return boring.NewSHA1() }
++func NewSHA224() hash.Hash     { return boring.NewSHA224() }
++func NewSHA256() hash.Hash     { return boring.NewSHA256() }
++func NewSHA384() hash.Hash     { return boring.NewSHA384() }
++func NewSHA512() hash.Hash     { return boring.NewSHA512() }
++func NewSHA512_224() hash.Hash { panic("cryptobackend: not available") }
++func NewSHA512_256() hash.Hash { panic("cryptobackend: not available") }
 +
 +func MD5(p []byte) (sum [16]byte)        { panic("cryptobackend: not available") }
 +func SHA1(p []byte) (sum [20]byte)       { return boring.SHA1(p) }

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  src/cmd/link/internal/ld/lib.go               |   1 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
  .../internal/backend/fips140/openssl.go       |  41 +++
- src/crypto/internal/backend/openssl_linux.go  | 331 ++++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 345 ++++++++++++++++++
  src/crypto/rsa/rsa_test.go                    |   3 +
  src/go.mod                                    |   1 +
  src/go.sum                                    |   2 +
@@ -19,7 +19,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../goexperiment/exp_opensslcrypto_on.go      |   9 +
  src/internal/goexperiment/flags.go            |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 15 files changed, 436 insertions(+), 5 deletions(-)
+ 15 files changed, 450 insertions(+), 5 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/fips140/openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
@@ -27,7 +27,7 @@ Subject: [PATCH] Add OpenSSL crypto backend
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_on.go
 
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 06bd01bc5bb995..9561bf2bca9a9d 100644
+index 0c992118f4287b..0de6e80fd985a3 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -1324,12 +1324,11 @@ func (t *tester) registerCgoTests(heading string) {
@@ -142,10 +142,10 @@ index 00000000000000..118efa3a492a7d
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..d3a663737a1ce3
+index 00000000000000..44d91d5b7ba3d5
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,331 @@
+@@ -0,0 +1,345 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -233,19 +233,23 @@ index 00000000000000..d3a663737a1ce3
 +	return openssl.SupportsHash(h)
 +}
 +
-+func NewMD5() hash.Hash    { return openssl.NewMD5() }
-+func NewSHA1() hash.Hash   { return openssl.NewSHA1() }
-+func NewSHA224() hash.Hash { return openssl.NewSHA224() }
-+func NewSHA256() hash.Hash { return openssl.NewSHA256() }
-+func NewSHA384() hash.Hash { return openssl.NewSHA384() }
-+func NewSHA512() hash.Hash { return openssl.NewSHA512() }
++func NewMD5() hash.Hash        { return openssl.NewMD5() }
++func NewSHA1() hash.Hash       { return openssl.NewSHA1() }
++func NewSHA224() hash.Hash     { return openssl.NewSHA224() }
++func NewSHA256() hash.Hash     { return openssl.NewSHA256() }
++func NewSHA384() hash.Hash     { return openssl.NewSHA384() }
++func NewSHA512() hash.Hash     { return openssl.NewSHA512() }
++func NewSHA512_224() hash.Hash { return openssl.NewSHA512_224() }
++func NewSHA512_256() hash.Hash { return openssl.NewSHA512_256() }
 +
-+func MD5(p []byte) (sum [16]byte)    { return openssl.MD5(p) }
-+func SHA1(p []byte) (sum [20]byte)   { return openssl.SHA1(p) }
-+func SHA224(p []byte) (sum [28]byte) { return openssl.SHA224(p) }
-+func SHA256(p []byte) (sum [32]byte) { return openssl.SHA256(p) }
-+func SHA384(p []byte) (sum [48]byte) { return openssl.SHA384(p) }
-+func SHA512(p []byte) (sum [64]byte) { return openssl.SHA512(p) }
++func MD5(p []byte) (sum [16]byte)        { return openssl.MD5(p) }
++func SHA1(p []byte) (sum [20]byte)       { return openssl.SHA1(p) }
++func SHA224(p []byte) (sum [28]byte)     { return openssl.SHA224(p) }
++func SHA256(p []byte) (sum [32]byte)     { return openssl.SHA256(p) }
++func SHA384(p []byte) (sum [48]byte)     { return openssl.SHA384(p) }
++func SHA512(p []byte) (sum [64]byte)     { return openssl.SHA512(p) }
++func SHA512_224(p []byte) (sum [28]byte) { return openssl.SHA512_224(p) }
++func SHA512_256(p []byte) (sum [32]byte) { return openssl.SHA512_256(p) }
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return openssl.NewHMAC(h, key) }
 +
@@ -411,12 +415,22 @@ index 00000000000000..d3a663737a1ce3
 +	return openssl.GenerateKeyEd25519()
 +}
 +
++// Deprecated: use NewPrivateKeyEd25519 instead.
 +func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
-+	return openssl.NewPrivateKeyEd25119(priv)
++	return openssl.NewPrivateKeyEd25519(priv)
 +}
 +
++// Deprecated: use NewPublicKeyEd25519 instead.
 +func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
-+	return openssl.NewPublicKeyEd25119(pub)
++	return openssl.NewPublicKeyEd25519(pub)
++}
++
++func NewPrivateKeyEd25519(priv []byte) (*PrivateKeyEd25519, error) {
++	return openssl.NewPrivateKeyEd25519(priv)
++}
++
++func NewPublicKeyEd25519(pub []byte) (*PublicKeyEd25519, error) {
++	return openssl.NewPublicKeyEd25519(pub)
 +}
 +
 +func NewPrivateKeyEd25519FromSeed(seed []byte) (*PrivateKeyEd25519, error) {
@@ -492,7 +506,7 @@ index f9543d9cc89e7b..f07c75821aab13 100644
  
  	msg := []byte{0xed, 0x36, 0x90, 0x8d, 0xbe, 0xfc, 0x35, 0x40, 0x70, 0x4f, 0xf5, 0x9d, 0x6e, 0xc2, 0xeb, 0xf5, 0x27, 0xae, 0x65, 0xb0, 0x59, 0x29, 0x45, 0x25, 0x8c, 0xc1, 0x91, 0x22}
 diff --git a/src/go.mod b/src/go.mod
-index 7a1318dcac32ba..186ced4a1123a8 100644
+index 7a1318dcac32ba..f12d9b4d9172ab 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
@@ -504,7 +518,7 @@ index 7a1318dcac32ba..186ced4a1123a8 100644
  	golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1
  )
 diff --git a/src/go.sum b/src/go.sum
-index 9e661352f16e0b..0a58eccb57a869 100644
+index 9e661352f16e0b..e51f0f57540a83 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
@@ -514,7 +528,7 @@ index 9e661352f16e0b..0a58eccb57a869 100644
  golang.org/x/crypto v0.30.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
  golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1 h1:+Yk1FZ5E+/ewA0nOO/HRYs9E4yeqpGOShuSAdzCNNoQ=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index de88160bcf3a1c..339cb53d8a1468 100644
+index b39db00839ab43..392f8d8c52c4b6 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -509,12 +509,14 @@ var depsRules = `

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/ecdsa/badlinkname.go               |  17 +
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 316 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 318 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |   9 +-
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/rsa/pss_test.go                    |   2 +-
@@ -18,7 +18,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 14 files changed, 416 insertions(+), 5 deletions(-)
+ 14 files changed, 418 insertions(+), 5 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -84,10 +84,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..c37247c8a2c7c6
+index 00000000000000..2c22deb7f14aaf
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,316 @@
+@@ -0,0 +1,318 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -141,12 +141,14 @@ index 00000000000000..c37247c8a2c7c6
 +func NewSHA384() hash.Hash { return cng.NewSHA384() }
 +func NewSHA512() hash.Hash { return cng.NewSHA512() }
 +
-+func MD5(p []byte) (sum [16]byte)    { return cng.MD5(p) }
-+func SHA1(p []byte) (sum [20]byte)   { return cng.SHA1(p) }
-+func SHA224(p []byte) (sum [28]byte) { panic("cngcrypto: not available") }
-+func SHA256(p []byte) (sum [32]byte) { return cng.SHA256(p) }
-+func SHA384(p []byte) (sum [48]byte) { return cng.SHA384(p) }
-+func SHA512(p []byte) (sum [64]byte) { return cng.SHA512(p) }
++func MD5(p []byte) (sum [16]byte)        { return cng.MD5(p) }
++func SHA1(p []byte) (sum [20]byte)       { return cng.SHA1(p) }
++func SHA224(p []byte) (sum [28]byte)     { panic("cngcrypto: not available") }
++func SHA256(p []byte) (sum [32]byte)     { return cng.SHA256(p) }
++func SHA384(p []byte) (sum [48]byte)     { return cng.SHA384(p) }
++func SHA512(p []byte) (sum [64]byte)     { return cng.SHA512(p) }
++func SHA512_224(p []byte) (sum [28]byte) { panic("cngcrypto: not available") }
++func SHA512_256(p []byte) (sum [32]byte) { panic("cngcrypto: not available") }
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 +	return cng.NewHMAC(h, key)
@@ -349,11 +351,11 @@ index 00000000000000..c37247c8a2c7c6
 +	panic("cryptobackend: not available")
 +}
 +
-+func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
++func NewPrivateKeyEd25519(priv []byte) (*PrivateKeyEd25519, error) {
 +	panic("cryptobackend: not available")
 +}
 +
-+func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
++func NewPublicKeyEd25519(pub []byte) (*PublicKeyEd25519, error) {
 +	panic("cryptobackend: not available")
 +}
 +
@@ -483,7 +485,7 @@ index a4af0a2144870a..7d7115cff81cea 100644
  		t.Fatal(err)
  	}
 diff --git a/src/go.mod b/src/go.mod
-index 186ced4a1123a8..e9da0eb1301b93 100644
+index f12d9b4d9172ab..96bdcd421e1129 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.24
@@ -495,7 +497,7 @@ index 186ced4a1123a8..e9da0eb1301b93 100644
  	golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1
  )
 diff --git a/src/go.sum b/src/go.sum
-index 0a58eccb57a869..b464f023942b74 100644
+index e51f0f57540a83..abebb59dcd7739 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
@@ -507,7 +509,7 @@ index 0a58eccb57a869..b464f023942b74 100644
  golang.org/x/crypto v0.30.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
  golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1 h1:+Yk1FZ5E+/ewA0nOO/HRYs9E4yeqpGOShuSAdzCNNoQ=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 339cb53d8a1468..1fcadbf6c19d79 100644
+index 392f8d8c52c4b6..997244c84e57c5 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -515,6 +515,10 @@ var depsRules = `

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/ecdsa/badlinkname.go               |  17 +
  src/crypto/internal/backend/backend_test.go   |   4 +-
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
- src/crypto/internal/backend/cng_windows.go    | 318 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 320 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |   9 +-
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/rsa/pss_test.go                    |   2 +-
@@ -18,7 +18,7 @@ Subject: [PATCH] Add CNG crypto backend
  .../goexperiment/exp_cngcrypto_off.go         |   9 +
  src/internal/goexperiment/exp_cngcrypto_on.go |   9 +
  src/internal/goexperiment/flags.go            |   1 +
- 14 files changed, 418 insertions(+), 5 deletions(-)
+ 14 files changed, 420 insertions(+), 5 deletions(-)
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
@@ -84,10 +84,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..2c22deb7f14aaf
+index 00000000000000..495260a08dd029
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,318 @@
+@@ -0,0 +1,320 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -134,12 +134,14 @@ index 00000000000000..2c22deb7f14aaf
 +	return cng.SupportsHash(h)
 +}
 +
-+func NewMD5() hash.Hash    { return cng.NewMD5() }
-+func NewSHA1() hash.Hash   { return cng.NewSHA1() }
-+func NewSHA224() hash.Hash { panic("cngcrypto: not available") }
-+func NewSHA256() hash.Hash { return cng.NewSHA256() }
-+func NewSHA384() hash.Hash { return cng.NewSHA384() }
-+func NewSHA512() hash.Hash { return cng.NewSHA512() }
++func NewMD5() hash.Hash        { return cng.NewMD5() }
++func NewSHA1() hash.Hash       { return cng.NewSHA1() }
++func NewSHA224() hash.Hash     { panic("cngcrypto: not available") }
++func NewSHA256() hash.Hash     { return cng.NewSHA256() }
++func NewSHA384() hash.Hash     { return cng.NewSHA384() }
++func NewSHA512() hash.Hash     { return cng.NewSHA512() }
++func NewSHA512_224() hash.Hash { panic("cngcrypto: not available") }
++func NewSHA512_256() hash.Hash { panic("cngcrypto: not available") }
 +
 +func MD5(p []byte) (sum [16]byte)        { return cng.MD5(p) }
 +func SHA1(p []byte) (sum [20]byte)       { return cng.SHA1(p) }


### PR DESCRIPTION
This PR is currently failing to build. Following the merge of https://github.com/golang-fips/openssl/pull/240, a go.mod update is required. This PR focuses solely on the changes unrelated to the necessary go.mod update.
When merged , it fixes #1456 
Also this PR renames the Ed25519, previously it was miswritten as Ed25119, but[ this pr](https://github.com/golang-fips/openssl/commit/d9e21e31a3eca378b35b55159a42b2a8dcbfd71c) fixed.