### PR TITLE
Remove `openssl.SetFIPS(true)` call

### DIFF
--- a/eng/_util/cmd/run-builder/systemfips_fallback.go
+++ b/eng/_util/cmd/run-builder/systemfips_fallback.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build !windows
+//go:build !windows && !linux
 
 package main
 

--- a/eng/_util/cmd/run-builder/systemfips_linux.go
+++ b/eng/_util/cmd/run-builder/systemfips_linux.go
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// enableSystemWideFIPS fallback is a no-op because the current platform either doesn't support or
+// doesn't require system-wide FIPS to be enabled to run tests.
+func enableSystemWideFIPS() (restore func(), err error) {
+	cmd := exec.Command("openssl", "version", "-a")
+	log.Printf("---- Running command: %v\n", cmd.Args)
+	out, err := cmd.CombinedOutput()
+	sout := string(out)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check openssl version: %v, %v", err, string(out))
+	}
+	log.Print(sout)
+
+	lines := strings.Split(sout, "\n")
+	if !strings.Contains(sout, "OpenSSL 1.") {
+		// Only OpenSSL 1 needs special handling for FIPS mode,
+		// at least on the platforms we test on.
+		log.Println("Using fallback (no-op) for enableSystemWideFIPS. It either isn't supported on this platform or isn't necessary.")
+		//return nil, nil
+	}
+
+	// Search for the OPENSSLDIR path in the output.
+	var ossldir string
+	for _, line := range lines {
+		var found bool
+		if ossldir, found = strings.CutPrefix(line, "OPENSSLDIR: "); found {
+			break
+		}
+	}
+	if ossldir == "" {
+		return nil, fmt.Errorf("failed to find OPENSSLDIR in openssl version output")
+	}
+	ossldir = strings.Trim(ossldir, `"`)
+
+	// Append the FIPS configuration to the openssl.cnf file.
+	// OpenSSL will merge duplicated sections, so we don't need
+	// to check if the section already exists.
+	opensslcnf := filepath.Join(ossldir, "openssl.cnf")
+	prevContent, err := os.ReadFile(opensslcnf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read openssl.cnf file: %v", err)
+	}
+	err = os.WriteFile(opensslcnf, append(prevContent, []byte("\n\n[evp_sect]\nfips_mode = yes\n")...), 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write to openssl.cnf file: %v", err)
+	}
+
+	log.Println("Enabled FIPS mode.")
+
+	return func() {
+		err := os.WriteFile(opensslcnf, prevContent, 0644)
+		if err != nil {
+			log.Printf("Unable to restore openssl.cnf file: %v\n", err)
+			return
+		}
+		log.Println("Successfully restored openssl.cnf file.")
+	}, nil
+}

--- a/eng/_util/cmd/run-builder/systemfips_linux.go
+++ b/eng/_util/cmd/run-builder/systemfips_linux.go
@@ -8,17 +8,18 @@ import (
 	"os"
 )
 
