### PR TITLE
Upgrade Go bootstrap version to go1.24.0-1

### DIFF
--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -149,16 +149,10 @@ stages:
 
           # Initialize stage 0 toolset ahead of time so we can track timing data separately from the
           # build operations. When we call this script again later, it won't download Go again.
-          - ${{ if eq(parameters.builder.os, 'darwin') }}:
-            - task: GoTool@0
-              inputs:
-                version: '1.23.3'
-              displayName: Init upstream stage 0 Go toolset
-          - ${{ else }}:
-            - pwsh: |
-                . eng/utilities.ps1
-                Download-Stage0
-              displayName: Init stage 0 Go toolset
+          - pwsh: |
+              . eng/utilities.ps1
+              Download-Stage0
+            displayName: Init stage 0 Go toolset
 
           - template: ../steps/init-submodule-task.yml
 

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -94,11 +94,6 @@ stages:
             - name: MS_GO_UTIL_ALLOW_ONLY_MINIMAL_DEPS
               value: '1'
 
-          # On darwin (macOS) we haven't released a Microsoft build Go toolchain.
-          - ${{ if eq(parameters.builder.os, 'darwin') }}:
-            - name: MS_USE_PATH_GO
-              value: '1'
-
           - ${{ if eq(parameters.builder.config, 'codeql_inner') }}:
             # Manually specify the repository being scanned by this job because
             # CodeQL can't detect the inner repository (the submodule)

--- a/eng/utilities.ps1
+++ b/eng/utilities.ps1
@@ -24,7 +24,7 @@ function Download-Stage0() {
   # pre-installed (or the right version pre-installed). This CI script installs a consistent version
   # of Go to handle this. This also makes it easier to locally repro issues in CI that involve a
   # specific version of Go. The downloaded copy of Go is called the "stage 0" version.
-  $stage0_go_version = 'go1.23.3-1'
+  $stage0_go_version = 'go1.24.0-1'
 
   # Source the install script so that we can use the PATH it assigns.
   $installScriptPath = Join-Path $PSScriptRoot "_util" "go-install.ps1"

--- a/eng/utilities.ps1
+++ b/eng/utilities.ps1
@@ -28,7 +28,7 @@ function Download-Stage0() {
 
   # Source the install script so that we can use the PATH it assigns.
   $installScriptPath = Join-Path $PSScriptRoot "_util" "go-install.ps1"
-  . $installScriptPath -Version $stage0_go_version
+  . $installScriptPath -Version $stage0_go_version -AzurePipelinePath
 }
 
 # Copied from https://github.com/dotnet/install-scripts/blob/49d5da7f7d313aa65d24fe95cc29767faef553fd/src/dotnet-install.ps1#L180-L197

--- a/eng/utilities.ps1
+++ b/eng/utilities.ps1
@@ -28,7 +28,7 @@ function Download-Stage0() {
 
   # Source the install script so that we can use the PATH it assigns.
   $installScriptPath = Join-Path $PSScriptRoot "_util" "go-install.ps1"
-  . $installScriptPath -Version $stage0_go_version -AzurePipelinePath
+  . $installScriptPath -Version $stage0_go_version
 }
 
 # Copied from https://github.com/dotnet/install-scripts/blob/49d5da7f7d313aa65d24fe95cc29767faef553fd/src/dotnet-install.ps1#L180-L197


### PR DESCRIPTION
Bump bootstrap version to go1.24.0-1. This allows using MS Go when bootstrapping on macOS.