### PR TITLE
Set go1.23 as previous stable version

### DIFF
--- a/eng/_util/cmd/updatelinktable/updatelinktable.go
+++ b/eng/_util/cmd/updatelinktable/updatelinktable.go
@@ -37,7 +37,8 @@ var supported = []version{
 		},
 	},
 	{
-		Number: "1.23",
+		Number:         "1.23",
+		PreviousStable: true,
 		Platforms: map[string]struct{}{
 			"linux-amd64":   {},
 			"linux-arm64":   {},

--- a/eng/doc/release-branch-links.json
+++ b/eng/doc/release-branch-links.json
@@ -86,6 +86,7 @@
   {
     "version": "go1.23",
     "stable": true,
+    "previousStable": true,
     "files": [
       {
         "filename": "go1.23.src.tar.gz",


### PR DESCRIPTION
We missed to mark Go 1.23 as the previous stable version in #1559. Do it now.