### PR TITLE
Clean up patch files

### DIFF
--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -9,6 +9,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  src/crypto/internal/backend/deps_ignore.go    |  16 +
  src/go.mod                                    |   5 +
  src/go.sum                                    |   4 +
+ src/go/build/vendor_test.go                   |   2 +
  .../golang-fips/openssl/v2/.gitignore         |   1 +
  .../golang-fips/openssl/v2/.gitleaks.toml     |   9 +
  .../github.com/golang-fips/openssl/v2/LICENSE |  20 +
@@ -73,7 +74,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 67 files changed, 11000 insertions(+)
+ 68 files changed, 11002 insertions(+)
  create mode 100644 src/crypto/internal/backend/deps_ignore.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
@@ -186,6 +187,19 @@ index 9e661352f16e0b..abebb59dcd7739 100644
  golang.org/x/crypto v0.30.0 h1:RwoQn3GkWiMkzlX562cLB7OxWvjH1L8xutO2WoJcRoY=
  golang.org/x/crypto v0.30.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
  golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1 h1:+Yk1FZ5E+/ewA0nOO/HRYs9E4yeqpGOShuSAdzCNNoQ=
+diff --git a/src/go/build/vendor_test.go b/src/go/build/vendor_test.go
+index 7f6237ffd59c11..1d0b9b20e9b1d4 100644
+--- a/src/go/build/vendor_test.go
++++ b/src/go/build/vendor_test.go
+@@ -22,6 +22,8 @@ var allowedPackagePrefixes = []string{
+ 	"github.com/google/pprof",
+ 	"github.com/ianlancetaylor/demangle",
+ 	"rsc.io/markdown",
++	"github.com/golang-fips/openssl",
++	"github.com/microsoft/go-crypto-winnative",
+ }
+ 
+ // Verify that the vendor directories contain only packages matching the list above.
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/.gitignore b/src/vendor/github.com/golang-fips/openssl/v2/.gitignore
 new file mode 100644
 index 00000000000000..79b5594df7fa29

--- a/patches/0003-Add-crypto-backend-foundation.patch
+++ b/patches/0003-Add-crypto-backend-foundation.patch
@@ -6,6 +6,7 @@ Subject: [PATCH] Add crypto backend foundation
 ---
  src/cmd/api/boring_test.go                    |   2 +-
  src/cmd/go/go_boring_test.go                  |   2 +-
+ .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/crypto/aes/aes.go                         |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
@@ -17,6 +18,7 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/ecdh/ecdh.go                       |   2 +-
  src/crypto/ecdh/ecdh_test.go                  |   4 +
  src/crypto/ecdh/nist.go                       |   2 +-
+ src/crypto/ecdsa/badlinkname.go               |  19 ++
  src/crypto/ecdsa/boring.go                    |   6 +-
  src/crypto/ecdsa/ecdsa.go                     |   4 +-
  src/crypto/ecdsa/notboring.go                 |   4 +-
@@ -29,12 +31,12 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/hmac/hmac_test.go                  |   2 +-
  src/crypto/internal/backend/backend_test.go   |  30 +++
  src/crypto/internal/backend/bbig/big.go       |  17 ++
- src/crypto/internal/backend/common.go         |  72 ++++++
- .../internal/backend/fips140/fips140.go       |  55 +++++
+ src/crypto/internal/backend/common.go         |  58 +++++
+ .../internal/backend/fips140/fips140.go       |  55 ++++
  .../internal/backend/fips140/isrequirefips.go |   9 +
  .../internal/backend/fips140/norequirefips.go |   9 +
  .../backend/fips140/nosystemcrypto.go         |  11 +
- src/crypto/internal/backend/nobackend.go      | 233 ++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go      | 236 ++++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/crypto/internal/cryptotest/allocations.go |   2 +-
  .../internal/cryptotest/implementations.go    |   2 +-
@@ -51,9 +53,9 @@ Subject: [PATCH] Add crypto backend foundation
  src/crypto/rsa/notboring.go                   |   4 +-
  src/crypto/rsa/pkcs1v15.go                    |   6 +-
  src/crypto/rsa/pkcs1v15_test.go               |   5 +
- src/crypto/rsa/pss_test.go                    |   5 +
+ src/crypto/rsa/pss_test.go                    |   9 +-
  src/crypto/rsa/rsa.go                         |   4 +-
