### PR TITLE
Add `Cross-Platform Cryptography` document

### DIFF
--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -66,7 +66,9 @@ This section includes the following packages:
 | HMAC                      | ✔️ <sup>3</sup>   | ✔️ <sup>3</sup>    |
 
 <sup>1</sup>Available starting in Microsoft Go 1.24.
+
 <sup>2</sup>Requires OpenSSL 1.1.1 or later.
+
 <sup>3</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
 
 ## Symmetric encryption
@@ -144,6 +146,7 @@ This section includes the following packages:
 | PKCS1v15 Signature (SHA-3)        | ❌                   | ❌                 |
 
 <sup>1</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
+
 <sup>2</sup>Available starting in Microsoft Go 1.24.
 
 #### RSA key sizes

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -30,11 +30,11 @@ SCOSSL is expected to be used with the default built-in provider enabled as a fa
 
 The following legend describes the symbols used in the tables to indicate the level of support for each cryptographic algorithm:
 
-| Symbol | Meaning                                                                                                            |
-|--------|--------------------------------------------------------------------------------------------------------------------|
-| ✔️     | Supported, possibly with minor limitations that don't require user action when using the latest Go and OS versions |
-| ⚠️     | Supported with limitations that require user action                                                                |
-| ❌     | Not supported                                                                                                      |
+| Symbol | Meaning                                                                                                                      |
+|--------|------------------------------------------------------------------------------------------------------------------------------|
+| ✔️     | Supported, possibly with minor limitations that don't require special configuration when using the latest Go and OS versions |
+| ⚠️     | Supported with limitations that require special configuration action                                                         |
+| ❌     | Not supported                                                                                                                |
 
 When an algorithm is not supported or the limitations are exceeded, Microsoft Go will fall back to the Go implementation.
 
@@ -159,7 +159,9 @@ This section includes the following packages:
 
 Multi-prime RSA keys are not supported.
 
