### PR TITLE
Fix Release Studio script gathering: stable target dir

### DIFF
--- a/eng/pipeline/stages/public-publish-stage.yml
+++ b/eng/pipeline/stages/public-publish-stage.yml
@@ -48,7 +48,7 @@ stages:
           - name: GoBinariesDir
             value: $(Pipeline.Workspace)/Binaries Signed
           - name: NetCorePublishingScripts
-            value: $(Build.SourcesDirectory)/eng/release-studio/bin/Debug/net7.0/MsGoPublishingScripts
+            value: $(Build.SourcesDirectory)/eng/release-studio/bin/MsGoPublishingScripts
 
           # This is read directly by release studio scripts through env.
           - name: RMExecutionEnvironment
@@ -70,6 +70,7 @@ stages:
               projects: '$(Build.SourcesDirectory)/eng/release-studio/ReleaseStudio.csproj'
               custom: build
               arguments: >-
+                /p:NetCorePublishingScripts=$(NetCorePublishingScripts)
                 /bl:eng/release-studio/Build.binlog
                 /v:n
 

--- a/eng/release-studio/ReleaseStudio.csproj
+++ b/eng/release-studio/ReleaseStudio.csproj
@@ -14,10 +14,27 @@
       We aren't actually building an app anyway, we just need the RM package.
     -->
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+
+    <!-- Default value for simple local repro. -->
+    <MsGoPublishingScripts>$(MSBuildThisFileDirectory)bin\MsGoPublishingScripts</MsGoPublishingScripts>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="DevDiv.RM.MS.Go.Publishing" Version="20240703.4.0" />
   </ItemGroup>
+
+  <!--
+    The scripts end up in a dir with Debug/Release and TargetFramework in the
+    path, which we don't want to rely on. So, copy them to a known place too.
+    Use the ScriptFilesToCopy items gathered by MsGoPublishingScriptsCopy.
+  -->
+  <Target
+    Name="CopyPublishingScriptsToStableLocation"
+    AfterTargets="MsGoPublishingScriptsCopy">
+
+    <Copy
+      SourceFiles="@(ScriptFilesToCopy)"
+      DestinationFolder="$([MSBuild]::NormalizeDirectory('$(MsGoPublishingScripts)', '%(RecursiveDir)'))" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
* Followup for https://github.com/microsoft/go/pull/1549

The build still depended on "net7.0" and failed. https://dev.azure.com/dnceng/internal/_build/results?buildId=2640418&view=results

Full test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2640583&view=results

Also started a publish-only run this time to get some earlier warning: https://dev.azure.com/dnceng/internal/_build/results?buildId=2640581&view=results