- src/crypto/rsa/rsa_test.go                    |  12 +-
+ src/crypto/rsa/rsa_test.go                    |  15 +-
  src/crypto/sha1/sha1.go                       |   8 +-
  src/crypto/sha1/sha1_test.go                  |  19 +-
  src/crypto/sha256/sha256.go                   |   6 +-
@@ -79,9 +81,10 @@ Subject: [PATCH] Add crypto backend foundation
  src/hash/notboring_test.go                    |   9 +
  src/net/smtp/smtp_test.go                     |  72 ++++--
  src/runtime/runtime_boring.go                 |   5 +
- 75 files changed, 1432 insertions(+), 96 deletions(-)
+ 77 files changed, 1455 insertions(+), 97 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
+ create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -124,6 +127,25 @@ index ed0fbf3d53d75b..06478963f4be44 100644
  
  package main_test
  
+diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
+index 4aaf46b5d0f0dc..ec58a217400caa 100644
+--- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
++++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
+@@ -1,5 +1,14 @@
+ env GO111MODULE=off
+ 
++# Disable systemcrypto while evaluating test dependencies to avoid importing
++# vendored crypto module dependencies like golang-fips/openssl. This test script
++# is not set up to handle any vendored libraries being imported other than
++# golang.org/x/net/http2/hpack, so we must make sure it is the only one.
++#
++# See https://github.com/microsoft/go/issues/481 for more details, such as the
++# dependency chain that would cause the failure if the gocrypt tag isn't used.
++env GOEXPERIMENT=none
++
+ [!compiler:gc] skip
+ 
+ go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/crypto/aes/aes.go b/src/crypto/aes/aes.go
 index 5bc2d13d673e0a..b803c77be62a66 100644
 --- a/src/crypto/aes/aes.go
@@ -539,6 +561,31 @@ index acef8298943c2b..ca6171cf775117 100644
  	"crypto/internal/fips140/ecdh"
  	"crypto/internal/fips140only"
  	"errors"
+diff --git a/src/crypto/ecdsa/badlinkname.go b/src/crypto/ecdsa/badlinkname.go
+new file mode 100644
+index 00000000000000..1dc05d09b2062d
+--- /dev/null
++++ b/src/crypto/ecdsa/badlinkname.go
+@@ -0,0 +1,19 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build goexperiment.systemcrypto
++
++package ecdsa
++
++import _ "unsafe"
++
++// The symbols below are pulled by some crypto backend in the Microsoft Go compiler.
++// We provide a push linkname here, to keep them accessible with pull linknames.
++
++//go:linkname encodeSignature
++//go:linkname parseSignature
++
++// This supplements other linknames that are already added by
++// https://github.com/golang/go/commit/41aab30bd260297ad8ddad47e98fdf8390a9a67e
++// See that commit for more information.
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
 index 275c60b4de49eb..ff8bddf28c4545 100644
 --- a/src/crypto/ecdsa/boring.go
@@ -964,10 +1011,10 @@ index 00000000000000..20251a290dc2e0
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..858e76e3c51c06
+index 00000000000000..0402524861dc53
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,58 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -977,7 +1024,6 @@ index 00000000000000..858e76e3c51c06
 +import (
 +	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
-+	"internal/goexperiment"
 +	"runtime"
 +)
 +
@@ -1014,7 +1060,11 @@ index 00000000000000..858e76e3c51c06
 +// UnreachableExceptTests marks code that should be unreachable
 +// when backend is in use. It panics.
 +func UnreachableExceptTests() {
-+	if Enabled {
++	// runtime_arg0 is not supported on windows.
++	// We are going through the same code patch on linux,
++	// so if we are unintentionally calling an 'unreachable' function,
++	// we will catch it there.
++	if Enabled && runtime.GOOS != "windows" {
 +		name := runtime_arg0()
 +		// If ran on Windows we'd need to allow _test.exe and .test.exe as well.
 +		if !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
@@ -1022,23 +1072,6 @@ index 00000000000000..858e76e3c51c06
 +			panic("cryptobackend: invalid code execution")
 +		}
 +	}
-+}
-+
-+func IsRSAKeySupported(primes int) bool {
-+	if goexperiment.BoringCrypto {
-+		return true
-+	}
-+	// CNG only supports 2-prime RSA keys.
-+	// The built-in OpenSSL 3 providers and OpenSSL 1 do support n-prime RSA keys,
-+	// but the SymCrypt provider for OpenSSL only supports 2-prime RSA keys.
-+	// Only 2-prime RSA keys are FIPS compliant, other n having compatibility
-+	// and security issues. Even crypto/rsa deprecated rsa.GenerateMultiPrimeKey as of Go 1.21.
-+	// Given the above reasons, we only support 2-prime RSA keys.
-+	return primes == 2
-+}
-+
-+func IsSaltSupported(salt int) bool {
-+	return true
 +}
 diff --git a/src/crypto/internal/backend/fips140/fips140.go b/src/crypto/internal/backend/fips140/fips140.go
 new file mode 100644
