### PR TITLE
[microsoft/release-branch.go1.24] Disable innerloop network isolation

### DIFF
--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -30,6 +30,10 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    featureFlags:
+      # Network Isolation causes standard library DNS net tests on Windows to fail.
+      # See https://github.com/microsoft/go-lab/issues/206
+      disableNetworkIsolation: true
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal


### PR DESCRIPTION
(cherry picked from commit 8dffa31b705261b37567ecd4e731293a8e3554a9)

* https://github.com/microsoft/go/pull/1668