### PR TITLE
Backport TLS13-KDF to 1.24 release branch

### DIFF
--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -30,13 +30,13 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../golang-fips/openssl/v2/goopenssl.c        | 248 ++++++
  .../golang-fips/openssl/v2/goopenssl.h        | 261 +++++++
  .../github.com/golang-fips/openssl/v2/hash.go | 714 ++++++++++++++++++
- .../github.com/golang-fips/openssl/v2/hkdf.go | 322 ++++++++
+ .../github.com/golang-fips/openssl/v2/hkdf.go | 442 +++++++++++
  .../github.com/golang-fips/openssl/v2/hmac.go | 274 +++++++
  .../github.com/golang-fips/openssl/v2/init.go |  64 ++
  .../golang-fips/openssl/v2/init_unix.go       |  31 +
  .../golang-fips/openssl/v2/init_windows.go    |  36 +
  .../golang-fips/openssl/v2/openssl.go         | 506 +++++++++++++
- .../golang-fips/openssl/v2/params.go          | 210 ++++++
+ .../golang-fips/openssl/v2/params.go          | 213 ++++++
  .../golang-fips/openssl/v2/pbkdf2.go          |  62 ++
  .../golang-fips/openssl/v2/port_dsa.c         |  85 +++
  .../github.com/golang-fips/openssl/v2/rand.go |  20 +
@@ -101,7 +101,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |  32 +
  .../internal/sysdll/sys_windows.go            |  55 ++
  src/vendor/modules.txt                        |  16 +
- 95 files changed, 13814 insertions(+), 7 deletions(-)
+ 95 files changed, 13937 insertions(+), 7 deletions(-)
  create mode 100644 src/crypto/internal/backend/deps_ignore.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
@@ -222,7 +222,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index cc6d24c8067e9e..89361850566dc4 100644
+index cc6d24c8067e9e..7abdef9991b4aa 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -231,17 +231,17 @@ index cc6d24c8067e9e..89361850566dc4 100644
  )
 +
 +require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20250115103809-bf655f6d08d6
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20250505132513-602014383322
 +	github.com/microsoft/go-crypto-darwin v0.0.2-0.20250116101429-467bd63a2d67
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20250211154640-f49c8e1379ea
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 7301ae09c45516..1dff2e4c9a9978 100644
+index 7301ae09c45516..2944f6089c8702 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250115103809-bf655f6d08d6 h1:FFp7Q2AwYX+IQhhQt3ljQDdWtG5ZbRu0u3ohWQdFow8=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250115103809-bf655f6d08d6/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20250505132513-602014383322 h1:KpwX+LsODtn2Y3foZ0HpbK4iTYIZk9jx3tTOBZgKbSQ=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20250505132513-602014383322/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250116101429-467bd63a2d67 h1:SI0IFiHducwfamZR7pv6jb92oc5o/z5tn66wynS6ADE=
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250116101429-467bd63a2d67/go.mod h1:LyP4oZ0QcysEJdqUTOk9ngNFArRFK94YRImkoJ8julQ=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20250211154640-f49c8e1379ea h1:JuRzAUOV9uaQdoNeuHyOEAJbpRahsICnwfPPGzzuzRw=
@@ -4382,10 +4382,10 @@ index 00000000000000..b2109857b49bdf
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
 new file mode 100644
-index 00000000000000..d4f8aa6a92a6fb
+index 00000000000000..cf14ac905a698a
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
-@@ -0,0 +1,322 @@
+@@ -0,0 +1,442 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -4408,6 +4408,20 @@ index 00000000000000..d4f8aa6a92a6fb
 +		return versionAtOrAbove(1, 1, 1)
 +	case 3:
 +		_, err := fetchHKDF3()