-The RSA key size is subject to the limitations of the underlying cryptographic library. For example, on Windows and when using SCOSSL, the key size should be multiple of 8.
+The RSA key size is subject to the limitations of the underlying cryptographic library.
+For example, on some Windows and SCOSSL configurations, the key size should be multiple of 8.
+Please refer to the documentation of the underlying cryptographic library for the specific limitations.
 
 #### PSS salt length
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -113,6 +113,9 @@ This section includes the following packages:
 This section includes the following subsections:
 
 * [RSA](#rsa)
+* [ECDSA](#ecdsa)
+* [ECDH](#ecdh)
+* [DSA](#dsa)
 
 ### RSA
 
@@ -131,27 +134,99 @@ This section includes the following packages:
 | PSS (SHA-2)                       | ✔️ <sup>1</sup>      | ✔️ <sup>1</sup>    |
 | PSS (SHA-3)                       | ❌                   | ❌                 |
 | PKCS1v15 Signature (Unhashed)     | ✔️                   | ✔️                 |
-| PKCS1v15 Signature (RIPMED160)    | ❌                   | ✔️                 |
-| PKCS1v15 Signature (MD4)          | ❌                   | ✔️                 |
+| PKCS1v15 Signature (RIPMED160)    | ❌ <sup>2</sup>      | ✔️ <sup>2</sup>    |
+| PKCS1v15 Signature (MD4)          | ❌ <sup>2</sup>      | ✔️ <sup>2</sup>    |
 | PKCS1v15 Signature (MD5)          | ✔️                   | ✔️                 |
-| PKCS1v15 Signature (MD5-SHA1)     | ✔️                   | ✔️                 |
+| PKCS1v15 Signature (MD5-SHA1)     | ✔️ <sup>2</sup>      | ✔️ <sup>2</sup>    |
 | PKCS1v15 Signature (SHA-1)        | ✔️                   | ✔️                 |
 | PKCS1v15 Signature (SHA-2)        | ✔️ <sup>1</sup>      | ✔️ <sup>1</sup>    |
 | PKCS1v15 Signature (SHA-3)        | ❌                   | ❌                 |
 
 <sup>1</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
+<sup>2</sup>Available starting in Microsoft Go 1.24.
 
 #### RSA key sizes
 
 [rsa.GenerateKey](https://pkg.go.dev/crypto/rsa#GenerateKey) only supports the following key sizes (in bits): 2048, 3072, 4096.
 
-Multiprime RSA keys are not supported.
+Multi-prime RSA keys are not supported.
+
+The RSA key size is subject to the limitations of the underlying cryptographic library. For example, on Windows and when using SCOSSL, the key size should be multiple of 8.
 
 #### PSS salt length
 
 On Windows, when verifying a PSS signature, [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.
 
-### Random number generation
+#### Random number generation
 
-For those padding modes that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
+For those operations that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
 
+### ECDSA
+
+This section includes the following packages:
+
+* [crypto/ecdsa](https://pkg.go.dev/crypto/ecdsa)
+* [crypto/elliptic](https://pkg.go.dev/crypto/elliptic)
+
+| Elliptic Curve            | Windows     | Linux        |
+|---------------------------|-------------|--------------|
+| NIST P-224 (secp224r1)    | ✔️          | ✔️          |
+| NIST P-256 (secp256r1)    | ✔️          | ✔️          |
+| NIST P-384 (secp384r1)    | ✔️          | ✔️          |
+| NIST P-521 (secp521r1)    | ✔️          | ✔️          |
+
+#### Random number generation
+
+For those operations that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
+
+### ECDH
+
+This section includes the following packages:
+
+* [crypto/ecdh](https://pkg.go.dev/crypto/ecdsa)
+
+| Elliptic Curve            | Windows     | Linux        |
+|---------------------------|-------------|--------------|
+| NIST P-224 (secp224r1)    | ✔️          | ✔️          |
+| NIST P-256 (secp256r1)    | ✔️          | ✔️          |
+| NIST P-384 (secp384r1)    | ✔️          | ✔️          |
+| NIST P-521 (secp521r1)    | ✔️          | ✔️          |
+| X25519 (curve25519)       | ❌          | ❌          |
+
+#### Random number generation
+
+For those operations that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
+
+### DSA
+
+| Parameters    | Windows     | Linux        |
+|---------------|-------------|--------------|
+| L1024N160     | ✔️          | ✔️          |
+| L2048N224     | ❌          | ✔️          |
+| L2048N256     | ✔️          | ✔️          |
+| L3072N256     | ✔️          | ✔️          |
+
+## KDF
+
+This section includes the following packages:
+
+* [crypto/hkdf](https://pkg.go.dev/crypto/hkdf)
+* [crypto/pbkdf2](https://pkg.go.dev/crypto/pbkdf2)
+
+| Functions     | Windows          | Linux             |
+|---------------|------------------|-------------------|
+| PBKDF2        | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
+| HKDF          | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
+
+<sup>1</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
+
+## ML-KEM
+
+This section includes the following packages:
+
+* [crypto/mlkem](https://pkg.go.dev/crypto/mlkem)
+
+| Parameters    | Windows     | Linux        |
+|---------------|-------------|--------------|
+|768            | ❌          | ❌          |
+|1024           | ❌          | ❌          |

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -14,6 +14,26 @@ This article identifies the features that are supported on each platform.
 
 This article assumes you have a working familiarity with cryptography in Go.
 
+## Platform support
+
+Microsoft Go supports the following platforms:
+
+### Windows
+
+On Windows, Microsoft Go uses the [Cryptography API: Next Generation](https://learn.microsoft.com/en-us/windows/win32/seccng/cng-portal) library, CNG from now on, for cryptographic operations.
+CNG is available since Windows Vista and Windows Server 2008 and it doesn't require any additional installation nor configuration.
+
+### Linux
+
+On Linux, Microsoft Go uses the [OpenSSL crypto library](https://docs.openssl.org/3.0/man7/crypto/) library, OpenSSL from now on, for cryptographic operations.
+OpenSSL is normally available on Linux distributions, but it may not be installed by default.
+If it is not installed, you can install it using the package manager of your distribution.
+
+OpenSSL 3 implements all the cryptographic algorithms using [Providers](https://docs.openssl.org/3.0/man7/crypto/#providers).
+Microsoft Go officially supports the built-in providers and the [SymCrypt provider](https://github.com/microsoft/SymCrypt-OpenSSL), SCOSSL from now on.
+The minimum SCOSSL version required is v1.6.1.
+The following tables assume that the SCOSSL provider is used together with the built-in providers.
+
 ## Hash and Message Authentication Algorithms
 
 This section includes the following packages:
@@ -25,34 +45,39 @@ This section includes the following packages:
 * [crypto/sha3](https://pkg.go.dev/golang.org/x/crypto/sha3)
 * [crypto/hmac](https://pkg.go.dev/crypto/hmac)
 
-|Algorithm                  |Windows   |Linux             |
-|---------------------------|----------|------------------|
-|MD5                        | ✔️       | ✔️ <sup>1</sup> |
-|SHA-1                      | ✔️       | ✔️              |
-|SHA-2-224                  | ❌       | ✔️              |
-|SHA-2-256                  | ✔️       | ✔️              |
-|SHA-2-384                  | ✔️       | ✔️              |
-|SHA-2-512                  | ✔️       | ✔️              |
-|SHA-3-224                  | ❌       | ❌              |
-|SHA-3-256                  | ❌       | ❌              |
-|SHA-3-384                  | ❌       | ❌              |
-|SHA-3-512                  | ❌       | ❌              |
-|SHAKE-128                  | ❌       | ❌              |
-|SHAKE-256                  | ❌       | ❌              |
-|CSHAKE-128                 | ❌       | ❌              |
-|CSHAKE-256                 | ❌       | ❌              |
-|HMAC-MD5                   | ✔️       | ✔️              |
-|HMAC-SHA-1                 | ✔️       | ✔️              |
-|HMAC-SHA-2-224             | ❌       | ✔️              |
-|HMAC-SHA-2-256             | ✔️       | ✔️              |
-|HMAC-SHA-2-384             | ✔️       | ✔️              |
-|HMAC-SHA-2-512             | ✔️       | ✔️              |
-|HMAC-SHA-3-224             | ❌       | ❌              |
-|HMAC-SHA-3-256             | ❌       | ❌              |
-|HMAC-SHA-3-384             | ❌       | ❌              |
-|HMAC-SHA-3-512             | ❌       | ❌              |
+|Algorithm                  |Windows   |Linux                |
+|---------------------------|----------|---------------------|
+|MD5                        | ✔️       | ✔️                 |
+|SHA-1                      | ✔️       | ✔️                 |
+|SHA-2-224                  | ❌       | ✔️                 |
+|SHA-2-256                  | ✔️       | ✔️                 |
+|SHA-2-384                  | ✔️       | ✔️                 |
+|SHA-2-512                  | ✔️       | ✔️                 |
+|SHA-2-512_224              | ✔️       | ✔️ <sup>1, 2</sup> |
+|SHA-2-512_256              | ❌       | ✔️ <sup>1, 2</sup> |
+|SHA-3-224                  | ❌       | ❌                 |
+|SHA-3-256                  | ❌       | ❌                 |
+|SHA-3-384                  | ❌       | ❌                 |
+|SHA-3-512                  | ❌       | ❌                 |
+|SHAKE-128                  | ❌       | ❌                 |
+|SHAKE-256                  | ❌       | ❌                 |
+|CSHAKE-128                 | ❌       | ❌                 |
+|CSHAKE-256                 | ❌       | ❌                 |
+|HMAC-MD5                   | ✔️       | ✔️                 |
+|HMAC-SHA-1                 | ✔️       | ✔️                 |
+|HMAC-SHA-2-224             | ❌       | ✔️                 |
+|HMAC-SHA-2-256             | ✔️       | ✔️                 |
+|HMAC-SHA-2-384             | ✔️       | ✔️                 |
+|HMAC-SHA-2-512             | ✔️       | ✔️                 |
+|HMAC-SHA-2-512_224         | ✔️       | ✔️ <sup>1, 2</sup> |
+|HMAC-SHA-2-512_256         | ❌       | ✔️ <sup>1, 2</sup> |
+|HMAC-SHA-3-224             | ❌       | ❌                 |
+|HMAC-SHA-3-256             | ❌       | ❌                 |
+|HMAC-SHA-3-384             | ❌       | ❌                 |
+|HMAC-SHA-3-512             | ❌       | ❌                 |
 
-<sup>1</sup>When using the built-in OpenSSL providers, this requires the legacy provider to be enabled.
+<sup>1</sup>Available starting in Microsoft Go 1.24.
+<sup>2</sup>Requires OpenSSL 1.1.1 or later.
 
 ## Symmetric encryption
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -1,6 +1,6 @@
 # Cross-Platform Cryptography in Microsoft Go
 
-Cryptographic operations in Microsoft Go are done by operating system (OS) libraries. This dependency has advantages:
+Cryptographic operations in Microsoft Go are delegated to the operating system (OS) libraries. This dependency has advantages:
 
 * Go apps benefit from OS reliability. Keeping cryptography libraries safe from vulnerabilities is a high priority for OS vendors. To do that, they provide updates that system administrators should be applying.
 * Go apps have access to FIPS-validated algorithms if the OS libraries are FIPS-validated.
@@ -25,7 +25,7 @@ CNG is available since Windows Vista and Windows Server 2008 and it doesn't requ
 
 ### Linux
 
-On Linux, Microsoft Go uses the [OpenSSL crypto library](https://docs.openssl.org/3.0/man7/crypto/) library, OpenSSL from now on, for cryptographic operations.
+On Linux, Microsoft Go uses the [OpenSSL crypto library](https://docs.openssl.org/3.0/man7/crypto/), OpenSSL from now on, for cryptographic operations.
 OpenSSL is normally available on Linux distributions, but it may not be installed by default.
 If it is not installed, you can install it using the package manager of your distribution.
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -1,13 +1,6 @@
 # Cross-Platform Cryptography in Microsoft Go
 
-Cryptographic operations in Microsoft Go are delegated to the operating system (OS) libraries in some conditions. This dependency has advantages:
-
-* Go apps benefit from OS reliability. Keeping cryptography libraries safe from vulnerabilities is a high priority for OS vendors. To do that, they provide updates that system administrators should be applying.
-* Go apps have access to FIPS-validated algorithms if the OS libraries are FIPS-validated.
-
-> [!NOTE]
-> Starting with Go 1.24, Go will also be FIPS 140-3 compliant, see https://github.com/golang/go/issues/69536.
-> If the only reason you are using Microsoft Go is for FIPS 140-3 compliance, you should consider using Microsoft Go 1.24 or later.
+Cryptographic operations in Microsoft Go are delegated to the operating system (OS) libraries in some conditions.
 
 Go apps will fall back to native Go implementations if the OS libraries don't support the algorithm.
 This article identifies the features that are supported on each platform.

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -1,6 +1,6 @@
 # Cross-Platform Cryptography in Microsoft Go
 
-Cryptographic operations in Microsoft Go are delegated to the operating system (OS) libraries. This dependency has advantages:
+Cryptographic operations in Microsoft Go are delegated to the operating system (OS) libraries in some conditions. This dependency has advantages:
 
 * Go apps benefit from OS reliability. Keeping cryptography libraries safe from vulnerabilities is a high priority for OS vendors. To do that, they provide updates that system administrators should be applying.
 * Go apps have access to FIPS-validated algorithms if the OS libraries are FIPS-validated.
@@ -9,7 +9,7 @@ Cryptographic operations in Microsoft Go are delegated to the operating system (
 > Starting with Go 1.24, Go will also be FIPS 140-3 compliant, see https://github.com/golang/go/issues/69536.
 > If the only reason you are using Microsoft Go is for FIPS 140-3 compliance, you should consider using Microsoft Go 1.24 or later.
 
-Go apps will fall back to native Go implementations if the OS libraries doesn't support the algorithm.
+Go apps will fall back to native Go implementations if the OS libraries don't support the algorithm.
 This article identifies the features that are supported on each platform.
 
 This article assumes you have a working familiarity with cryptography in Go.
@@ -20,17 +20,17 @@ Microsoft Go supports the following platforms:
 
 ### Windows
 
-On Windows, Microsoft Go uses the [Cryptography API: Next Generation](https://learn.microsoft.com/en-us/windows/win32/seccng/cng-portal) library, CNG from now on, for cryptographic operations.
+On Windows, Microsoft Go uses the [CNG library (Cryptography API: Next Generation)](https://learn.microsoft.com/en-us/windows/win32/seccng/cng-portal) for cryptographic operations.
 CNG is available since Windows Vista and Windows Server 2008 and it doesn't require any additional installation nor configuration.
 
 ### Linux
 
-On Linux, Microsoft Go uses the [OpenSSL crypto library](https://docs.openssl.org/3.0/man7/crypto/), OpenSSL from now on, for cryptographic operations.
+On Linux, Microsoft Go uses the [OpenSSL crypto library](https://docs.openssl.org/3.0/man7/crypto/) for cryptographic operations.
 OpenSSL is normally available on Linux distributions, but it may not be installed by default.
 If it is not installed, you can install it using the package manager of your distribution.
 
 OpenSSL 3 implements all the cryptographic algorithms using [Providers](https://docs.openssl.org/3.0/man7/crypto/#providers).
-Microsoft Go officially supports the built-in providers and the [SymCrypt provider](https://github.com/microsoft/SymCrypt-OpenSSL), SCOSSL from now on.
+Microsoft Go officially supports the built-in providers and [SCOSSL (SymCrypt provider for OpenSSL)](https://github.com/microsoft/SymCrypt-OpenSSL).
 The minimum SCOSSL version required is v1.6.1.
 The following tables assume that the SCOSSL provider is used together with the built-in providers.
 
@@ -69,7 +69,7 @@ This section includes the following packages:
 
 <sup>2</sup>Requires OpenSSL 1.1.1 or later.
 
-<sup>3</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
+<sup>3</sup>Supports only hash algorithms that are supported as standalone hash functions.
 
 ## Symmetric encryption
 
@@ -181,7 +181,7 @@ This section includes the following packages:
 
 #### Random number generation
 
-For those operations that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
+Operations that require random numbers (rand io.Reader) only support [rand.Reader](https://pkg.go.dev/crypto/rand#Reader).
 
 ### ECDH
 
@@ -248,8 +248,8 @@ This section includes the following packages:
 
 | Parameters    | Windows     | Linux        |
 |---------------|-------------|--------------|
-|768            | ❌          | ❌          |
-|1024           | ❌          | ❌          |
+| 768           | ❌          | ❌          |
+| 1024          | ❌          | ❌          |
 
 ## TLS
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -45,39 +45,29 @@ This section includes the following packages:
 * [crypto/sha3](https://pkg.go.dev/golang.org/x/crypto/sha3)
 * [crypto/hmac](https://pkg.go.dev/crypto/hmac)
 
-|Algorithm                  |Windows   |Linux                |
-|---------------------------|----------|---------------------|
-|MD5                        | ✔️       | ✔️                 |
-|SHA-1                      | ✔️       | ✔️                 |
-|SHA-2-224                  | ❌       | ✔️                 |
-|SHA-2-256                  | ✔️       | ✔️                 |
-|SHA-2-384                  | ✔️       | ✔️                 |
-|SHA-2-512                  | ✔️       | ✔️                 |
-|SHA-2-512_224              | ✔️       | ✔️ <sup>1, 2</sup> |
-|SHA-2-512_256              | ❌       | ✔️ <sup>1, 2</sup> |
-|SHA-3-224                  | ❌       | ❌                 |
-|SHA-3-256                  | ❌       | ❌                 |
-|SHA-3-384                  | ❌       | ❌                 |
-|SHA-3-512                  | ❌       | ❌                 |
-|SHAKE-128                  | ❌       | ❌                 |
-|SHAKE-256                  | ❌       | ❌                 |
-|CSHAKE-128                 | ❌       | ❌                 |
-|CSHAKE-256                 | ❌       | ❌                 |
-|HMAC-MD5                   | ✔️       | ✔️                 |
-|HMAC-SHA-1                 | ✔️       | ✔️                 |
-|HMAC-SHA-2-224             | ❌       | ✔️                 |
-|HMAC-SHA-2-256             | ✔️       | ✔️                 |
-|HMAC-SHA-2-384             | ✔️       | ✔️                 |
-|HMAC-SHA-2-512             | ✔️       | ✔️                 |
-|HMAC-SHA-2-512_224         | ✔️       | ✔️ <sup>1, 2</sup> |
-|HMAC-SHA-2-512_256         | ❌       | ✔️ <sup>1, 2</sup> |
-|HMAC-SHA-3-224             | ❌       | ❌                 |
-|HMAC-SHA-3-256             | ❌       | ❌                 |
-|HMAC-SHA-3-384             | ❌       | ❌                 |
-|HMAC-SHA-3-512             | ❌       | ❌                 |
+|Algorithm                  |Windows            |Linux                |
+|---------------------------|-------------------|---------------------|
+| MD5                       | ✔️                | ✔️                 |
+| SHA-1                     | ✔️                | ✔️                 |
+| SHA-2-224                 | ❌                | ✔️                 |
+| SHA-2-256                 | ✔️                | ✔️                 |
+| SHA-2-384                 | ✔️                | ✔️                 |
+| SHA-2-512                 | ✔️                | ✔️                 |
+| SHA-2-512_224             | ❌                | ✔️ <sup>1, 2</sup> |
+| SHA-2-512_256             | ❌                | ✔️ <sup>1, 2</sup> |
+| SHA-3-224                 | ❌                | ❌                 |
+| SHA-3-256                 | ❌                | ❌                 |
+| SHA-3-384                 | ❌                | ❌                 |
+| SHA-3-512                 | ❌                | ❌                 |
+| SHAKE-128                 | ❌                | ❌                 |
+| SHAKE-256                 | ❌                | ❌                 |
+| CSHAKE-128                | ❌                | ❌                 |
+| CSHAKE-256                | ❌                | ❌                 |
+| HMAC                      | ✔️ <sup>3</sup>   | ✔️ <sup>3</sup>    |
 
 <sup>1</sup>Available starting in Microsoft Go 1.24.
 <sup>2</sup>Requires OpenSSL 1.1.1 or later.
+<sup>3</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
 
 ## Symmetric encryption
 
@@ -117,3 +107,51 @@ This section includes the following packages:
 * Tag Sizes
   
   AES-GCM works with 16-byte tags.
+
+## Asymmetric encryption
+
+This section includes the following subsections:
+
+* [RSA](#rsa)
+
+### RSA
+
+This section includes the following packages:
+
+* [crypto/rsa](https://pkg.go.dev/crypto/rsa)
+
+| Padding Mode                      | Windows              | Linux               |
+|-----------------------------------|----------------------|---------------------|
+| OAEP (MD5)                        | ✔️                   | ✔️                 |
+| OAEP (SHA-1)                      | ✔️                   | ✔️                 |
+| OAEP (SHA-2)                      | ✔️ <sup>1</sup>      | ✔️ <sup>1</sup>    |
+| OAEP (SHA-3)                      | ❌                   | ❌                 |
+| PSS (MD5)                         | ✔️                   | ✔️                 |
+| PSS (SHA-1)                       | ✔️                   | ✔️                 |
+| PSS (SHA-2)                       | ✔️ <sup>1</sup>      | ✔️ <sup>1</sup>    |
+| PSS (SHA-3)                       | ❌                   | ❌                 |
+| PKCS1v15 Signature (Unhashed)     | ✔️                   | ✔️                 |
+| PKCS1v15 Signature (RIPMED160)    | ❌                   | ✔️                 |
+| PKCS1v15 Signature (MD4)          | ❌                   | ✔️                 |
+| PKCS1v15 Signature (MD5)          | ✔️                   | ✔️                 |
+| PKCS1v15 Signature (MD5-SHA1)     | ✔️                   | ✔️                 |
+| PKCS1v15 Signature (SHA-1)        | ✔️                   | ✔️                 |
+| PKCS1v15 Signature (SHA-2)        | ✔️ <sup>1</sup>      | ✔️ <sup>1</sup>    |
+| PKCS1v15 Signature (SHA-3)        | ❌                   | ❌                 |
+
+<sup>1</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
+
+#### RSA key sizes
+
+[rsa.GenerateKey](https://pkg.go.dev/crypto/rsa#GenerateKey) only supports the following key sizes (in bits): 2048, 3072, 4096.
+
+Multiprime RSA keys are not supported.
+
+#### PSS salt length
+
+On Windows, when verifying a PSS signature, [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.
+
+### Random number generation
+
+For those padding modes that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
+

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -88,22 +88,21 @@ This section includes the following packages:
 * [crypto/des](https://pkg.go.dev/crypto/des)
 * [crypto/rc4](https://pkg.go.dev/crypto/rc4)
 
-| Cipher + Mode | Windows  | Linux               |
-|---------------|----------|---------------------|
-| AES-ECB       | ✔️       | ✔️                 |
-| AES-CBC       | ✔️       | ✔️                 |
-| AES-CTR       | ❌       | ✔️                 |
-| AES-CFB       | ❌       | ❌                 |
-| AES-OFB       | ❌       | ❌                 |
-| AES-GCM       | ✔️       | ✔️                 |
-| DES-CBC       | ✔️       | ⚠️ <sup>1, 2</sup> |
-| DES-ECB       | ✔️       | ⚠️ <sup>1, 2</sup> |
-| 3DES-ECB      | ✔️       | ⚠️ <sup>2</sup>    |
-| 3DES-CBC      | ✔️       | ⚠️ <sup>2</sup>    |
-| RC4           | ✔️       | ⚠️ <sup>1, 2</sup> |
+| Cipher + Mode | Windows  | Linux            |
+|---------------|----------|------------------|
+| AES-ECB       | ✔️       | ✔️              |
+| AES-CBC       | ✔️       | ✔️              |
+| AES-CTR       | ❌       | ✔️              |
+| AES-CFB       | ❌       | ❌              |
+| AES-OFB       | ❌       | ❌              |
+| AES-GCM       | ✔️       | ✔️              |
+| DES-CBC       | ✔️       | ✔️ <sup>1</sup> |
+| DES-ECB       | ✔️       | ✔️ <sup>1</sup> |
+| 3DES-ECB      | ✔️       | ✔️              |
+| 3DES-CBC      | ✔️       | ✔️              |
+| RC4           | ✔️       | ✔️ <sup>1</sup> |
 
-<sup>1</sup>Not supported by the SymCrypt provider for OpenSSL.
-<sup>2</sup>When using the built-in OpenSSL providers, this requires the legacy provider to be enabled.
+<sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
 ### AES-GCM keys, nonces, and tags
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -1,8 +1,8 @@
 # Cross-Platform Cryptography in Microsoft Go
 
-Cryptographic operations in Microsoft Go are delegated to the operating system (OS) libraries in some conditions.
-
-Go apps will fall back to native Go implementations if the OS libraries don't support the algorithm.
+Cryptographic operations in Microsoft Go are delegated to the operating system (OS) libraries in some conditions described.
+The high level conditions and the benefits of delegating cryptographic operations are described in the [Microsoft Go FIPS README](./Readme.md).
+At a fine-grained level, Go apps will fall back to the native Go implementation of an algorithm if the OS libraries don't support it.
 This article identifies the features that are supported on each platform.
 
 This article assumes you have a working familiarity with cryptography in Go.
@@ -24,11 +24,11 @@ If it is not installed, you can install it using the package manager of your dis
 
 OpenSSL 3 implements all the cryptographic algorithms using [Providers](https://docs.openssl.org/3.0/man7/crypto/#providers).
 Microsoft Go officially supports the built-in providers and [SCOSSL (SymCrypt provider for OpenSSL)](https://github.com/microsoft/SymCrypt-OpenSSL) v1.6.1 or later.
-SCOSSL is expected to be used with the default built-in provider enable as a fallback (which is the case when using [Azure Linux 3](https://github.com/microsoft/AzureLinux)).
+SCOSSL is expected to be used with the default built-in provider enabled as a fallback (which is the case when using [Azure Linux 3](https://github.com/microsoft/AzureLinux)).
 
 ## Table legend
 
-The following table legend is used to indicate the level of support for each cryptographic algorithm:
+The following legend describes the symbols used in the tables to indicate the level of support for each cryptographic algorithm:
 
 | Symbol | Meaning                                                                                                            |
 |--------|--------------------------------------------------------------------------------------------------------------------|
@@ -36,7 +36,7 @@ The following table legend is used to indicate the level of support for each cry
 | ⚠️     | Supported with limitations that require user action                                                                |
 | ❌     | Not supported                                                                                                      |
 
-When an algorithm is not supported or the limitations are not met, Microsoft Go will fall back to the Go implementation.
+When an algorithm is not supported or the limitations are exceeded, Microsoft Go will fall back to the Go implementation.
 
 ## Hash and Message Authentication Algorithms
 
@@ -149,7 +149,7 @@ This section includes the following packages:
 | PKCS1v15 Signature (SHA-2)<sup>1</sup> | ✔️                   | ✔️                 |
 | PKCS1v15 Signature (SHA-3)             | ❌                  | ❌                 |
 
-<sup>1</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
+<sup>1</sup>Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).
 
 <sup>2</sup>Available starting in Microsoft Go 1.24.
 
@@ -167,7 +167,7 @@ On Windows, when verifying a PSS signature, [rsa.PSSSaltLengthAuto](https://pkg.
 
 #### Random number generation
 
-For those operations that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
+Operations that require random numbers (rand io.Reader) only support [rand.Reader](https://pkg.go.dev/crypto/rand#Reader).
 
 ### ECDSA
 
@@ -203,7 +203,7 @@ This section includes the following packages:
 
 #### Random number generation
 
-For those operations that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
+Operations that require random numbers (rand io.Reader) only support [rand.Reader](https://pkg.go.dev/crypto/rand#Reader).
 
 ### Ed25519
 
@@ -219,7 +219,7 @@ This section includes the following packages:
 
 #### Random number generation
 
-For those operations that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
+Operations that require random numbers (rand io.Reader) only support [rand.Reader](https://pkg.go.dev/crypto/rand#Reader).
 
 ### DSA
 
@@ -242,7 +242,7 @@ This section includes the following packages:
 | PBKDF2        | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
 | HKDF          | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
 
-<sup>1</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
+<sup>1</sup>Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).
 
 ## ML-KEM
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -331,6 +331,6 @@ This section includes the following packages:
 | ECDSAWithP256AndSHA256    | ✔️          | ✔️          |
 | ECDSAWithP384AndSHA384    | ✔️          | ✔️          |
 | ECDSAWithP521AndSHA512    | ✔️          | ✔️          |
-| Ed25519                   | ✔️          | ✔️          |
+| Ed25519                   | ❌          | ✔️          |
 | PKCS1WithSHA1             | ✔️          | ✔️          |
 | ECDSAWithSHA1             | ✔️          | ✔️          |

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -268,10 +268,10 @@ This section includes the following packages:
 
 | Version        | Windows     | Linux   |
 |----------------|-------------|---------|
-| SSL 3.0        | ❌          | ❌          |
-| TLS 1.0        | ✔️          | ✔️          |
-| TLS 1.2        | ✔️          | ✔️          |
-| TLS 1.3        | ✔️          | ✔️          |
+| SSL 3.0        | ❌          | ❌     |
+| TLS 1.0        | ✔️          | ✔️     |
+| TLS 1.2        | ✔️          | ✔️     |
+| TLS 1.3        | ✔️          | ✔️     |
 
 ### Cipher Suites
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -204,8 +204,8 @@ This section includes the following packages:
 
 * [crypto/ed25519](https://pkg.go.dev/crypto/ed25519)
 
-| Schemes     | Windows     | Linux        |
-|-------------|-------------|--------------|
+| Schemes     | Windows    | Linux         |
+|-------------|------------|---------------|
 | Ed25519     | ❌         | ✔️           |
 | Ed25519ctx  | ❌         | ❌           |
 | Ed25519ph   | ❌         | ❌           |
@@ -263,14 +263,12 @@ This section includes the following packages:
 
 ### TLS Versions
 
-| Version        | Windows          | Linux             |
-|----------------|------------------|-------------------|
-| SSL 3.0        | ❌               | ❌               |
-| TLS 1.0        | ✔️               | ✔️               |
-| TLS 1.2        | ✔️               | ✔️               |
-| TLS 1.3        | ⚠️ <sup>1</sup>  | ⚠️ <sup>1</sup>  |
-
-<sup>1</sup>The TLS 1.3 PRF is implemented using native Go code.
+| Version        | Windows     | Linux   |
+|----------------|-------------|---------|
+| SSL 3.0        | ❌          | ❌          |
+| TLS 1.0        | ✔️          | ✔️          |
+| TLS 1.2        | ✔️          | ✔️          |
+| TLS 1.3        | ✔️          | ✔️          |
 
 ### Cipher Suites
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -23,9 +23,20 @@ OpenSSL is normally available on Linux distributions, but it may not be installe
 If it is not installed, you can install it using the package manager of your distribution.
 
 OpenSSL 3 implements all the cryptographic algorithms using [Providers](https://docs.openssl.org/3.0/man7/crypto/#providers).
-Microsoft Go officially supports the built-in providers and [SCOSSL (SymCrypt provider for OpenSSL)](https://github.com/microsoft/SymCrypt-OpenSSL).
-The minimum SCOSSL version required is v1.6.1.
-The following tables assume that the SCOSSL provider is used together with the built-in providers.
+Microsoft Go officially supports the built-in providers and [SCOSSL (SymCrypt provider for OpenSSL)](https://github.com/microsoft/SymCrypt-OpenSSL) v1.6.1 or later.
+SCOSSL is expected to be used with the default built-in provider enable as a fallback (which is the case when using [Azure Linux 3](https://github.com/microsoft/AzureLinux)).
+
+## Table legend
+
+The following table legend is used to indicate the level of support for each cryptographic algorithm:
+
+| Symbol | Meaning                                                                                                            |
+|--------|--------------------------------------------------------------------------------------------------------------------|
+| ✔️     | Supported, possibly with minor limitations that don't require user action when using the latest Go and OS versions |
+| ⚠️     | Supported with limitations that require user action                                                                |
+| ❌     | Not supported                                                                                                      |
+
+When an algorithm is not supported or the limitations are not met, Microsoft Go will fall back to the Go implementation.
 
 ## Hash and Message Authentication Algorithms
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -312,7 +312,7 @@ This section includes the following packages:
 
 | Name            | Windows     | Linux        |
 |-----------------|-------------|--------------|
-| CurveP2         | ✔️          | ✔️          |
+| CurveP256       | ✔️          | ✔️          |
 | CurveP384       | ✔️          | ✔️          |
 | CurveP521       | ✔️          | ✔️          |
 | X25519          | ❌          | ❌          |

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -9,7 +9,7 @@ Cryptographic operations in Microsoft Go are done by operating system (OS) libra
 > Starting with Go 1.24, Go will also be FIPS 140-3 compliant, see https://github.com/golang/go/issues/69536.
 > If the only reason you are using Microsoft Go is for FIPS 140-3 compliance, you should consider using Microsoft Go 1.24 or later.
 
-Go apps will fall back to native Go implementations if the OS libraries are not available.
+Go apps will fall back to native Go implementations if the OS libraries doesn't support the algorithm.
 This article identifies the features that are supported on each platform.
 
 This article assumes you have a working familiarity with cryptography in Go.
@@ -86,11 +86,11 @@ This section includes the following packages:
 | AES-CFB       | ❌       | ❌              |
 | AES-OFB       | ❌       | ❌              |
 | AES-GCM       | ✔️       | ✔️              |
-| DES-CBC       | ✔️       | ✔️ <sup>1</sup> |
-| DES-ECB       | ✔️       | ✔️ <sup>1</sup> |
+| DES-CBC       | ✔️       | ⚠️ <sup>1</sup> |
+| DES-ECB       | ✔️       | ⚠️ <sup>1</sup> |
 | 3DES-ECB      | ✔️       | ✔️              |
 | 3DES-CBC      | ✔️       | ✔️              |
-| RC4           | ✔️       | ✔️ <sup>1</sup> |
+| RC4           | ✔️       | ⚠️ <sup>1</sup> |
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
@@ -115,6 +115,7 @@ This section includes the following subsections:
 * [RSA](#rsa)
 * [ECDSA](#ecdsa)
 * [ECDH](#ecdh)
+* [Ed25519](#ed25519)
 * [DSA](#dsa)
 
 ### RSA
@@ -197,6 +198,22 @@ This section includes the following packages:
 
 For those operations that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
 
+### Ed25519
+
+This section includes the following packages:
+
+* [crypto/ed25519](https://pkg.go.dev/crypto/ed25519)
+
+| Schemes     | Windows     | Linux        |
+|-------------|-------------|--------------|
+| Ed25519     | ❌         | ✔️           |
+| Ed25519ctx  | ❌         | ❌           |
+| Ed25519ph   | ❌         | ❌           |
+
+#### Random number generation
+
+For those operations that require random numbers, only the [rand.Reader](https://pkg.go.dev/crypto/rand#Reader) is supported.
+
 ### DSA
 
 | Parameters    | Windows     | Linux        |
@@ -230,3 +247,89 @@ This section includes the following packages:
 |---------------|-------------|--------------|
 |768            | ❌          | ❌          |
 |1024           | ❌          | ❌          |
+
+## TLS
+
+This section includes the following subsections:
+
+* [TLS Versions](#tls-versions)
+* [Cipher Suites](#cipher-suites)
+* [Curves and Groups](#curves-and-groups)
+* [Signature Algorithms](#signature-algorithms)
+
+This section includes the following packages:
+
+* [crypto/tls](https://pkg.go.dev/crypto/tls)
+
+### TLS Versions
+
+| Version        | Windows          | Linux             |
+|----------------|------------------|-------------------|
+| SSL 3.0        | ❌               | ❌               |
+| TLS 1.0        | ✔️               | ✔️               |
+| TLS 1.2        | ✔️               | ✔️               |
+| TLS 1.3        | ⚠️ <sup>1</sup>  | ⚠️ <sup>1</sup>  |
+
+<sup>1</sup>The TLS 1.3 PRF is implemented using native Go code.
+
+### Cipher Suites
+
+| Name                                              | Windows     | Linux             |
+|---------------------------------------------------|-------------|-------------------|
+| TLS_RSA_WITH_RC4_128_SHA                          | ✔️          | ⚠️ <sup>1</sup>  |
+| TLS_RSA_WITH_3DES_EDE_CBC_SHA                     | ✔️          | ⚠️ <sup>1</sup>  |
+| TLS_RSA_WITH_AES_128_CBC_SHA                      | ✔️          | ✔️               |
+| TLS_RSA_WITH_AES_256_CBC_SHA                      | ✔️          | ✔️               |
+| TLS_RSA_WITH_AES_128_CBC_SHA256                   | ✔️          | ✔️               |
+| TLS_RSA_WITH_AES_128_GCM_SHA256                   | ✔️          | ✔️               |
+| TLS_RSA_WITH_AES_256_GCM_SHA384                   | ✔️          | ✔️               |
+| TLS_ECDHE_ECDSA_WITH_RC4_128_SHA                  | ✔️          | ⚠️ <sup>1</sup>  |
+| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA              | ✔️          | ✔️               |
+| TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA              | ✔️          | ✔️               |
+| TLS_ECDHE_RSA_WITH_RC4_128_SHA                    | ✔️          | ⚠️ <sup>1</sup>  |
+| TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA               | ✔️          | ⚠️ <sup>1</sup>  |
+| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA                | ✔️          | ✔️               |
+| TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA                | ✔️          | ✔️               |
+| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256           | ✔️          | ✔️               |
+| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256             | ✔️          | ✔️               |
+| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             | ✔️          | ✔️               |
+| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256           | ✔️          | ✔️               |
+| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             | ✔️          | ✔️               |
+| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384           | ✔️          | ✔️               |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256       | ❌          | ❌               |
+| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256     | ❌          | ❌               |
+| TLS_AES_128_GCM_SHA256                            | ✔️          | ✔️               |
+| TLS_AES_256_GCM_SHA384                            | ✔️          | ✔️               |
+| TLS_CHACHA20_POLY1305_SHA256                      | ❌          | ❌               |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305              | ❌          | ❌               |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305              | ❌          | ❌               |
+| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305            | ❌          | ❌               |
+
+<sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
+
+### Curves and Groups
+
+| Name            | Windows     | Linux        |
+|-----------------|-------------|--------------|
+| CurveP2         | ✔️          | ✔️          |
+| CurveP384       | ✔️          | ✔️          |
+| CurveP521       | ✔️          | ✔️          |
+| X25519          | ❌          | ❌          |
+| X25519MLKEM768  | ❌          | ❌          |
+
+### Signature Algorithms
+
+| Name                      | Windows     | Linux        |
+|---------------------------|-------------|--------------|
+| PKCS1WithSHA256           | ✔️          | ✔️          |
+| PKCS1WithSHA384           | ✔️          | ✔️          |
+| PKCS1WithSHA512           | ✔️          | ✔️          |
+| PSSWithSHA256             | ✔️          | ✔️          |
+| PSSWithSHA384             | ✔️          | ✔️          |
+| PSSWithSHA512             | ✔️          | ✔️          |
+| ECDSAWithP256AndSHA256    | ✔️          | ✔️          |
+| ECDSAWithP384AndSHA384    | ✔️          | ✔️          |
+| ECDSAWithP521AndSHA512    | ✔️          | ✔️          |
+| Ed25519                   | ✔️          | ✔️          |
+| PKCS1WithSHA1             | ✔️          | ✔️          |
+| ECDSAWithSHA1             | ✔️          | ✔️          |

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -1,0 +1,95 @@
+# Cross-Platform Cryptography in Microsoft Go
+
+Cryptographic operations in Microsoft Go are done by operating system (OS) libraries. This dependency has advantages:
+
+* Go apps benefit from OS reliability. Keeping cryptography libraries safe from vulnerabilities is a high priority for OS vendors. To do that, they provide updates that system administrators should be applying.
+* Go apps have access to FIPS-validated algorithms if the OS libraries are FIPS-validated.
+
+> [!NOTE]
+> Starting with Go 1.24, Go will also be FIPS 140-3 compliant, see https://github.com/golang/go/issues/69536.
+> If the only reason you are using Microsoft Go is for FIPS 140-3 compliance, you should consider using Microsoft Go 1.24 or later.
+
+Go apps will fall back to native Go implementations if the OS libraries are not available.
+This article identifies the features that are supported on each platform.
+
+This article assumes you have a working familiarity with cryptography in Go.
+
+## Hash and Message Authentication Algorithms
+
+This section includes the following packages:
+
+* [crypto/md5](https://pkg.go.dev/crypto/md5)
+* [crypto/sha1](https://pkg.go.dev/crypto/sha1)
+* [crypto/sha256](https://pkg.go.dev/crypto/sha256)
+* [crypto/sha512](https://pkg.go.dev/crypto/sha512)
+* [crypto/sha3](https://pkg.go.dev/golang.org/x/crypto/sha3)
+* [crypto/hmac](https://pkg.go.dev/crypto/hmac)
+
+|Algorithm                  |Windows   |Linux             |
+|---------------------------|----------|------------------|
+|MD5                        | ✔️       | ✔️ <sup>1</sup> |
+|SHA-1                      | ✔️       | ✔️              |
+|SHA-2-224                  | ❌       | ✔️              |
+|SHA-2-256                  | ✔️       | ✔️              |
+|SHA-2-384                  | ✔️       | ✔️              |
+|SHA-2-512                  | ✔️       | ✔️              |
+|SHA-3-224                  | ❌       | ❌              |
+|SHA-3-256                  | ❌       | ❌              |
+|SHA-3-384                  | ❌       | ❌              |
+|SHA-3-512                  | ❌       | ❌              |
+|SHAKE-128                  | ❌       | ❌              |
+|SHAKE-256                  | ❌       | ❌              |
+|CSHAKE-128                 | ❌       | ❌              |
+|CSHAKE-256                 | ❌       | ❌              |
+|HMAC-MD5                   | ✔️       | ✔️              |
+|HMAC-SHA-1                 | ✔️       | ✔️              |
+|HMAC-SHA-2-224             | ❌       | ✔️              |
+|HMAC-SHA-2-256             | ✔️       | ✔️              |
+|HMAC-SHA-2-384             | ✔️       | ✔️              |
+|HMAC-SHA-2-512             | ✔️       | ✔️              |
+|HMAC-SHA-3-224             | ❌       | ❌              |
+|HMAC-SHA-3-256             | ❌       | ❌              |
+|HMAC-SHA-3-384             | ❌       | ❌              |
+|HMAC-SHA-3-512             | ❌       | ❌              |
+
+<sup>1</sup>When using the built-in OpenSSL providers, this requires the legacy provider to be enabled.
+
+## Symmetric encryption
+
+This section includes the following packages:
+
+* [crypto/aes](https://pkg.go.dev/crypto/aes)
+* [crypto/cipher](https://pkg.go.dev/crypto/cipher)
+* [crypto/des](https://pkg.go.dev/crypto/des)
+* [crypto/rc4](https://pkg.go.dev/crypto/rc4)
+
+| Cipher + Mode | Windows  | Linux               |
+|---------------|----------|---------------------|
+| AES-ECB       | ✔️       | ✔️                 |
+| AES-CBC       | ✔️       | ✔️                 |
+| AES-CTR       | ❌       | ✔️                 |
+| AES-CFB       | ❌       | ❌                 |
+| AES-OFB       | ❌       | ❌                 |
+| AES-GCM       | ✔️       | ✔️                 |
+| DES-CBC       | ✔️       | ⚠️ <sup>1, 2</sup> |
+| DES-ECB       | ✔️       | ⚠️ <sup>1, 2</sup> |
+| 3DES-ECB      | ✔️       | ⚠️ <sup>2</sup>    |
+| 3DES-CBC      | ✔️       | ⚠️ <sup>2</sup>    |
+| RC4           | ✔️       | ⚠️ <sup>1, 2</sup> |
+
+<sup>1</sup>Not supported by the SymCrypt provider for OpenSSL.
+<sup>2</sup>When using the built-in OpenSSL providers, this requires the legacy provider to be enabled.
+
+### AES-GCM keys, nonces, and tags
+
+* Key Sizes
+
+  AES-GCM works with 128, 192, and 256-bit keys.
+
+* Nonce Sizes
+
+  AES-GCM works with 12-byte nonces.
+
+* Tag Sizes
+  
+  AES-GCM works with 16-byte tags.

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -45,25 +45,25 @@ This section includes the following packages:
 * [crypto/sha3](https://pkg.go.dev/golang.org/x/crypto/sha3)
 * [crypto/hmac](https://pkg.go.dev/crypto/hmac)
 
-|Algorithm                  |Windows            |Linux                |
-|---------------------------|-------------------|---------------------|
-| MD5                       | ✔️                | ✔️                 |
-| SHA-1                     | ✔️                | ✔️                 |
-| SHA-2-224                 | ❌                | ✔️                 |
-| SHA-2-256                 | ✔️                | ✔️                 |
-| SHA-2-384                 | ✔️                | ✔️                 |
-| SHA-2-512                 | ✔️                | ✔️                 |
-| SHA-2-512_224             | ❌                | ✔️ <sup>1, 2</sup> |
-| SHA-2-512_256             | ❌                | ✔️ <sup>1, 2</sup> |
-| SHA-3-224                 | ❌                | ❌                 |
-| SHA-3-256                 | ❌                | ❌                 |
-| SHA-3-384                 | ❌                | ❌                 |
-| SHA-3-512                 | ❌                | ❌                 |
-| SHAKE-128                 | ❌                | ❌                 |
-| SHAKE-256                 | ❌                | ❌                 |
-| CSHAKE-128                | ❌                | ❌                 |
-| CSHAKE-256                | ❌                | ❌                 |
-| HMAC                      | ✔️ <sup>3</sup>   | ✔️ <sup>3</sup>    |
+|Algorithm                  |Windows             |Linux                |
+|---------------------------|--------------------|---------------------|
+| MD5                       | ✔️                 | ✔️                 |
+| SHA-1                     | ✔️                 | ✔️                 |
+| SHA-2-224                 | ❌                 | ✔️                 |
+| SHA-2-256                 | ✔️                 | ✔️                 |
+| SHA-2-384                 | ✔️                 | ✔️                 |
+| SHA-2-512                 | ✔️                 | ✔️                 |
+| SHA-2-512_224             | ❌                 | ✔️<sup>1, 2</sup>  |
+| SHA-2-512_256             | ❌                 | ✔️<sup>1, 2</sup>  |
+| SHA-3-224                 | ❌                 | ❌                 |
+| SHA-3-256                 | ❌                 | ❌                 |
+| SHA-3-384                 | ❌                 | ❌                 |
+| SHA-3-512                 | ❌                 | ❌                 |
+| SHAKE-128                 | ❌                 | ❌                 |
+| SHAKE-256                 | ❌                 | ❌                 |
+| CSHAKE-128                | ❌                 | ❌                 |
+| CSHAKE-256                | ❌                 | ❌                 |
+| HMAC<sup>3</sup>          | ✔️                 | ✔️                 |
 
 <sup>1</sup>Available starting in Microsoft Go 1.24.
 
@@ -88,11 +88,11 @@ This section includes the following packages:
 | AES-CFB       | ❌       | ❌              |
 | AES-OFB       | ❌       | ❌              |
 | AES-GCM       | ✔️       | ✔️              |
-| DES-CBC       | ✔️       | ⚠️ <sup>1</sup> |
-| DES-ECB       | ✔️       | ⚠️ <sup>1</sup> |
+| DES-CBC       | ✔️       | ⚠️<sup>1</sup>  |
+| DES-ECB       | ✔️       | ⚠️<sup>1</sup>  |
 | 3DES-ECB      | ✔️       | ✔️              |
 | 3DES-CBC      | ✔️       | ✔️              |
-| RC4           | ✔️       | ⚠️ <sup>1</sup> |
+| RC4           | ✔️       | ⚠️<sup>1</sup>  |
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
@@ -126,24 +126,24 @@ This section includes the following packages:
 
 * [crypto/rsa](https://pkg.go.dev/crypto/rsa)
 
-| Padding Mode                      | Windows              | Linux               |
-|-----------------------------------|----------------------|---------------------|
-| OAEP (MD5)                        | ✔️                   | ✔️                 |
-| OAEP (SHA-1)                      | ✔️                   | ✔️                 |
-| OAEP (SHA-2)                      | ✔️ <sup>1</sup>      | ✔️ <sup>1</sup>    |
-| OAEP (SHA-3)                      | ❌                   | ❌                 |
-| PSS (MD5)                         | ✔️                   | ✔️                 |
-| PSS (SHA-1)                       | ✔️                   | ✔️                 |
-| PSS (SHA-2)                       | ✔️ <sup>1</sup>      | ✔️ <sup>1</sup>    |
-| PSS (SHA-3)                       | ❌                   | ❌                 |
-| PKCS1v15 Signature (Unhashed)     | ✔️                   | ✔️                 |
-| PKCS1v15 Signature (RIPMED160)    | ❌ <sup>2</sup>      | ✔️ <sup>2</sup>    |
-| PKCS1v15 Signature (MD4)          | ❌ <sup>2</sup>      | ✔️ <sup>2</sup>    |
-| PKCS1v15 Signature (MD5)          | ✔️                   | ✔️                 |
-| PKCS1v15 Signature (MD5-SHA1)     | ✔️ <sup>2</sup>      | ✔️ <sup>2</sup>    |
-| PKCS1v15 Signature (SHA-1)        | ✔️                   | ✔️                 |
-| PKCS1v15 Signature (SHA-2)        | ✔️ <sup>1</sup>      | ✔️ <sup>1</sup>    |
-| PKCS1v15 Signature (SHA-3)        | ❌                   | ❌                 |
+| Padding Mode                           | Windows              | Linux               |
+|----------------------------------------|----------------------|---------------------|
+| OAEP (MD5)                             | ✔️                   | ✔️                 |
+| OAEP (SHA-1)                           | ✔️                   | ✔️                 |
+| OAEP (SHA-2)<sup>1</sup>               | ✔️                   | ✔️                 |
+| OAEP (SHA-3)                           | ❌                   | ❌                 |
+| PSS (MD5)                              | ✔️                   | ✔️                 |
+| PSS (SHA-1)                            | ✔️                   | ✔️                 |
+| PSS (SHA-2)<sup>1</sup>                | ✔️                   | ✔️                 |
+| PSS (SHA-3)                            | ❌                   | ❌                 |
+| PKCS1v15 Signature (Unhashed)          | ✔️                   | ✔️                 |
+| PKCS1v15 Signature (RIPMED160)         | ❌                   | ✔️<sup>2</sup>     |
+| PKCS1v15 Signature (MD4)               | ❌                   | ✔️<sup>2</sup>     |
+| PKCS1v15 Signature (MD5)               | ✔️                   | ✔️                 |
+| PKCS1v15 Signature (MD5-SHA1)          | ✔️<sup>2</sup>       | ✔️<sup>2</sup>     |
+| PKCS1v15 Signature (SHA-1)             | ✔️                   | ✔️                 |
+| PKCS1v15 Signature (SHA-2)<sup>1</sup> | ✔️                   | ✔️                 |
+| PKCS1v15 Signature (SHA-3)             | ❌                  | ❌                 |
 
 <sup>1</sup>The supported hash algorithms are the same as the ones supported as standalone hash functions.
 
@@ -277,18 +277,18 @@ This section includes the following packages:
 
 | Name                                              | Windows     | Linux             |
 |---------------------------------------------------|-------------|-------------------|
-| TLS_RSA_WITH_RC4_128_SHA                          | ✔️          | ⚠️ <sup>1</sup>  |
-| TLS_RSA_WITH_3DES_EDE_CBC_SHA                     | ✔️          | ⚠️ <sup>1</sup>  |
+| TLS_RSA_WITH_RC4_128_SHA                          | ✔️          | ⚠️<sup>1</sup>   |
+| TLS_RSA_WITH_3DES_EDE_CBC_SHA                     | ✔️          | ⚠️<sup>1</sup>   |
 | TLS_RSA_WITH_AES_128_CBC_SHA                      | ✔️          | ✔️               |
 | TLS_RSA_WITH_AES_256_CBC_SHA                      | ✔️          | ✔️               |
 | TLS_RSA_WITH_AES_128_CBC_SHA256                   | ✔️          | ✔️               |
 | TLS_RSA_WITH_AES_128_GCM_SHA256                   | ✔️          | ✔️               |
 | TLS_RSA_WITH_AES_256_GCM_SHA384                   | ✔️          | ✔️               |
-| TLS_ECDHE_ECDSA_WITH_RC4_128_SHA                  | ✔️          | ⚠️ <sup>1</sup>  |
+| TLS_ECDHE_ECDSA_WITH_RC4_128_SHA                  | ✔️          | ⚠️<sup>1</sup>   |
 | TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA              | ✔️          | ✔️               |
 | TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA              | ✔️          | ✔️               |
-| TLS_ECDHE_RSA_WITH_RC4_128_SHA                    | ✔️          | ⚠️ <sup>1</sup>  |
-| TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA               | ✔️          | ⚠️ <sup>1</sup>  |
+| TLS_ECDHE_RSA_WITH_RC4_128_SHA                    | ✔️          | ⚠️<sup>1</sup>   |
+| TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA               | ✔️          | ⚠️<sup>1</sup>   |
 | TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA                | ✔️          | ✔️               |
 | TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA                | ✔️          | ✔️               |
 | TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256           | ✔️          | ✔️               |

--- a/eng/doc/README.md
+++ b/eng/doc/README.md
@@ -2,6 +2,7 @@ This directory, `/eng/doc`, contains documents describing the Microsoft
 infrastructure used to build Go, in particular any designs that are not obvious
 by reading the infrastructure code itself.
 
+For cryptography information, see the [CrossPlatformCryptography.md](CrossPlatformCryptography.md) doc.
 For dev scenario documentation, see the [DeveloperGuide.md](DeveloperGuide.md) doc.
 
 The [Downloads.md](Downloads.md) doc contains a table of links to the latest assets for each supported Go release branch.


### PR DESCRIPTION
This document is a port of [Cross-Platform Cryptography in .NET](https://learn.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography).

This guide aims to replace our [FIPS User Guide](https://github.com/microsoft/go/blob/c09f0a94c696e2bf7d0c0d1080d2927c0fdaea25/eng/doc/fips/UserGuide.md) by being more user-friendly and easier to maintain. It is also a nice visual summary of what each backend supports and what needs more work.

Preview: https://github.com/microsoft/go/blob/dev/qmuntal/cpdoc/eng/doc/CrossPlatformCryptography.md

For #1377.