### PR TITLE
darwin: add macOS to CrossPlatformCryptography document

### DIFF
--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -132,9 +132,6 @@ This section includes the following subsections:
 
 ### RSA
 
-> [!WARNING]  
-> System libraries might not fully implement all RSA features. Please see the subsections below for more information.
-
 This section includes the following packages:
 
 - [crypto/rsa](https://pkg.go.dev/crypto/rsa)

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -131,6 +131,9 @@ This section includes the following subsections:
 
 ### RSA
 
+> [!WARNING]  
+> System Libraries might not fully implement all RSA features. Please see the subsections below for more information.
+
 This section includes the following packages:
 
 - [crypto/rsa](https://pkg.go.dev/crypto/rsa)
@@ -141,9 +144,9 @@ This section includes the following packages:
 | OAEP (SHA-1)                           | ✔️             | ✔️             | ✔️<sup>3</sup> |
 | OAEP (SHA-2)<sup>1</sup>               | ✔️             | ✔️             | ✔️<sup>3</sup> |
 | OAEP (SHA-3)                           | ❌             | ❌             | ❌             |
-| PSS (MD5)                              | ✔️             | ✔️             | ✔️<sup>4</sup> |
-| PSS (SHA-1)                            | ✔️             | ✔️             | ✔️<sup>4</sup> |
-| PSS (SHA-2)<sup>1</sup>                | ✔️             | ✔️             | ✔️<sup>4</sup> |
+| PSS (MD5)                              | ✔️             | ✔️             | ❌             |
+| PSS (SHA-1)                            | ✔️             | ✔️             | ✔️             |
+| PSS (SHA-2)<sup>1</sup>                | ✔️             | ✔️             | ✔️             |
 | PSS (SHA-3)                            | ❌             | ❌             | ❌             |
 | PKCS1v15 Signature (Unhashed)          | ✔️             | ✔️             | ✔️             |
 | PKCS1v15 Signature (RIPMED160)         | ❌             | ✔️<sup>2</sup> | ❌             |
@@ -158,13 +161,11 @@ This section includes the following packages:
 
 <sup>2</sup>Available starting in Microsoft Go 1.24.
 
-<sup>3</sup>macOS doesn't support passing a label to OAEP functions.
-
-<sup>4</sup>macOS doesn't support passing a custom salt length to PSS functions.
+<sup>3</sup>macOS doesn't support passing a custom label to OAEP functions.
 
 #### RSA key sizes
 
-[rsa.GenerateKey](https://pkg.go.dev/crypto/rsa#GenerateKey) only supports the following key sizes (in bits): 2048, 3072, 4096.
+[`rsa.GenerateKey`](https://pkg.go.dev/crypto/rsa#GenerateKey) only supports the following key sizes (in bits): 2048, 3072, 4096.
 
 Multi-prime RSA keys are not supported.
 
@@ -174,11 +175,13 @@ Please refer to the documentation of the underlying cryptographic library for th
 
 #### PSS salt length
 
-On Windows, when verifying a PSS signature, [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.
+On Windows, when verifying a PSS signature, [`rsa.PSSSaltLengthAuto`](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.
+
+On macOS, custom salt lengths are not supported, it always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).
 
 #### Random number generation
 
-Operations that require random numbers (rand io.Reader) only support [rand.Reader](https://pkg.go.dev/crypto/rand#Reader).
+Operations that require random numbers (rand io.Reader) only support [`rand.Reader`](https://pkg.go.dev/crypto/rand#Reader).
 
 ### ECDSA
 
@@ -214,7 +217,7 @@ This section includes the following packages:
 
 #### Random number generation
 
-Operations that require random numbers (rand io.Reader) only support [rand.Reader](https://pkg.go.dev/crypto/rand#Reader).
+Operations that require random numbers (rand io.Reader) only support [`rand.Reader`](https://pkg.go.dev/crypto/rand#Reader).
 
 ### Ed25519
 
@@ -230,7 +233,7 @@ This section includes the following packages:
 
 #### Random number generation
 
-Operations that require random numbers (rand io.Reader) only support [rand.Reader](https://pkg.go.dev/crypto/rand#Reader).
+Operations that require random numbers (rand io.Reader) only support [`rand.Reader`](https://pkg.go.dev/crypto/rand#Reader).
 
 ### DSA
 
@@ -281,49 +284,54 @@ This section includes the following packages:
 
 ### TLS Versions
 
+The TLS stack is implemented using native Go code but the crypto primatives are provided by the system cryptographic libraries.
+
 | Version | Windows | Linux | macOS |
 | ------- | ------- | ----- | ----- |
 | SSL 3.0 | ❌      | ❌    | ❌    |
 | TLS 1.0 | ✔️      | ✔️    | ❌    |
-| TLS 1.2 | ✔️      | ✔️    | ❌    |
-| TLS 1.3 | ✔️      | ✔️    | ❌    |
+| TLS 1.1 | ✔️      | ✔️    | ❌    |
+| TLS 1.2 | ✔️      | ✔️    | ✔️    |
+| TLS 1.3 | ✔️      | ✔️    | ✔️    |
 
 ### Cipher Suites
 
-| Name                                          | Windows | Linux          |
-| --------------------------------------------- | ------- | -------------- |
-| TLS_RSA_WITH_RC4_128_SHA                      | ✔️      | ⚠️<sup>1</sup> |
-| TLS_RSA_WITH_3DES_EDE_CBC_SHA                 | ✔️      | ⚠️<sup>1</sup> |
-| TLS_RSA_WITH_AES_128_CBC_SHA                  | ✔️      | ✔️             |
-| TLS_RSA_WITH_AES_256_CBC_SHA                  | ✔️      | ✔️             |
-| TLS_RSA_WITH_AES_128_CBC_SHA256               | ✔️      | ✔️             |
-| TLS_RSA_WITH_AES_128_GCM_SHA256               | ✔️      | ✔️             |
-| TLS_RSA_WITH_AES_256_GCM_SHA384               | ✔️      | ✔️             |
-| TLS_ECDHE_ECDSA_WITH_RC4_128_SHA              | ✔️      | ⚠️<sup>1</sup> |
-| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA          | ✔️      | ✔️             |
-| TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA          | ✔️      | ✔️             |
-| TLS_ECDHE_RSA_WITH_RC4_128_SHA                | ✔️      | ⚠️<sup>1</sup> |
-| TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA           | ✔️      | ⚠️<sup>1</sup> |
-| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA            | ✔️      | ✔️             |
-| TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA            | ✔️      | ✔️             |
-| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256       | ✔️      | ✔️             |
-| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256         | ✔️      | ✔️             |
-| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256         | ✔️      | ✔️             |
-| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256       | ✔️      | ✔️             |
-| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384         | ✔️      | ✔️             |
-| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384       | ✔️      | ✔️             |
-| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   | ❌      | ❌             |
-| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 | ❌      | ❌             |
-| TLS_AES_128_GCM_SHA256                        | ✔️      | ✔️             |
-| TLS_AES_256_GCM_SHA384                        | ✔️      | ✔️             |
-| TLS_CHACHA20_POLY1305_SHA256                  | ❌      | ❌             |
-| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305          | ❌      | ❌             |
-| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305          | ❌      | ❌             |
-| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305        | ❌      | ❌             |
+| Name                                          | Windows | Linux          | macOS |
+| --------------------------------------------- | ------- | -------------- | ----- |
+| TLS_RSA_WITH_RC4_128_SHA                      | ✔️      | ⚠️<sup>1</sup> | ✔️    |
+| TLS_RSA_WITH_3DES_EDE_CBC_SHA                 | ✔️      | ⚠️<sup>1</sup> | ✔️    |
+| TLS_RSA_WITH_AES_128_CBC_SHA                  | ✔️      | ✔️             | ✔️    |
+| TLS_RSA_WITH_AES_256_CBC_SHA                  | ✔️      | ✔️             | ✔️    |
+| TLS_RSA_WITH_AES_128_CBC_SHA256               | ✔️      | ✔️             | ✔️    |
+| TLS_RSA_WITH_AES_128_GCM_SHA256               | ✔️      | ✔️             | ✔️    |
+| TLS_RSA_WITH_AES_256_GCM_SHA384               | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_ECDSA_WITH_RC4_128_SHA              | ✔️      | ⚠️<sup>1</sup> | ✔️    |
+| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA          | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA          | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_RSA_WITH_RC4_128_SHA                | ✔️      | ⚠️<sup>1</sup> | ✔️    |
+| TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA           | ✔️      | ⚠️<sup>1</sup> | ✔️    |
+| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA            | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA            | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256       | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256         | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256         | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256       | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384         | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384       | ✔️      | ✔️             | ✔️    |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   | ❌      | ❌             | ❌    |
+| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 | ❌      | ❌             | ❌    |
+| TLS_AES_128_GCM_SHA256                        | ✔️      | ✔️             | ✔️    |
+| TLS_AES_256_GCM_SHA384                        | ✔️      | ✔️             | ✔️    |
+| TLS_CHACHA20_POLY1305_SHA256                  | ❌      | ❌             | ❌    |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305          | ❌      | ❌             | ❌    |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305          | ❌      | ❌             | ❌    |
+| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305        | ❌      | ❌             | ❌    |
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
 ### Curves and Groups
+
+Below are the supported [`tls.CurveIDs`](https://pkg.go.dev/crypto/tls#CurveID).
 
 | Name           | Windows | Linux | macOS |
 | -------------- | ------- | ----- | ----- |
@@ -333,7 +341,9 @@ This section includes the following packages:
 | X25519         | ❌      | ❌    | ❌    |
 | X25519MLKEM768 | ❌      | ❌    | ❌    |
 
-### Signature Algorithms
+### Signature Schemes
+
+Below are the supported [`tls.SignatureSchemes`](https://pkg.go.dev/crypto/tls#SignatureScheme).
 
 | Name                   | Windows | Linux | macOS |
 | ---------------------- | ------- | ----- | ----- |
@@ -345,8 +355,8 @@ This section includes the following packages:
 | PSSWithSHA256          | ✔️      | ✔️    | ✔️    |
 | PSSWithSHA384          | ✔️      | ✔️    | ✔️    |
 | PSSWithSHA512          | ✔️      | ✔️    | ✔️    |
-| ECDSAWithP256AndSHA256 | ✔️      | ✔️    | ❌    |
-| ECDSAWithP384AndSHA384 | ✔️      | ✔️    | ❌    |
-| ECDSAWithP521AndSHA512 | ✔️      | ✔️    | ❌    |
-| ECDSAWithSHA1          | ✔️      | ✔️    | ❌    |
+| ECDSAWithSHA1          | ✔️      | ✔️    | ✔️    |
+| ECDSAWithP256AndSHA256 | ✔️      | ✔️    | ✔️    |
+| ECDSAWithP384AndSHA384 | ✔️      | ✔️    | ✔️    |
+| ECDSAWithP521AndSHA512 | ✔️      | ✔️    | ✔️    |
 | Ed25519                | ❌      | ✔️    | ✔️    |

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -351,7 +351,6 @@ Below are the supported [`tls.SignatureSchemes`](https://pkg.go.dev/crypto/tls#S
 | PKCS1WithSHA256        | ✔️      | ✔️    | ✔️    |
 | PKCS1WithSHA384        | ✔️      | ✔️    | ✔️    |
 | PKCS1WithSHA512        | ✔️      | ✔️    | ✔️    |
-| PSSWithSHA1            | ❌      | ❌    | ✔️    |
 | PSSWithSHA256          | ✔️      | ✔️    | ✔️    |
 | PSSWithSHA384          | ✔️      | ✔️    | ✔️    |
 | PSSWithSHA512          | ✔️      | ✔️    | ✔️    |

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -26,6 +26,11 @@ OpenSSL 3 implements all the cryptographic algorithms using [Providers](https://
 Microsoft Go officially supports the built-in providers and [SCOSSL (SymCrypt provider for OpenSSL)](https://github.com/microsoft/SymCrypt-OpenSSL) v1.6.1 or later.
 SCOSSL is expected to be used with the default built-in provider enabled as a fallback (which is the case when using [Azure Linux 3](https://github.com/microsoft/AzureLinux)).
 
+## macOS
+
+On macOS, Microsoft Go uses [CommonCrypto](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/Common%20Crypto.3cc.html) and [CryptoKit](https://developer.apple.com/documentation/cryptokit) for cryptographic operations.
+CommonCrypto and CryptoKit is shipped with macOS and it doesn't require any additional installation nor configuration. Currently macOS 13 and above is supported.
+
 ## Table legend
 
 The following legend describes the symbols used in the tables to indicate the level of support for each cryptographic algorithm:
@@ -49,25 +54,25 @@ This section includes the following packages:
 * [crypto/sha3](https://pkg.go.dev/golang.org/x/crypto/sha3)
 * [crypto/hmac](https://pkg.go.dev/crypto/hmac)
 
-|Algorithm                  |Windows             |Linux                |
-|---------------------------|--------------------|---------------------|
-| MD5                       | ✔️                 | ✔️                 |
-| SHA-1                     | ✔️                 | ✔️                 |
-| SHA-2-224                 | ❌                 | ✔️                 |
-| SHA-2-256                 | ✔️                 | ✔️                 |
-| SHA-2-384                 | ✔️                 | ✔️                 |
-| SHA-2-512                 | ✔️                 | ✔️                 |
-| SHA-2-512_224             | ❌                 | ✔️<sup>1, 2</sup>  |
-| SHA-2-512_256             | ❌                 | ✔️<sup>1, 2</sup>  |
-| SHA-3-224                 | ❌                 | ❌                 |
-| SHA-3-256                 | ❌                 | ❌                 |
-| SHA-3-384                 | ❌                 | ❌                 |
-| SHA-3-512                 | ❌                 | ❌                 |
-| SHAKE-128                 | ❌                 | ❌                 |
-| SHAKE-256                 | ❌                 | ❌                 |
-| CSHAKE-128                | ❌                 | ❌                 |
-| CSHAKE-256                | ❌                 | ❌                 |
-| HMAC<sup>3</sup>          | ✔️                 | ✔️                 |
+|Algorithm                  |Windows             |Linux                |macOS           |
+|---------------------------|--------------------|------------------|-------------------|
+| MD5                       | ✔️                  | ✔️                | ✔️                 |
+| SHA-1                     | ✔️                  | ✔️                | ✔️                 |
+| SHA-2-224                 | ❌                 | ✔️                | ✔️                 |
+| SHA-2-256                 | ✔️                  | ✔️                | ✔️                 |
+| SHA-2-384                 | ✔️                  | ✔️                | ✔️                 |
+| SHA-2-512                 | ✔️                  | ✔️                | ✔️                 |
+| SHA-2-512_224             | ❌                 | ✔️<sup>1, 2</sup> | ❌                |
+| SHA-2-512_256             | ❌                 | ✔️<sup>1, 2</sup> | ❌                |
+| SHA-3-224                 | ❌                 | ❌               | ❌                |
+| SHA-3-256                 | ❌                 | ❌               | ❌                |
+| SHA-3-384                 | ❌                 | ❌               | ❌                |
+| SHA-3-512                 | ❌                 | ❌               | ❌                |
+| SHAKE-128                 | ❌                 | ❌               | ❌                |
+| SHAKE-256                 | ❌                 | ❌               | ❌                |
+| CSHAKE-128                | ❌                 | ❌               | ❌                |
+| CSHAKE-256                | ❌                 | ❌               | ❌                |
+| HMAC<sup>3</sup>          | ✔️                 | ✔️                 | ✔️                 |
 
 <sup>1</sup>Available starting in Microsoft Go 1.24.
 
@@ -84,19 +89,19 @@ This section includes the following packages:
 * [crypto/des](https://pkg.go.dev/crypto/des)
 * [crypto/rc4](https://pkg.go.dev/crypto/rc4)
 
-| Cipher + Mode | Windows  | Linux            |
-|---------------|----------|------------------|
-| AES-ECB       | ✔️       | ✔️              |
-| AES-CBC       | ✔️       | ✔️              |
-| AES-CTR       | ❌       | ✔️              |
-| AES-CFB       | ❌       | ❌              |
-| AES-OFB       | ❌       | ❌              |
-| AES-GCM       | ✔️       | ✔️              |
-| DES-CBC       | ✔️       | ⚠️<sup>1</sup>  |
-| DES-ECB       | ✔️       | ⚠️<sup>1</sup>  |
-| 3DES-ECB      | ✔️       | ✔️              |
-| 3DES-CBC      | ✔️       | ✔️              |
-| RC4           | ✔️       | ⚠️<sup>1</sup>  |
+| Cipher + Mode | Windows  | Linux         | macOS         |
+|---------------|----------|---------------|---------------|
+| AES-ECB       | ✔️        | ✔️             | ✔️             |
+| AES-CBC       | ✔️        | ✔️             | ✔️             |
+| AES-CTR       | ❌       | ✔️             | ❌            |
+| AES-CFB       | ❌       | ❌            | ❌            |
+| AES-OFB       | ❌       | ❌            | ❌            |
+| AES-GCM       | ✔️        | ✔️             | ✔️             |
+| DES-CBC       | ✔️        | ⚠️<sup>1</sup> | ✔️             |
+| DES-ECB       | ✔️       | ⚠️<sup>1</sup>  | ✔️             |
+| 3DES-ECB      | ✔️       | ✔️              | ✔️             |
+| 3DES-CBC      | ✔️       | ✔️              | ✔️             |
+| RC4           | ✔️       | ⚠️<sup>1</sup>  | ✔️             |
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
@@ -130,28 +135,32 @@ This section includes the following packages:
 
 * [crypto/rsa](https://pkg.go.dev/crypto/rsa)
 
-| Padding Mode                           | Windows              | Linux               |
-|----------------------------------------|----------------------|---------------------|
-| OAEP (MD5)                             | ✔️                   | ✔️                 |
-| OAEP (SHA-1)                           | ✔️                   | ✔️                 |
-| OAEP (SHA-2)<sup>1</sup>               | ✔️                   | ✔️                 |
-| OAEP (SHA-3)                           | ❌                   | ❌                 |
-| PSS (MD5)                              | ✔️                   | ✔️                 |
-| PSS (SHA-1)                            | ✔️                   | ✔️                 |
-| PSS (SHA-2)<sup>1</sup>                | ✔️                   | ✔️                 |
-| PSS (SHA-3)                            | ❌                   | ❌                 |
-| PKCS1v15 Signature (Unhashed)          | ✔️                   | ✔️                 |
-| PKCS1v15 Signature (RIPMED160)         | ❌                   | ✔️<sup>2</sup>     |
-| PKCS1v15 Signature (MD4)               | ❌                   | ✔️<sup>2</sup>     |
-| PKCS1v15 Signature (MD5)               | ✔️                   | ✔️                 |
-| PKCS1v15 Signature (MD5-SHA1)          | ✔️<sup>2</sup>       | ✔️<sup>2</sup>     |
-| PKCS1v15 Signature (SHA-1)             | ✔️                   | ✔️                 |
-| PKCS1v15 Signature (SHA-2)<sup>1</sup> | ✔️                   | ✔️                 |
-| PKCS1v15 Signature (SHA-3)             | ❌                  | ❌                 |
+| Padding Mode                           | Windows             | Linux            | macOS         |
+|----------------------------------------|---------------------|------------------|---------------|
+| OAEP (MD5)                             | ✔️                   | ✔️                | ✔️<sup>3</sup> |
+| OAEP (SHA-1)                           | ✔️                   | ✔️                | ✔️<sup>3</sup> |
+| OAEP (SHA-2)<sup>1</sup>               | ✔️                   | ✔️                | ✔️<sup>3</sup> |
+| OAEP (SHA-3)                           | ❌                  | ❌               | ❌            |
+| PSS (MD5)                              | ✔️                   | ✔️                | ✔️<sup>4</sup> |
+| PSS (SHA-1)                            | ✔️                   | ✔️                | ✔️<sup>4</sup> |
+| PSS (SHA-2)<sup>1</sup>                | ✔️                   | ✔️                | ✔️<sup>4</sup> |
+| PSS (SHA-3)                            | ❌                  | ❌               | ❌            |
+| PKCS1v15 Signature (Unhashed)          | ✔️                   | ✔️                | ✔️             |
+| PKCS1v15 Signature (RIPMED160)         | ❌                  | ✔️<sup>2</sup>    | ❌            |
+| PKCS1v15 Signature (MD4)               | ❌                  | ✔️<sup>2</sup>    | ❌            |
+| PKCS1v15 Signature (MD5)               | ✔️                   | ✔️                | ❌            |
+| PKCS1v15 Signature (MD5-SHA1)          | ✔️<sup>2</sup>       | ✔️<sup>2</sup>    | ❌            |
+| PKCS1v15 Signature (SHA-1)             | ✔️                   | ✔️                | ✔️             |
+| PKCS1v15 Signature (SHA-2)<sup>1</sup> | ✔️                   | ✔️                | ✔️             |
+| PKCS1v15 Signature (SHA-3)             | ❌                  | ❌               | ❌            |
 
 <sup>1</sup>Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).
 
 <sup>2</sup>Available starting in Microsoft Go 1.24.
+
+<sup>3</sup>macOS doesn't support passing a label to OAEP functions.
+
+<sup>4</sup>macOS doesn't support passing a custom salt length to PSS functions.
 
 #### RSA key sizes
 
@@ -178,12 +187,12 @@ This section includes the following packages:
 * [crypto/ecdsa](https://pkg.go.dev/crypto/ecdsa)
 * [crypto/elliptic](https://pkg.go.dev/crypto/elliptic)
 
-| Elliptic Curve            | Windows     | Linux        |
-|---------------------------|-------------|--------------|
-| NIST P-224 (secp224r1)    | ✔️          | ✔️          |
-| NIST P-256 (secp256r1)    | ✔️          | ✔️          |
-| NIST P-384 (secp384r1)    | ✔️          | ✔️          |
-| NIST P-521 (secp521r1)    | ✔️          | ✔️          |
+| Elliptic Curve            | Windows     | Linux     | macOS     |
+|---------------------------|-------------|-----------|-----------|
+| NIST P-224 (secp224r1)    | ✔️           | ✔️         | ❌        |
+| NIST P-256 (secp256r1)    | ✔️           | ✔️         | ✔️         |
+| NIST P-384 (secp384r1)    | ✔️           | ✔️         | ✔️         |
+| NIST P-521 (secp521r1)    | ✔️           | ✔️         | ✔️         |
 
 #### Random number generation
 
@@ -195,13 +204,13 @@ This section includes the following packages:
 
 * [crypto/ecdh](https://pkg.go.dev/crypto/ecdsa)
 
-| Elliptic Curve            | Windows     | Linux        |
-|---------------------------|-------------|--------------|
-| NIST P-224 (secp224r1)    | ✔️          | ✔️          |
-| NIST P-256 (secp256r1)    | ✔️          | ✔️          |
-| NIST P-384 (secp384r1)    | ✔️          | ✔️          |
-| NIST P-521 (secp521r1)    | ✔️          | ✔️          |
-| X25519 (curve25519)       | ❌          | ❌          |
+| Elliptic Curve            | Windows     | Linux      | macOS      |
+|---------------------------|-------------|------------|------------|
+| NIST P-224 (secp224r1)    | ✔️           | ✔️          | ❌         |
+| NIST P-256 (secp256r1)    | ✔️           | ✔️          | ✔️          |
+| NIST P-384 (secp384r1)    | ✔️           | ✔️          | ✔️          |
+| NIST P-521 (secp521r1)    | ✔️           | ✔️          | ✔️          |
+| X25519 (curve25519)       | ❌          | ❌         | ❌         |
 
 #### Random number generation
 
@@ -213,11 +222,11 @@ This section includes the following packages:
 
 * [crypto/ed25519](https://pkg.go.dev/crypto/ed25519)
 
-| Schemes     | Windows    | Linux         |
-|-------------|------------|---------------|
-| Ed25519     | ❌         | ✔️           |
-| Ed25519ctx  | ❌         | ❌           |
-| Ed25519ph   | ❌         | ❌           |
+| Schemes     | Windows    | Linux        | macOS        |
+|-------------|------------|--------------|--------------|
+| Ed25519     | ❌         | ✔️            | ✔️            |
+| Ed25519ctx  | ❌         | ❌           | ❌           |
+| Ed25519ph   | ❌         | ❌           | ❌           |
 
 #### Random number generation
 
@@ -225,12 +234,12 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 
 ### DSA
 
-| Parameters    | Windows     | Linux        |
-|---------------|-------------|--------------|
-| L1024N160     | ✔️          | ✔️          |
-| L2048N224     | ❌          | ✔️          |
-| L2048N256     | ✔️          | ✔️          |
-| L3072N256     | ✔️          | ✔️          |
+| Parameters    | Windows     | Linux      | macOS      |
+|---------------|-------------|------------|------------|
+| L1024N160     | ✔️           | ✔️          | ❌         |
+| L2048N224     | ❌          | ✔️          | ❌         |
+| L2048N256     | ✔️           | ✔️          | ❌         |
+| L3072N256     | ✔️           | ✔️          | ❌         |
 
 ## KDF
 
@@ -239,10 +248,10 @@ This section includes the following packages:
 * [crypto/hkdf](https://pkg.go.dev/crypto/hkdf)
 * [crypto/pbkdf2](https://pkg.go.dev/crypto/pbkdf2)
 
-| Functions     | Windows          | Linux             |
-|---------------|------------------|-------------------|
-| PBKDF2        | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
-| HKDF          | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
+| Functions     | Windows          | Linux           | macOS           |
+|---------------|------------------|-----------------|-----------------|
+| PBKDF2        | ✔️ <sup>1</sup>   | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
+| HKDF          | ✔️ <sup>1</sup>   | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
 
 <sup>1</sup>Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).
 
@@ -252,10 +261,10 @@ This section includes the following packages:
 
 * [crypto/mlkem](https://pkg.go.dev/crypto/mlkem)
 
-| Parameters    | Windows     | Linux        |
-|---------------|-------------|--------------|
-| 768           | ❌          | ❌          |
-| 1024          | ❌          | ❌          |
+| Parameters    | Windows     | Linux       | macOS       |
+|---------------|-------------|-------------|-------------|
+| 768           | ❌          | ❌          | ❌          |
+| 1024          | ❌          | ❌          | ❌          |
 
 ## TLS
 
@@ -272,12 +281,12 @@ This section includes the following packages:
 
 ### TLS Versions
 
-| Version        | Windows     | Linux   |
-|----------------|-------------|---------|
-| SSL 3.0        | ❌          | ❌     |
-| TLS 1.0        | ✔️          | ✔️     |
-| TLS 1.2        | ✔️          | ✔️     |
-| TLS 1.3        | ✔️          | ✔️     |
+| Version        | Windows    | Linux   | macOS   |
+|----------------|------------|---------|---------|
+| SSL 3.0        | ❌         | ❌      | ❌      |
+| TLS 1.0        | ✔️          | ✔️       | ❌      |
+| TLS 1.2        | ✔️          | ✔️       | ❌      |
+| TLS 1.3        | ✔️          | ✔️       | ❌      |
 
 ### Cipher Suites
 
@@ -316,27 +325,28 @@ This section includes the following packages:
 
 ### Curves and Groups
 
-| Name            | Windows     | Linux        |
-|-----------------|-------------|--------------|
-| CurveP256       | ✔️          | ✔️          |
-| CurveP384       | ✔️          | ✔️          |
-| CurveP521       | ✔️          | ✔️          |
-| X25519          | ❌          | ❌          |
-| X25519MLKEM768  | ❌          | ❌          |
+| Name            | Windows     | Linux      | macOS      |
+|-----------------|-------------|------------|------------|
+| CurveP256       | ✔️           | ✔️          | ✔️          |
+| CurveP384       | ✔️           | ✔️          | ✔️          |
+| CurveP521       | ✔️           | ✔️          | ✔️          |
+| X25519          | ❌          | ❌         | ❌         |
+| X25519MLKEM768  | ❌          | ❌         | ❌         |
 
 ### Signature Algorithms
 
-| Name                      | Windows     | Linux        |
-|---------------------------|-------------|--------------|
-| PKCS1WithSHA256           | ✔️          | ✔️          |
-| PKCS1WithSHA384           | ✔️          | ✔️          |
-| PKCS1WithSHA512           | ✔️          | ✔️          |
-| PSSWithSHA256             | ✔️          | ✔️          |
-| PSSWithSHA384             | ✔️          | ✔️          |
-| PSSWithSHA512             | ✔️          | ✔️          |
-| ECDSAWithP256AndSHA256    | ✔️          | ✔️          |
-| ECDSAWithP384AndSHA384    | ✔️          | ✔️          |
-| ECDSAWithP521AndSHA512    | ✔️          | ✔️          |
-| Ed25519                   | ❌          | ✔️          |
-| PKCS1WithSHA1             | ✔️          | ✔️          |
-| ECDSAWithSHA1             | ✔️          | ✔️          |
+| Name                      | Windows    | Linux      | macOS      |
+|---------------------------|------------|------------|------------|
+| PKCS1WithSHA1             | ✔️          | ✔️          | ✔️          |
+| PKCS1WithSHA256           | ✔️          | ✔️          | ✔️          |
+| PKCS1WithSHA384           | ✔️          | ✔️          | ✔️          |
+| PKCS1WithSHA512           | ✔️          | ✔️          | ✔️          |
+| PSSWithSHA1               | ❌         | ❌         | ✔️          |
+| PSSWithSHA256             | ✔️          | ✔️          | ✔️          |
+| PSSWithSHA384             | ✔️          | ✔️          | ✔️          |
+| PSSWithSHA512             | ✔️          | ✔️          | ✔️          |
+| ECDSAWithP256AndSHA256    | ✔️          | ✔️          | ❌         |
+| ECDSAWithP384AndSHA384    | ✔️          | ✔️          | ❌         |
+| ECDSAWithP521AndSHA512    | ✔️          | ✔️          | ❌         |
+| ECDSAWithSHA1             | ✔️          | ✔️          | ❌         |
+| Ed25519                   | ❌         | ✔️          | ✔️          |

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -36,7 +36,7 @@ CommonCrypto and CryptoKit is shipped with macOS and it doesn't require any addi
 The following legend describes the symbols used in the tables to indicate the level of support for each cryptographic algorithm:
 
 | Symbol | Meaning                                                                                                                      |
-|--------|------------------------------------------------------------------------------------------------------------------------------|
+| ------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | ✔️     | Supported, possibly with minor limitations that don't require special configuration when using the latest Go and OS versions |
 | ⚠️     | Supported with limitations that require special configuration action                                                         |
 | ❌     | Not supported                                                                                                                |
@@ -47,32 +47,32 @@ When an algorithm is not supported or the limitations are exceeded, Microsoft Go
 
 This section includes the following packages:
 
-* [crypto/md5](https://pkg.go.dev/crypto/md5)
-* [crypto/sha1](https://pkg.go.dev/crypto/sha1)
-* [crypto/sha256](https://pkg.go.dev/crypto/sha256)
-* [crypto/sha512](https://pkg.go.dev/crypto/sha512)
-* [crypto/sha3](https://pkg.go.dev/golang.org/x/crypto/sha3)
-* [crypto/hmac](https://pkg.go.dev/crypto/hmac)
+- [crypto/md5](https://pkg.go.dev/crypto/md5)
+- [crypto/sha1](https://pkg.go.dev/crypto/sha1)
+- [crypto/sha256](https://pkg.go.dev/crypto/sha256)
+- [crypto/sha512](https://pkg.go.dev/crypto/sha512)
+- [crypto/sha3](https://pkg.go.dev/golang.org/x/crypto/sha3)
+- [crypto/hmac](https://pkg.go.dev/crypto/hmac)
 
-|Algorithm                  |Windows             |Linux                |macOS           |
-|---------------------------|--------------------|------------------|-------------------|
-| MD5                       | ✔️                  | ✔️                | ✔️                 |
-| SHA-1                     | ✔️                  | ✔️                | ✔️                 |
-| SHA-2-224                 | ❌                 | ✔️                | ✔️                 |
-| SHA-2-256                 | ✔️                  | ✔️                | ✔️                 |
-| SHA-2-384                 | ✔️                  | ✔️                | ✔️                 |
-| SHA-2-512                 | ✔️                  | ✔️                | ✔️                 |
-| SHA-2-512_224             | ❌                 | ✔️<sup>1, 2</sup> | ❌                |
-| SHA-2-512_256             | ❌                 | ✔️<sup>1, 2</sup> | ❌                |
-| SHA-3-224                 | ❌                 | ❌               | ❌                |
-| SHA-3-256                 | ❌                 | ❌               | ❌                |
-| SHA-3-384                 | ❌                 | ❌               | ❌                |
-| SHA-3-512                 | ❌                 | ❌               | ❌                |
-| SHAKE-128                 | ❌                 | ❌               | ❌                |
-| SHAKE-256                 | ❌                 | ❌               | ❌                |
-| CSHAKE-128                | ❌                 | ❌               | ❌                |
-| CSHAKE-256                | ❌                 | ❌               | ❌                |
-| HMAC<sup>3</sup>          | ✔️                 | ✔️                 | ✔️                 |
+| Algorithm        | Windows | Linux             | macOS |
+| ---------------- | ------- | ----------------- | ----- |
+| MD5              | ✔️      | ✔️                | ✔️    |
+| SHA-1            | ✔️      | ✔️                | ✔️    |
+| SHA-2-224        | ❌      | ✔️                | ✔️    |
+| SHA-2-256        | ✔️      | ✔️                | ✔️    |
+| SHA-2-384        | ✔️      | ✔️                | ✔️    |
+| SHA-2-512        | ✔️      | ✔️                | ✔️    |
+| SHA-2-512_224    | ❌      | ✔️<sup>1, 2</sup> | ❌    |
+| SHA-2-512_256    | ❌      | ✔️<sup>1, 2</sup> | ❌    |
+| SHA-3-224        | ❌      | ❌                | ❌    |
+| SHA-3-256        | ❌      | ❌                | ❌    |
+| SHA-3-384        | ❌      | ❌                | ❌    |
+| SHA-3-512        | ❌      | ❌                | ❌    |
+| SHAKE-128        | ❌      | ❌                | ❌    |
+| SHAKE-256        | ❌      | ❌                | ❌    |
+| CSHAKE-128       | ❌      | ❌                | ❌    |
+| CSHAKE-256       | ❌      | ❌                | ❌    |
+| HMAC<sup>3</sup> | ✔️      | ✔️                | ✔️    |
 
 <sup>1</sup>Available starting in Microsoft Go 1.24.
 
@@ -84,75 +84,75 @@ This section includes the following packages:
 
 This section includes the following packages:
 
-* [crypto/aes](https://pkg.go.dev/crypto/aes)
-* [crypto/cipher](https://pkg.go.dev/crypto/cipher)
-* [crypto/des](https://pkg.go.dev/crypto/des)
-* [crypto/rc4](https://pkg.go.dev/crypto/rc4)
+- [crypto/aes](https://pkg.go.dev/crypto/aes)
+- [crypto/cipher](https://pkg.go.dev/crypto/cipher)
+- [crypto/des](https://pkg.go.dev/crypto/des)
+- [crypto/rc4](https://pkg.go.dev/crypto/rc4)
 
-| Cipher + Mode | Windows  | Linux         | macOS         |
-|---------------|----------|---------------|---------------|
-| AES-ECB       | ✔️        | ✔️             | ✔️             |
-| AES-CBC       | ✔️        | ✔️             | ✔️             |
-| AES-CTR       | ❌       | ✔️             | ❌            |
-| AES-CFB       | ❌       | ❌            | ❌            |
-| AES-OFB       | ❌       | ❌            | ❌            |
-| AES-GCM       | ✔️        | ✔️             | ✔️             |
-| DES-CBC       | ✔️        | ⚠️<sup>1</sup> | ✔️             |
-| DES-ECB       | ✔️       | ⚠️<sup>1</sup>  | ✔️             |
-| 3DES-ECB      | ✔️       | ✔️              | ✔️             |
-| 3DES-CBC      | ✔️       | ✔️              | ✔️             |
-| RC4           | ✔️       | ⚠️<sup>1</sup>  | ✔️             |
+| Cipher + Mode | Windows | Linux          | macOS |
+| ------------- | ------- | -------------- | ----- |
+| AES-ECB       | ✔️      | ✔️             | ✔️    |
+| AES-CBC       | ✔️      | ✔️             | ✔️    |
+| AES-CTR       | ❌      | ✔️             | ❌    |
+| AES-CFB       | ❌      | ❌             | ❌    |
+| AES-OFB       | ❌      | ❌             | ❌    |
+| AES-GCM       | ✔️      | ✔️             | ✔️    |
+| DES-CBC       | ✔️      | ⚠️<sup>1</sup> | ✔️    |
+| DES-ECB       | ✔️      | ⚠️<sup>1</sup> | ✔️    |
+| 3DES-ECB      | ✔️      | ✔️             | ✔️    |
+| 3DES-CBC      | ✔️      | ✔️             | ✔️    |
+| RC4           | ✔️      | ⚠️<sup>1</sup> | ✔️    |
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
 ### AES-GCM keys, nonces, and tags
 
-* Key Sizes
+- Key Sizes
 
   AES-GCM works with 128, 192, and 256-bit keys.
 
-* Nonce Sizes
+- Nonce Sizes
 
   AES-GCM works with 12-byte nonces.
 
-* Tag Sizes
-  
+- Tag Sizes
+
   AES-GCM works with 16-byte tags.
 
 ## Asymmetric encryption
 
 This section includes the following subsections:
 
-* [RSA](#rsa)
-* [ECDSA](#ecdsa)
-* [ECDH](#ecdh)
-* [Ed25519](#ed25519)
-* [DSA](#dsa)
+- [RSA](#rsa)
+- [ECDSA](#ecdsa)
+- [ECDH](#ecdh)
+- [Ed25519](#ed25519)
+- [DSA](#dsa)
 
 ### RSA
 
 This section includes the following packages:
 
-* [crypto/rsa](https://pkg.go.dev/crypto/rsa)
+- [crypto/rsa](https://pkg.go.dev/crypto/rsa)
 
-| Padding Mode                           | Windows             | Linux            | macOS         |
-|----------------------------------------|---------------------|------------------|---------------|
-| OAEP (MD5)                             | ✔️                   | ✔️                | ✔️<sup>3</sup> |
-| OAEP (SHA-1)                           | ✔️                   | ✔️                | ✔️<sup>3</sup> |
-| OAEP (SHA-2)<sup>1</sup>               | ✔️                   | ✔️                | ✔️<sup>3</sup> |
-| OAEP (SHA-3)                           | ❌                  | ❌               | ❌            |
-| PSS (MD5)                              | ✔️                   | ✔️                | ✔️<sup>4</sup> |
-| PSS (SHA-1)                            | ✔️                   | ✔️                | ✔️<sup>4</sup> |
-| PSS (SHA-2)<sup>1</sup>                | ✔️                   | ✔️                | ✔️<sup>4</sup> |
-| PSS (SHA-3)                            | ❌                  | ❌               | ❌            |
-| PKCS1v15 Signature (Unhashed)          | ✔️                   | ✔️                | ✔️             |
-| PKCS1v15 Signature (RIPMED160)         | ❌                  | ✔️<sup>2</sup>    | ❌            |
-| PKCS1v15 Signature (MD4)               | ❌                  | ✔️<sup>2</sup>    | ❌            |
-| PKCS1v15 Signature (MD5)               | ✔️                   | ✔️                | ❌            |
-| PKCS1v15 Signature (MD5-SHA1)          | ✔️<sup>2</sup>       | ✔️<sup>2</sup>    | ❌            |
-| PKCS1v15 Signature (SHA-1)             | ✔️                   | ✔️                | ✔️             |
-| PKCS1v15 Signature (SHA-2)<sup>1</sup> | ✔️                   | ✔️                | ✔️             |
-| PKCS1v15 Signature (SHA-3)             | ❌                  | ❌               | ❌            |
+| Padding Mode                           | Windows        | Linux          | macOS          |
+| -------------------------------------- | -------------- | -------------- | -------------- |
+| OAEP (MD5)                             | ✔️             | ✔️             | ✔️<sup>3</sup> |
+| OAEP (SHA-1)                           | ✔️             | ✔️             | ✔️<sup>3</sup> |
+| OAEP (SHA-2)<sup>1</sup>               | ✔️             | ✔️             | ✔️<sup>3</sup> |
+| OAEP (SHA-3)                           | ❌             | ❌             | ❌             |
+| PSS (MD5)                              | ✔️             | ✔️             | ✔️<sup>4</sup> |
+| PSS (SHA-1)                            | ✔️             | ✔️             | ✔️<sup>4</sup> |
+| PSS (SHA-2)<sup>1</sup>                | ✔️             | ✔️             | ✔️<sup>4</sup> |
+| PSS (SHA-3)                            | ❌             | ❌             | ❌             |
+| PKCS1v15 Signature (Unhashed)          | ✔️             | ✔️             | ✔️             |
+| PKCS1v15 Signature (RIPMED160)         | ❌             | ✔️<sup>2</sup> | ❌             |
+| PKCS1v15 Signature (MD4)               | ❌             | ✔️<sup>2</sup> | ❌             |
+| PKCS1v15 Signature (MD5)               | ✔️             | ✔️             | ❌             |
+| PKCS1v15 Signature (MD5-SHA1)          | ✔️<sup>2</sup> | ✔️<sup>2</sup> | ❌             |
+| PKCS1v15 Signature (SHA-1)             | ✔️             | ✔️             | ✔️             |
+| PKCS1v15 Signature (SHA-2)<sup>1</sup> | ✔️             | ✔️             | ✔️             |
+| PKCS1v15 Signature (SHA-3)             | ❌             | ❌             | ❌             |
 
 <sup>1</sup>Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).
 
@@ -184,15 +184,15 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 
 This section includes the following packages:
 
-* [crypto/ecdsa](https://pkg.go.dev/crypto/ecdsa)
-* [crypto/elliptic](https://pkg.go.dev/crypto/elliptic)
+- [crypto/ecdsa](https://pkg.go.dev/crypto/ecdsa)
+- [crypto/elliptic](https://pkg.go.dev/crypto/elliptic)
 
-| Elliptic Curve            | Windows     | Linux     | macOS     |
-|---------------------------|-------------|-----------|-----------|
-| NIST P-224 (secp224r1)    | ✔️           | ✔️         | ❌        |
-| NIST P-256 (secp256r1)    | ✔️           | ✔️         | ✔️         |
-| NIST P-384 (secp384r1)    | ✔️           | ✔️         | ✔️         |
-| NIST P-521 (secp521r1)    | ✔️           | ✔️         | ✔️         |
+| Elliptic Curve         | Windows | Linux | macOS |
+| ---------------------- | ------- | ----- | ----- |
+| NIST P-224 (secp224r1) | ✔️      | ✔️    | ❌    |
+| NIST P-256 (secp256r1) | ✔️      | ✔️    | ✔️    |
+| NIST P-384 (secp384r1) | ✔️      | ✔️    | ✔️    |
+| NIST P-521 (secp521r1) | ✔️      | ✔️    | ✔️    |
 
 #### Random number generation
 
@@ -202,15 +202,15 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 
 This section includes the following packages:
 
-* [crypto/ecdh](https://pkg.go.dev/crypto/ecdsa)
+- [crypto/ecdh](https://pkg.go.dev/crypto/ecdsa)
 
-| Elliptic Curve            | Windows     | Linux      | macOS      |
-|---------------------------|-------------|------------|------------|
-| NIST P-224 (secp224r1)    | ✔️           | ✔️          | ❌         |
-| NIST P-256 (secp256r1)    | ✔️           | ✔️          | ✔️          |
-| NIST P-384 (secp384r1)    | ✔️           | ✔️          | ✔️          |
-| NIST P-521 (secp521r1)    | ✔️           | ✔️          | ✔️          |
-| X25519 (curve25519)       | ❌          | ❌         | ❌         |
+| Elliptic Curve         | Windows | Linux | macOS |
+| ---------------------- | ------- | ----- | ----- |
+| NIST P-224 (secp224r1) | ✔️      | ✔️    | ❌    |
+| NIST P-256 (secp256r1) | ✔️      | ✔️    | ✔️    |
+| NIST P-384 (secp384r1) | ✔️      | ✔️    | ✔️    |
+| NIST P-521 (secp521r1) | ✔️      | ✔️    | ✔️    |
+| X25519 (curve25519)    | ❌      | ❌    | ❌    |
 
 #### Random number generation
 
@@ -220,13 +220,13 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 
 This section includes the following packages:
 
-* [crypto/ed25519](https://pkg.go.dev/crypto/ed25519)
+- [crypto/ed25519](https://pkg.go.dev/crypto/ed25519)
 
-| Schemes     | Windows    | Linux        | macOS        |
-|-------------|------------|--------------|--------------|
-| Ed25519     | ❌         | ✔️            | ✔️            |
-| Ed25519ctx  | ❌         | ❌           | ❌           |
-| Ed25519ph   | ❌         | ❌           | ❌           |
+| Schemes    | Windows | Linux | macOS |
+| ---------- | ------- | ----- | ----- |
+| Ed25519    | ❌      | ✔️    | ✔️    |
+| Ed25519ctx | ❌      | ❌    | ❌    |
+| Ed25519ph  | ❌      | ❌    | ❌    |
 
 #### Random number generation
 
@@ -234,24 +234,24 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 
 ### DSA
 
-| Parameters    | Windows     | Linux      | macOS      |
-|---------------|-------------|------------|------------|
-| L1024N160     | ✔️           | ✔️          | ❌         |
-| L2048N224     | ❌          | ✔️          | ❌         |
-| L2048N256     | ✔️           | ✔️          | ❌         |
-| L3072N256     | ✔️           | ✔️          | ❌         |
+| Parameters | Windows | Linux | macOS |
+| ---------- | ------- | ----- | ----- |
+| L1024N160  | ✔️      | ✔️    | ❌    |
+| L2048N224  | ❌      | ✔️    | ❌    |
+| L2048N256  | ✔️      | ✔️    | ❌    |
+| L3072N256  | ✔️      | ✔️    | ❌    |
 
 ## KDF
 
 This section includes the following packages:
 
-* [crypto/hkdf](https://pkg.go.dev/crypto/hkdf)
-* [crypto/pbkdf2](https://pkg.go.dev/crypto/pbkdf2)
+- [crypto/hkdf](https://pkg.go.dev/crypto/hkdf)
+- [crypto/pbkdf2](https://pkg.go.dev/crypto/pbkdf2)
 
-| Functions     | Windows          | Linux           | macOS           |
-|---------------|------------------|-----------------|-----------------|
-| PBKDF2        | ✔️ <sup>1</sup>   | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
-| HKDF          | ✔️ <sup>1</sup>   | ✔️ <sup>1</sup>  | ✔️ <sup>1</sup>  |
+| Functions | Windows         | Linux           | macOS           |
+| --------- | --------------- | --------------- | --------------- |
+| PBKDF2    | ✔️ <sup>1</sup> | ✔️ <sup>1</sup> | ✔️ <sup>1</sup> |
+| HKDF      | ✔️ <sup>1</sup> | ✔️ <sup>1</sup> | ✔️ <sup>1</sup> |
 
 <sup>1</sup>Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).
 
@@ -259,94 +259,94 @@ This section includes the following packages:
 
 This section includes the following packages:
 
-* [crypto/mlkem](https://pkg.go.dev/crypto/mlkem)
+- [crypto/mlkem](https://pkg.go.dev/crypto/mlkem)
 
-| Parameters    | Windows     | Linux       | macOS       |
-|---------------|-------------|-------------|-------------|
-| 768           | ❌          | ❌          | ❌          |
-| 1024          | ❌          | ❌          | ❌          |
+| Parameters | Windows | Linux | macOS |
+| ---------- | ------- | ----- | ----- |
+| 768        | ❌      | ❌    | ❌    |
+| 1024       | ❌      | ❌    | ❌    |
 
 ## TLS
 
 This section includes the following subsections:
 
-* [TLS Versions](#tls-versions)
-* [Cipher Suites](#cipher-suites)
-* [Curves and Groups](#curves-and-groups)
-* [Signature Algorithms](#signature-algorithms)
+- [TLS Versions](#tls-versions)
+- [Cipher Suites](#cipher-suites)
+- [Curves and Groups](#curves-and-groups)
+- [Signature Algorithms](#signature-algorithms)
 
 This section includes the following packages:
 
-* [crypto/tls](https://pkg.go.dev/crypto/tls)
+- [crypto/tls](https://pkg.go.dev/crypto/tls)
 
 ### TLS Versions
 
-| Version        | Windows    | Linux   | macOS   |
-|----------------|------------|---------|---------|
-| SSL 3.0        | ❌         | ❌      | ❌      |
-| TLS 1.0        | ✔️          | ✔️       | ❌      |
-| TLS 1.2        | ✔️          | ✔️       | ❌      |
-| TLS 1.3        | ✔️          | ✔️       | ❌      |
+| Version | Windows | Linux | macOS |
+| ------- | ------- | ----- | ----- |
+| SSL 3.0 | ❌      | ❌    | ❌    |
+| TLS 1.0 | ✔️      | ✔️    | ❌    |
+| TLS 1.2 | ✔️      | ✔️    | ❌    |
+| TLS 1.3 | ✔️      | ✔️    | ❌    |
 
 ### Cipher Suites
 
-| Name                                              | Windows     | Linux             |
-|---------------------------------------------------|-------------|-------------------|
-| TLS_RSA_WITH_RC4_128_SHA                          | ✔️          | ⚠️<sup>1</sup>   |
-| TLS_RSA_WITH_3DES_EDE_CBC_SHA                     | ✔️          | ⚠️<sup>1</sup>   |
-| TLS_RSA_WITH_AES_128_CBC_SHA                      | ✔️          | ✔️               |
-| TLS_RSA_WITH_AES_256_CBC_SHA                      | ✔️          | ✔️               |
-| TLS_RSA_WITH_AES_128_CBC_SHA256                   | ✔️          | ✔️               |
-| TLS_RSA_WITH_AES_128_GCM_SHA256                   | ✔️          | ✔️               |
-| TLS_RSA_WITH_AES_256_GCM_SHA384                   | ✔️          | ✔️               |
-| TLS_ECDHE_ECDSA_WITH_RC4_128_SHA                  | ✔️          | ⚠️<sup>1</sup>   |
-| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA              | ✔️          | ✔️               |
-| TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA              | ✔️          | ✔️               |
-| TLS_ECDHE_RSA_WITH_RC4_128_SHA                    | ✔️          | ⚠️<sup>1</sup>   |
-| TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA               | ✔️          | ⚠️<sup>1</sup>   |
-| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA                | ✔️          | ✔️               |
-| TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA                | ✔️          | ✔️               |
-| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256           | ✔️          | ✔️               |
-| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256             | ✔️          | ✔️               |
-| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             | ✔️          | ✔️               |
-| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256           | ✔️          | ✔️               |
-| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             | ✔️          | ✔️               |
-| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384           | ✔️          | ✔️               |
-| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256       | ❌          | ❌               |
-| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256     | ❌          | ❌               |
-| TLS_AES_128_GCM_SHA256                            | ✔️          | ✔️               |
-| TLS_AES_256_GCM_SHA384                            | ✔️          | ✔️               |
-| TLS_CHACHA20_POLY1305_SHA256                      | ❌          | ❌               |
-| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305              | ❌          | ❌               |
-| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305              | ❌          | ❌               |
-| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305            | ❌          | ❌               |
+| Name                                          | Windows | Linux          |
+| --------------------------------------------- | ------- | -------------- |
+| TLS_RSA_WITH_RC4_128_SHA                      | ✔️      | ⚠️<sup>1</sup> |
+| TLS_RSA_WITH_3DES_EDE_CBC_SHA                 | ✔️      | ⚠️<sup>1</sup> |
+| TLS_RSA_WITH_AES_128_CBC_SHA                  | ✔️      | ✔️             |
+| TLS_RSA_WITH_AES_256_CBC_SHA                  | ✔️      | ✔️             |
+| TLS_RSA_WITH_AES_128_CBC_SHA256               | ✔️      | ✔️             |
+| TLS_RSA_WITH_AES_128_GCM_SHA256               | ✔️      | ✔️             |
+| TLS_RSA_WITH_AES_256_GCM_SHA384               | ✔️      | ✔️             |
+| TLS_ECDHE_ECDSA_WITH_RC4_128_SHA              | ✔️      | ⚠️<sup>1</sup> |
+| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA          | ✔️      | ✔️             |
+| TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA          | ✔️      | ✔️             |
+| TLS_ECDHE_RSA_WITH_RC4_128_SHA                | ✔️      | ⚠️<sup>1</sup> |
+| TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA           | ✔️      | ⚠️<sup>1</sup> |
+| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA            | ✔️      | ✔️             |
+| TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA            | ✔️      | ✔️             |
+| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256       | ✔️      | ✔️             |
+| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256         | ✔️      | ✔️             |
+| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256         | ✔️      | ✔️             |
+| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256       | ✔️      | ✔️             |
+| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384         | ✔️      | ✔️             |
+| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384       | ✔️      | ✔️             |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   | ❌      | ❌             |
+| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 | ❌      | ❌             |
+| TLS_AES_128_GCM_SHA256                        | ✔️      | ✔️             |
+| TLS_AES_256_GCM_SHA384                        | ✔️      | ✔️             |
+| TLS_CHACHA20_POLY1305_SHA256                  | ❌      | ❌             |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305          | ❌      | ❌             |
+| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305          | ❌      | ❌             |
+| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305        | ❌      | ❌             |
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
 ### Curves and Groups
 
-| Name            | Windows     | Linux      | macOS      |
-|-----------------|-------------|------------|------------|
-| CurveP256       | ✔️           | ✔️          | ✔️          |
-| CurveP384       | ✔️           | ✔️          | ✔️          |
-| CurveP521       | ✔️           | ✔️          | ✔️          |
-| X25519          | ❌          | ❌         | ❌         |
-| X25519MLKEM768  | ❌          | ❌         | ❌         |
+| Name           | Windows | Linux | macOS |
+| -------------- | ------- | ----- | ----- |
+| CurveP256      | ✔️      | ✔️    | ✔️    |
+| CurveP384      | ✔️      | ✔️    | ✔️    |
+| CurveP521      | ✔️      | ✔️    | ✔️    |
+| X25519         | ❌      | ❌    | ❌    |
+| X25519MLKEM768 | ❌      | ❌    | ❌    |
 
 ### Signature Algorithms
 
-| Name                      | Windows    | Linux      | macOS      |
-|---------------------------|------------|------------|------------|
-| PKCS1WithSHA1             | ✔️          | ✔️          | ✔️          |
-| PKCS1WithSHA256           | ✔️          | ✔️          | ✔️          |
-| PKCS1WithSHA384           | ✔️          | ✔️          | ✔️          |
-| PKCS1WithSHA512           | ✔️          | ✔️          | ✔️          |
-| PSSWithSHA1               | ❌         | ❌         | ✔️          |
-| PSSWithSHA256             | ✔️          | ✔️          | ✔️          |
-| PSSWithSHA384             | ✔️          | ✔️          | ✔️          |
-| PSSWithSHA512             | ✔️          | ✔️          | ✔️          |
-| ECDSAWithP256AndSHA256    | ✔️          | ✔️          | ❌         |
-| ECDSAWithP384AndSHA384    | ✔️          | ✔️          | ❌         |
-| ECDSAWithP521AndSHA512    | ✔️          | ✔️          | ❌         |
-| ECDSAWithSHA1             | ✔️          | ✔️          | ❌         |
-| Ed25519                   | ❌         | ✔️          | ✔️          |
+| Name                   | Windows | Linux | macOS |
+| ---------------------- | ------- | ----- | ----- |
+| PKCS1WithSHA1          | ✔️      | ✔️    | ✔️    |
+| PKCS1WithSHA256        | ✔️      | ✔️    | ✔️    |
+| PKCS1WithSHA384        | ✔️      | ✔️    | ✔️    |
+| PKCS1WithSHA512        | ✔️      | ✔️    | ✔️    |
+| PSSWithSHA1            | ❌      | ❌    | ✔️    |
+| PSSWithSHA256          | ✔️      | ✔️    | ✔️    |
+| PSSWithSHA384          | ✔️      | ✔️    | ✔️    |
+| PSSWithSHA512          | ✔️      | ✔️    | ✔️    |
+| ECDSAWithP256AndSHA256 | ✔️      | ✔️    | ❌    |
+| ECDSAWithP384AndSHA384 | ✔️      | ✔️    | ❌    |
+| ECDSAWithP521AndSHA512 | ✔️      | ✔️    | ❌    |
+| ECDSAWithSHA1          | ✔️      | ✔️    | ❌    |
+| Ed25519                | ❌      | ✔️    | ✔️    |

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -29,7 +29,8 @@ SCOSSL is expected to be used with the default built-in provider enabled as a fa
 ## macOS
 
 On macOS, Microsoft Go uses [CommonCrypto](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/Common%20Crypto.3cc.html) and [CryptoKit](https://developer.apple.com/documentation/cryptokit) for cryptographic operations.
-CommonCrypto and CryptoKit is shipped with macOS and it doesn't require any additional installation nor configuration. Currently macOS 13 and above is supported.
+CommonCrypto and CryptoKit are shipped with macOS and don't require any additional installation nor configuration.
+Currently macOS 13 and above is supported.
 
 ## Table legend
 
@@ -132,7 +133,7 @@ This section includes the following subsections:
 ### RSA
 
 > [!WARNING]  
-> System Libraries might not fully implement all RSA features. Please see the subsections below for more information.
+> System libraries might not fully implement all RSA features. Please see the subsections below for more information.
 
 This section includes the following packages:
 


### PR DESCRIPTION
Documents which algorithms are supported for macOS.

I used prettier to format the markdown better