### PR TITLE
Upgrade go-crypto-winnative CNG backend to latest

### DIFF
--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -94,14 +94,14 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/rc4.go  |  65 ++
  .../microsoft/go-crypto-winnative/cng/rsa.go  | 396 ++++++++++
  .../microsoft/go-crypto-winnative/cng/sha3.go | 311 ++++++++
- .../go-crypto-winnative/cng/tls1prf.go        |  88 +++
+ .../go-crypto-winnative/cng/tls1prf.go        |  89 +++
  .../internal/bcrypt/bcrypt_windows.go         | 368 +++++++++
  .../internal/bcrypt/ntstatus_windows.go       |  45 ++
  .../internal/bcrypt/zsyscall_windows.go       | 412 ++++++++++
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  16 +
- 95 files changed, 13813 insertions(+), 7 deletions(-)
+ 95 files changed, 13814 insertions(+), 7 deletions(-)
  create mode 100644 src/crypto/internal/backend/deps_ignore.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
@@ -222,7 +222,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index ccfdbd8ea22d77..848995bdafa375 100644
+index ccfdbd8ea22d77..8279edd727aada 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -233,10 +233,10 @@ index ccfdbd8ea22d77..848995bdafa375 100644
 +require (
 +	github.com/golang-fips/openssl/v2 v2.0.4-0.20250115103809-bf655f6d08d6
 +	github.com/microsoft/go-crypto-darwin v0.0.2-0.20250116101429-467bd63a2d67
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20250110072644-50d2dfac4b70
++	github.com/microsoft/go-crypto-winnative v0.0.0-20250211154640-f49c8e1379ea
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 4d6a33e34a4e63..6a09a77031befa 100644
+index 4d6a33e34a4e63..501aecb4cccb41 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
@@ -244,8 +244,8 @@ index 4d6a33e34a4e63..6a09a77031befa 100644
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20250115103809-bf655f6d08d6/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250116101429-467bd63a2d67 h1:SI0IFiHducwfamZR7pv6jb92oc5o/z5tn66wynS6ADE=
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250116101429-467bd63a2d67/go.mod h1:LyP4oZ0QcysEJdqUTOk9ngNFArRFK94YRImkoJ8julQ=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20250110072644-50d2dfac4b70 h1:97wOagHu7OExwU929NjuPIlUEUaFIQtffQMaVj0mR5E=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20250110072644-50d2dfac4b70/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250211154640-f49c8e1379ea h1:JuRzAUOV9uaQdoNeuHyOEAJbpRahsICnwfPPGzzuzRw=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250211154640-f49c8e1379ea/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
  golang.org/x/crypto v0.30.0 h1:RwoQn3GkWiMkzlX562cLB7OxWvjH1L8xutO2WoJcRoY=
  golang.org/x/crypto v0.30.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
  golang.org/x/net v0.32.1-0.20250121202134-9a960c88dd98 h1:36bTiCRO7f/J3t+LumnLTJDXqxsp1x6Q7754SsRD9u4=
@@ -427,7 +427,7 @@ index 00000000000000..1bfbaf60f4dd58
 +All supported OpenSSL versions pass a small set of automatic tests that ensure they can be built and that there are no major regressions.
 +These tests do not validate the cryptographic correctness of the `openssl` package.
 +
-+On top of that, the [golang-fips Go fork](https://github.com/golang-fips/go) -maintained by Red Hat- and the [Microsoft build of Go](https://github.com/microsoft/go), tests a subset of the supported OpenSSL versions when integrated with the Go `crypto` package.
++On top of that, the [golang-fips Go fork](https://github.com/golang-fips/go) -maintained by Red Hat- and the [Microsoft Go fork](https://github.com/microsoft/go), tests a subset of the supported OpenSSL versions when integrated with the Go `crypto` package.
 +These tests are much more exhaustive and validate a specific OpenSSL version can produce working applications.
 +
 +### Building without OpenSSL headers
@@ -14134,10 +14134,10 @@ index 00000000000000..15c1345475a3b1
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
 new file mode 100644
-index 00000000000000..5a3fb01606ef95
+index 00000000000000..56131a6bc93d3f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
-@@ -0,0 +1,88 @@
+@@ -0,0 +1,89 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -14184,6 +14184,7 @@ index 00000000000000..5a3fb01606ef95
 +	if err := bcrypt.GenerateSymmetricKey(alg, &kh, nil, secret, 0); err != nil {
 +		return err
 +	}
++	defer bcrypt.DestroyKey(kh)
 +
 +	buffers := make([]bcrypt.Buffer, 0, 3)
 +	if len(label) > 0 {
@@ -15169,7 +15170,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index d42f50b43ccdba..61fda0cbe57e34 100644
+index d42f50b43ccdba..8f04bd6fc8fd78 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,19 @@
@@ -15182,7 +15183,7 @@ index d42f50b43ccdba..61fda0cbe57e34 100644
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/cryptokit
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20250110072644-50d2dfac4b70
++# github.com/microsoft/go-crypto-winnative v0.0.0-20250211154640-f49c8e1379ea
 +## explicit; go 1.22
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
This was already applied to the 1.24 branch, but not main.