### PR TITLE
[microsoft/release-branch.go1.23] Port CODEOWNERS to 1.23 for infra compatibility

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
-# Require review from golang-compiler team for changes in any file. This keeps us in the loop on
-# auto-merge PRs. The review bot is also an owner so that it can still trigger auto-merge for sync
-# PRs on its own. We may remove this rule once auto-merges are routine.
-* @microsoft/golang-compiler @microsoft-golang-review-bot
+# Require review from golang-compiler team for changes in all files.
 
-# Automatically request review from golang-compiler team for changes in the Microsoft-specific
-# files. This takes precedence over earlier rules in the file.
-/eng/ @microsoft/golang-compiler
+* @microsoft/golang-compiler
+
+# Don't assign a code owner to automatically updated files to allow GitHub apps to use the
+# auto-merge flow without human intervention.
+/go
+/MICROSOFT_REVISION
+/VERSION


### PR DESCRIPTION
Port current state of CODEOWNERS file in microsoft/main to release branch for infrastructure compatibility.