### PR TITLE
Log all stdout in CI

### DIFF
--- a/eng/_util/buildutil/buildutil.go
+++ b/eng/_util/buildutil/buildutil.go
@@ -5,8 +5,6 @@
 package buildutil
 
 import (
-	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -123,39 +121,6 @@ func UnassignGOROOT() error {
 		}
 	}
 	return nil
-}
-
-// NewStripTestJSONWriter strips all individual test results and output entries from a JSON stream.
-// Only the overall package test results are written to the underlying writer.
-func NewStripTestJSONWriter(w io.Writer) io.Writer {
-	pr, pw := io.Pipe()
-	go func() {
-		type test struct {
-			Action  string
-			Package string
-			Test    string
-		}
-		sc := bufio.NewScanner(pr)
-		for sc.Scan() {
-			var t test
-			err := json.Unmarshal(sc.Bytes(), &t)
-			if err == nil && (t.Test != "" || t.Action == "output") {
-				// Omit the test result.
-				continue
-			}
-			_, err = w.Write(append(sc.Bytes(), '\n'))
-			if err != nil {
-				pw.CloseWithError(err)
-				return
-			}
-		}
-		if err := sc.Err(); err != nil {
-			pw.CloseWithError(err)
-			return
-		}
-		pw.Close()
-	}()
-	return pw
 }
 
 // RunCmdMultiWriter runs a command and outputs the stdout to multiple [io.Writer].

--- a/eng/_util/cmd/build/build.go
+++ b/eng/_util/cmd/build/build.go
@@ -223,7 +223,7 @@ func build(o *options) (err error) {
 					err = closeErr
 				}
 			}()
-			if err := buildutil.RunCmdMultiWriter(testCommandLine, conv, buildutil.NewStripTestJSONWriter(os.Stdout)); err != nil {
+			if err := buildutil.RunCmdMultiWriter(testCommandLine, conv, os.Stdout); err != nil {
 				return err
 			}
 		} else {

--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -215,7 +215,7 @@ func main() {
 					log.Fatal(err)
 				}
 			}()
-			err = buildutil.RunCmdMultiWriter(cmdline, conv, buildutil.NewStripTestJSONWriter(os.Stdout))
+			err = buildutil.RunCmdMultiWriter(cmdline, conv, os.Stdout)
 			// If we got an ExitError, the error message was already printed by the command. We just
 			// need to exit with the same exit code.
 			if exitErr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
Having all the test logs is handy when debugging issues, even if it is too verbose.