### PR TITLE
Add TLS13-KDF support for openssl backend

### DIFF
--- a/eng/doc/DeveloperGuide.md
+++ b/eng/doc/DeveloperGuide.md
@@ -44,7 +44,7 @@ The [`git-go-patch`](https://github.com/microsoft/go-infra/tree/main/cmd/git-go-
 To install the `git-go-patch` command, run the following command:
 
 ```
-go install github.com/microsoft/go-infra/cmd/go-patch@latest
+go install github.com/microsoft/go-infra/cmd/git-go-patch@latest
 ```
 
 > [!NOTE]

--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -19,7 +19,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../golang-fips/openssl/v2/bbig/big.go        |   37 +
  .../github.com/golang-fips/openssl/v2/big.go  |   11 +
  .../golang-fips/openssl/v2/cipher.go          |  603 +++++
- .../golang-fips/openssl/v2/const.go           |   87 +
+ .../golang-fips/openssl/v2/const.go           |   93 +
  .../github.com/golang-fips/openssl/v2/des.go  |  113 +
  .../github.com/golang-fips/openssl/v2/dsa.go  |  309 +++
  .../github.com/golang-fips/openssl/v2/ec.go   |   67 +
@@ -27,9 +27,9 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../golang-fips/openssl/v2/ecdsa.go           |  226 ++
  .../golang-fips/openssl/v2/ed25519.go         |  229 ++
  .../github.com/golang-fips/openssl/v2/evp.go  |  552 +++++
- .../github.com/golang-fips/openssl/v2/hash.go |  715 ++++++
- .../github.com/golang-fips/openssl/v2/hkdf.go |  348 +++
- .../github.com/golang-fips/openssl/v2/hmac.go |  249 ++
+ .../github.com/golang-fips/openssl/v2/hash.go |  717 ++++++
+ .../github.com/golang-fips/openssl/v2/hkdf.go |  444 ++++
+ .../github.com/golang-fips/openssl/v2/hmac.go |  244 ++
  .../github.com/golang-fips/openssl/v2/init.go |  157 ++
  .../golang-fips/openssl/v2/init_unix.go       |   31 +
  .../golang-fips/openssl/v2/init_windows.go    |   36 +
@@ -39,7 +39,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../openssl/v2/internal/ossl/zossl.c          | 2011 +++++++++++++++++
  .../openssl/v2/internal/ossl/zossl.go         | 1297 +++++++++++
  .../openssl/v2/internal/ossl/zossl.h          |  330 +++
- .../openssl/v2/internal/ossl/zossl_go124.go   |   33 +
+ .../openssl/v2/internal/ossl/zossl_go124.go   |   37 +
  .../golang-fips/openssl/v2/openssl.go         |  384 ++++
  .../golang-fips/openssl/v2/params.go          |  185 ++
  .../golang-fips/openssl/v2/pbkdf2.go          |   55 +
@@ -103,7 +103,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 97 files changed, 16912 insertions(+), 7 deletions(-)
+ 97 files changed, 17015 insertions(+), 7 deletions(-)
  create mode 100644 src/crypto/internal/backend/deps_ignore.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
@@ -226,7 +226,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index d7c0cfb6dd3cf8..243a6d1537030f 100644
+index d7c0cfb6dd3cf8..6d98327ccad050 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -235,17 +235,17 @@ index d7c0cfb6dd3cf8..243a6d1537030f 100644
  )
 +
 +require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20250422132932-d1d9967cabc9
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20250424082917-c494c2169791
 +	github.com/microsoft/go-crypto-darwin v0.0.2-0.20250422083516-a883ce76dd56
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20250224213920-97653fcd3f40
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 834044f135aba5..2550758ed18e51 100644
+index 834044f135aba5..d2c1817e26f50f 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250422132932-d1d9967cabc9 h1:FWWd0Sc4BULEU4m18Qgl1YWUkcHVXNThIplVp06ERbk=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250422132932-d1d9967cabc9/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20250424082917-c494c2169791 h1:5PZl6k34BcDxn4DT+f8GLx51OZBtmx22oQ01ygrbGt0=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20250424082917-c494c2169791/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250422083516-a883ce76dd56 h1:rignn19hDdGfSVEtNeR0msL6wnkiqr61/VoB0i3zbSI=
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250422083516-a883ce76dd56/go.mod h1:LyP4oZ0QcysEJdqUTOk9ngNFArRFK94YRImkoJ8julQ=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20250224213920-97653fcd3f40 h1:6K+qAlu0vRBqoZ938zEdZ0+jFDVVU+67ZzKOrvTsNSk=
@@ -1288,10 +1288,10 @@ index 00000000000000..2a3a91eb549a68
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/const.go b/src/vendor/github.com/golang-fips/openssl/v2/const.go
 new file mode 100644
