### PR TITLE
[release-branch.go1.23] Add dotnet-public NuGet feed to Release Studio project

### DIFF
--- a/eng/release-studio/NuGet.config
+++ b/eng/release-studio/NuGet.config
@@ -7,6 +7,12 @@
   <packageSources>
     <clear />
     <add key="MicroBuildToolset" value="https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json" />
+    <!--
+      When the .NET SDK version doesn't match the TargetFramework, get targeting
+      packs (Microsoft.NETCore.App.Ref, Microsoft.WindowsDesktop.App.Ref, and
+      Microsoft.AspNetCore.App.Ref) from here.
+    -->
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
This helps the project be resilient to .NET SDK version changes in the build agent.

(cherry picked from commit 7dc0b5eaa6ac80d24ac03252381944e4e877cd46, https://github.com/microsoft/go/pull/1528)