### PR TITLE
Work around Component Governance false positives

### DIFF
--- a/eng/_util/go.mod
+++ b/eng/_util/go.mod
@@ -4,16 +4,18 @@
 
 module github.com/microsoft/go/_util
 
-go 1.22.0
+go 1.23.0
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/microsoft/go-infra v0.0.7-0.20250217095817-3d02b2f77127
 	github.com/microsoft/go-infra/goinstallscript v0.0.0-20250210150554-f31015b54477
-	golang.org/x/sys v0.30.0
+	golang.org/x/net v0.39.0
+	golang.org/x/sys v0.32.0
 )
 
 require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5 // indirect
-	golang.org/x/text v0.22.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
 )

--- a/eng/_util/go.sum
+++ b/eng/_util/go.sum
@@ -1,5 +1,7 @@
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -9,9 +11,11 @@ github.com/microsoft/go-infra v0.0.7-0.20250217095817-3d02b2f77127 h1:nb0pU3pHQU
 github.com/microsoft/go-infra v0.0.7-0.20250217095817-3d02b2f77127/go.mod h1:TYHdrIvfN+aAbpD0KYTK7zUMHu/HjOr3FSjpLtuLA2k=
 github.com/microsoft/go-infra/goinstallscript v0.0.0-20250210150554-f31015b54477 h1:wTb+eE4fmHYaHok8MROCDSNBprhBPlj5IAx3KP4MGfU=
 github.com/microsoft/go-infra/goinstallscript v0.0.0-20250210150554-f31015b54477/go.mod h1:SFsdKAEHdmGsGoh8FkksVaxoQ3rnnJ/TBqN09Ml/0Cw=
-golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
-golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
-golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
 golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=

--- a/eng/_util/tools/cg_tools.go
+++ b/eng/_util/tools/cg_tools.go
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build tools
+
+package tools
+
+// Work around Go detector false positives: import dependencies just so that we can upgrade
+// them. See https://github.com/microsoft/component-detection/issues/1333
+
+import (
+	_ "github.com/golang-jwt/jwt/v5"
+	_ "golang.org/x/net/http2"
+)


### PR DESCRIPTION
Apply usual workaround (no side effects) for:

* https://github.com/microsoft/component-detection/issues/1333

This will get our CG detections down to zero in s360 with minimal work by hand now and generating minimal ongoing work in the future.