### PR TITLE
Fix vendor patch

### DIFF
--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -9,6 +9,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  src/crypto/internal/backend/deps_ignore.go    |  19 +
  src/go.mod                                    |   5 +
  src/go.sum                                    |   4 +
+ src/go/build/deps_test.go                     |  14 +-
  src/go/build/vendor_test.go                   |   2 +
  .../golang-fips/openssl/v2/.gitignore         |   1 +
  .../golang-fips/openssl/v2/.gitleaks.toml     |   9 +
@@ -74,7 +75,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 68 files changed, 11005 insertions(+)
+ 69 files changed, 11016 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/deps_ignore.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
@@ -142,7 +143,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
 
 diff --git a/src/crypto/internal/backend/deps_ignore.go b/src/crypto/internal/backend/deps_ignore.go
 new file mode 100644
-index 00000000000000..979ee34f54acba
+index 00000000000000..ba6d196a54f69d
 --- /dev/null
 +++ b/src/crypto/internal/backend/deps_ignore.go
 @@ -0,0 +1,19 @@
@@ -152,7 +153,7 @@ index 00000000000000..979ee34f54acba
 +
 +//go:build ms_ignore_backend_deps
 +
-+package backend
++package main
 +
 +import (
 +	_ "github.com/golang-fips/openssl/v2"
@@ -190,6 +191,59 @@ index 9e661352f16e0b..abebb59dcd7739 100644
  golang.org/x/crypto v0.30.0 h1:RwoQn3GkWiMkzlX562cLB7OxWvjH1L8xutO2WoJcRoY=
  golang.org/x/crypto v0.30.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
  golang.org/x/net v0.32.1-0.20241206180132-552d8ac903a1 h1:+Yk1FZ5E+/ewA0nOO/HRYs9E4yeqpGOShuSAdzCNNoQ=
+diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
+index e3e01077c18b17..5551a24f8a844e 100644
+--- a/src/go/build/deps_test.go
++++ b/src/go/build/deps_test.go
+@@ -503,7 +503,7 @@ var depsRules = `
+ 	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
+ 	sync/atomic < crypto/internal/boring/bcache;
+ 
+-	FIPS, internal/godebug, hash, embed,
++	FIPS, internal/godebug, hash, embed, encoding/binary,
+ 	crypto/internal/boring/sig,
+ 	crypto/internal/boring/syso,
+ 	crypto/internal/boring/bcache
+@@ -513,6 +513,12 @@ var depsRules = `
+ 	< crypto/sha3
+ 	< crypto/internal/fips140hash
+ 	< crypto/cipher
++	< github.com/golang-fips/openssl/v2/internal/subtle
++	< github.com/golang-fips/openssl/v2
++	< github.com/microsoft/go-crypto-winnative/internal/subtle
++	< github.com/microsoft/go-crypto-winnative/internal/sysdll
++	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
++	< github.com/microsoft/go-crypto-winnative/cng
+ 	< crypto/internal/boring
+ 	< crypto/boring
+ 	< crypto/aes,
+@@ -534,6 +540,8 @@ var depsRules = `
+ 	# CRYPTO-MATH is crypto that exposes math/big APIs - no cgo, net; fmt now ok.
+ 
+ 	CRYPTO, FMT, math/big
++	< github.com/golang-fips/openssl/v2/bbig
++	< github.com/microsoft/go-crypto-winnative/cng/bbig
+ 	< crypto/internal/boring/bbig
+ 	< crypto/rand
+ 	< crypto/ed25519 # depends on crypto/rand.Reader
+@@ -837,7 +845,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+ 
+ func findImports(pkg string) ([]string, error) {
+ 	vpkg := pkg
+-	if strings.HasPrefix(pkg, "golang.org") {
++	if strings.HasPrefix(pkg, "golang.org") || strings.HasPrefix(pkg, "github.com") {
+ 		vpkg = "vendor/" + pkg
+ 	}
+ 	dir := filepath.Join(Default.GOROOT, "src", vpkg)
+@@ -847,7 +855,7 @@ func findImports(pkg string) ([]string, error) {
+ 	}
+ 	var imports []string
+ 	var haveImport = map[string]bool{}
+-	if pkg == "crypto/internal/boring" {
++	if pkg == "crypto/internal/boring" || pkg == "github.com/golang-fips/openssl/v2" {
+ 		haveImport["C"] = true // kludge: prevent C from appearing in crypto/internal/boring imports
+ 	}
+ 	fset := token.NewFileSet()
 diff --git a/src/go/build/vendor_test.go b/src/go/build/vendor_test.go
 index 7f6237ffd59c11..1d0b9b20e9b1d4 100644
 --- a/src/go/build/vendor_test.go

--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Vendor crypto backends
 To reproduce changes in 'src/vendor', run 'go mod vendor' in 'src'.
 Use a 'go' that was recently built by the current branch to ensure stable results.
 ---
- src/crypto/internal/backend/deps_ignore.go    |  16 +
+ src/crypto/internal/backend/deps_ignore.go    |  19 +
  src/go.mod                                    |   5 +
  src/go.sum                                    |   4 +
  src/go/build/vendor_test.go                   |   2 +
@@ -74,7 +74,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 68 files changed, 11002 insertions(+)
+ 68 files changed, 11005 insertions(+)
  create mode 100644 src/crypto/internal/backend/deps_ignore.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
@@ -142,21 +142,24 @@ Use a 'go' that was recently built by the current branch to ensure stable result
 
 diff --git a/src/crypto/internal/backend/deps_ignore.go b/src/crypto/internal/backend/deps_ignore.go
 new file mode 100644
-index 00000000000000..7e537a55af954e
+index 00000000000000..979ee34f54acba
 --- /dev/null
 +++ b/src/crypto/internal/backend/deps_ignore.go
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,19 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build ignore
++//go:build ms_ignore_backend_deps
 +
 +package backend
 +
 +import (
 +	_ "github.com/golang-fips/openssl/v2"
++	_ "github.com/golang-fips/openssl/v2/bbig"
++
 +	_ "github.com/microsoft/go-crypto-winnative/cng"
++	_ "github.com/microsoft/go-crypto-winnative/cng/bbig"
 +)
 +
 +// This file is here just to declare the external dependencies

--- a/patches/0003-Add-crypto-backend-foundation.patch
+++ b/patches/0003-Add-crypto-backend-foundation.patch
@@ -519,7 +519,7 @@ index 00000000000000..5e4b436554d44d
 +// from complaining about the missing body
 +// (because the implementation might be here).
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index e3e01077c18b17..a46d6c034ca1e0 100644
+index 5551a24f8a844e..c86b63454c6f7a 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -493,6 +493,8 @@ var depsRules = `
@@ -532,7 +532,7 @@ index e3e01077c18b17..a46d6c034ca1e0 100644
  
  	crypto, hash !< FIPS;
 @@ -506,7 +508,8 @@ var depsRules = `
- 	FIPS, internal/godebug, hash, embed,
+ 	FIPS, internal/godebug, hash, embed, encoding/binary,
  	crypto/internal/boring/sig,
  	crypto/internal/boring/syso,
 -	crypto/internal/boring/bcache
@@ -541,17 +541,17 @@ index e3e01077c18b17..a46d6c034ca1e0 100644
  	< crypto/internal/fips140only
  	< crypto
  	< crypto/subtle
-@@ -514,6 +517,7 @@ var depsRules = `
- 	< crypto/internal/fips140hash
- 	< crypto/cipher
+@@ -520,6 +523,7 @@ var depsRules = `
+ 	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
+ 	< github.com/microsoft/go-crypto-winnative/cng
  	< crypto/internal/boring
 +	< crypto/internal/backend
  	< crypto/boring
  	< crypto/aes,
  	  crypto/des,
-@@ -535,6 +539,7 @@ var depsRules = `
- 
- 	CRYPTO, FMT, math/big
+@@ -543,6 +547,7 @@ var depsRules = `
+ 	< github.com/golang-fips/openssl/v2/bbig
+ 	< github.com/microsoft/go-crypto-winnative/cng/bbig
  	< crypto/internal/boring/bbig
 +	< crypto/internal/backend/bbig
  	< crypto/rand

--- a/patches/0005-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0005-Add-OpenSSL-crypto-backend.patch
@@ -9,9 +9,8 @@ Subject: [PATCH] Add OpenSSL crypto backend
  .../internal/backend/bbig/big_openssl.go      |  12 +
  .../internal/backend/fips140/openssl.go       |  41 ++
  src/crypto/internal/backend/openssl_linux.go  | 358 ++++++++++++++++++
- src/go/build/deps_test.go                     |   9 +-
  src/os/exec/exec_test.go                      |   9 +
- 7 files changed, 428 insertions(+), 5 deletions(-)
+ 6 files changed, 422 insertions(+), 2 deletions(-)
  create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
  create mode 100644 src/crypto/internal/backend/fips140/openssl.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
@@ -475,54 +474,6 @@ index 00000000000000..0f3aea733ac2a5
 +
 +	return openssl.VerifyDSA(pub, hashed, sig)
 +}
-diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index a46d6c034ca1e0..12086de2c2e766 100644
---- a/src/go/build/deps_test.go
-+++ b/src/go/build/deps_test.go
-@@ -505,7 +505,7 @@ var depsRules = `
- 	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
- 	sync/atomic < crypto/internal/boring/bcache;
- 
--	FIPS, internal/godebug, hash, embed,
-+	FIPS, internal/godebug, hash, embed, encoding/binary,
- 	crypto/internal/boring/sig,
- 	crypto/internal/boring/syso,
- 	crypto/internal/boring/bcache,
-@@ -516,6 +516,8 @@ var depsRules = `
- 	< crypto/sha3
- 	< crypto/internal/fips140hash
- 	< crypto/cipher
-+	< github.com/golang-fips/openssl/v2/internal/subtle
-+	< github.com/golang-fips/openssl/v2
- 	< crypto/internal/boring
- 	< crypto/internal/backend
- 	< crypto/boring
-@@ -538,6 +540,7 @@ var depsRules = `
- 	# CRYPTO-MATH is crypto that exposes math/big APIs - no cgo, net; fmt now ok.
- 
- 	CRYPTO, FMT, math/big
-+	< github.com/golang-fips/openssl/v2/bbig
- 	< crypto/internal/boring/bbig
- 	< crypto/internal/backend/bbig
- 	< crypto/rand
-@@ -842,7 +845,7 @@ var buildIgnore = []byte("\n//go:build ignore")
- 
- func findImports(pkg string) ([]string, error) {
- 	vpkg := pkg
--	if strings.HasPrefix(pkg, "golang.org") {
-+	if strings.HasPrefix(pkg, "golang.org") || strings.HasPrefix(pkg, "github.com") {
- 		vpkg = "vendor/" + pkg
- 	}
- 	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -852,7 +855,7 @@ func findImports(pkg string) ([]string, error) {
- 	}
- 	var imports []string
- 	var haveImport = map[string]bool{}
--	if pkg == "crypto/internal/boring" {
-+	if pkg == "crypto/internal/boring" || pkg == "github.com/golang-fips/openssl/v2" {
- 		haveImport["C"] = true // kludge: prevent C from appearing in crypto/internal/boring imports
- 	}
- 	fset := token.NewFileSet()
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
 index 8c623871932f7d..2fa55073f5c19c 100644
 --- a/src/os/exec/exec_test.go

--- a/patches/0006-Add-CNG-crypto-backend.patch
+++ b/patches/0006-Add-CNG-crypto-backend.patch
@@ -7,8 +7,7 @@ Subject: [PATCH] Add CNG crypto backend
  src/crypto/internal/backend/bbig/big_cng.go |  12 +
  src/crypto/internal/backend/cng_windows.go  | 329 ++++++++++++++++++++
  src/crypto/internal/backend/fips140/cng.go  |  33 ++
- src/go/build/deps_test.go                   |   5 +
- 4 files changed, 379 insertions(+)
+ 3 files changed, 374 insertions(+)
  create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/crypto/internal/backend/fips140/cng.go
@@ -405,26 +404,3 @@ index 00000000000000..f769d15f94ab05
 +	}
 +	return enabled != 0
 +}
-diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 3de94c93629e3d..8effe9041f3f5f 100644
---- a/src/go/build/deps_test.go
-+++ b/src/go/build/deps_test.go
-@@ -517,6 +517,10 @@ var depsRules = `
- 	< crypto/sha3
- 	< crypto/internal/fips140hash
- 	< crypto/cipher
-+	< github.com/microsoft/go-crypto-winnative/internal/subtle
-+	< github.com/microsoft/go-crypto-winnative/internal/sysdll
-+	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
-+	< github.com/microsoft/go-crypto-winnative/cng
- 	< github.com/golang-fips/openssl/v2/internal/subtle
- 	< github.com/golang-fips/openssl/v2
- 	< crypto/internal/boring
-@@ -542,6 +546,7 @@ var depsRules = `
- 	# CRYPTO-MATH is crypto that exposes math/big APIs - no cgo, net; fmt now ok.
- 
- 	CRYPTO, FMT, math/big
-+	< github.com/microsoft/go-crypto-winnative/cng/bbig
- 	< github.com/golang-fips/openssl/v2/bbig
- 	< crypto/internal/boring/bbig
- 	< crypto/internal/backend/bbig


### PR DESCRIPTION
Looks like the `ignore` tag is special-cased to completely ignore the gated files from any kind of toolchain operation. This makes `go mod tidy` to remove the external backends entries from the `go.mod` file.

Fix it by replacing `ignore` with a custom build tag.