-index 00000000000000..aa4a163aaab405
+index 00000000000000..e4aaf3bbe8a6dc
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/const.go
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,93 @@
 +package openssl
 +
 +import "C"
@@ -1342,10 +1342,11 @@ index 00000000000000..aa4a163aaab405
 +	_DigestNameSHA2_256 cString = "SHA2-256\x00"
 +
 +	// KDF names
-+	_OSSL_KDF_NAME_HKDF     cString = "HKDF\x00"
-+	_OSSL_KDF_NAME_PBKDF2   cString = "PBKDF2\x00"
-+	_OSSL_KDF_NAME_TLS1_PRF cString = "TLS1-PRF\x00"
-+	_OSSL_MAC_NAME_HMAC     cString = "HMAC\x00"
++	_OSSL_KDF_NAME_HKDF      cString = "HKDF\x00"
++	_OSSL_KDF_NAME_PBKDF2    cString = "PBKDF2\x00"
++	_OSSL_KDF_NAME_TLS1_PRF	 cString = "TLS1-PRF\x00"
++	_OSSL_KDF_NAME_TLS13_KDF cString = "TLS13-KDF\x00"
++	_OSSL_MAC_NAME_HMAC      cString = "HMAC\x00"
 +
 +	// KDF parameters
 +	_OSSL_KDF_PARAM_DIGEST cString = "digest\x00"
@@ -1355,6 +1356,11 @@ index 00000000000000..aa4a163aaab405
 +	_OSSL_KDF_PARAM_INFO   cString = "info\x00"
 +	_OSSL_KDF_PARAM_SALT   cString = "salt\x00"
 +	_OSSL_KDF_PARAM_MODE   cString = "mode\x00"
++
++	// TLS3-KDF parameters
++	_OSSL_KDF_PARAM_PREFIX cString = "prefix\x00"
++	_OSSL_KDF_PARAM_LABEL  cString = "label\x00"
++	_OSSL_KDF_PARAM_DATA   cString = "data\x00"
 +
 +	// PKEY parameters
 +	_OSSL_PKEY_PARAM_PUB_KEY          cString = "pub\x00"
@@ -3225,10 +3231,10 @@ index 00000000000000..20777c0728c7c1
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hash.go b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
 new file mode 100644
-index 00000000000000..d084fdf776696f
+index 00000000000000..033169bece66b8
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
-@@ -0,0 +1,715 @@
+@@ -0,0 +1,717 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -3480,6 +3486,7 @@ index 00000000000000..d084fdf776696f
 +	// the state of ctx. Having it here allows reusing the
 +	// same allocated object multiple times.
 +	ctx2 ossl.EVP_MD_CTX_PTR