++		return err == nil
++	default:
++		panic(errUnsupportedVersion())
++	}
++}
++
++// SupprtsTLS13KDF reports whether the current OpenSSL version supports TLS13-KDF.
++func SupportsTLS13KDF() bool {
++	switch vMajor {
++	case 1:
++		return false
++	case 3:
++		// TLS13-KDF is available in OpenSSL 3.0.0 and later.
++		_, err := fetchTLS13_KDF()
 +		return err == nil
 +	default:
 +		panic(errUnsupportedVersion())
@@ -4497,6 +4511,14 @@ index 00000000000000..d4f8aa6a92a6fb
 +	return n, nil
 +}
 +
++// hkdfAllZerosSalt is a preallocated buffer of zeros used in ExtractHKDF().
++// The size should be kept as large as the output length of any hash algorithm
++// used with HKDF.
++var hkdfAllZerosSalt [64]byte
++
++// ExtractHDKF implements the HDKF extract step.
++// If salt is nil, then this function replaces it internally with a buffer of
++// zeros whose length equals the output length of the specified hash algorithm.
 +func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 +	if !SupportsHKDF() {
 +		return nil, errUnsupportedVersion()
@@ -4505,6 +4527,20 @@ index 00000000000000..d4f8aa6a92a6fb
 +	md, err := hashFuncToMD(h)
 +	if err != nil {
 +		return nil, err
++	}
++
++	// If calling code specifies nil salt, replace it with a buffer of hashLen
++	// zeros, as specified in RFC 5896 and as OpenSSL EVP_KDF-HKDF documentation
++	// instructs. Take a slice of a preallocated buffer to avoid allocating new
++	// buffer per call, but fall back to allocating a buffer if preallocated
++	// buffer is not large enough.
++	if salt == nil {
++		hlen := h().Size()
++		if hlen > len(hkdfAllZerosSalt) {
++			salt = make([]byte, hlen)
++		} else {
++			salt = hkdfAllZerosSalt[:hlen]
++		}
 +	}
 +
 +	switch vMajor {
@@ -4576,6 +4612,31 @@ index 00000000000000..d4f8aa6a92a6fb
 +	return out, nil
 +}
 +
++// ExpandTLS13KDF derives a key from the given hash, key, label and context. It will use
++// "TLS13-KDF" algorithm to do so.
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	if !SupportsTLS13KDF() {
++		return nil, errUnsupportedVersion()
++	}
++
++	md, err := hashFuncToMD(h)
++	if err != nil {
++		return nil, err
++	}
++
++	out := make([]byte, keyLength)
++
++	ctx, err := newTLS13KDFExpandCtx3(md, label, context, pseudorandomKey)
++	if err != nil {
++		return nil, err
++	}
++	defer C.go_openssl_EVP_KDF_CTX_free(ctx)
++	if _, err := C.go_openssl_EVP_KDF_derive(ctx, base(out), C.size_t(keyLength), nil); err != nil {
++		return nil, err
++	}
++	return out, nil
++}
++
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
 +	if !SupportsHKDF() {
 +		return nil, errUnsupportedVersion()
@@ -4619,6 +4680,65 @@ index 00000000000000..d4f8aa6a92a6fb
 +	if c.ctx != nil {
 +		C.go_openssl_EVP_KDF_CTX_free(c.ctx)
 +	}
++}
++
++// fetchTLS13_KDF fetches the TLS13-KDF algorithm.
++// It is safe to call this function concurrently.
++// The returned EVP_KDF_PTR shouldn't be freed.
++var fetchTLS13_KDF = sync.OnceValues(func() (C.GO_EVP_KDF_PTR, error) {
++	checkMajorVersion(3)
++
++	name := C.CString("TLS13-KDF")
++	kdf := C.go_openssl_EVP_KDF_fetch(nil, name, nil)
++	C.free(unsafe.Pointer(name))
++	if kdf == nil {
++		return nil, newOpenSSLError("EVP_KDF_fetch")
++	}
++	return kdf, nil
++})
++
++// newTLS13KDFExpandCtx3 fetches the "TLS13-KDF" for TLS 1.3 handshakes.
++func newTLS13KDFExpandCtx3(md C.GO_EVP_MD_PTR, label, context, pseudorandomKey []byte) (_ C.GO_EVP_KDF_CTX_PTR, err error) {
++	checkMajorVersion(3)
++
++	kdf, err := fetchTLS13_KDF()
++	if err != nil {
++		return nil, err
++	}
++
++	ctx, err := C.go_openssl_EVP_KDF_CTX_new(kdf)
++	if err != nil {
++		return nil, err
++	}
++	defer func() {
++		if err != nil {
++			C.go_openssl_EVP_KDF_CTX_free(ctx)
++		}
++	}()
++
++	bld, err := newParamBuilder()
++	if err != nil {
++		return ctx, err
++	}
++	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, C.go_openssl_EVP_MD_get0_name(md), 0)
++	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(C.GO_EVP_KDF_HKDF_MODE_EXPAND_ONLY))
++	bld.addOctetString(_OSSL_KDF_PARAM_PREFIX, []byte("tls13 "))
++	bld.addOctetString(_OSSL_KDF_PARAM_LABEL, label)
++	bld.addOctetString(_OSSL_KDF_PARAM_DATA, context)
++	if len(pseudorandomKey) > 0 {
++		bld.addOctetString(_OSSL_KDF_PARAM_KEY, pseudorandomKey)
++	}
++
++	params, err := bld.build()
++	if err != nil {
++		return ctx, err
++	}
++	defer C.go_openssl_OSSL_PARAM_free(params)
++
++	if _, err := C.go_openssl_EVP_KDF_CTX_set_params(ctx, params); err != nil {
++		return ctx, err
++	}
++	return ctx, nil
 +}
 +
 +// fetchHKDF3 fetches the HKDF algorithm.
