### PR TITLE
Fix single-feed error with Release Studio nuget.config

### DIFF
--- a/eng/release-studio/NuGet.config
+++ b/eng/release-studio/NuGet.config
@@ -6,13 +6,8 @@
 <configuration>
   <packageSources>
     <clear />
+    <!-- Only one feed is allowed. https://aka.ms/cfs/nuget -->
     <add key="MicroBuildToolset" value="https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json" />
-    <!--
-      When the .NET SDK version doesn't match the TargetFramework, get targeting
-      packs (Microsoft.NETCore.App.Ref, Microsoft.WindowsDesktop.App.Ref, and
-      Microsoft.AspNetCore.App.Ref) from here.
-    -->
-    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/release-studio/ReleaseStudio.csproj
+++ b/eng/release-studio/ReleaseStudio.csproj
@@ -3,7 +3,17 @@
 
   <!-- Minimal info for '.csproj' to work. -->
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <!--
+      We only have a single NuGet feed, and that feed doesn't have any targeting
+      packs (Microsoft.NETCore.App.Ref, Microsoft.WindowsDesktop.App.Ref, and
+      Microsoft.AspNetCore.App.Ref). To avoid downloading any targeting packs,
+      we need the Target Framework to match the .NET SDK exactly. The SDK may be
+      upgraded without our knowledge, so a hard-coded version is fragile. Use
+      BundledNETCoreAppTargetFrameworkVersion to be flexible.
+
+      We aren't actually building an app anyway, we just need the RM package.
+    -->
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/signing/NuGet.config
+++ b/eng/signing/NuGet.config
@@ -6,6 +6,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <!-- Multiple feeds are allowed, but only because they are both in dnceng/public. -->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
Noticed this issue in our main and release builds after https://github.com/microsoft/go/pull/1528. ([Ex](https://dev.azure.com/dnceng/internal/_build/results?buildId=2639478&view=results).) It turns out that using multiple feeds in this situation is a problem. (See comments.) Fix it by removing the feed and using a workaround.

I didn't catch it because the multi-feed detector is only working on our macOS agents. (We don't use a shallow checkout there, and shallow checkout seems to cause a silent detector failure on all our other stages.) I had only internally tested that https://github.com/microsoft/go/pull/1528 didn't break our publish stages.

I'll need to backport this fix to the release branches.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2640418&view=results

---

I'd considered this `BundledNETCoreAppTargetFrameworkVersion` workaround earlier, but didn't apply it at first because it seemed like the simpler fix of using multiple feeds was working. I'm not the first person to think of it, though:

* https://github.com/xamarin/xamarin-macios/blob/e438c227c1388299bc569cdf573bff2f88b3a21c/tools/nnyeah/nnyeah/nnyeah.csproj#L5
* https://github.com/NuGet/NuGet.Client/blob/372cc75f8686d386752cf8677eb4e62a12e4d3d9/test/NuGet.Tests.Apex/NuGet.OptProf/Assets/PackageReferenceSdk/PackageReferenceSdk/PackageReferenceSdk.csproj#L4