### PR TITLE
Override prod branch classification settings

### DIFF
--- a/.azuredevops/policies/branchClassification.yml
+++ b/.azuredevops/policies/branchClassification.yml
@@ -10,5 +10,6 @@ configuration:
     ruleset:
       - name: prod-branches
         branchNames:
+          - microsoft/main
           - microsoft/release-branch.go*
         classification: production

--- a/.azuredevops/policies/branchClassification.yml
+++ b/.azuredevops/policies/branchClassification.yml
@@ -1,0 +1,14 @@
+# Schema taken from https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/product-catalog/branch-classification/branch-classification#optional-update-branch-classification-at-the-repo.
+name: branch_classification
+description: Branch classification configuration for repository
+resource: repository
+disabled: false
+where:
+configuration:
+  branchClassificationSettings:
+    defaultClassification: nonproduction
+    ruleset:
+      - name: prod-branches
+        branchNames:
+          - microsoft/release-branch.go*
+        classification: production


### PR DESCRIPTION
Our release branches doesn't follow the naming convention defined in the [1ES docs](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/release-features/release-gating#branch-validation-1es-pt). It is currently triggers a warning in the CI pipeline: https://dev.azure.com/dnceng/internal/_build/results?buildId=2631901&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=addd52ba-d56f-51fd-7dca-9d3595bf7642&l=15, but it will soon (~10 days) start failing the build.

We could change the name of the production branch to follow the documented patterns, but that would require non-trivial changes in several places. For now, just override the branch detection settings as defined in [this other 1ES docs](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/product-catalog/branch-classification/branch-classification#optional-update-branch-classification-at-the-repo).