-// enableSystemWideFIPS enables Mariner and Azure Linux 3 process-wide FIPS mode.
+// enableSystemWideFIPS enables Mariner and Azure Linux 3 process-wide FIPS mode
+// for any process that inherits the current process' environment variables.
 func enableSystemWideFIPS() (restore func(), err error) {
 	// FIPS mode is enabled if OPENSSL_FORCE_FIPS_MODE is set, regardless of the value.
 	_, ok := os.LookupEnv("OPENSSL_FORCE_FIPS_MODE")
 	if ok {
-		log.Println("FIPS mode already enabled.")
+		log.Println("Mariner and Azure Linux 3 forced FIPS mode (OPENSSL_FORCE_FIPS_MODE) already enabled.")
 		return nil, nil
 	}
 
 	env("OPENSSL_FORCE_FIPS_MODE", "1")
-	log.Println("Enabled Mariner and Azure Linux 3 FIPS mode.")
+	log.Println("Enabled Mariner and Azure Linux 3 FIPS mode (OPENSSL_FORCE_FIPS_MODE).")
 
 	return func() {
 		err := os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")

--- a/eng/_util/cmd/run-builder/systemfips_linux.go
+++ b/eng/_util/cmd/run-builder/systemfips_linux.go
@@ -1,73 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build linux
-
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 )
 
-// enableSystemWideFIPS fallback is a no-op because the current platform either doesn't support or
-// doesn't require system-wide FIPS to be enabled to run tests.
+// enableSystemWideFIPS enables Mariner and Azure Linux 3 process-wide FIPS mode.
 func enableSystemWideFIPS() (restore func(), err error) {
-	cmd := exec.Command("openssl", "version", "-a")
-	log.Printf("---- Running command: %v\n", cmd.Args)
-	out, err := cmd.CombinedOutput()
-	sout := string(out)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check openssl version: %v, %v", err, string(out))
-	}
-	log.Print(sout)
-
-	lines := strings.Split(sout, "\n")
-	if !strings.Contains(sout, "OpenSSL 1.") {
-		// Only OpenSSL 1 needs special handling for FIPS mode,
-		// at least on the platforms we test on.
-		log.Println("Using fallback (no-op) for enableSystemWideFIPS. It either isn't supported on this platform or isn't necessary.")
-		//return nil, nil
+	// FIPS mode is enabled if OPENSSL_FORCE_FIPS_MODE is set, regardless of the value.
+	_, ok := os.LookupEnv("OPENSSL_FORCE_FIPS_MODE")
+	if ok {
+		log.Println("FIPS mode already enabled.")
+		return nil, nil
 	}
 
-	// Search for the OPENSSLDIR path in the output.
-	var ossldir string
-	for _, line := range lines {
-		var found bool
-		if ossldir, found = strings.CutPrefix(line, "OPENSSLDIR: "); found {
-			break
-		}
-	}
-	if ossldir == "" {
-		return nil, fmt.Errorf("failed to find OPENSSLDIR in openssl version output")
-	}
-	ossldir = strings.Trim(ossldir, `"`)
-
-	// Append the FIPS configuration to the openssl.cnf file.
-	// OpenSSL will merge duplicated sections, so we don't need
-	// to check if the section already exists.
-	opensslcnf := filepath.Join(ossldir, "openssl.cnf")
-	prevContent, err := os.ReadFile(opensslcnf)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read openssl.cnf file: %v", err)
-	}
-	err = os.WriteFile(opensslcnf, append(prevContent, []byte("\n\n[evp_sect]\nfips_mode = yes\n")...), 0644)
-	if err != nil {
-		return nil, fmt.Errorf("failed to write to openssl.cnf file: %v", err)
-	}
-
-	log.Println("Enabled FIPS mode.")
+	env("OPENSSL_FORCE_FIPS_MODE", "1")
+	log.Println("Enabled Mariner and Azure Linux 3 FIPS mode.")
 
 	return func() {
-		err := os.WriteFile(opensslcnf, prevContent, 0644)
+		err := os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")
 		if err != nil {
-			log.Printf("Unable to restore openssl.cnf file: %v\n", err)
+			log.Printf("Unable to unset OPENSSL_FORCE_FIPS_MODE: %v\n", err)
 			return
 		}
-		log.Println("Successfully restored openssl.cnf file.")
+		log.Println("Successfully unset OPENSSL_FORCE_FIPS_MODE.")
 	}, nil
 }

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -256,15 +256,11 @@ stages:
             # Build. This includes retry logic internally if necessary for this builder.
             - pwsh: |
                 eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ `
-                  $env:SUDO_CMD pwsh eng/run.ps1 run-builder -build `
+                  pwsh eng/run.ps1 run-builder -build `
                     -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
                     $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
                     $(if ('${{ parameters.builder.fips }}') { '-fipsmode' })
               displayName: Build
-              env:
-                ${{ if and(eq(parameters.builder.os, 'linux'), eq(parameters.builder.fips, true)) }}:
-                  # FIPS mode may require sudo to enable system-wide FIPS mode.
-                  SUDO_CMD: 'sudo'
 
             # Run each test retry attempt in its own step. Benefits over a single step:
             #
@@ -286,7 +282,7 @@ stages:
                   }
 
                   eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -successvar TEST_BUILDER_SUCCESSFUL -- `
