### PR TITLE
Remove unnecessary hash from fips140 godebug

### DIFF
--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -1684,7 +1684,7 @@ index 00000000000000..ef5af5d956163e
 +}
 diff --git a/src/crypto/internal/backend/fips140/fips140.go b/src/crypto/internal/backend/fips140/fips140.go
 new file mode 100644
-index 00000000000000..72f7a1644deedd
+index 00000000000000..7e5dd9b1544940
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/fips140.go
 @@ -0,0 +1,63 @@
@@ -1699,7 +1699,7 @@ index 00000000000000..72f7a1644deedd
 +	"syscall"
 +)
 +
-+var fips140GODEBUG = godebug.New("#fips140")
++var fips140GODEBUG = godebug.New("fips140")
 +
 +// Enabled reports whether FIPS 140 mode is enabled by using GODEBUG, GOFIPS, GOLANG_FIPS,
 +// the 'requirefips' build tag, or any other platform-specific mechanism.
@@ -2672,10 +2672,10 @@ index 00000000000000..5e4b436554d44d
 +// from complaining about the missing body
 +// (because the implementation might be here).
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index fd1ee4f0e36bce..9881eab7c523a2 100644
+index 2adf8c897229cf..74d0bc1d6439a3 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -515,6 +515,11 @@ var depsRules = `
+@@ -536,6 +536,11 @@ var depsRules = `
  	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
  	< github.com/microsoft/go-crypto-winnative/cng;
  
@@ -2687,7 +2687,7 @@ index fd1ee4f0e36bce..9881eab7c523a2 100644
  	FIPS, internal/godebug < crypto/fips140;
  
  	crypto, hash !< FIPS;
-@@ -525,16 +530,28 @@ var depsRules = `
+@@ -546,16 +551,28 @@ var depsRules = `
  	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
  	sync/atomic < crypto/internal/boring/bcache;
  
@@ -2718,7 +2718,7 @@ index fd1ee4f0e36bce..9881eab7c523a2 100644
  	< crypto/boring
  	< crypto/aes,
  	  crypto/des,
-@@ -558,8 +575,12 @@ var depsRules = `
+@@ -579,8 +596,12 @@ var depsRules = `
  	math/big, github.com/microsoft/go-crypto-darwin/xcrypto < github.com/microsoft/go-crypto-darwin/bbig;
  	math/big, github.com/microsoft/go-crypto-winnative/cng < github.com/microsoft/go-crypto-winnative/cng/bbig;
  
@@ -2763,7 +2763,7 @@ index 00000000000000..8d0c3fde9ab5e8
 +const AllowCryptoFallback = true
 +const AllowCryptoFallbackInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 33110d172fc009..1791c684524e08 100644
+index 6b4289503d57ae..12fba96b868c9e 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -78,6 +78,14 @@ type Flags struct {


### PR DESCRIPTION
The `fips140` GODEBUG setting has been documented in the Go 1.25 development branch: https://github.com/golang/go/commit/10cef816aa9769345016c04032090ae7f5851f5c. This means that we can drop the leading hash when instantiating it-

For https://github.com/microsoft/go/pull/1503#discussion_r2057033420.