++	out  [maxHashSize]byte
 +}
 +
 +func newEvpHash(ch crypto.Hash) *evpHash {
@@ -3582,12 +3589,13 @@ index 00000000000000..d084fdf776696f
 +
 +func (h *evpHash) Sum(in []byte) []byte {
 +	h.init()
-+	out := make([]byte, h.Size(), maxHashSize) // explicit cap to allow stack allocation
-+	if err := ossl.HashSum(h.ctx, h.ctx2, out); err != nil {
++	tmp := h.out[:h.Size()] // Create slice view
++	clear(tmp)
++	if err := ossl.HashSum(h.ctx, h.ctx2, tmp); err != nil {
 +		panic(err)
 +	}
 +	runtime.KeepAlive(h)
-+	return append(in, out...)
++	return append(in, tmp...)
 +}
 +
 +// Clone returns a new evpHash object that is a deep clone of itself.
@@ -3946,10 +3954,10 @@ index 00000000000000..d084fdf776696f
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
 new file mode 100644
-index 00000000000000..a0c5f112e09682
+index 00000000000000..e95268a352ebb9
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
-@@ -0,0 +1,348 @@
+@@ -0,0 +1,444 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -3973,6 +3981,20 @@ index 00000000000000..a0c5f112e09682
 +		return versionAtOrAbove(1, 1, 1)
 +	case 3:
 +		_, err := fetchHKDF3()
++		return err == nil
++	default:
++		panic(errUnsupportedVersion())
++	}
++}
++
++// SupprtsTLS13KDF reports whether the current OpenSSL version supports TLS13-KDF.
++func SupportsTLS13KDF() bool {
++	switch vMajor {
++	case 1:
++		return false
++	case 3:
++		// TLS13-KDF is available in OpenSSL 3.0.0 and later.
++		_, err := fetchTLS13_KDF()
 +		return err == nil
 +	default:
 +		panic(errUnsupportedVersion())
@@ -4166,6 +4188,31 @@ index 00000000000000..a0c5f112e09682
 +	return out, nil
 +}
 +
++// ExpandTLS13KDF derives a key from the given hash, key, label and context. It will use
++// "TLS13-KDF" algorithm to do so.
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	if !SupportsTLS13KDF() {
++		return nil, errUnsupportedVersion()
++	}
++
++	md, err := hashFuncToMD(h)
++	if err != nil {
++		return nil, err
++	}
++
++	out := make([]byte, keyLength)
++
++	ctx, err := newTLS13KDFExpandCtx3(md, label, context, pseudorandomKey)
++	if err != nil {
++		return nil, err
++	}
++	defer ossl.EVP_KDF_CTX_free(ctx)
++	if _, err := ossl.EVP_KDF_derive(ctx, base(out), keyLength, nil); err != nil {
++		return nil, err
++	}
++	return out, nil
++}
++
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
 +	if !SupportsHKDF() {
 +		return nil, errUnsupportedVersion()
@@ -4211,6 +4258,63 @@ index 00000000000000..a0c5f112e09682
 +	if c.ctx != nil {
 +		ossl.EVP_KDF_CTX_free(c.ctx)
 +	}
++}
++
++// fetchTLS13_KDF fetches the TLS13-KDF algorithm.
++// It is safe to call this function concurrently.
++// The returned EVP_KDF_PTR shouldn't be freed.
++var fetchTLS13_KDF = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
++	checkMajorVersion(3)
++
++	kdf, err := ossl.EVP_KDF_fetch(nil, _OSSL_KDF_NAME_TLS13_KDF.ptr(), nil)
++	if err != nil {
++		return nil, err
++	}
++	return kdf, nil
++})
++
++// newTLS13KDFExpandCtx3 fetches the "TLS13-KDF" for TLS 1.3 handshakes.
++func newTLS13KDFExpandCtx3(md ossl.EVP_MD_PTR, label, context, pseudorandomKey []byte) (_ ossl.EVP_KDF_CTX_PTR, err error) {
++	checkMajorVersion(3)
++
++	kdf, err := fetchTLS13_KDF()
++	if err != nil {
++		return nil, err
++	}
++
++	ctx, err := ossl.EVP_KDF_CTX_new(kdf)
++	if err != nil {
++		return nil, err
++	}
++	defer func() {
++		if err != nil {
++			ossl.EVP_KDF_CTX_free(ctx)
++		}
++	}()
++
++	bld, err := newParamBuilder()
++	if err != nil {
++		return ctx, err
++	}
++	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
++	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(ossl.EVP_KDF_HKDF_MODE_EXPAND_ONLY))
++	bld.addOctetString(_OSSL_KDF_PARAM_PREFIX, []byte("tls13 "))
++	bld.addOctetString(_OSSL_KDF_PARAM_LABEL, label)
++	bld.addOctetString(_OSSL_KDF_PARAM_DATA, context)
++	if len(pseudorandomKey) > 0 {
++		bld.addOctetString(_OSSL_KDF_PARAM_KEY, pseudorandomKey)
++	}
++
++	params, err := bld.build()
++	if err != nil {
++		return ctx, err
++	}
++	defer ossl.OSSL_PARAM_free(params)
++
++	if _, err := ossl.EVP_KDF_CTX_set_params(ctx, params); err != nil {
++		return ctx, err
++	}
++	return ctx, nil
 +}
 +
 +// fetchHKDF3 fetches the HKDF algorithm.