-                    pwsh eng/run.ps1 run-builder -test `
+                    $env:SUDO_CMD pwsh eng/run.ps1 run-builder -test `
                       -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
                       $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
                       $(if ('${{ parameters.builder.fips }}') { '-fipsmode' })
@@ -295,6 +291,10 @@ stages:
                 ${{ else }}:
                   displayName: Test (🔁 ${{ attempt }})
                 name: test_${{ attempt }}
+                env:
+                  ${{ if eq(parameters.builder.os, 'linux'), eq(parameters.builder.fips, true)) }}:
+                    # FIPS mode may require sudo to enable system-wide FIPS mode.
+                    SUDO_CMD: 'sudo'
                 # Run unless a previous retry was successful or something catastrophic happens.
                 # Note: test failure returns success, so it doesn't count as catastrophic.
                 condition: and(ne(variables['TEST_BUILDER_SUCCESSFUL'], 'true'), succeeded())

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -282,7 +282,7 @@ stages:
                   }
 
                   eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ -successvar TEST_BUILDER_SUCCESSFUL -- `
-                    $env:SUDO_CMD pwsh eng/run.ps1 run-builder -test `
+                    pwsh eng/run.ps1 run-builder -test `
                       -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
                       $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
                       $(if ('${{ parameters.builder.fips }}') { '-fipsmode' })
@@ -291,10 +291,6 @@ stages:
                 ${{ else }}:
                   displayName: Test (🔁 ${{ attempt }})
                 name: test_${{ attempt }}
-                env:
-                  ${{ if and(eq(parameters.builder.os, 'linux'), eq(parameters.builder.fips, true)) }}:
-                    # FIPS mode may require sudo to enable system-wide FIPS mode.
-                    SUDO_CMD: 'sudo'
                 # Run unless a previous retry was successful or something catastrophic happens.
                 # Note: test failure returns success, so it doesn't count as catastrophic.
                 condition: and(ne(variables['TEST_BUILDER_SUCCESSFUL'], 'true'), succeeded())

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -292,7 +292,7 @@ stages:
                   displayName: Test (🔁 ${{ attempt }})
                 name: test_${{ attempt }}
                 env:
-                  ${{ if eq(parameters.builder.os, 'linux'), eq(parameters.builder.fips, true)) }}:
+                  ${{ if and(eq(parameters.builder.os, 'linux'), eq(parameters.builder.fips, true)) }}:
                     # FIPS mode may require sudo to enable system-wide FIPS mode.
                     SUDO_CMD: 'sudo'
                 # Run unless a previous retry was successful or something catastrophic happens.

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -256,11 +256,15 @@ stages:
             # Build. This includes retry logic internally if necessary for this builder.
             - pwsh: |
                 eng/run.ps1 cmdscan -envprefix GO_CMDSCAN_RULE_ `
-                  pwsh eng/run.ps1 run-builder -build `
+                  $env:SUDO_CMD pwsh eng/run.ps1 run-builder -build `
                     -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
                     $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
                     $(if ('${{ parameters.builder.fips }}') { '-fipsmode' })
               displayName: Build
+              env:
+                ${{ if and(eq(parameters.builder.os, 'linux'), eq(parameters.builder.fips, true)) }}:
+                  # FIPS mode may require sudo to enable system-wide FIPS mode.
+                  SUDO_CMD: 'sudo'
 
             # Run each test retry attempt in its own step. Benefits over a single step:
             #

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -2167,7 +2167,7 @@ index 00000000000000..a66c66ca386847
 +			// - In OpenSSL 1, the active engine doesn't support FIPS mode.
 +			// - In OpenSSL 1, the active engine supports FIPS mode, but it is not enabled.
 +			// - In OpenSSL 3, the provider used by default doesn't match the `fips=yes` query.