@@ -1153,10 +1186,10 @@ index 00000000000000..83691d7dd42d51
 +}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..3ebb6d5e4b4bb5
+index 00000000000000..4a3d8b729da30f
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,233 @@
+@@ -0,0 +1,236 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1227,6 +1260,9 @@ index 00000000000000..3ebb6d5e4b4bb5
 +func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, sig []byte) bool {
 +	panic("cryptobackend: not available")
 +}
++
++func SupportsRSAKeyPrimes(primes int) bool { panic("cryptobackend: not available") }
++func SupportsRSASaltLength(salt int) bool  { panic("cryptobackend: not available") }
 +
 +type PublicKeyRSA struct{ _ int }
 +type PrivateKeyRSA struct{ _ int }
@@ -1689,7 +1725,7 @@ index 838fcc1244bdbe..d89f732345e8a3 100644
  // Note: Can run these tests against the non-BoringCrypto
  // version of the code by using "CGO_ENABLED=0 go test".
 diff --git a/src/crypto/rsa/fips.go b/src/crypto/rsa/fips.go
-index 8373c125ae3096..bcc534151f9ac3 100644
+index 8373c125ae3096..cee523891d5897 100644
 --- a/src/crypto/rsa/fips.go
 +++ b/src/crypto/rsa/fips.go
 @@ -6,7 +6,7 @@ package rsa
