### PR TITLE
[release-branch.go1.23] Upgrade CNG backend

### DIFF
--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1094,26 +1094,26 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index 49d6362771d4b2..1cba724d406b3a 100644
+index 49d6362771d4b2..e6732366baebd4 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.23
  
  require (
  	github.com/golang-fips/openssl/v2 v2.0.4-0.20241114123251-c5672cc7ce15
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
++	github.com/microsoft/go-crypto-winnative v0.0.0-20250211161411-fea4f38f45ec
  	golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a
  	golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c
  )
 diff --git a/src/go.sum b/src/go.sum
-index f88678bf643820..c86114e6cf3c8a 100644
+index f88678bf643820..73e7bc41ab2fe2 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/golang-fips/openssl/v2 v2.0.4-0.20241114123251-c5672cc7ce15 h1:6Mb55x7RlLVNEPY6liVYeVTMR5FuZqHViyyrr7tih7A=
  github.com/golang-fips/openssl/v2 v2.0.4-0.20241114123251-c5672cc7ce15/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd h1:2ziav5Bdjyv0VYCCftEExmA+QQZ193w8BvSgoEZ+qAY=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250211161411-fea4f38f45ec h1:sgB+KKrkX1u1v8C1kFrGThsVw0rPUSqNmWYmzGs0Iy4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250211161411-fea4f38f45ec/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a h1:37MIv+iGfwMYzWJECGyrPCtd5nuqcciRUeJfkNCkCf0=
  golang.org/x/crypto v0.23.1-0.20240603234054-0b431c7de36a/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
  golang.org/x/net v0.25.1-0.20240603202750-6249541f2a6c h1:CR/7/SLUhIJw6g675eeoDiwggElO2MV9rGkNYjqi8GM=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -55,13 +55,13 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../microsoft/go-crypto-winnative/cng/rand.go |  28 +
  .../microsoft/go-crypto-winnative/cng/rc4.go  |  61 ++
  .../microsoft/go-crypto-winnative/cng/rsa.go  | 374 ++++++++
- .../go-crypto-winnative/cng/tls1prf.go        |  92 ++
+ .../go-crypto-winnative/cng/tls1prf.go        |  93 ++
  .../internal/bcrypt/bcrypt_windows.go         | 284 ++++++
  .../internal/bcrypt/zsyscall_windows.go       | 389 ++++++++
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 56 files changed, 9221 insertions(+)
+ 56 files changed, 9222 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -8780,10 +8780,10 @@ index 00000000000000..7e3f7abe3487cb
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
 new file mode 100644
-index 00000000000000..30ef2242bc3cf3
+index 00000000000000..e8f5c904fec325
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,93 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -8834,6 +8834,7 @@ index 00000000000000..30ef2242bc3cf3
 +	if err := bcrypt.GenerateSymmetricKey(alg, &kh, nil, secret, 0); err != nil {
 +		return err
 +	}
++	defer bcrypt.DestroyKey(kh)
 +
 +	buffers := make([]bcrypt.Buffer, 0, 3)
 +	if len(label) > 0 {
@@ -9661,7 +9662,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b8a0b84a282a32..8329b1b4649b69 100644
+index b8a0b84a282a32..676e784fcf04e2 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
@@ -9669,7 +9670,7 @@ index b8a0b84a282a32..8329b1b4649b69 100644
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
++# github.com/microsoft/go-crypto-winnative v0.0.0-20250211161411-fea4f38f45ec
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
Contains https://github.com/microsoft/go-crypto-winnative/pull/89.