-+			panic("opensslcrypto: FIPS mode requested (" + fips140.Message + ") but not available in " + openssl.VersionText() + ": " + err.Error())
++			panic("opensslcrypto: FIPS mode requested (" + fips140.Message + ") but not available in " + openssl.VersionText())
 +		}
 +	} else if fips140.Disabled() {
 +		// TODO: Remove this block when GOFIPS=0 is no longer supported.

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .gitignore                                    |   2 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
- .../internal/backend/backendgen_test.go       | 284 +++++++++++++
+ .../internal/backend/backendgen_test.go       | 284 ++++++++++++++
  src/crypto/internal/backend/bbig/big.go       |  17 +
  .../internal/backend/bbig/big_boring.go       |  12 +
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
@@ -25,8 +25,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/backend/fips140/norequirefips.go |   9 +
  .../backend/fips140/nosystemcrypto.go         |  11 +
  .../internal/backend/fips140/openssl.go       |  41 ++
- src/crypto/internal/backend/nobackend.go      | 240 +++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 377 ++++++++++++++++++
+ src/crypto/internal/backend/nobackend.go      | 240 ++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 368 ++++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |   7 +-
  .../exp_allowcryptofallback_off.go            |   9 +
@@ -45,7 +45,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 41 files changed, 2517 insertions(+), 1 deletion(-)
+ 41 files changed, 2508 insertions(+), 1 deletion(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -2087,10 +2087,10 @@ index 00000000000000..7c3a95c2c64a2d
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..0c4e0c9da6e1ce
+index 00000000000000..a66c66ca386847
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,377 @@
+@@ -0,0 +1,368 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2167,16 +2167,7 @@ index 00000000000000..0c4e0c9da6e1ce
 +			// - In OpenSSL 1, the active engine doesn't support FIPS mode.
 +			// - In OpenSSL 1, the active engine supports FIPS mode, but it is not enabled.
 +			// - In OpenSSL 3, the provider used by default doesn't match the `fips=yes` query.
-+			//
-+			// A best-effort attempt is made to enable FIPS mode. It will only succeed if the following conditions are met:
-+			// - In OpenSSL 1, the active engine supports FIPS mode and FIPS mode can be enabled.
-+			// - In OpenSSL 3, there is an available provider that supports the `fips=yes` query.
-+			//
-+			// Note that this best effort is mainly to support test environments. FIPS-compliant production environments
-+			// like Mariner 2 and Azure Linux 3 (when executed in kernel FIPS mode) will already be properly configured.
-+			if err := openssl.SetFIPS(true); err != nil {
-+				panic("opensslcrypto: FIPS mode requested (" + fips140.Message + ") but not available in " + openssl.VersionText() + ": " + err.Error())
-+			}
++			panic("opensslcrypto: FIPS mode requested (" + fips140.Message + ") but not available in " + openssl.VersionText() + ": " + err.Error())
 +		}
 +	} else if fips140.Disabled() {
 +		// TODO: Remove this block when GOFIPS=0 is no longer supported.

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -8,6 +8,7 @@ Subject: [PATCH] Use crypto backends
  src/cmd/dist/build.go                         |  13 ++
  src/cmd/dist/test.go                          |  10 +-
  src/cmd/go/go_boring_test.go                  |  11 +-
+ src/cmd/go/script_test.go                     |   1 +
  src/cmd/go/testdata/script/darwin_no_cgo.txt  |   2 +
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/config.go            |   8 +
@@ -83,7 +84,7 @@ Subject: [PATCH] Use crypto backends
  src/net/smtp/smtp_test.go                     |  72 ++++---
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 79 files changed, 1118 insertions(+), 111 deletions(-)
+ 80 files changed, 1119 insertions(+), 111 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -198,6 +199,18 @@ index ed0fbf3d53d75b..8111b143a1295b 100644
  	tg := testgo(t)
  	defer tg.cleanup()
  	tg.parallel()
+diff --git a/src/cmd/go/script_test.go b/src/cmd/go/script_test.go
+index 390a36723787f4..105bac4e1c627b 100644
+--- a/src/cmd/go/script_test.go
++++ b/src/cmd/go/script_test.go
+@@ -254,6 +254,7 @@ func scriptEnv(srv *vcstest.Server, srvCertFile string) ([]string, error) {
+ 		"HGRCPATH=",
+ 		"GOTOOLCHAIN=auto",
+ 		"newline=\n",
++		"OPENSSL_FORCE_FIPS_MODE=" + os.Getenv("OPENSSL_FORCE_FIPS_MODE"), // useful for testing on Mariner 2.
+ 	}
+ 
+ 	if testenv.Builder() != "" || os.Getenv("GIT_TRACE_CURL") == "1" {
 diff --git a/src/cmd/go/testdata/script/darwin_no_cgo.txt b/src/cmd/go/testdata/script/darwin_no_cgo.txt
 index fa445925b7c374..e36ac86fcaa58d 100644
 --- a/src/cmd/go/testdata/script/darwin_no_cgo.txt

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Use crypto backends
  src/cmd/dist/build.go                         |  13 ++
  src/cmd/dist/test.go                          |  10 +-
  src/cmd/go/go_boring_test.go                  |  11 +-
- src/cmd/go/script_test.go                     |   1 +
+ src/cmd/go/script_test.go                     |   2 +
  src/cmd/go/testdata/script/darwin_no_cgo.txt  |   2 +
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/config.go            |   8 +
@@ -84,7 +84,7 @@ Subject: [PATCH] Use crypto backends
  src/net/smtp/smtp_test.go                     |  72 ++++---
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 80 files changed, 1119 insertions(+), 111 deletions(-)
+ 80 files changed, 1120 insertions(+), 111 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -200,17 +200,18 @@ index ed0fbf3d53d75b..8111b143a1295b 100644
  	defer tg.cleanup()
  	tg.parallel()
 diff --git a/src/cmd/go/script_test.go b/src/cmd/go/script_test.go
-index 390a36723787f4..105bac4e1c627b 100644
+index 390a36723787f4..0576ea8add72af 100644
 --- a/src/cmd/go/script_test.go
 +++ b/src/cmd/go/script_test.go
-@@ -254,6 +254,7 @@ func scriptEnv(srv *vcstest.Server, srvCertFile string) ([]string, error) {
- 		"HGRCPATH=",
- 		"GOTOOLCHAIN=auto",
- 		"newline=\n",
-+		"OPENSSL_FORCE_FIPS_MODE=" + os.Getenv("OPENSSL_FORCE_FIPS_MODE"), // useful for testing on Mariner 2.
- 	}
+@@ -297,6 +297,8 @@ var extraEnvKeys = []string{
+ 	"GO_TESTING_GOTOOLS", // for gccgo testing
+ 	"GCCGO",              // for gccgo testing
+ 	"GCCGOTOOLDIR",       // for gccgo testing
++
++	"OPENSSL_FORCE_FIPS_MODE", // useful for testing on Mariner 2.
+ }
  
- 	if testenv.Builder() != "" || os.Getenv("GIT_TRACE_CURL") == "1" {
+ // updateSum runs 'go mod tidy', 'go list -mod=mod -m all', or
 diff --git a/src/cmd/go/testdata/script/darwin_no_cgo.txt b/src/cmd/go/testdata/script/darwin_no_cgo.txt
 index fa445925b7c374..e36ac86fcaa58d 100644
 --- a/src/cmd/go/testdata/script/darwin_no_cgo.txt


### PR DESCRIPTION
As agreed in https://github.com/microsoft/go-lab/blob/main/docs/adr/0012-remove-gofips.md, we shouldn't try to modify the OpenSSL FIPS mode.

This PR removes the `openssl.SetFIPS(true)` call and update our build scripts to enable FIPS mode system-wide.

Our CI Mariner 2 image is not FIPS-enabled by default, so we need to force FIPS mode by setting `OPENSSL_FORCE_FIPS_MODE`. That flag should be passes to the `TestScript` child processes as they only inherit a filtered set of environment variables, which includes `GODEBUG`.

Note that since we switched from `GOFIPS` to `GODEBUG=fips140`, our test FIPS test coverage has increased, as `GOFIPS` was not being passed to `TestScript` child processes, making them not aware of the required FIPS mode.

Also, this is unlikely that users need to update their code to also pass `OPENSSL_FORCE_FIPS_MODE` to child processes that don't inherit all environment variables. Mainly because they should be running a FIPS-enabled Mariner image on production. If they don't, possible for testing purposes, then child processes won't inherit the `GODEBUG` env var neither.

For #1445.