### PR TITLE
Add docs/ readme, update release note file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Release Notes
+
+This directory contains release notes for the current branch's major version of the Microsoft build of Go.
+Each branch contains the final release notes for that major version and notes for minor releases of that major version, if any have been written.
+
+> [!IMPORTANT]
+> General docs for the Microsoft build of Go are in the [root README](/README.md), and additional docs are [in `eng/doc`](/eng/doc).

--- a/docs/go1.23.md
+++ b/docs/go1.23.md
@@ -1,3 +1,0 @@
-# Microsoft build of Go 1.23 release notes
-
-After the release of 1.23, 1.21 is no longer supported, per the [Go release policy](https://go.dev/doc/devel/release).

--- a/docs/go1.25.md
+++ b/docs/go1.25.md
@@ -1,0 +1,3 @@
+# Microsoft build of Go 1.25 release notes
+
+After the release of 1.25, 1.23 is no longer supported, per the [Go release policy](https://go.dev/doc/devel/release).


### PR DESCRIPTION
Add a readme to docs/ with links to the readme and eng/doc for those who click on docs/ instinctively.

Update the old release notes doc to 1.25 while I'm here.