### PR TITLE
Make mariner2arm64 default distro when no distro is specified

### DIFF
--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -76,8 +76,7 @@ stages:
               ${{ else }}:
                 container: mariner2
             ${{ elseif eq(parameters.builder.hostArch, 'arm64') }}:
-              ${{ if eq(parameters.builder.distro, 'mariner2') }}:
-                container: mariner2arm64
+              container: mariner2arm64
 
         variables:
           - group: go-cmdscan-rules


### PR DESCRIPTION
In #1651 we set amd64 architectures default OS to mariner2. This PR makes mariner2arm64 the default distro when no distro is specified on arm64.