@@ -4300,10 +4404,10 @@ index 00000000000000..a0c5f112e09682
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hmac.go b/src/vendor/github.com/golang-fips/openssl/v2/hmac.go
 new file mode 100644
-index 00000000000000..35cbc289532524
+index 00000000000000..a6bb884d15d747
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hmac.go
-@@ -0,0 +1,249 @@
+@@ -0,0 +1,244 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -4379,7 +4483,7 @@ index 00000000000000..35cbc289532524
 +	ctx3      hmacCtx3
 +	size      int
 +	blockSize int
-+	sum       []byte
++	sum       [maxHashSize]byte
 +}
 +
 +func newHMAC1(key []byte, md ossl.EVP_MD_PTR) hmacCtx1 {
@@ -4486,7 +4590,6 @@ index 00000000000000..35cbc289532524
 +	}
 +
 +	runtime.KeepAlive(h) // Next line will keep h alive too; just making doubly sure.
-+	h.sum = nil
 +}
 +
 +func (h *opensslHMAC) finalize() {
@@ -4522,10 +4625,6 @@ index 00000000000000..35cbc289532524
 +}
 +
 +func (h *opensslHMAC) Sum(in []byte) []byte {
-+	if h.sum == nil {
-+		size := h.Size()
-+		h.sum = make([]byte, size)
-+	}
 +	// Make copy of context because Go hash.Hash mandates
 +	// that Sum has no effect on the underlying stream.
 +	// In particular it is OK to Sum, then Write more, then Sum again,
@@ -4540,18 +4639,18 @@ index 00000000000000..35cbc289532524
 +		if _, err := ossl.HMAC_CTX_copy(ctx2, h.ctx1.ctx); err != nil {
 +			panic(err)
 +		}
-+		ossl.HMAC_Final(ctx2, base(h.sum), nil)
++		ossl.HMAC_Final(ctx2, base(h.sum[:h.size]), nil)
 +	case 3:
 +		ctx2, err := ossl.EVP_MAC_CTX_dup(h.ctx3.ctx)
 +		if err != nil {
 +			panic(err)
 +		}
 +		defer ossl.EVP_MAC_CTX_free(ctx2)
-+		ossl.EVP_MAC_final(ctx2, base(h.sum), nil, len(h.sum))
++		ossl.EVP_MAC_final(ctx2, base(h.sum[:h.size]), nil, len(h.sum))
 +	default:
 +		panic(errUnsupportedVersion())
 +	}
-+	return append(in, h.sum...)
++	return append(in, h.sum[:h.size]...)
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/init.go b/src/vendor/github.com/golang-fips/openssl/v2/init.go
 new file mode 100644
@@ -4974,7 +5073,7 @@ index 00000000000000..4a64c2f09f1f9c
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/shims.h b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/shims.h
 new file mode 100644
-index 00000000000000..a5f0a56190f90e
+index 00000000000000..012d60f83eed85
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/shims.h
 @@ -0,0 +1,390 @@
@@ -5167,13 +5266,13 @@ index 00000000000000..a5f0a56190f90e
 +
 +_EVP_MD_CTX_PTR EVP_MD_CTX_new(void);
 +void EVP_MD_CTX_free(_EVP_MD_CTX_PTR ctx);