@@ -5651,10 +5771,10 @@ index 00000000000000..ec39bf1533cae0
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/params.go b/src/vendor/github.com/golang-fips/openssl/v2/params.go
 new file mode 100644
-index 00000000000000..fa24a8cd673ed0
+index 00000000000000..fd5bd405ca0b17
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/params.go
-@@ -0,0 +1,210 @@
+@@ -0,0 +1,213 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -5675,6 +5795,9 @@ index 00000000000000..fa24a8cd673ed0
 +	_OSSL_KDF_PARAM_INFO   = C.CString("info")
 +	_OSSL_KDF_PARAM_SALT   = C.CString("salt")
 +	_OSSL_KDF_PARAM_MODE   = C.CString("mode")
++	_OSSL_KDF_PARAM_PREFIX = C.CString("prefix")
++	_OSSL_KDF_PARAM_LABEL  = C.CString("label")
++	_OSSL_KDF_PARAM_DATA   = C.CString("data")
 +
 +	// PKEY parameters
 +	_OSSL_PKEY_PARAM_PUB_KEY          = C.CString("pub")
@@ -15170,11 +15293,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 7ca8e349081787..13b13d6f565fa0 100644
+index 7ca8e349081787..3651eba0e3cb82 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,19 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20250115103809-bf655f6d08d6
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20250505132513-602014383322
 +## explicit; go 1.22
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/boring_linux.go   | 279 ++++++++++++++
- src/crypto/internal/backend/cng_windows.go    | 336 ++++++++++++++++
+ src/crypto/internal/backend/boring_linux.go   | 287 ++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 344 ++++++++++++++++
  src/crypto/internal/backend/common.go         |  59 +++
- src/crypto/internal/backend/darwin_darwin.go  | 359 ++++++++++++++++++
+ src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/internal/backend/fips140/darwin.go |  11 +
@@ -29,9 +29,11 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/opensslsetup/opensslsetup.go     |  70 ++++
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
- src/crypto/internal/backend/nobackend.go      | 240 ++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 331 ++++++++++++++++
+ src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 339 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
+ .../internal/backend/tls13kdf_default.go      |   9 +
+ .../internal/backend/tls13kdf_ms_kdftls13.go  |   9 +
  src/go/build/deps_test.go                     |  27 +-
  .../exp_allowcryptofallback_off.go            |   9 +
  .../exp_allowcryptofallback_on.go             |   9 +
@@ -49,7 +51,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2690 insertions(+), 3 deletions(-)
+ 47 files changed, 2746 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -77,6 +79,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  create mode 100644 src/crypto/internal/backend/nobackend.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/crypto/internal/backend/stub.s
+ create mode 100644 src/crypto/internal/backend/tls13kdf_default.go
+ create mode 100644 src/crypto/internal/backend/tls13kdf_ms_kdftls13.go
  create mode 100644 src/internal/goexperiment/exp_allowcryptofallback_off.go
  create mode 100644 src/internal/goexperiment/exp_allowcryptofallback_on.go
  create mode 100644 src/runtime/backenderr_gen_conflict_boring_cng.go
@@ -554,10 +558,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..f06fcc63b5af11
+index 00000000000000..48d44ec1723ab6
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,279 @@
+@@ -0,0 +1,287 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -724,6 +728,14 @@ index 00000000000000..f06fcc63b5af11
 +	return boring.NewPublicKeyECDH(curve, bytes)
 +}
 +
++func SupportsTLS13KDF() bool {
++	return false
++}
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
 +func SupportsHKDF() bool { return false }
 +
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
@@ -839,10 +851,10 @@ index 00000000000000..f06fcc63b5af11
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..31dfc9b19ee63e
+index 00000000000000..6abb6ff007c99f
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,336 @@
+@@ -0,0 +1,344 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1058,6 +1070,14 @@ index 00000000000000..31dfc9b19ee63e
 +	return cng.NewPublicKeyECDH(curve, bytes)
 +}
 +
++func SupportsTLS13KDF() bool {
++	return false
++}
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
 +func SupportsHKDF() bool {
 +	return cng.SupportsHKDF()
 +}
