### PR TITLE
[release-branch.go1.22] Upgrade CNG backend

### DIFF
--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1068,26 +1068,26 @@ index a0548a7f9179c5..ae6117a1554b7f 100644
  package x509
  
 diff --git a/src/go.mod b/src/go.mod
-index d5ab3864107477..de6d1d58a0665e 100644
+index d5ab3864107477..04e1efe2a5a926 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -4,6 +4,7 @@ go 1.22
  
  require (
  	github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241114123242-248af7388443
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
++	github.com/microsoft/go-crypto-winnative v0.0.0-20250211161421-4edbd9b94d35
  	golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb
  	golang.org/x/net v0.19.1-0.20240412193750-db050b07227e
  )
 diff --git a/src/go.sum b/src/go.sum
-index be018b2249bcbf..6422ae3e1e8abd 100644
+index be018b2249bcbf..b1a71dcac5b369 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,5 +1,7 @@
  github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241114123242-248af7388443 h1:Mc/ODcDwmipcEj9deXLpre2xfu2uv9HalqpQXtJvN5o=
  github.com/golang-fips/openssl/v2 v2.0.0-rc.3.0.20241114123242-248af7388443/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd h1:2ziav5Bdjyv0VYCCftEExmA+QQZ193w8BvSgoEZ+qAY=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250211161421-4edbd9b94d35 h1:VPMHBcE3GucQdMQylMeuk5XGpduM5P7FF5j1HbGDlWg=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250211161421-4edbd9b94d35/go.mod h1:fveERXKbeK+XLmOyU24caKnIT/S5nniAX9XCRHfnrM4=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb h1:1ceSY7sk6sJuiDREHpfyrqDnDljsLfEP2GuTClhBBfI=
  golang.org/x/crypto v0.16.1-0.20231129163542-152cdb1503eb/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
  golang.org/x/net v0.19.1-0.20240412193750-db050b07227e h1:oDnvqaqHo3ho8OChMtkQbQAyp9eqnm3J7JRtt0+Cabc=

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -53,13 +53,13 @@ To reproduce, run 'go mod vendor' in 'go/src'.
  .../microsoft/go-crypto-winnative/cng/rand.go |  28 +
  .../microsoft/go-crypto-winnative/cng/rc4.go  |  61 ++
  .../microsoft/go-crypto-winnative/cng/rsa.go  | 374 ++++++++
- .../go-crypto-winnative/cng/tls1prf.go        |  92 ++
+ .../go-crypto-winnative/cng/tls1prf.go        |  93 ++
  .../internal/bcrypt/bcrypt_windows.go         | 284 ++++++
  .../internal/bcrypt/zsyscall_windows.go       | 389 ++++++++
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  11 +
- 54 files changed, 9072 insertions(+)
+ 54 files changed, 9073 insertions(+)
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/LICENSE
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/README.md
@@ -8615,10 +8615,10 @@ index 00000000000000..7e3f7abe3487cb
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
 new file mode 100644
-index 00000000000000..30ef2242bc3cf3
+index 00000000000000..e8f5c904fec325
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,93 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -8669,6 +8669,7 @@ index 00000000000000..30ef2242bc3cf3
 +	if err := bcrypt.GenerateSymmetricKey(alg, &kh, nil, secret, 0); err != nil {
 +		return err
 +	}
++	defer bcrypt.DestroyKey(kh)
 +
 +	buffers := make([]bcrypt.Buffer, 0, 3)
 +	if len(label) > 0 {
@@ -9496,7 +9497,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 9a234e59b10c8c..832d0ac91cdaea 100644
+index 9a234e59b10c8c..52273a8e600c78 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@
@@ -9504,7 +9505,7 @@ index 9a234e59b10c8c..832d0ac91cdaea 100644
 +## explicit; go 1.20
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20240925170411-b29b5cde7fdd
++# github.com/microsoft/go-crypto-winnative v0.0.0-20250211161421-4edbd9b94d35
 +## explicit; go 1.17
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
Contains https://github.com/microsoft/go-crypto-winnative/pull/88.