-+int EVP_MD_CTX_copy(_EVP_MD_CTX_PTR out, const _EVP_MD_CTX_PTR in);
++int EVP_MD_CTX_copy(_EVP_MD_CTX_PTR out, const _EVP_MD_CTX_PTR in) __attribute__((noescape,nocallback));
 +int EVP_MD_CTX_copy_ex(_EVP_MD_CTX_PTR out, const _EVP_MD_CTX_PTR in);
 +int EVP_Digest(const void *data, size_t count, unsigned char *md, unsigned int *size, const _EVP_MD_PTR type, _ENGINE_PTR impl) __attribute__((noescape,nocallback,nocheckptr("data")));
 +int EVP_DigestInit_ex(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type, _ENGINE_PTR impl);
 +int EVP_DigestInit(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type);
 +int EVP_DigestUpdate(_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt) __attribute__((noescape,nocallback,nocheckptr("d")));
-+int EVP_DigestFinal_ex(_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s);
++int EVP_DigestFinal_ex(_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s) __attribute__((noescape,nocallback));
 +int EVP_DigestSign(_EVP_MD_CTX_PTR ctx, unsigned char *sigret, size_t *siglen, const unsigned char *tbs, size_t tbslen) __attribute__((tag("111"),noescape,nocallback));
 +int EVP_DigestSignInit(_EVP_MD_CTX_PTR ctx, _EVP_PKEY_CTX_PTR *pctx, const _EVP_MD_PTR type, _ENGINE_PTR e, _EVP_PKEY_PTR pkey);
 +int EVP_DigestSignFinal(_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen);
@@ -9026,10 +9125,10 @@ index 00000000000000..66249349e78e22
 +#endif // MKCGO_H
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_go124.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_go124.go
 new file mode 100644
-index 00000000000000..045bb3806745a0
+index 00000000000000..ae64d2f7ee9990
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_go124.go
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,37 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +//go:build go1.24 && !cmd_go_bootstrap
@@ -9045,6 +9144,8 @@ index 00000000000000..045bb3806745a0
 +#cgo nocallback _mkcgo_EVP_DecryptUpdate
 +#cgo noescape _mkcgo_EVP_Digest
 +#cgo nocallback _mkcgo_EVP_Digest
++#cgo noescape _mkcgo_EVP_DigestFinal_ex
++#cgo nocallback _mkcgo_EVP_DigestFinal_ex
 +#cgo noescape _mkcgo_EVP_DigestSign
 +#cgo nocallback _mkcgo_EVP_DigestSign
 +#cgo noescape _mkcgo_EVP_DigestUpdate
@@ -9053,6 +9154,8 @@ index 00000000000000..045bb3806745a0
 +#cgo nocallback _mkcgo_EVP_EncryptFinal_ex
 +#cgo noescape _mkcgo_EVP_EncryptUpdate
 +#cgo nocallback _mkcgo_EVP_EncryptUpdate
++#cgo noescape _mkcgo_EVP_MD_CTX_copy
++#cgo nocallback _mkcgo_EVP_MD_CTX_copy
 +#cgo noescape _mkcgo_EVP_PKEY_derive
 +#cgo nocallback _mkcgo_EVP_PKEY_derive
 +#cgo noescape _mkcgo_EVP_PKEY_get_raw_private_key
@@ -18734,11 +18837,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 6eaae03de31d05..efdc01d1d9cfe5 100644
+index 6eaae03de31d05..a773f0dfb0e3db 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,20 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20250422132932-d1d9967cabc9
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20250424082917-c494c2169791
 +## explicit; go 1.22
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/boring_linux.go   | 279 ++++++++++++++
- src/crypto/internal/backend/cng_windows.go    | 336 ++++++++++++++++
+ src/crypto/internal/backend/boring_linux.go   | 287 ++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 344 ++++++++++++++++
  src/crypto/internal/backend/common.go         |  59 +++
- src/crypto/internal/backend/darwin_darwin.go  | 359 ++++++++++++++++++
+ src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/internal/backend/fips140/darwin.go |  11 +
@@ -29,8 +29,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/opensslsetup/opensslsetup.go     |  70 ++++
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
- src/crypto/internal/backend/nobackend.go      | 240 ++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 331 ++++++++++++++++
+ src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 339 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |  27 +-
  .../exp_allowcryptofallback_off.go            |   9 +
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2690 insertions(+), 3 deletions(-)
+ 45 files changed, 2728 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -554,10 +554,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..f06fcc63b5af11
+index 00000000000000..48d44ec1723ab6
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,279 @@
+@@ -0,0 +1,287 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -724,6 +724,14 @@ index 00000000000000..f06fcc63b5af11
 +	return boring.NewPublicKeyECDH(curve, bytes)
 +}
 +
