### PR TITLE
Retry Darwin CI builds

### DIFF
--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -43,6 +43,10 @@ stages:
                 # "Access Denied" during EXE copying and general flakiness during tests.
                 ${{ if eq(builder.os, 'windows') }}:
                   retryAttempts: [1, 2, 3, 4, "FINAL"]
+                # Attempt to retry the build on macOS to mitigate flakiness:
+                # "read: connection reset by peer" in cmd/go tests
+                ${{ if eq(builder.os, 'darwin') }}:
+                  retryAttempts: [1, 2, "FINAL"]
 
     - ${{ if eq(parameters.sign, true) }}:
       - template: pool.yml


### PR DESCRIPTION
Darwin builds are flaky due to ocasional `read: connection reset by peer`, even when connecting to localhost. This is an infra issue, not a bug in the code, so we can mitigate it by retrying.