@@ -1706,7 +1742,7 @@ index 8373c125ae3096..bcc534151f9ac3 100644
  	}
  
 -	if boring.Enabled && rand == boring.RandReader {
-+	if boring.Enabled && rand == boring.RandReader && boring.IsRSAKeySupported(len(priv.Primes)) && boring.SupportsHash(hash) {
++	if boring.Enabled && rand == boring.RandReader && boring.SupportsRSAKeyPrimes(len(priv.Primes)) && boring.SupportsHash(hash) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
@@ -1715,7 +1751,7 @@ index 8373c125ae3096..bcc534151f9ac3 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.IsSaltSupported(opts.saltLength()) && boring.SupportsHash(hash) {
++	if boring.Enabled && boring.SupportsRSASaltLength(opts.saltLength()) && boring.SupportsHash(hash) {
  		bkey, err := boringPublicKey(pub)
  		if err != nil {
  			return err
@@ -1724,7 +1760,7 @@ index 8373c125ae3096..bcc534151f9ac3 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.IsRSAKeySupported(len(priv.Primes)) {
++	if boring.Enabled && boring.SupportsRSAKeyPrimes(len(priv.Primes)) {
  		k := priv.Size()
  		if len(ciphertext) > k ||
  			k < hash.Size()*2+2 {
@@ -1733,7 +1769,7 @@ index 8373c125ae3096..bcc534151f9ac3 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.IsRSAKeySupported(len(priv.Primes)) {
++	if boring.Enabled && boring.SupportsRSAKeyPrimes(len(priv.Primes)) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
@@ -1756,7 +1792,7 @@ index 2abc0436405f8a..3e4d6f3eef61e6 100644
  func boringPublicKey(*PublicKey) (*boring.PublicKeyRSA, error) {
  	panic("boringcrypto: not available")
 diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
-index f1e4ef48a4fd1c..cb5aa30920bb7d 100644
+index f1e4ef48a4fd1c..a179a4388e3ee5 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
 @@ -5,7 +5,7 @@
@@ -1773,7 +1809,7 @@ index f1e4ef48a4fd1c..cb5aa30920bb7d 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.IsRSAKeySupported(len(priv.Primes)) {
++	if boring.Enabled && boring.SupportsRSAKeyPrimes(len(priv.Primes)) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
@@ -1782,7 +1818,7 @@ index f1e4ef48a4fd1c..cb5aa30920bb7d 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.IsRSAKeySupported(len(priv.Primes)) {
++	if boring.Enabled && boring.SupportsRSAKeyPrimes(len(priv.Primes)) {
  		var bkey *boring.PrivateKeyRSA
  		bkey, err = boringPrivateKey(priv)
  		if err != nil {
@@ -1810,7 +1846,7 @@ index c65552cd93526a..910416abe842f5 100644
  	ciphertext := decodeBase64("fjOVdirUzFoLlukv80dBllMLjXythIf22feqPrNo0YoIjzyzyoMFiLjAc/Y4krkeZ11XFThIrEvw\nkRiZcCq5ng==")
  	_, err := DecryptPKCS1v15(nil, test512Key, ciphertext)
 diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
-index e03f4ab06603c6..a4af0a2144870a 100644
+index e03f4ab06603c6..f31d492d53cf96 100644
 --- a/src/crypto/rsa/pss_test.go
 +++ b/src/crypto/rsa/pss_test.go
 @@ -8,6 +8,7 @@ import (
@@ -1832,6 +1868,17 @@ index e03f4ab06603c6..a4af0a2144870a 100644
  		opts.SaltLength = test.verifySaltLength
  		err = VerifyPSS(&rsaPrivateKey.PublicKey, hash, hashed, sig, &opts)
  		good := test.good
+@@ -241,7 +246,9 @@ func fromHex(hexStr string) []byte {
+ 
+ func TestInvalidPSSSaltLength(t *testing.T) {
+ 	t.Setenv("GODEBUG", "rsa1024min=0")
+-	key, err := GenerateKey(rand.Reader, 245)
++	// Most crypto backends don't support generating RSA keys with a bit size
++	// lower than 512, so we use 512 here.
++	key, err := GenerateKey(rand.Reader, 512)
+ 	if err != nil {
+ 		t.Fatal(err)
+ 	}
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
 index 95bb4becd2ff8c..73991434dabaf1 100644
 --- a/src/crypto/rsa/rsa.go
@@ -1848,7 +1895,7 @@ index 95bb4becd2ff8c..73991434dabaf1 100644
  	"crypto/internal/fips140/rsa"
  	"crypto/internal/fips140only"
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 73b0c3749eedb2..b527a355074482 100644
+index 73b0c3749eedb2..1a712a0e1c5d95 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -8,7 +8,7 @@ import (
@@ -1884,6 +1931,16 @@ index 73b0c3749eedb2..b527a355074482 100644
  
  	msg := []byte("test")
  	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
+@@ -853,6 +863,9 @@ func TestDecryptOAEP(t *testing.T) {
+ }
+ 
+ func Test2DecryptOAEP(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("Some crypto backends don't supports OAEPOptions.MGFHash.")
++	}
+ 	random := rand.Reader
+ 
+ 	msg := []byte{0xed, 0x36, 0x90, 0x8d, 0xbe, 0xfc, 0x35, 0x40, 0x70, 0x4f, 0xf5, 0x9d, 0x6e, 0xc2, 0xeb, 0xf5, 0x27, 0xae, 0x65, 0xb0, 0x59, 0x29, 0x45, 0x25, 0x8c, 0xc1, 0x91, 0x22}
 diff --git a/src/crypto/sha1/sha1.go b/src/crypto/sha1/sha1.go
 index d2ffaac0aeb674..23d8ad44d0bd9a 100644
 --- a/src/crypto/sha1/sha1.go

--- a/patches/0004-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0004-Add-BoringSSL-crypto-backend.patch
@@ -5,9 +5,9 @@ Subject: [PATCH] Add BoringSSL crypto backend
 
 ---
  .../internal/backend/bbig/big_boring.go       |  12 +
- src/crypto/internal/backend/boring_linux.go   | 267 ++++++++++++++++++
+ src/crypto/internal/backend/boring_linux.go   | 275 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
- 3 files changed, 290 insertions(+)
+ 3 files changed, 298 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_boring.go
  create mode 100644 src/crypto/internal/backend/boring_linux.go
  create mode 100644 src/crypto/internal/backend/fips140/boring.go
@@ -32,10 +32,10 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..94bc444f10eb2b
+index 00000000000000..c49291c2f62b4c
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,267 @@
+@@ -0,0 +1,275 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -114,6 +114,14 @@ index 00000000000000..94bc444f10eb2b
 +
 +func VerifyECDSA(pub *boring.PublicKeyECDSA, hash []byte, sig []byte) bool {
 +	return boring.VerifyECDSA(pub, hash, sig)
++}
++
++func SupportsRSAKeyPrimes(primes int) bool {
++	return true
++}
++
++func SupportsRSASaltLength(salt int) bool {
++	return true
 +}
 +
 +type PublicKeyRSA = boring.PublicKeyRSA

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -5,16 +5,13 @@ Subject: [PATCH] Add OpenSSL crypto backend
 
 ---
  src/cmd/dist/test.go                          |   3 +-
- .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/lib.go               |   1 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- .../internal/backend/fips140/openssl.go       |  41 +++
- src/crypto/internal/backend/openssl_linux.go  | 345 ++++++++++++++++++
- src/crypto/rsa/rsa_test.go                    |   3 +
+ .../internal/backend/fips140/openssl.go       |  41 ++
+ src/crypto/internal/backend/openssl_linux.go  | 358 ++++++++++++++++++
  src/go/build/deps_test.go                     |   9 +-
- src/go/build/vendor_test.go                   |   1 +
  src/os/exec/exec_test.go                      |   9 +
- 10 files changed, 428 insertions(+), 5 deletions(-)
+ 7 files changed, 428 insertions(+), 5 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/fips140/openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
@@ -37,25 +34,6 @@ index 0c992118f4287b..0de6e80fd985a3 100644
  			// Static linking tests
  			if goos != "android" && p != "netbsd/arm" && !t.msan && !t.asan {
  				// TODO(#56629): Why does this fail on netbsd-arm?
-diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
-index 4aaf46b5d0f0dc..6fe798cf4a94e9 100644
---- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
-+++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
-@@ -1,5 +1,14 @@
- env GO111MODULE=off
- 
-+# Disable OpenSSLCrypto backend while evaluating test dependencies to avoid importing
-+# vendored crypto module dependencies like golang-fips/openssl. This test script
-+# is not set up to handle any vendored libraries being imported other than
-+# golang.org/x/net/http2/hpack, so we must make sure it is the only one.
-+#
-+# See https://github.com/microsoft/go/issues/481 for more details, such as the
-+# dependency chain that would cause the failure if the gocrypt tag isn't used.
-+env GOEXPERIMENT=none
-+
- [!compiler:gc] skip
- 
- go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
 index 2d8f964f3594c6..a587e1abde57c9 100644
 --- a/src/cmd/link/internal/ld/lib.go
@@ -135,10 +113,10 @@ index 00000000000000..118efa3a492a7d
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..44d91d5b7ba3d5
+index 00000000000000..0f3aea733ac2a5
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,345 @@
+@@ -0,0 +1,358 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -271,6 +249,19 @@ index 00000000000000..44d91d5b7ba3d5
 +
 +func VerifyECDSA(pub *openssl.PublicKeyECDSA, hash []byte, sig []byte) bool {
 +	return openssl.VerifyECDSA(pub, hash, sig)
++}
++
++func SupportsRSAKeyPrimes(primes int) bool {
++	// The built-in OpenSSL 3 providers and OpenSSL 1 do support n-prime RSA keys,
++	// but SCOSSL only supports 2-prime RSA keys.
++	// Only 2-prime RSA keys are FIPS compliant, other n having compatibility
++	// and security issues. Even crypto/rsa deprecated rsa.GenerateMultiPrimeKey as of Go 1.21.
++	// Given the above reasons, we only support what SCOSSL supports.
++	return primes == 2
++}
++
++func SupportsRSASaltLength(salt int) bool {
++	return true
 +}
 +
 +type PublicKeyRSA = openssl.PublicKeyRSA
@@ -484,20 +475,6 @@ index 00000000000000..44d91d5b7ba3d5
 +
 +	return openssl.VerifyDSA(pub, hashed, sig)
 +}
-diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index b527a355074482..906c469482030a 100644
---- a/src/crypto/rsa/rsa_test.go
-+++ b/src/crypto/rsa/rsa_test.go
-@@ -863,6 +863,9 @@ func TestDecryptOAEP(t *testing.T) {
- }
- 
- func Test2DecryptOAEP(t *testing.T) {
-+	if boring.Enabled {
-+		t.Skip("OpenSSL backend does not supports OAEPOptions.MGFHash yet.")
-+	}
- 	random := rand.Reader
- 
- 	msg := []byte{0xed, 0x36, 0x90, 0x8d, 0xbe, 0xfc, 0x35, 0x40, 0x70, 0x4f, 0xf5, 0x9d, 0x6e, 0xc2, 0xeb, 0xf5, 0x27, 0xae, 0x65, 0xb0, 0x59, 0x29, 0x45, 0x25, 0x8c, 0xc1, 0x91, 0x22}
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index 30811455e88418..3de94c93629e3d 100644
 --- a/src/go/build/deps_test.go
@@ -546,18 +523,6 @@ index 30811455e88418..3de94c93629e3d 100644
  		haveImport["C"] = true // kludge: prevent C from appearing in crypto/internal/boring imports
  	}
  	fset := token.NewFileSet()
-diff --git a/src/go/build/vendor_test.go b/src/go/build/vendor_test.go
-index 7f6237ffd59c11..7c821ae4bc5727 100644
---- a/src/go/build/vendor_test.go
-+++ b/src/go/build/vendor_test.go
-@@ -22,6 +22,7 @@ var allowedPackagePrefixes = []string{
- 	"github.com/google/pprof",
- 	"github.com/ianlancetaylor/demangle",
- 	"rsc.io/markdown",
-+	"github.com/golang-fips/openssl",
- }
- 
- // Verify that the vendor directories contain only packages matching the list above.
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
 index 8c623871932f7d..2fa55073f5c19c 100644
 --- a/src/os/exec/exec_test.go

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -4,59 +4,15 @@ Date: Tue, 19 Jul 2022 15:58:02 +0200
 Subject: [PATCH] Add CNG crypto backend
 
 ---
- src/crypto/ecdsa/badlinkname.go             |  17 ++
- src/crypto/internal/backend/backend_test.go |   4 +-
  src/crypto/internal/backend/bbig/big_cng.go |  12 +
- src/crypto/internal/backend/cng_windows.go  | 320 ++++++++++++++++++++
- src/crypto/internal/backend/common.go       |   9 +-
+ src/crypto/internal/backend/cng_windows.go  | 329 ++++++++++++++++++++
  src/crypto/internal/backend/fips140/cng.go  |  33 ++
- src/crypto/rsa/pss_test.go                  |   2 +-
  src/go/build/deps_test.go                   |   5 +
- src/go/build/vendor_test.go                 |   1 +
- 9 files changed, 398 insertions(+), 5 deletions(-)
- create mode 100644 src/crypto/ecdsa/badlinkname.go
+ 4 files changed, 379 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/crypto/internal/backend/fips140/cng.go
 
-diff --git a/src/crypto/ecdsa/badlinkname.go b/src/crypto/ecdsa/badlinkname.go
-new file mode 100644
-index 00000000000000..0d00b7bb3a7fc8
---- /dev/null
-+++ b/src/crypto/ecdsa/badlinkname.go
-@@ -0,0 +1,17 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+package ecdsa
-+
-+import _ "unsafe"
-+
-+// The symbols below are pulled by the CNG backend in the Microsoft Go compiler.
-+// We provide a push linkname here, to keep them accessible with pull linknames.
-+
-+//go:linkname encodeSignature
-+//go:linkname parseSignature
-+
-+// This supplements other linknames that are already added by
-+// https://github.com/golang/go/commit/41aab30bd260297ad8ddad47e98fdf8390a9a67e
-+// See that commit for more information.
-diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
-index c2c06d3bff8c74..837cff477e257e 100644
---- a/src/crypto/internal/backend/backend_test.go
-+++ b/src/crypto/internal/backend/backend_test.go
-@@ -4,9 +4,7 @@
- 
- package backend
- 
--import (
--	"testing"
--)
-+import "testing"
- 
- // Test that Unreachable panics.
- func TestUnreachable(t *testing.T) {
 diff --git a/src/crypto/internal/backend/bbig/big_cng.go b/src/crypto/internal/backend/bbig/big_cng.go
 new file mode 100644
 index 00000000000000..92623031fd87d0
@@ -77,10 +33,10 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..495260a08dd029
+index 00000000000000..6bfbdc57f0518b
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,320 @@
+@@ -0,0 +1,329 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -204,6 +160,15 @@ index 00000000000000..495260a08dd029
 +
 +func VerifyECDSARaw(pub *cng.PublicKeyECDSA, hash []byte, r, s cng.BigInt) bool {
 +	return cng.VerifyECDSA(pub, hash, r, s)
++}
++
++func SupportsRSAKeyPrimes(primes int) bool {
++	// CNG only supports 2-prime RSA keys.
++	return primes == 2
++}
++
++func SupportsRSASaltLength(salt int) bool {
++	return salt != 0 // rsa.PSSSaltLengthAuto
 +}
 +
 +type PublicKeyRSA = cng.PublicKeyRSA
@@ -401,32 +366,6 @@ index 00000000000000..495260a08dd029
 +func VerifyDSA(pub *PublicKeyDSA, hashed []byte, r, s cng.BigInt, encodeSignature func(r, s cng.BigInt) ([]byte, error)) bool {
 +	return cng.VerifyDSA(pub, hashed, r, s)
 +}
-diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
-index 858e76e3c51c06..91223c0ef0f810 100644
---- a/src/crypto/internal/backend/common.go
-+++ b/src/crypto/internal/backend/common.go
-@@ -44,7 +44,11 @@ func hasSuffix(s, t string) bool {
- // UnreachableExceptTests marks code that should be unreachable
- // when backend is in use. It panics.
- func UnreachableExceptTests() {
--	if Enabled {
-+	// runtime_arg0 is not supported on windows.
-+	// We are going through the same code patch on linux,
-+	// so if we are unintentionally calling an 'unreachable' function,
-+	// we will catch it there.
-+	if Enabled && !goexperiment.CNGCrypto {
- 		name := runtime_arg0()
- 		// If ran on Windows we'd need to allow _test.exe and .test.exe as well.
- 		if !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
-@@ -68,5 +72,8 @@ func IsRSAKeySupported(primes int) bool {
- }
- 
- func IsSaltSupported(salt int) bool {
-+	if goexperiment.CNGCrypto {
-+		return salt != 0 // rsa.PSSSaltLengthAuto
-+	}
- 	return true
- }
 diff --git a/src/crypto/internal/backend/fips140/cng.go b/src/crypto/internal/backend/fips140/cng.go
 new file mode 100644
 index 00000000000000..f769d15f94ab05
@@ -466,19 +405,6 @@ index 00000000000000..f769d15f94ab05
 +	}
 +	return enabled != 0
 +}
-diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
-index a4af0a2144870a..7d7115cff81cea 100644
---- a/src/crypto/rsa/pss_test.go
-+++ b/src/crypto/rsa/pss_test.go
-@@ -246,7 +246,7 @@ func fromHex(hexStr string) []byte {
- 
- func TestInvalidPSSSaltLength(t *testing.T) {
- 	t.Setenv("GODEBUG", "rsa1024min=0")
--	key, err := GenerateKey(rand.Reader, 245)
-+	key, err := GenerateKey(rand.Reader, 512)
- 	if err != nil {
- 		t.Fatal(err)
- 	}
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index 3de94c93629e3d..8effe9041f3f5f 100644
 --- a/src/go/build/deps_test.go
@@ -502,15 +428,3 @@ index 3de94c93629e3d..8effe9041f3f5f 100644
  	< github.com/golang-fips/openssl/v2/bbig
  	< crypto/internal/boring/bbig
  	< crypto/internal/backend/bbig
-diff --git a/src/go/build/vendor_test.go b/src/go/build/vendor_test.go
-index 7c821ae4bc5727..1d0b9b20e9b1d4 100644
---- a/src/go/build/vendor_test.go
-+++ b/src/go/build/vendor_test.go
-@@ -23,6 +23,7 @@ var allowedPackagePrefixes = []string{
- 	"github.com/ianlancetaylor/demangle",
- 	"rsc.io/markdown",
- 	"github.com/golang-fips/openssl",
-+	"github.com/microsoft/go-crypto-winnative",
- }
- 
- // Verify that the vendor directories contain only packages matching the list above.


### PR DESCRIPTION
This PR moves common code from the backend patch files to the vendor and foundation patch files, and vice versa. There is no behavior change. There are also some small refactors so that the patch files are easier to maintain.

For #1478.