++func SupportsTLS13KDF() bool {
++	return false
++}
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
 +func SupportsHKDF() bool { return false }
 +
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
@@ -839,10 +847,10 @@ index 00000000000000..f06fcc63b5af11
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..31dfc9b19ee63e
+index 00000000000000..6abb6ff007c99f
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,336 @@
+@@ -0,0 +1,344 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1058,6 +1066,14 @@ index 00000000000000..31dfc9b19ee63e
 +	return cng.NewPublicKeyECDH(curve, bytes)
 +}
 +
++func SupportsTLS13KDF() bool {
++	return false
++}
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
 +func SupportsHKDF() bool {
 +	return cng.SupportsHKDF()
 +}
@@ -1246,10 +1262,10 @@ index 00000000000000..9436b00381aaf8
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..e09524cd430125
+index 00000000000000..0c374baf8d3f80
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
-@@ -0,0 +1,359 @@
+@@ -0,0 +1,367 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1496,6 +1512,14 @@ index 00000000000000..e09524cd430125
 +
 +func NewPublicKeyECDH(curve string, bytes []byte) (*xcrypto.PublicKeyECDH, error) {
 +	return xcrypto.NewPublicKeyECDH(curve, bytes)
++}
++
++func SupportsTLS13KDF() bool {
++	return false
++}
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	panic("cryptobackend: not available")
 +}
 +
 +func SupportsHKDF() bool {
@@ -2074,10 +2098,10 @@ index 00000000000000..3b92bfc5fbabf6
 +package opensslsetup
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..7c3a95c2c64a2d
+index 00000000000000..1675358749323f
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,240 @@
+@@ -0,0 +1,246 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2211,6 +2235,12 @@ index 00000000000000..7c3a95c2c64a2d
 +func (*PublicKeyECDH) Bytes() []byte                          { panic("cryptobackend: not available") }
 +func (*PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error)    { panic("cryptobackend: not available") }
 +
++func SupportsTLS13KDF() bool { panic("cryptobackend: not available") }
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
 +func SupportsHKDF() bool { panic("cryptobackend: not available") }
 +
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
@@ -2320,10 +2350,10 @@ index 00000000000000..7c3a95c2c64a2d
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..fe575dd8c71435
+index 00000000000000..ac656468e3ed32
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,331 @@
+@@ -0,0 +1,339 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2518,6 +2548,14 @@ index 00000000000000..fe575dd8c71435
 +	return openssl.NewPublicKeyECDH(curve, bytes)
 +}
 +
++func SupportsTLS13KDF() bool {
++	return openssl.SupportsTLS13KDF()
++}
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	return openssl.ExpandTLS13KDF(h, pseudorandomKey, label, context, keyLength)
++}
++
 +func SupportsHKDF() bool {
 +	return openssl.SupportsHKDF()
 +}
@@ -2672,10 +2710,10 @@ index 00000000000000..5e4b436554d44d
 +// from complaining about the missing body
 +// (because the implementation might be here).
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 2adf8c897229cf..74d0bc1d6439a3 100644
+index 0095243ce2b0b7..af62328edf5eca 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -536,6 +536,11 @@ var depsRules = `
+@@ -535,6 +535,11 @@ var depsRules = `
  	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
  	< github.com/microsoft/go-crypto-winnative/cng;
  
@@ -2687,7 +2725,7 @@ index 2adf8c897229cf..74d0bc1d6439a3 100644
  	FIPS, internal/godebug < crypto/fips140;
  
  	crypto, hash !< FIPS;
-@@ -546,16 +551,28 @@ var depsRules = `
+@@ -545,16 +550,28 @@ var depsRules = `
  	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
  	sync/atomic < crypto/internal/boring/bcache;
  
@@ -2718,7 +2756,7 @@ index 2adf8c897229cf..74d0bc1d6439a3 100644
  	< crypto/boring
  	< crypto/aes,
  	  crypto/des,