@@ -1246,10 +1266,10 @@ index 00000000000000..9436b00381aaf8
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..2250852ada8cc8
+index 00000000000000..102427445d02bd
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
-@@ -0,0 +1,359 @@
+@@ -0,0 +1,367 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1496,6 +1516,14 @@ index 00000000000000..2250852ada8cc8
 +
 +func NewPublicKeyECDH(curve string, bytes []byte) (*xcrypto.PublicKeyECDH, error) {
 +	return xcrypto.NewPublicKeyECDH(curve, bytes)
++}
++
++func SupportsTLS13KDF() bool {
++	return false
++}
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	panic("cryptobackend: not available")
 +}
 +
 +func SupportsHKDF() bool {
@@ -2074,10 +2102,10 @@ index 00000000000000..3b92bfc5fbabf6
 +package opensslsetup
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..7c3a95c2c64a2d
+index 00000000000000..1675358749323f
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,240 @@
+@@ -0,0 +1,246 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2211,6 +2239,12 @@ index 00000000000000..7c3a95c2c64a2d
 +func (*PublicKeyECDH) Bytes() []byte                          { panic("cryptobackend: not available") }
 +func (*PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error)    { panic("cryptobackend: not available") }
 +
++func SupportsTLS13KDF() bool { panic("cryptobackend: not available") }
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	panic("cryptobackend: not available")
++}
++
 +func SupportsHKDF() bool { panic("cryptobackend: not available") }
 +
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
@@ -2320,10 +2354,10 @@ index 00000000000000..7c3a95c2c64a2d
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..fe575dd8c71435
+index 00000000000000..ac656468e3ed32
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,331 @@
+@@ -0,0 +1,339 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2518,6 +2552,14 @@ index 00000000000000..fe575dd8c71435
 +	return openssl.NewPublicKeyECDH(curve, bytes)
 +}
 +
++func SupportsTLS13KDF() bool {
++	return openssl.SupportsTLS13KDF()
++}
++
++func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
++	return openssl.ExpandTLS13KDF(h, pseudorandomKey, label, context, keyLength)
++}
++
 +func SupportsHKDF() bool {
 +	return openssl.SupportsHKDF()
 +}
@@ -2671,6 +2713,36 @@ index 00000000000000..5e4b436554d44d
 +// Having this assembly file keeps the go command
 +// from complaining about the missing body
 +// (because the implementation might be here).
+diff --git a/src/crypto/internal/backend/tls13kdf_default.go b/src/crypto/internal/backend/tls13kdf_default.go
+new file mode 100644
+index 00000000000000..0786f34a9c7749
+--- /dev/null
++++ b/src/crypto/internal/backend/tls13kdf_default.go
+@@ -0,0 +1,9 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !ms_tls13kdf
++
++package backend
++
++const TLS13KDFEnabled = false
+diff --git a/src/crypto/internal/backend/tls13kdf_ms_kdftls13.go b/src/crypto/internal/backend/tls13kdf_ms_kdftls13.go
+new file mode 100644
+index 00000000000000..032d6df3405a1b
+--- /dev/null
++++ b/src/crypto/internal/backend/tls13kdf_ms_kdftls13.go
+@@ -0,0 +1,9 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build ms_tls13kdf
++
++package backend
++
++const TLS13KDFEnabled = true
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index 72e56b5da8e582..45ceb3e2b4ce11 100644
 --- a/src/go/build/deps_test.go
@@ -2763,7 +2835,7 @@ index 00000000000000..8d0c3fde9ab5e8
 +const AllowCryptoFallback = true
 +const AllowCryptoFallbackInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index e6c9b7d5e62dc0..65d339be7dde32 100644
+index bcdba27b0f836d..d8c518a78bf973 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -78,6 +78,14 @@ type Flags struct {

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -19,8 +19,8 @@ Subject: [PATCH] Use crypto backends
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
  src/crypto/cipher/gcm_test.go                 |   2 +-
  src/crypto/des/cipher.go                      |   7 +
- src/crypto/dsa/boring.go                      | 113 +++++++++++
- src/crypto/dsa/dsa.go                         |  88 +++++++++
+ src/crypto/dsa/boring.go                      | 113 ++++++++++
+ src/crypto/dsa/dsa.go                         |  88 ++++++++
  src/crypto/dsa/notboring.go                   |  16 ++
  src/crypto/ecdh/ecdh.go                       |   2 +-
  src/crypto/ecdh/ecdh_test.go                  |   4 +
@@ -73,7 +73,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/tls/handshake_server_tls13.go      |  27 ++-
  src/crypto/tls/internal/fips140tls/fipstls.go |   4 +-
  src/crypto/tls/internal/tls13/doc.go          |  18 ++
- src/crypto/tls/internal/tls13/tls13.go        | 182 ++++++++++++++++++
+ src/crypto/tls/internal/tls13/tls13.go        | 195 ++++++++++++++++++
  src/crypto/tls/key_schedule.go                |   2 +-
  src/crypto/tls/prf.go                         |  41 ++++
  src/go/build/deps_test.go                     |   5 +-
@@ -85,7 +85,7 @@ Subject: [PATCH] Use crypto backends
  src/net/smtp/smtp_test.go                     |  72 ++++---
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 81 files changed, 1138 insertions(+), 112 deletions(-)
+ 81 files changed, 1151 insertions(+), 112 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -1081,7 +1081,7 @@ index 00000000000000..77b69a3be88183
 +	panic("boringcrypto: not available")
 +}
 diff --git a/src/crypto/fips140/fips140.go b/src/crypto/fips140/fips140.go
