### PR TITLE
Add dotnet-public NuGet feed to Release Studio project

### DIFF
--- a/eng/release-studio/NuGet.config
+++ b/eng/release-studio/NuGet.config
@@ -7,6 +7,12 @@
   <packageSources>
     <clear />
     <add key="MicroBuildToolset" value="https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json" />
+    <!--
+      When the .NET SDK version doesn't match the TargetFramework, get targeting
+      packs (Microsoft.NETCore.App.Ref, Microsoft.WindowsDesktop.App.Ref, and
+      Microsoft.AspNetCore.App.Ref) from here.
+    -->
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
This helps the project be resilient to .NET SDK version changes in the build agent.

Fixes https://dev.azure.com/dnceng/internal/_build/results?buildId=2634826&view=logs&j=b47266cd-7034-57a5-a108-6a47cef1cb63&t=a60f8fbd-d15a-5db3-b99f-17371d79840f&l=32:

```
##[error]eng\release-studio\ReleaseStudio.csproj(0,0): Error NU1101: Unable to find package Microsoft.NETCore.App.Ref. No packages exist with this id in source(s): MicroBuildToolset
##[error]eng\release-studio\ReleaseStudio.csproj(0,0): Error NU1101: Unable to find package Microsoft.WindowsDesktop.App.Ref. No packages exist with this id in source(s): MicroBuildToolset
##[error]eng\release-studio\ReleaseStudio.csproj(0,0): Error NU1101: Unable to find package Microsoft.AspNetCore.App.Ref. No packages exist with this id in source(s): MicroBuildToolset
```

Tested in 1.22 branch, no conflicts when applying to main: https://dev.azure.com/dnceng/internal/_build/results?buildId=2635362&view=results

Kicked off a build with this branch: https://dev.azure.com/dnceng/internal/_build/results?buildId=2635366&view=results