-@@ -579,8 +596,12 @@ var depsRules = `
+@@ -578,8 +595,12 @@ var depsRules = `
  	math/big, github.com/microsoft/go-crypto-darwin/xcrypto < github.com/microsoft/go-crypto-darwin/bbig;
  	math/big, github.com/microsoft/go-crypto-winnative/cng < github.com/microsoft/go-crypto-winnative/cng/bbig;
  
@@ -2763,7 +2801,7 @@ index 00000000000000..8d0c3fde9ab5e8
 +const AllowCryptoFallback = true
 +const AllowCryptoFallbackInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 6b4289503d57ae..12fba96b868c9e 100644
+index c2a8b7f860d780..451a8924ae423d 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -78,6 +78,14 @@ type Flags struct {

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -20,8 +20,8 @@ Subject: [PATCH] Use crypto backends
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
  src/crypto/cipher/gcm_test.go                 |   2 +-
  src/crypto/des/cipher.go                      |   7 +
- src/crypto/dsa/boring.go                      | 113 +++++++++++
- src/crypto/dsa/dsa.go                         |  88 +++++++++
+ src/crypto/dsa/boring.go                      | 113 ++++++++++
+ src/crypto/dsa/dsa.go                         |  88 ++++++++
  src/crypto/dsa/notboring.go                   |  16 ++
  src/crypto/ecdh/ecdh.go                       |   2 +-
  src/crypto/ecdh/ecdh_test.go                  |   4 +
@@ -78,7 +78,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/tls/handshake_server.go            |  10 +-
  src/crypto/tls/handshake_server_tls13.go      |  13 +-
  src/crypto/tls/internal/tls13/doc.go          |  18 ++
- src/crypto/tls/internal/tls13/tls13.go        | 182 ++++++++++++++++++
+ src/crypto/tls/internal/tls13/tls13.go        | 195 ++++++++++++++++++
  src/crypto/tls/key_schedule.go                |   2 +-
  src/crypto/tls/prf.go                         |  41 ++++
  src/go/build/deps_test.go                     |   3 +-
@@ -89,7 +89,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 85 files changed, 1096 insertions(+), 89 deletions(-)
+ 85 files changed, 1109 insertions(+), 89 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -2430,10 +2430,10 @@ index 00000000000000..acfa551001af9c
 +package tls13
 diff --git a/src/crypto/tls/internal/tls13/tls13.go b/src/crypto/tls/internal/tls13/tls13.go
 new file mode 100644
-index 00000000000000..573896b9c1e6a8
+index 00000000000000..579aaedabb188a
 --- /dev/null
 +++ b/src/crypto/tls/internal/tls13/tls13.go
-@@ -0,0 +1,182 @@
+@@ -0,0 +1,195 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2443,6 +2443,9 @@ index 00000000000000..573896b9c1e6a8
 +package tls13
 +
 +import (
++	boring "crypto/internal/backend"
++	"crypto/internal/fips140hash"
++
 +	"crypto/hkdf"
 +	"hash"
 +	"internal/byteorder"
@@ -2465,6 +2468,16 @@ index 00000000000000..573896b9c1e6a8
 +		// confusing to users.
 +		panic("tls13: label or context too long")
 +	}
++
++	if boring.Enabled && boring.SupportsTLS13KDF() {
++		fh := fips140hash.UnwrapNew(hash)
++		key, err := boring.ExpandTLS13KDF(fh, secret, []byte(label), context, length)
++		if err != nil {
++			panic(err)
++		}
++		return key
++	}
++
 +	hkdfLabel := make([]byte, 0, 2+1+len("tls13 ")+len(label)+1+len(context))
 +	hkdfLabel = byteorder.BEAppendUint16(hkdfLabel, uint16(length))
 +	hkdfLabel = append(hkdfLabel, byte(len("tls13 ")+len(label)))


### PR DESCRIPTION
Relevant issue: https://github.com/microsoft/go/issues/1626

Add TLS13-KDF support
- Update golang-fips to [c494c21](https://github.com/golang-fips/openssl/commit/c494c216979153a2fc07afab57c0858f055ccdc0)
- Use new functions in openssl backend
- Add stub functions for other backends
- Minor documentation fix