-index 41d0d170cf9fc8..b6b413532d8104 100644
+index 1c4036d5e74735..05266dea864aa3 100644
 --- a/src/crypto/fips140/fips140.go
 +++ b/src/crypto/fips140/fips140.go
 @@ -5,6 +5,7 @@
@@ -1211,7 +1211,7 @@ index 3fa730459050f6..1f28f12a6e7b4f 100644
  	"internal/goos"
  	"internal/testenv"
 diff --git a/src/crypto/internal/fips140test/check_test.go b/src/crypto/internal/fips140test/check_test.go
-index 6b0cd3f39e1695..aa586ed30454a2 100644
+index e635a248096783..7ff73423d353b6 100644
 --- a/src/crypto/internal/fips140test/check_test.go
 +++ b/src/crypto/internal/fips140test/check_test.go
 @@ -5,6 +5,8 @@
@@ -2338,10 +2338,10 @@ index 00000000000000..1adf3098356307
 +package tls13
 diff --git a/src/crypto/tls/internal/tls13/tls13.go b/src/crypto/tls/internal/tls13/tls13.go
 new file mode 100644
-index 00000000000000..573896b9c1e6a8
+index 00000000000000..d179a01e2df069
 --- /dev/null
 +++ b/src/crypto/tls/internal/tls13/tls13.go
-@@ -0,0 +1,182 @@
+@@ -0,0 +1,195 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2351,6 +2351,9 @@ index 00000000000000..573896b9c1e6a8
 +package tls13
 +
 +import (
++	boring "crypto/internal/backend"
++	"crypto/internal/fips140hash"
++
 +	"crypto/hkdf"
 +	"hash"
 +	"internal/byteorder"
@@ -2373,6 +2376,16 @@ index 00000000000000..573896b9c1e6a8
 +		// confusing to users.
 +		panic("tls13: label or context too long")
 +	}
++
++	if boring.Enabled && boring.TLS13KDFEnabled && boring.SupportsTLS13KDF() {
++		fh := fips140hash.UnwrapNew(hash)
++		key, err := boring.ExpandTLS13KDF(fh, secret, []byte(label), context, length)
++		if err != nil {
++			panic(err)
++		}
++		return key
++	}
++
 +	hkdfLabel := make([]byte, 0, 2+1+len("tls13 ")+len(label)+1+len(context))
 +	hkdfLabel = byteorder.BEAppendUint16(hkdfLabel, uint16(length))
 +	hkdfLabel = append(hkdfLabel, byte(len("tls13 ")+len(label)))


### PR DESCRIPTION
Issue: https://github.com/microsoft/go/issues/1658
 - Generally speaking, this back-ports https://github.com/microsoft/go/pull/1654 from main to the 1.24 release branch
---
 - Update the golang-fips/openssl vendor to https://github.com/golang-fips/openssl/commit/6020143833228ed05e0f2a570f1afb53d97427ad (which is the result of this [PR](https://github.com/golang-fips/openssl/pull/276) )
 - Adds a new build tag to gate the use of TLS13-KDF. This was accomplished by adding: `internal/backend/tls13kdf_default.go` and `internal/backend/tls13kdf_ms_kdftls13.go` in `patches/0003-Implement-crypto-internal-backend.patch`. The files are conditionally compiled via ~`//go:build goexperiment.opensslcrypto && !goexperiment.ms_tls13kdf && linux && cgo`~ `//go:build !ms_tls13kdf` and ~`//go:build goexperiment.opensslcrypto && goexperiment.ms_tls13kdf && linux && cgo`~ `//go:build ms_tls13kdf`, respectively. So, without adding the new build flag, `ms_tls13kdf`, `TLS13-KDF` will not be used.
