### PR TITLE
fix: move go.mod and go.sum changes back to respective patch files

### DIFF
--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -499,7 +499,7 @@ index 7a1318dcac32ba..186ced4a1123a8 100644
  go 1.24
  
  require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20241211125030-65f2a3ae34cf
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20250107115006-eb155dada337
  	golang.org/x/crypto v0.30.0
  	golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1
  )
@@ -508,8 +508,8 @@ index 9e661352f16e0b..0a58eccb57a869 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20241211125030-65f2a3ae34cf h1:gkjE7LMxjlaSn8fdvbT/HJrpGcW/ZnwYpps7sSBhLD4=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20241211125030-65f2a3ae34cf/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20250107115006-eb155dada337 h1:OhuURhDVbg+f/BvlG+qT5sQVkutwhI0Kmsy7koQ4l9A=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20250107115006-eb155dada337/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
  golang.org/x/crypto v0.30.0 h1:RwoQn3GkWiMkzlX562cLB7OxWvjH1L8xutO2WoJcRoY=
  golang.org/x/crypto v0.30.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
  golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1 h1:+Yk1FZ5E+/ewA0nOO/HRYs9E4yeqpGOShuSAdzCNNoQ=

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -489,8 +489,8 @@ index 186ced4a1123a8..e9da0eb1301b93 100644
 @@ -4,6 +4,7 @@ go 1.24
  
  require (
- 	github.com/golang-fips/openssl/v2 v2.0.4-0.20241211125030-65f2a3ae34cf
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20241212090637-6d419040e383
+ 	github.com/golang-fips/openssl/v2 v2.0.4-0.20250107115006-eb155dada337
++	github.com/microsoft/go-crypto-winnative v0.0.0-20250108090702-b49854c00e37
  	golang.org/x/crypto v0.30.0
  	golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1
  )
@@ -499,10 +499,10 @@ index 0a58eccb57a869..b464f023942b74 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
- github.com/golang-fips/openssl/v2 v2.0.4-0.20241211125030-65f2a3ae34cf h1:gkjE7LMxjlaSn8fdvbT/HJrpGcW/ZnwYpps7sSBhLD4=
- github.com/golang-fips/openssl/v2 v2.0.4-0.20241211125030-65f2a3ae34cf/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20241212090637-6d419040e383 h1:fMAxrMWT19/kkIZIuB9cjqW8SqRxCH2+2ZiZr5qrpuI=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20241212090637-6d419040e383/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
+ github.com/golang-fips/openssl/v2 v2.0.4-0.20250107115006-eb155dada337 h1:OhuURhDVbg+f/BvlG+qT5sQVkutwhI0Kmsy7koQ4l9A=
+ github.com/golang-fips/openssl/v2 v2.0.4-0.20250107115006-eb155dada337/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250108090702-b49854c00e37 h1:KB8xmJcFSPlZFMg2mxz5b6DCE8k1qpHy2HFevAJLELI=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250108090702-b49854c00e37/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
  golang.org/x/crypto v0.30.0 h1:RwoQn3GkWiMkzlX562cLB7OxWvjH1L8xutO2WoJcRoY=
  golang.org/x/crypto v0.30.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
  golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1 h1:+Yk1FZ5E+/ewA0nOO/HRYs9E4yeqpGOShuSAdzCNNoQ=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -5,8 +5,6 @@ Subject: [PATCH] Vendor crypto backends
 
 To reproduce, run 'go mod vendor' in 'go/src'.
 ---
- src/go.mod                                    |   4 +-
- src/go.sum                                    |   8 +-
  .../golang-fips/openssl/v2/.gitignore         |   1 +
  .../golang-fips/openssl/v2/.gitleaks.toml     |   9 +
  .../github.com/golang-fips/openssl/v2/LICENSE |  20 +
@@ -71,7 +69,7 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 66 files changed, 10981 insertions(+), 6 deletions(-)
+ 64 files changed, 10969 insertions(+), 6 deletions(-)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
@@ -136,37 +134,6 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/subtle/aliasing.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 
-diff --git a/src/go.mod b/src/go.mod
-index e9da0eb1301b93..96bdcd421e1129 100644
---- a/src/go.mod
-+++ b/src/go.mod
-@@ -3,8 +3,8 @@ module std
- go 1.24
- 
- require (
--	github.com/golang-fips/openssl/v2 v2.0.4-0.20241211125030-65f2a3ae34cf
--	github.com/microsoft/go-crypto-winnative v0.0.0-20241212090637-6d419040e383
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20250107115006-eb155dada337
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20250108090702-b49854c00e37
- 	golang.org/x/crypto v0.30.0
- 	golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1
- )
-diff --git a/src/go.sum b/src/go.sum
-index b464f023942b74..abebb59dcd7739 100644
---- a/src/go.sum
-+++ b/src/go.sum
-@@ -1,7 +1,7 @@
--github.com/golang-fips/openssl/v2 v2.0.4-0.20241211125030-65f2a3ae34cf h1:gkjE7LMxjlaSn8fdvbT/HJrpGcW/ZnwYpps7sSBhLD4=
--github.com/golang-fips/openssl/v2 v2.0.4-0.20241211125030-65f2a3ae34cf/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
--github.com/microsoft/go-crypto-winnative v0.0.0-20241212090637-6d419040e383 h1:fMAxrMWT19/kkIZIuB9cjqW8SqRxCH2+2ZiZr5qrpuI=
--github.com/microsoft/go-crypto-winnative v0.0.0-20241212090637-6d419040e383/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250107115006-eb155dada337 h1:OhuURhDVbg+f/BvlG+qT5sQVkutwhI0Kmsy7koQ4l9A=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250107115006-eb155dada337/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20250108090702-b49854c00e37 h1:KB8xmJcFSPlZFMg2mxz5b6DCE8k1qpHy2HFevAJLELI=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20250108090702-b49854c00e37/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
- golang.org/x/crypto v0.30.0 h1:RwoQn3GkWiMkzlX562cLB7OxWvjH1L8xutO2WoJcRoY=
- golang.org/x/crypto v0.30.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
- golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1 h1:+Yk1FZ5E+/ewA0nOO/HRYs9E4yeqpGOShuSAdzCNNoQ=
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/.gitignore b/src/vendor/github.com/golang-fips/openssl/v2/.gitignore
 new file mode 100644
 index 00000000000000..79b5594df7fa29


### PR DESCRIPTION
I inadvertently changed the `go.mod` and `go.sum` files in the vendor patch as part of https://github.com/microsoft/go/commit/1eb2f56c23ee5917e165dbb98eb24813580d168d. This PR corrects this.