### PR TITLE
Support backend ciphers in cipher.NewGCMWithRandomNonce

### DIFF
--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -18,7 +18,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../github.com/golang-fips/openssl/v2/aes.go  |  146 ++
  .../golang-fips/openssl/v2/bbig/big.go        |   37 +
  .../github.com/golang-fips/openssl/v2/big.go  |   11 +
- .../golang-fips/openssl/v2/cipher.go          |  603 +++++
+ .../golang-fips/openssl/v2/cipher.go          |  653 ++++++
  .../golang-fips/openssl/v2/const.go           |   93 +
  .../github.com/golang-fips/openssl/v2/des.go  |  113 +
  .../github.com/golang-fips/openssl/v2/dsa.go  |  309 +++
@@ -103,7 +103,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 97 files changed, 17015 insertions(+), 7 deletions(-)
+ 97 files changed, 17065 insertions(+), 7 deletions(-)
  create mode 100644 src/crypto/internal/backend/deps_ignore.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
@@ -226,7 +226,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index 28e250668dd52c..0856b1d14f7d34 100644
+index 28e250668dd52c..e5aa4b223a54d4 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -240,7 +240,7 @@ index 28e250668dd52c..0856b1d14f7d34 100644
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20250224213920-97653fcd3f40
 +)
 diff --git a/src/go.sum b/src/go.sum
-index ca2e7027fad3bd..00efdf0cb6041e 100644
+index ca2e7027fad3bd..f623f220d18598 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
@@ -254,7 +254,7 @@ index ca2e7027fad3bd..00efdf0cb6041e 100644
  golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
  golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 1eb683a5ae77b7..2adf8c897229cf 100644
+index b261af47e2167c..3ad0b0a3f2f465 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -518,6 +518,24 @@ var depsRules = `
@@ -311,7 +311,7 @@ index 1eb683a5ae77b7..2adf8c897229cf 100644
  	CRYPTO, FMT, math/big
  	< crypto/internal/boring/bbig
  	< crypto/rand
-@@ -858,7 +879,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -861,7 +882,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -320,7 +320,7 @@ index 1eb683a5ae77b7..2adf8c897229cf 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -868,7 +889,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -871,7 +892,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}
@@ -679,10 +679,10 @@ index 00000000000000..6461f241f863fc
 +type BigInt []uint
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cipher.go b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
 new file mode 100644
-index 00000000000000..2a3a91eb549a68
+index 00000000000000..56f1354d63da76
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
-@@ -0,0 +1,603 @@
+@@ -0,0 +1,653 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1163,6 +1163,56 @@ index 00000000000000..2a3a91eb549a68
 +	}
 +	runtime.KeepAlive(g)
 +	return ret
++}
++
++func (g *cipherGCM) SealWithRandomNonce(out, nonce, plaintext, aad []byte) {
++	if uint64(len(plaintext)) > uint64((1<<32)-2)*aesBlockSize {
++		panic("crypto/cipher: message too large for GCM")
++	}
++	if len(nonce) != gcmStandardNonceSize {
++		panic("crypto/cipher: incorrect nonce length given to GCMWithRandomNonce")
++	}
++	if len(out) != len(plaintext)+gcmTagSize {
++		panic("crypto/cipher: incorrect output length given to GCMWithRandomNonce")
++	}
++	if inexactOverlap(out, plaintext) {
++		panic("crypto/cipher: invalid buffer overlap of output and input")
++	}
++	if anyOverlap(out, aad) {
++		panic("crypto/cipher: invalid buffer overlap of output and additional data")
++	}
++
++	if g.tls != cipherGCMTLSNone {
++		panic("cipher: encryption failed")
++	}
++
++	RandReader.Read(nonce)
++	ctx, err := newCipherCtx(g.c.kind, cipherModeGCM, cipherOpNone, g.c.key, nil)
++	if err != nil {
++		panic(err)
++	}
++	defer ossl.EVP_CIPHER_CTX_free(ctx)
++	if _, err := ossl.EVP_EncryptInit_ex(ctx, nil, nil, nil, base(nonce)); err != nil {
++		panic(err)
++	}
++	var outl, discard int32
++	if _, err := ossl.EVP_EncryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), int32(len(aad))); err != nil {
++		panic(err)
++	}
++	if _, err := ossl.EVP_EncryptUpdate(ctx, base(out), &outl, baseNeverEmpty(plaintext), int32(len(plaintext))); err != nil {
++		panic(err)
++	}
++	if len(plaintext) != int(outl) {
++		panic("cipher: incorrect length returned from GCM EncryptUpdate")
++	}
++	if _, err := ossl.EVP_EncryptFinal_ex(ctx, base(out[outl:]), &discard); err != nil {
++		panic(err)
++	}
++	if _, err := ossl.EVP_CIPHER_CTX_ctrl(ctx, ossl.EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(base(out[outl:]))); err != nil {
++		panic(err)
++	}
++	runtime.KeepAlive(g)
++	return
 +}
 +
 +var errOpen = errors.New("cipher: message authentication failed")
@@ -18837,7 +18887,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 4c87639632f887..35848b6d6cd2dd 100644
+index 4c87639632f887..271c698c1d681b 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,20 @@

--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -18,7 +18,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../github.com/golang-fips/openssl/v2/aes.go  |  146 ++
  .../golang-fips/openssl/v2/bbig/big.go        |   37 +
  .../github.com/golang-fips/openssl/v2/big.go  |   11 +
- .../golang-fips/openssl/v2/cipher.go          |  653 ++++++
+ .../golang-fips/openssl/v2/cipher.go          |  654 ++++++
  .../golang-fips/openssl/v2/const.go           |   93 +
  .../github.com/golang-fips/openssl/v2/des.go  |  113 +
  .../github.com/golang-fips/openssl/v2/dsa.go  |  309 +++
@@ -103,7 +103,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 97 files changed, 17065 insertions(+), 7 deletions(-)
+ 97 files changed, 17066 insertions(+), 7 deletions(-)
  create mode 100644 src/crypto/internal/backend/deps_ignore.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
@@ -679,10 +679,10 @@ index 00000000000000..6461f241f863fc
 +type BigInt []uint
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cipher.go b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
 new file mode 100644
-index 00000000000000..56f1354d63da76
+index 00000000000000..c9b2a64e181d3e
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
-@@ -0,0 +1,653 @@
+@@ -0,0 +1,654 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -1010,6 +1010,7 @@ index 00000000000000..56f1354d63da76
 +}
 +
 +const (
++	aesBlockSize         = 16
 +	gcmTagSize           = 16
 +	gcmStandardNonceSize = 12
 +	// TLS 1.2 additional data is constructed as:

--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -59,7 +59,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/cryptokit/hash.go                |  255 +++
  .../internal/cryptokit/hkdf.go                |   77 +
  .../internal/cryptokit/hmac.go                |  144 ++
- .../microsoft/go-crypto-darwin/xcrypto/aes.go |  306 +++
+ .../microsoft/go-crypto-darwin/xcrypto/aes.go |  336 +++
  .../microsoft/go-crypto-darwin/xcrypto/big.go |   16 +
  .../go-crypto-darwin/xcrypto/cgo_go124.go     |   23 +
  .../go-crypto-darwin/xcrypto/cipher.go        |  122 +
@@ -78,7 +78,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-darwin/xcrypto/rsa.go |  194 ++
  .../go-crypto-darwin/xcrypto/xcrypto.go       |   49 +
  .../microsoft/go-crypto-winnative/LICENSE     |   21 +
- .../microsoft/go-crypto-winnative/cng/aes.go  |  393 ++++
+ .../microsoft/go-crypto-winnative/cng/aes.go  |  427 ++++
  .../go-crypto-winnative/cng/bbig/big.go       |   31 +
  .../microsoft/go-crypto-winnative/cng/big.go  |   30 +
  .../go-crypto-winnative/cng/cipher.go         |   52 +
@@ -103,7 +103,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 97 files changed, 17066 insertions(+), 7 deletions(-)
+ 97 files changed, 17130 insertions(+), 7 deletions(-)
  create mode 100644 src/crypto/internal/backend/deps_ignore.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitignore
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
@@ -12450,10 +12450,10 @@ index 00000000000000..c9f4d67de4c9f3
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/aes.go b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/aes.go
 new file mode 100644
-index 00000000000000..27a42bfc89ca06
+index 00000000000000..c9611eef5e2697
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/aes.go
-@@ -0,0 +1,306 @@
+@@ -0,0 +1,336 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -12672,6 +12672,36 @@ index 00000000000000..27a42bfc89ca06
 +		panic("cipher: encryption failed")
 +	}
 +	return ret
++}
++
++func (g *aesGCM) SealWithRandomNonce(out, nonce, plaintext, additionalData []byte) {
++	if uint64(len(plaintext)) > uint64((1<<32)-2)*aesBlockSize {
++		panic("crypto/cipher: message too large for GCM")
++	}
++	if len(nonce) != gcmStandardNonceSize {
++		panic("crypto/cipher: incorrect nonce length given to GCMWithRandomNonce")
++	}
++	if len(out) != len(plaintext)+gcmTagSize {
++		panic("crypto/cipher: incorrect output length given to GCMWithRandomNonce")
++	}
++	if inexactOverlap(out, plaintext) {
++		panic("crypto/cipher: invalid buffer overlap of output and input")
++	}
++	if anyOverlap(out, additionalData) {
++		panic("crypto/cipher: invalid buffer overlap of output and additional data")
++	}
++
++	if g.tls != cipherGCMTLSNone {
++		panic("cipher: TLS 1.2 and 1.3 modes do not support random nonce")
++	}
++
++	tag := out[len(out)-gcmTagSize:]
++	// Generate a random nonce
++	RandReader.Read(nonce)
++	err := cryptokit.EncryptAESGCM(g.key, plaintext, nonce, additionalData, out[:len(out)-gcmTagSize], tag)
++	if err != 0 {
++		panic("cipher: encryption failed")
++	}
 +}
 +
 +var errOpen = errors.New("cipher: message authentication failed")
@@ -14534,10 +14564,10 @@ index 00000000000000..9e841e7a26e4eb
 +    SOFTWARE
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
 new file mode 100644
-index 00000000000000..097a0fc77f0adb
+index 00000000000000..692a36ec7079cc
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/aes.go
-@@ -0,0 +1,393 @@
+@@ -0,0 +1,427 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -14875,6 +14905,40 @@ index 00000000000000..097a0fc77f0adb
 +	}
 +	runtime.KeepAlive(g)
 +	return ret
++}
++
++func (g *aesGCM) SealWithRandomNonce(out, nonce, plaintext, additionalData []byte) {
++	if uint64(len(plaintext)) > uint64((1<<32)-2)*aesBlockSize {
++		panic("crypto/cipher: message too large for GCM")
++	}
++	if len(nonce) != gcmStandardNonceSize {
++		panic("crypto/cipher: incorrect nonce length given to GCMWithRandomNonce")
++	}
++	if len(out) != len(plaintext)+gcmTagSize {
++		panic("crypto/cipher: incorrect output length given to GCMWithRandomNonce")
++	}
++	if subtle.InexactOverlap(out, plaintext) {
++		panic("crypto/cipher: invalid buffer overlap of output and input")
++	}
++	if subtle.AnyOverlap(out, additionalData) {
++		panic("crypto/cipher: invalid buffer overlap of output and additional data")
++	}
++
++	if g.tls != cipherGCMTLSNone {
++		panic("cipher: TLS 1.2 and 1.3 modes do not support random nonce")
++	}
++
++	RandReader.Read(nonce)
++	info := bcrypt.NewAUTHENTICATED_CIPHER_MODE_INFO(nonce, additionalData, out[len(out)-gcmTagSize:])
++	var encSize uint32
++	err := bcrypt.Encrypt(g.kh, plaintext, unsafe.Pointer(info), nil, out, &encSize, 0)
++	if err != nil {
++		panic(err)
++	}
++	if int(encSize) != len(plaintext) {
++		panic("crypto/cipher: plaintext not fully encrypted")
++	}
++	runtime.KeepAlive(g)
 +}
 +
 +var errOpen = errors.New("cipher: message authentication failed")

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -15,7 +15,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/backend/bbig/big_openssl.go      |  12 +
  src/crypto/internal/backend/boring_linux.go   | 294 ++++++++++++++
  src/crypto/internal/backend/cng_windows.go    | 348 +++++++++++++++++
- src/crypto/internal/backend/common.go         | 150 +++++++
+ src/crypto/internal/backend/common.go         |  65 ++++
  src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2837 insertions(+), 3 deletions(-)
+ 45 files changed, 2752 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -554,7 +554,7 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..5befae98deed4d
+index 00000000000000..dba1ac10532eef
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
 @@ -0,0 +1,294 @@
@@ -620,7 +620,7 @@ index 00000000000000..5befae98deed4d
 +	if err != nil {
 +		return nil, err
 +	}
-+	return wrapGCMCapableBlock(cipher), nil
++	return cipher, nil
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return boring.NewGCMTLS(c) }
@@ -854,7 +854,7 @@ index 00000000000000..5befae98deed4d
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..21345775fe387c
+index 00000000000000..bb001dca9b7a0b
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,348 @@
@@ -935,7 +935,7 @@ index 00000000000000..21345775fe387c
 +	if err != nil {
 +		return nil, err
 +	}
-+	return wrapGCMCapableBlock(cipher), nil
++	return cipher, nil
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) {
@@ -1208,10 +1208,10 @@ index 00000000000000..21345775fe387c
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..6a85c9af5c5dd7
+index 00000000000000..a6786c5ad8e33d
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,150 @@
+@@ -0,0 +1,65 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1219,12 +1219,10 @@ index 00000000000000..6a85c9af5c5dd7
 +package backend
 +
 +import (
-+	"crypto/cipher"
 +	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
 +	"internal/goexperiment"
 +	"runtime"
-+	"unsafe"
 +)
 +
 +func init() {
@@ -1279,89 +1277,6 @@ index 00000000000000..6a85c9af5c5dd7
 +	gcmStandardNonceSize = 12
 +	gcmTagSize           = 16
 +)
-+
-+// gcmMCapableBlock extends cipher.Block with the ability to create customizable GCM AEADs.
-+// Based on the gcmAble interface from crypto/cipher/gcm.go.
-+type gcmCapableBlock interface {
-+	cipher.Block
-+	NewGCM(nonceSize, tagSize int) (cipher.AEAD, error)
-+}
-+
-+// wrapGCMCapableBlock checks if the given cipher.Block implements gcmCapableBlock.
-+// If it does, it wraps it in an extendedBlockCipher; otherwise, it returns the block as is.
-+func wrapGCMCapableBlock(block cipher.Block) cipher.Block {
-+	if gcmBlock, ok := block.(gcmCapableBlock); ok {
-+		return &extendedBlockCipher{gcmBlock}
-+	}
-+	return block
-+}
-+
-+type extendedBlockCipher struct {
-+	gcmCapableBlock
-+}
-+
-+func (e *extendedBlockCipher) NewGCM(nonceSize, tagSize int) (cipher.AEAD, error) {
-+	gcm, err := e.gcmCapableBlock.NewGCM(nonceSize, tagSize)
-+	if err != nil {
-+		return nil, err
-+	}
-+	return &extendedAEAD{AEAD: gcm}, nil
-+}
-+
-+type extendedAEAD struct {
-+	cipher.AEAD
-+}
-+
-+// SealWithRandomNonce encrypts plaintext to out, and writes a random nonce to
-+// nonce. nonce must be 12 bytes, and out must be 16 bytes longer than plaintext.
-+// out and plaintext may overlap exactly or not at all. additionalData and out
-+// must not overlap.
-+//
-+// This complies with FIPS 140-3 IG C.H Scenario 2.
-+//
-+// Note that this is NOT a [cipher.AEAD].Seal method.
-+// This methods implementation is copied from fips140/aes/gcm
-+func (g *extendedAEAD) SealWithRandomNonce(nonce, out, plaintext, additionalData []byte) {
-+	if uint64(len(plaintext)) > uint64((1<<32)-2)*gcmBlockSize {
-+		panic("crypto/cipher: message too large for GCM")
-+	}
-+	if len(nonce) != gcmStandardNonceSize {
-+		panic("crypto/cipher: incorrect nonce length given to GCMWithRandomNonce")
-+	}
-+	if len(out) != len(plaintext)+gcmTagSize {
-+		panic("crypto/cipher: incorrect output length given to GCMWithRandomNonce")
-+	}
-+	if inexactOverlap(out, plaintext) {
-+		panic("crypto/cipher: invalid buffer overlap of output and input")
-+	}
-+	if anyOverlap(out, additionalData) {
-+		panic("crypto/cipher: invalid buffer overlap of output and additional data")
-+	}
-+	// #TODO fips140.RecordApproved()
-+	RandReader.Read(nonce)
-+	g.Seal(out, nonce, plaintext, additionalData)
-+}
-+
-+// anyOverlap reports whether x and y share memory at any (not necessarily
-+// corresponding) index. The memory beyond the slice length is ignored.
-+func anyOverlap(x, y []byte) bool {
-+	return len(x) > 0 && len(y) > 0 &&
-+		uintptr(unsafe.Pointer(&x[0])) <= uintptr(unsafe.Pointer(&y[len(y)-1])) &&
-+		uintptr(unsafe.Pointer(&y[0])) <= uintptr(unsafe.Pointer(&x[len(x)-1]))
-+}
-+
-+// inexactOverlap reports whether x and y share memory at any non-corresponding
-+// index. The memory beyond the slice length is ignored. Note that x and y can
-+// have different lengths and still not have any inexact overlap.
-+//
-+// InexactOverlap can be used to implement the requirements of the crypto/cipher
-+// AEAD, Block, BlockMode and Stream interfaces.
-+func inexactOverlap(x, y []byte) bool {
-+	if len(x) == 0 || len(y) == 0 || &x[0] == &y[0] {
-+		return false
-+	}
-+	return anyOverlap(x, y)
-+}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
 index 00000000000000..0c374baf8d3f80
@@ -2452,7 +2367,7 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..33c0fa4c583425
+index 00000000000000..597e65029419df
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,346 @@
@@ -2541,7 +2456,7 @@ index 00000000000000..33c0fa4c583425
 +	if err != nil {
 +		return nil, err
 +	}
-+	return wrapGCMCapableBlock(cipher), nil
++	return cipher, nil
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return openssl.NewGCMTLS(c) }

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/boring_linux.go   | 290 ++++++++++++++
+ src/crypto/internal/backend/boring_linux.go   | 287 ++++++++++++++
  src/crypto/internal/backend/cng_windows.go    | 344 ++++++++++++++++
  src/crypto/internal/backend/common.go         |  59 +++
  src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
@@ -30,7 +30,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 342 ++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 339 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |  27 +-
  .../exp_allowcryptofallback_off.go            |   9 +
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2734 insertions(+), 3 deletions(-)
+ 45 files changed, 2728 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -554,10 +554,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..f2cc7a74e09410
+index 00000000000000..48d44ec1723ab6
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,290 @@
+@@ -0,0 +1,287 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -615,10 +615,7 @@ index 00000000000000..f2cc7a74e09410
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return boring.NewHMAC(h, key) }
 +
-+func NewAESCipher(key []byte) (cipher.Block, error) {
-+	return boring.NewAESCipher(key)
-+}
-+
++func NewAESCipher(key []byte) (cipher.Block, error)   { return boring.NewAESCipher(key) }
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return boring.NewGCMTLS(c) }
 +func NewGCMTLS13(c cipher.Block) (cipher.AEAD, error) { return boring.NewGCMTLS13(c) }
 +
@@ -2353,10 +2350,10 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..b7c8b27be72362
+index 00000000000000..ac656468e3ed32
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,342 @@
+@@ -0,0 +1,339 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2437,10 +2434,7 @@ index 00000000000000..b7c8b27be72362
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return openssl.NewHMAC(h, key) }
 +
-+func NewAESCipher(key []byte) (cipher.Block, error) {
-+	return openssl.NewAESCipher(key)
-+}
-+
++func NewAESCipher(key []byte) (cipher.Block, error)   { return openssl.NewAESCipher(key) }
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return openssl.NewGCMTLS(c) }
 +func NewGCMTLS13(c cipher.Block) (cipher.AEAD, error) { return openssl.NewGCMTLS13(c) }
 +

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,9 +13,9 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/boring_linux.go   | 294 ++++++++++++++
- src/crypto/internal/backend/cng_windows.go    | 348 +++++++++++++++++
- src/crypto/internal/backend/common.go         |  65 ++++
+ src/crypto/internal/backend/boring_linux.go   | 290 ++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 344 ++++++++++++++++
+ src/crypto/internal/backend/common.go         |  59 +++
  src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
@@ -30,7 +30,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 346 +++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 342 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |  27 +-
  .../exp_allowcryptofallback_off.go            |   9 +
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2752 insertions(+), 3 deletions(-)
+ 45 files changed, 2734 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -554,10 +554,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..dba1ac10532eef
+index 00000000000000..f2cc7a74e09410
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,294 @@
+@@ -0,0 +1,290 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -616,11 +616,7 @@ index 00000000000000..dba1ac10532eef
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return boring.NewHMAC(h, key) }
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) {
-+	cipher, err := boring.NewAESCipher(key)
-+	if err != nil {
-+		return nil, err
-+	}
-+	return cipher, nil
++	return boring.NewAESCipher(key)
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return boring.NewGCMTLS(c) }
@@ -854,10 +850,10 @@ index 00000000000000..dba1ac10532eef
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..bb001dca9b7a0b
+index 00000000000000..6abb6ff007c99f
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,348 @@
+@@ -0,0 +1,344 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -931,11 +927,7 @@ index 00000000000000..bb001dca9b7a0b
 +}
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) {
-+	cipher, err := cng.NewAESCipher(key)
-+	if err != nil {
-+		return nil, err
-+	}
-+	return cipher, nil
++	return cng.NewAESCipher(key)
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) {
@@ -1208,10 +1200,10 @@ index 00000000000000..bb001dca9b7a0b
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..a6786c5ad8e33d
+index 00000000000000..9436b00381aaf8
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,59 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1271,12 +1263,6 @@ index 00000000000000..a6786c5ad8e33d
 +		}
 +	}
 +}
-+
-+const (
-+	gcmBlockSize         = 16
-+	gcmStandardNonceSize = 12
-+	gcmTagSize           = 16
-+)
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
 index 00000000000000..0c374baf8d3f80
@@ -2367,10 +2353,10 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..597e65029419df
+index 00000000000000..b7c8b27be72362
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,346 @@
+@@ -0,0 +1,342 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2452,11 +2438,7 @@ index 00000000000000..597e65029419df
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return openssl.NewHMAC(h, key) }
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) {
-+	cipher, err := openssl.NewAESCipher(key)
-+	if err != nil {
-+		return nil, err
-+	}
-+	return cipher, nil
++	return openssl.NewAESCipher(key)
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return openssl.NewGCMTLS(c) }

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,9 +13,9 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/boring_linux.go   | 287 ++++++++++++++
+ src/crypto/internal/backend/boring_linux.go   | 289 ++++++++++++++
  src/crypto/internal/backend/cng_windows.go    | 344 ++++++++++++++++
- src/crypto/internal/backend/common.go         |  59 +++
+ src/crypto/internal/backend/common.go         | 122 ++++++
  src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
@@ -30,7 +30,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 339 ++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 341 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |  27 +-
  .../exp_allowcryptofallback_off.go            |   9 +
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2728 insertions(+), 3 deletions(-)
+ 45 files changed, 2795 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -554,10 +554,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..48d44ec1723ab6
+index 00000000000000..57da4675217f3f
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,287 @@
+@@ -0,0 +1,289 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -615,7 +615,9 @@ index 00000000000000..48d44ec1723ab6
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return boring.NewHMAC(h, key) }
 +
-+func NewAESCipher(key []byte) (cipher.Block, error)   { return boring.NewAESCipher(key) }
++func NewAESCipher(key []byte) (cipher.Block, error) {
++	return extendedBlockCipher(boring.NewAESCipher(key))
++}
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return boring.NewGCMTLS(c) }
 +func NewGCMTLS13(c cipher.Block) (cipher.AEAD, error) { return boring.NewGCMTLS13(c) }
 +
@@ -847,7 +849,7 @@ index 00000000000000..48d44ec1723ab6
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..6abb6ff007c99f
+index 00000000000000..2cf6e1e435552a
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,344 @@
@@ -924,7 +926,7 @@ index 00000000000000..6abb6ff007c99f
 +}
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) {
-+	return cng.NewAESCipher(key)
++	return extendedBlockCipher(cng.NewAESCipher(key))
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) {
@@ -1197,10 +1199,10 @@ index 00000000000000..6abb6ff007c99f
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..9436b00381aaf8
+index 00000000000000..19b9818f8931e0
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,122 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1208,10 +1210,12 @@ index 00000000000000..9436b00381aaf8
 +package backend
 +
 +import (
++	"crypto/cipher"
 +	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
 +	"internal/goexperiment"
 +	"runtime"
++	"unsafe"
 +)
 +
 +func init() {
@@ -1259,6 +1263,67 @@ index 00000000000000..9436b00381aaf8
 +			panic("cryptobackend: invalid code execution")
 +		}
 +	}
++}
++
++const (
++	gcmBlockSize         = 16
++	gcmStandardNonceSize = 12
++	gcmTagSize           = 16
++)
++
++type extendedBlockCipher struct {
++	cipher.AEAD
++}
++
++// SealWithRandomNonce encrypts plaintext to out, and writes a random nonce to
++// nonce. nonce must be 12 bytes, and out must be 16 bytes longer than plaintext.
++// out and plaintext may overlap exactly or not at all. additionalData and out
++// must not overlap.
++//
++// This complies with FIPS 140-3 IG C.H Scenario 2.
++//
++// Note that this is NOT a [cipher.AEAD].Seal method.
++// This methods implementation is copied from fips140/aes/gcm
++func (g *extendedBlockCipher) SealWithRandomNonce(nonce, out, plaintext, additionalData []byte) {
++	if uint64(len(plaintext)) > uint64((1<<32)-2)*gcmBlockSize {
++		panic("crypto/cipher: message too large for GCM")
++	}
++	if len(nonce) != gcmStandardNonceSize {
++		panic("crypto/cipher: incorrect nonce length given to GCMWithRandomNonce")
++	}
++	if len(out) != len(plaintext)+gcmTagSize {
++		panic("crypto/cipher: incorrect output length given to GCMWithRandomNonce")
++	}
++	if inexactOverlap(out, plaintext) {
++		panic("crypto/cipher: invalid buffer overlap of output and input")
++	}
++	if anyOverlap(out, additionalData) {
++		panic("crypto/cipher: invalid buffer overlap of output and additional data")
++	}
++	// #TODO fips140.RecordApproved()
++	RandReader.Read(nonce)
++	g.Seal(out, nonce, plaintext, additionalData)
++}
++
++// anyOverlap reports whether x and y share memory at any (not necessarily
++// corresponding) index. The memory beyond the slice length is ignored.
++func anyOverlap(x, y []byte) bool {
++	return len(x) > 0 && len(y) > 0 &&
++		uintptr(unsafe.Pointer(&x[0])) <= uintptr(unsafe.Pointer(&y[len(y)-1])) &&
++		uintptr(unsafe.Pointer(&y[0])) <= uintptr(unsafe.Pointer(&x[len(x)-1]))
++}
++
++// inexactOverlap reports whether x and y share memory at any non-corresponding
++// index. The memory beyond the slice length is ignored. Note that x and y can
++// have different lengths and still not have any inexact overlap.
++//
++// InexactOverlap can be used to implement the requirements of the crypto/cipher
++// AEAD, Block, BlockMode and Stream interfaces.
++func inexactOverlap(x, y []byte) bool {
++	if len(x) == 0 || len(y) == 0 || &x[0] == &y[0] {
++		return false
++	}
++	return anyOverlap(x, y)
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
@@ -2350,10 +2415,10 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..ac656468e3ed32
+index 00000000000000..5e9cb4b2691a82
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,339 @@
+@@ -0,0 +1,341 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2434,7 +2499,9 @@ index 00000000000000..ac656468e3ed32
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return openssl.NewHMAC(h, key) }
 +
-+func NewAESCipher(key []byte) (cipher.Block, error)   { return openssl.NewAESCipher(key) }
++func NewAESCipher(key []byte) (cipher.Block, error) {
++	return extendedBlockCipher(openssl.NewAESCipher(key))
++}
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return openssl.NewGCMTLS(c) }
 +func NewGCMTLS13(c cipher.Block) (cipher.AEAD, error) { return openssl.NewGCMTLS13(c) }
 +
@@ -2710,10 +2777,10 @@ index 00000000000000..5e4b436554d44d
 +// from complaining about the missing body
 +// (because the implementation might be here).
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 0095243ce2b0b7..af62328edf5eca 100644
+index 3ad0b0a3f2f465..2e4b1fd1b370cc 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -535,6 +535,11 @@ var depsRules = `
+@@ -536,6 +536,11 @@ var depsRules = `
  	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
  	< github.com/microsoft/go-crypto-winnative/cng;
  
@@ -2725,7 +2792,7 @@ index 0095243ce2b0b7..af62328edf5eca 100644
  	FIPS, internal/godebug < crypto/fips140;
  
  	crypto, hash !< FIPS;
-@@ -545,16 +550,28 @@ var depsRules = `
+@@ -546,16 +551,28 @@ var depsRules = `
  	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
  	sync/atomic < crypto/internal/boring/bcache;
  
@@ -2756,7 +2823,7 @@ index 0095243ce2b0b7..af62328edf5eca 100644
  	< crypto/boring
  	< crypto/aes,
  	  crypto/des,
-@@ -578,8 +595,12 @@ var depsRules = `
+@@ -579,8 +596,12 @@ var depsRules = `
  	math/big, github.com/microsoft/go-crypto-darwin/xcrypto < github.com/microsoft/go-crypto-darwin/bbig;
  	math/big, github.com/microsoft/go-crypto-winnative/cng < github.com/microsoft/go-crypto-winnative/cng/bbig;
  
@@ -2801,7 +2868,7 @@ index 00000000000000..8d0c3fde9ab5e8
 +const AllowCryptoFallback = true
 +const AllowCryptoFallbackInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index c2a8b7f860d780..451a8924ae423d 100644
+index 6b4289503d57ae..12fba96b868c9e 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -78,6 +78,14 @@ type Flags struct {

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -15,7 +15,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/backend/bbig/big_openssl.go      |  12 +
  src/crypto/internal/backend/boring_linux.go   | 294 ++++++++++++++
  src/crypto/internal/backend/cng_windows.go    | 348 +++++++++++++++++
- src/crypto/internal/backend/common.go         | 122 ++++++
+ src/crypto/internal/backend/common.go         | 150 +++++++
  src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2809 insertions(+), 3 deletions(-)
+ 45 files changed, 2837 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -554,7 +554,7 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..3146d26e7ba7f2
+index 00000000000000..5befae98deed4d
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
 @@ -0,0 +1,294 @@
@@ -620,7 +620,7 @@ index 00000000000000..3146d26e7ba7f2
 +	if err != nil {
 +		return nil, err
 +	}
-+	return extendedBlockCipher(cipher), nil
++	return wrapGCMCapableBlock(cipher), nil
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return boring.NewGCMTLS(c) }
@@ -854,7 +854,7 @@ index 00000000000000..3146d26e7ba7f2
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..696a45ed87405d
+index 00000000000000..21345775fe387c
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,348 @@
@@ -935,7 +935,7 @@ index 00000000000000..696a45ed87405d
 +	if err != nil {
 +		return nil, err
 +	}
-+	return extendedBlockCipher(cipher), nil
++	return wrapGCMCapableBlock(cipher), nil
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) {
@@ -1208,10 +1208,10 @@ index 00000000000000..696a45ed87405d
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..19b9818f8931e0
+index 00000000000000..6a85c9af5c5dd7
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,150 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1280,7 +1280,35 @@ index 00000000000000..19b9818f8931e0
 +	gcmTagSize           = 16
 +)
 +
++// gcmMCapableBlock extends cipher.Block with the ability to create customizable GCM AEADs.
++// Based on the gcmAble interface from crypto/cipher/gcm.go.
++type gcmCapableBlock interface {
++	cipher.Block
++	NewGCM(nonceSize, tagSize int) (cipher.AEAD, error)
++}
++
++// wrapGCMCapableBlock checks if the given cipher.Block implements gcmCapableBlock.
++// If it does, it wraps it in an extendedBlockCipher; otherwise, it returns the block as is.
++func wrapGCMCapableBlock(block cipher.Block) cipher.Block {
++	if gcmBlock, ok := block.(gcmCapableBlock); ok {
++		return &extendedBlockCipher{gcmBlock}
++	}
++	return block
++}
++
 +type extendedBlockCipher struct {
++	gcmCapableBlock
++}
++
++func (e *extendedBlockCipher) NewGCM(nonceSize, tagSize int) (cipher.AEAD, error) {
++	gcm, err := e.gcmCapableBlock.NewGCM(nonceSize, tagSize)
++	if err != nil {
++		return nil, err
++	}
++	return &extendedAEAD{AEAD: gcm}, nil
++}
++
++type extendedAEAD struct {
 +	cipher.AEAD
 +}
 +
@@ -1293,7 +1321,7 @@ index 00000000000000..19b9818f8931e0
 +//
 +// Note that this is NOT a [cipher.AEAD].Seal method.
 +// This methods implementation is copied from fips140/aes/gcm
-+func (g *extendedBlockCipher) SealWithRandomNonce(nonce, out, plaintext, additionalData []byte) {
++func (g *extendedAEAD) SealWithRandomNonce(nonce, out, plaintext, additionalData []byte) {
 +	if uint64(len(plaintext)) > uint64((1<<32)-2)*gcmBlockSize {
 +		panic("crypto/cipher: message too large for GCM")
 +	}
@@ -2424,7 +2452,7 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..a99b10566710e0
+index 00000000000000..33c0fa4c583425
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,346 @@
@@ -2513,7 +2541,7 @@ index 00000000000000..a99b10566710e0
 +	if err != nil {
 +		return nil, err
 +	}
-+	return extendedBlockCipher(cipher), nil
++	return wrapGCMCapableBlock(cipher), nil
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return openssl.NewGCMTLS(c) }

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,8 +13,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/boring_linux.go   | 289 ++++++++++++++
- src/crypto/internal/backend/cng_windows.go    | 344 ++++++++++++++++
+ src/crypto/internal/backend/boring_linux.go   | 294 ++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 348 +++++++++++++++++
  src/crypto/internal/backend/common.go         | 122 ++++++
  src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
@@ -30,7 +30,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 341 ++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 346 +++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |  27 +-
  .../exp_allowcryptofallback_off.go            |   9 +
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2795 insertions(+), 3 deletions(-)
+ 45 files changed, 2809 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -554,10 +554,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..57da4675217f3f
+index 00000000000000..3146d26e7ba7f2
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,289 @@
+@@ -0,0 +1,294 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -616,8 +616,13 @@ index 00000000000000..57da4675217f3f
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return boring.NewHMAC(h, key) }
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) {
-+	return extendedBlockCipher(boring.NewAESCipher(key))
++	cipher, err := boring.NewAESCipher(key)
++	if err != nil {
++		return nil, err
++	}
++	return extendedBlockCipher(cipher), nil
 +}
++
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return boring.NewGCMTLS(c) }
 +func NewGCMTLS13(c cipher.Block) (cipher.AEAD, error) { return boring.NewGCMTLS13(c) }
 +
@@ -849,10 +854,10 @@ index 00000000000000..57da4675217f3f
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..2cf6e1e435552a
+index 00000000000000..696a45ed87405d
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,344 @@
+@@ -0,0 +1,348 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -926,7 +931,11 @@ index 00000000000000..2cf6e1e435552a
 +}
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) {
-+	return extendedBlockCipher(cng.NewAESCipher(key))
++	cipher, err := cng.NewAESCipher(key)
++	if err != nil {
++		return nil, err
++	}
++	return extendedBlockCipher(cipher), nil
 +}
 +
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) {
@@ -2415,10 +2424,10 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..5e9cb4b2691a82
+index 00000000000000..a99b10566710e0
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,341 @@
+@@ -0,0 +1,346 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2500,8 +2509,13 @@ index 00000000000000..5e9cb4b2691a82
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return openssl.NewHMAC(h, key) }
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) {
-+	return extendedBlockCipher(openssl.NewAESCipher(key))
++	cipher, err := openssl.NewAESCipher(key)
++	if err != nil {
++		return nil, err
++	}
++	return extendedBlockCipher(cipher), nil
 +}
++
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return openssl.NewGCMTLS(c) }
 +func NewGCMTLS13(c cipher.Block) (cipher.AEAD, error) { return openssl.NewGCMTLS13(c) }
 +

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..442fb872b384a9 100644
+index 5580f96d55a0fb..94abd2a4cc1bad 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,7 +93,14 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -457,16 +457,16 @@ index 5580f96d55a0fb..442fb872b384a9 100644
 +	aead AEAD
 +}
 +
-+func (g *customGCMWrapper) NonceSize() int { g.aead.NonceSize() }
++func (g *customGCMWrapper) NonceSize() int { return g.aead.NonceSize() }
 +
-+func (g *customGCMWrapper) Overhead() int { g.aead.Overhead() }
++func (g *customGCMWrapper) Overhead() int { return g.aead.Overhead() }
 +
 +func (g *customGCMWrapper) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
-+	g.aead.Seal(dst, nonce, plaintext, additionalData)
++	return g.aead.Seal(dst, nonce, plaintext, additionalData)
 +}
 +
 +func (g *customGCMWrapper) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
-+	g.aead.Open(dst, nonce, ciphertext, additionalData)
++	return g.aead.Open(dst, nonce, ciphertext, additionalData)
 +}
 +
  // gcmFallback is only used for non-AES ciphers, which regrettably we

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  19 +-
+ src/crypto/cipher/gcm.go                      |  46 ++++-
  src/crypto/cipher/gcm_test.go                 |  12 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1132 insertions(+), 95 deletions(-)
+ 86 files changed, 1158 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,23 +381,26 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..256234217507ae 100644
+index 5580f96d55a0fb..442fb872b384a9 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
-@@ -93,7 +93,11 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -93,7 +93,14 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  	c, ok := cipher.(*aes.Block)
  	if !ok {
 -		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
-+		g, err := newGCMFallback(cipher, gcmStandardNonceSize, gcmTagSize)
-+		if err != nil {
-+			return nil, err
++		if cipher, ok := cipher.(gcmAble); ok {
++			g, err := cipher.NewGCM(nonceSize, tagSize)
++			if err != nil {
++				return nil, err
++			}
++
++			return gcmWithRandomNonce{g}, nil
 +		}
-+		return gcmWithRandomNonce{g}, nil
  	}
  	g, err := gcm.New(c, gcmStandardNonceSize, gcmTagSize)
  	if err != nil {
-@@ -103,7 +107,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
+@@ -103,7 +110,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  }
  
  type gcmWithRandomNonce struct {
@@ -406,7 +409,7 @@ index 5580f96d55a0fb..256234217507ae 100644
  }
  
  func (g gcmWithRandomNonce) NonceSize() int {
-@@ -157,7 +161,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
+@@ -157,7 +164,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
  		plaintext = ciphertext[:len(plaintext)]
  	}
  
@@ -422,7 +425,7 @@ index 5580f96d55a0fb..256234217507ae 100644
  	return ret
  }
  
-@@ -190,7 +201,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
+@@ -190,7 +204,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
  		ciphertext = ciphertext[gcmStandardNonceSize:]
  	}
  
@@ -431,6 +434,44 @@ index 5580f96d55a0fb..256234217507ae 100644
  	if err != nil {
  		return nil, err
  	}
+@@ -212,7 +226,11 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+ 		return nil, errors.New("cipher: the nonce can't have zero length")
+ 	}
+ 	if cipher, ok := cipher.(gcmAble); ok {
+-		return cipher.NewGCM(nonceSize, tagSize)
++		g, err := cipher.NewGCM(nonceSize, tagSize)
++		if err != nil {
++			return nil, err
++		}
++		return &customGCMWrapper{aead: g}, nil
+ 	}
+ 	if cipher.BlockSize() != gcmBlockSize {
+ 		return nil, errors.New("cipher: NewGCM requires 128-bit block cipher")
+@@ -220,6 +238,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+ 	return &gcmFallback{cipher: cipher, nonceSize: nonceSize, tagSize: tagSize}, nil
+ }
+ 
++// customGCMWrapper wraps an AEAD implementation to expose only the AEAD interface methods.
++// This prevents extra exported methods from causing test failures in cryptotest.NoExtraMethods.
++type customGCMWrapper struct {
++	aead AEAD
++}
++
++func (g *customGCMWrapper) NonceSize() int { g.aead.NonceSize() }
++
++func (g *customGCMWrapper) Overhead() int { g.aead.Overhead() }
++
++func (g *customGCMWrapper) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
++	g.aead.Seal(dst, nonce, plaintext, additionalData)
++}
++
++func (g *customGCMWrapper) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
++	g.aead.Open(dst, nonce, ciphertext, additionalData)
++}
++
+ // gcmFallback is only used for non-AES ciphers, which regrettably we
+ // theoretically support. It's a copy of the generic implementation from
+ // crypto/internal/fips140/aes/gcm/gcm_generic.go, refer to that file for more details.
 diff --git a/src/crypto/cipher/gcm_test.go b/src/crypto/cipher/gcm_test.go
 index e574822c9aa6f8..6a51981cb508e5 100644
 --- a/src/crypto/cipher/gcm_test.go

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  48 ++++-
+ src/crypto/cipher/gcm.go                      |  57 ++++-
  src/crypto/cipher/gcm_test.go                 |  13 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1161 insertions(+), 96 deletions(-)
+ 86 files changed, 1170 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,19 +381,28 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..59a4264bd8092f 100644
+index 5580f96d55a0fb..fb72f96e7cd6d6 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
-@@ -93,7 +93,7 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -93,7 +93,16 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  	c, ok := cipher.(*aes.Block)
  	if !ok {
 -		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
-+		return newGCM(cipher, gcmStandardNonceSize, gcmTagSize)
++		if cipher, ok := cipher.(gcmAble); ok {
++			g, err := cipher.NewGCM(gcmStandardNonceSize, gcmTagSize)
++			if err != nil {
++				return nil, err
++			}
++
++			return gcmWithRandomNonce{g}, nil
++		} else {
++			return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
++		}
  	}
  	g, err := gcm.New(c, gcmStandardNonceSize, gcmTagSize)
  	if err != nil {
-@@ -103,7 +103,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
+@@ -103,7 +112,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  }
  
  type gcmWithRandomNonce struct {
@@ -402,7 +411,7 @@ index 5580f96d55a0fb..59a4264bd8092f 100644
  }
  
  func (g gcmWithRandomNonce) NonceSize() int {
-@@ -157,7 +157,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
+@@ -157,7 +166,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
  		plaintext = ciphertext[:len(plaintext)]
  	}
  
@@ -412,13 +421,13 @@ index 5580f96d55a0fb..59a4264bd8092f 100644
 +	} else if gc, ok := g.aead.(randomNonceSealer); ok {
 +		gc.SealWithRandomNonce(ciphertext, nonce, plaintext, additionalData)
 +	} else {
-+		panic("crypto/cipher: GCMWithRandomNonce requires aes.Block or a cipher with random nonce support")
++		panic("cipher: NewGCMWithRandomNonce requires aes.Block")
 +	}
 +
  	return ret
  }
  
-@@ -190,7 +197,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
+@@ -190,7 +206,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
  		ciphertext = ciphertext[gcmStandardNonceSize:]
  	}
  
@@ -427,7 +436,7 @@ index 5580f96d55a0fb..59a4264bd8092f 100644
  	if err != nil {
  		return nil, err
  	}
-@@ -204,6 +211,10 @@ type gcmAble interface {
+@@ -204,6 +220,10 @@ type gcmAble interface {
  	NewGCM(nonceSize, tagSize int) (AEAD, error)
  }
  
@@ -438,7 +447,7 @@ index 5580f96d55a0fb..59a4264bd8092f 100644
  func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	if tagSize < gcmMinimumTagSize || tagSize > gcmBlockSize {
  		return nil, errors.New("cipher: incorrect tag size given to GCM")
-@@ -212,7 +223,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -212,7 +232,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  		return nil, errors.New("cipher: the nonce can't have zero length")
  	}
  	if cipher, ok := cipher.(gcmAble); ok {
@@ -449,14 +458,14 @@ index 5580f96d55a0fb..59a4264bd8092f 100644
 +		}
 +
 +		if _, ok := g.(randomNonceSealer); ok {
-+			return &gcmWithRandomNonce{g}, nil
++			return &customGCMWrapper{g}, nil
 +		}
 +
-+		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
++		return g, err
  	}
  	if cipher.BlockSize() != gcmBlockSize {
  		return nil, errors.New("cipher: NewGCM requires 128-bit block cipher")
-@@ -220,6 +240,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -220,6 +249,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	return &gcmFallback{cipher: cipher, nonceSize: nonceSize, tagSize: tagSize}, nil
  }
  

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  55 ++++-
+ src/crypto/cipher/gcm.go                      |  48 ++++-
  src/crypto/cipher/gcm_test.go                 |  13 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1168 insertions(+), 96 deletions(-)
+ 86 files changed, 1161 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,26 +381,19 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..cb6cc900fde083 100644
+index 5580f96d55a0fb..59a4264bd8092f 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
-@@ -93,7 +93,14 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -93,7 +93,7 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  	c, ok := cipher.(*aes.Block)
  	if !ok {
 -		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
-+		if cipher, ok := cipher.(gcmAble); ok {
-+			g, err := cipher.NewGCM(gcmStandardNonceSize, gcmTagSize)
-+			if err != nil {
-+				return nil, err
-+			}
-+
-+			return gcmWithRandomNonce{g}, nil
-+		}
++		return newGCM(cipher, gcmStandardNonceSize, gcmTagSize)
  	}
  	g, err := gcm.New(c, gcmStandardNonceSize, gcmTagSize)
  	if err != nil {
-@@ -103,7 +110,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
+@@ -103,7 +103,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  }
  
  type gcmWithRandomNonce struct {
@@ -409,7 +402,7 @@ index 5580f96d55a0fb..cb6cc900fde083 100644
  }
  
  func (g gcmWithRandomNonce) NonceSize() int {
-@@ -157,7 +164,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
+@@ -157,7 +157,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
  		plaintext = ciphertext[:len(plaintext)]
  	}
  
@@ -425,7 +418,7 @@ index 5580f96d55a0fb..cb6cc900fde083 100644
  	return ret
  }
  
-@@ -190,7 +204,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
+@@ -190,7 +197,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
  		ciphertext = ciphertext[gcmStandardNonceSize:]
  	}
  
@@ -434,7 +427,7 @@ index 5580f96d55a0fb..cb6cc900fde083 100644
  	if err != nil {
  		return nil, err
  	}
-@@ -204,6 +218,10 @@ type gcmAble interface {
+@@ -204,6 +211,10 @@ type gcmAble interface {
  	NewGCM(nonceSize, tagSize int) (AEAD, error)
  }
  
@@ -445,7 +438,7 @@ index 5580f96d55a0fb..cb6cc900fde083 100644
  func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	if tagSize < gcmMinimumTagSize || tagSize > gcmBlockSize {
  		return nil, errors.New("cipher: incorrect tag size given to GCM")
-@@ -212,7 +230,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -212,7 +223,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  		return nil, errors.New("cipher: the nonce can't have zero length")
  	}
  	if cipher, ok := cipher.(gcmAble); ok {
@@ -456,14 +449,14 @@ index 5580f96d55a0fb..cb6cc900fde083 100644
 +		}
 +
 +		if _, ok := g.(randomNonceSealer); ok {
-+			return &customGCMWrapper{g}, nil
++			return &gcmWithRandomNonce{g}, nil
 +		}
 +
 +		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
  	}
  	if cipher.BlockSize() != gcmBlockSize {
  		return nil, errors.New("cipher: NewGCM requires 128-bit block cipher")
-@@ -220,6 +247,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -220,6 +240,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	return &gcmFallback{cipher: cipher, nonceSize: nonceSize, tagSize: tagSize}, nil
  }
  

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -19,7 +19,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
  src/crypto/cipher/gcm.go                      |  53 ++++-
- src/crypto/cipher/gcm_test.go                 |  15 +-
+ src/crypto/cipher/gcm_test.go                 |  13 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
  src/crypto/dsa/dsa.go                         |  88 ++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1167 insertions(+), 97 deletions(-)
+ 86 files changed, 1166 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -487,7 +487,7 @@ index 5580f96d55a0fb..cc759af19b116b 100644
  // theoretically support. It's a copy of the generic implementation from
  // crypto/internal/fips140/aes/gcm/gcm_generic.go, refer to that file for more details.
 diff --git a/src/crypto/cipher/gcm_test.go b/src/crypto/cipher/gcm_test.go
-index e574822c9aa6f8..b14780fe885a27 100644
+index e574822c9aa6f8..f32707146a369a 100644
 --- a/src/crypto/cipher/gcm_test.go
 +++ b/src/crypto/cipher/gcm_test.go
 @@ -8,7 +8,6 @@ import (
@@ -506,7 +506,7 @@ index e574822c9aa6f8..b14780fe885a27 100644
  	"io"
  	"reflect"
  	"testing"
-@@ -727,15 +727,19 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
+@@ -727,9 +727,13 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
  
  			// Test NewGCMWithRandomNonce.
  			t.Run("GCMWithRandomNonce", func(t *testing.T) {
@@ -521,13 +521,6 @@ index e574822c9aa6f8..b14780fe885a27 100644
  				cryptotest.TestAEAD(t, func() (cipher.AEAD, error) { return cipher.NewGCMWithRandomNonce(block) })
  			})
  		})
- 	}
- }
--
-+z
- func TestGCMExtraMethods(t *testing.T) {
- 	testAllImplementations(t, func(t *testing.T, newCipher func([]byte) cipher.Block) {
- 		t.Run("NewGCM", func(t *testing.T) {
 @@ -752,10 +756,13 @@ func TestGCMExtraMethods(t *testing.T) {
  		})
  		t.Run("NewGCMWithRandomNonce", func(t *testing.T) {

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  57 ++++-
+ src/crypto/cipher/gcm.go                      |  55 ++++-
  src/crypto/cipher/gcm_test.go                 |  13 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1170 insertions(+), 96 deletions(-)
+ 86 files changed, 1169 insertions(+), 95 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,27 +381,25 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..fb72f96e7cd6d6 100644
+index 5580f96d55a0fb..0113589bd7c7be 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
-@@ -93,7 +93,16 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -93,6 +93,15 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  	c, ok := cipher.(*aes.Block)
  	if !ok {
--		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
 +		if cipher, ok := cipher.(gcmAble); ok {
 +			g, err := cipher.NewGCM(gcmStandardNonceSize, gcmTagSize)
 +			if err != nil {
 +				return nil, err
 +			}
-+
-+			return gcmWithRandomNonce{g}, nil
-+		} else {
-+			return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
++			if _, ok := g.(randomNonceSealer); ok {
++				return gcmWithRandomNonce{g}, nil
++			}
 +		}
+ 		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
  	}
  	g, err := gcm.New(c, gcmStandardNonceSize, gcmTagSize)
- 	if err != nil {
 @@ -103,7 +112,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  }
  

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..f82b95e2c85cb7 100644
+index 5580f96d55a0fb..cc759af19b116b 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,7 +93,14 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -417,7 +417,7 @@ index 5580f96d55a0fb..f82b95e2c85cb7 100644
 +	if gc, ok := g.aead.(*gcm.GCM); ok {
 +		gcm.SealWithRandomNonce(gc, nonce, ciphertext, plaintext, additionalData)
 +	} else if gc, ok := g.aead.(randomNonceSealer); ok {
-+		gc.SealWithRandomNonce(nonce, ciphertext, plaintext, additionalData)
++		gc.SealWithRandomNonce(ciphertext, nonce, plaintext, additionalData)
 +	}
 +
  	return ret
@@ -437,7 +437,7 @@ index 5580f96d55a0fb..f82b95e2c85cb7 100644
  }
  
 +type randomNonceSealer interface {
-+	SealWithRandomNonce(nonce, out, plaintext, additionalData []byte)
++	SealWithRandomNonce(out, nonce, plaintext, additionalData []byte)
 +}
 +
  func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  58 +++++-
+ src/crypto/cipher/gcm.go                      |  59 +++++-
  src/crypto/cipher/gcm_test.go                 |  10 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1169 insertions(+), 95 deletions(-)
+ 86 files changed, 1170 insertions(+), 95 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..07573084c55257 100644
+index 5580f96d55a0fb..9599e9bf604d3f 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,6 +93,15 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -434,13 +434,14 @@ index 5580f96d55a0fb..07573084c55257 100644
  	if err != nil {
  		return nil, err
  	}
-@@ -204,6 +220,13 @@ type gcmAble interface {
+@@ -204,6 +220,14 @@ type gcmAble interface {
  	NewGCM(nonceSize, tagSize int) (AEAD, error)
  }
  
-+// randomnoncesealer is an interface implemented by AEADs that can seal
-+// messages with a random nonce. This is used by NewGCMWithRandomNonce to
-+// check if AEAD is implementing its own SealWithRandomNonce method.
++// randomNonceSealer is an interface for AEAD implementations that support
++// sealing messages using a randomly generated nonce.
++// It is used by NewGCMWithRandomNonce to determine whether the AEAD instance
++// provides its own implementation of SealWithRandomNonce.
 +type randomNonceSealer interface {
 +	SealWithRandomNonce(out, nonce, plaintext, additionalData []byte)
 +}
@@ -448,7 +449,7 @@ index 5580f96d55a0fb..07573084c55257 100644
  func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	if tagSize < gcmMinimumTagSize || tagSize > gcmBlockSize {
  		return nil, errors.New("cipher: incorrect tag size given to GCM")
-@@ -212,7 +235,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -212,7 +236,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  		return nil, errors.New("cipher: the nonce can't have zero length")
  	}
  	if cipher, ok := cipher.(gcmAble); ok {
@@ -466,7 +467,7 @@ index 5580f96d55a0fb..07573084c55257 100644
  	}
  	if cipher.BlockSize() != gcmBlockSize {
  		return nil, errors.New("cipher: NewGCM requires 128-bit block cipher")
-@@ -220,6 +252,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -220,6 +253,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	return &gcmFallback{cipher: cipher, nonceSize: nonceSize, tagSize: tagSize}, nil
  }
  

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..94abd2a4cc1bad 100644
+index 5580f96d55a0fb..ec264badc5f415 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,7 +93,14 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -390,7 +390,7 @@ index 5580f96d55a0fb..94abd2a4cc1bad 100644
  	if !ok {
 -		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
 +		if cipher, ok := cipher.(gcmAble); ok {
-+			g, err := cipher.NewGCM(nonceSize, tagSize)
++			g, err := cipher.NewGCM(gcmStandardNonceSize, gcmTagSize)
 +			if err != nil {
 +				return nil, err
 +			}

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  53 ++++-
+ src/crypto/cipher/gcm.go                      |  55 ++++-
  src/crypto/cipher/gcm_test.go                 |  13 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1166 insertions(+), 96 deletions(-)
+ 86 files changed, 1168 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..cc759af19b116b 100644
+index 5580f96d55a0fb..cb6cc900fde083 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,7 +93,14 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -409,7 +409,7 @@ index 5580f96d55a0fb..cc759af19b116b 100644
  }
  
  func (g gcmWithRandomNonce) NonceSize() int {
-@@ -157,7 +164,12 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
+@@ -157,7 +164,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
  		plaintext = ciphertext[:len(plaintext)]
  	}
  
@@ -418,12 +418,14 @@ index 5580f96d55a0fb..cc759af19b116b 100644
 +		gcm.SealWithRandomNonce(gc, nonce, ciphertext, plaintext, additionalData)
 +	} else if gc, ok := g.aead.(randomNonceSealer); ok {
 +		gc.SealWithRandomNonce(ciphertext, nonce, plaintext, additionalData)
++	} else {
++		panic("crypto/cipher: GCMWithRandomNonce requires aes.Block or a cipher with random nonce support")
 +	}
 +
  	return ret
  }
  
-@@ -190,7 +202,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
+@@ -190,7 +204,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
  		ciphertext = ciphertext[gcmStandardNonceSize:]
  	}
  
@@ -432,7 +434,7 @@ index 5580f96d55a0fb..cc759af19b116b 100644
  	if err != nil {
  		return nil, err
  	}
-@@ -204,6 +216,10 @@ type gcmAble interface {
+@@ -204,6 +218,10 @@ type gcmAble interface {
  	NewGCM(nonceSize, tagSize int) (AEAD, error)
  }
  
@@ -443,7 +445,7 @@ index 5580f96d55a0fb..cc759af19b116b 100644
  func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	if tagSize < gcmMinimumTagSize || tagSize > gcmBlockSize {
  		return nil, errors.New("cipher: incorrect tag size given to GCM")
-@@ -212,7 +228,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -212,7 +230,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  		return nil, errors.New("cipher: the nonce can't have zero length")
  	}
  	if cipher, ok := cipher.(gcmAble); ok {
@@ -457,11 +459,11 @@ index 5580f96d55a0fb..cc759af19b116b 100644
 +			return &customGCMWrapper{g}, nil
 +		}
 +
-+		return g, nil
++		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
  	}
  	if cipher.BlockSize() != gcmBlockSize {
  		return nil, errors.New("cipher: NewGCM requires 128-bit block cipher")
-@@ -220,6 +245,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -220,6 +247,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	return &gcmFallback{cipher: cipher, nonceSize: nonceSize, tagSize: tagSize}, nil
  }
  

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  31 ++-
+ src/crypto/cipher/gcm.go                      |  53 ++++-
  src/crypto/cipher/gcm_test.go                 |  13 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1144 insertions(+), 96 deletions(-)
+ 86 files changed, 1166 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..d6f6a1538e782f 100644
+index 5580f96d55a0fb..cc759af19b116b 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,7 +93,14 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -443,7 +443,7 @@ index 5580f96d55a0fb..d6f6a1538e782f 100644
  func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	if tagSize < gcmMinimumTagSize || tagSize > gcmBlockSize {
  		return nil, errors.New("cipher: incorrect tag size given to GCM")
-@@ -212,7 +228,12 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -212,7 +228,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  		return nil, errors.New("cipher: the nonce can't have zero length")
  	}
  	if cipher, ok := cipher.(gcmAble); ok {
@@ -453,10 +453,39 @@ index 5580f96d55a0fb..d6f6a1538e782f 100644
 +			return nil, err
 +		}
 +
++		if _, ok := g.(randomNonceSealer); ok {
++			return &customGCMWrapper{g}, nil
++		}
++
 +		return g, nil
  	}
  	if cipher.BlockSize() != gcmBlockSize {
  		return nil, errors.New("cipher: NewGCM requires 128-bit block cipher")
+@@ -220,6 +245,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+ 	return &gcmFallback{cipher: cipher, nonceSize: nonceSize, tagSize: tagSize}, nil
+ }
+ 
++// customGCMWrapper wraps an AEAD implementation to expose only the AEAD interface methods.
++// This prevents extra exported methods from causing test failures in cryptotest.NoExtraMethods.
++type customGCMWrapper struct {
++	aead AEAD
++}
++
++func (g *customGCMWrapper) NonceSize() int { return g.aead.NonceSize() }
++
++func (g *customGCMWrapper) Overhead() int { return g.aead.Overhead() }
++
++func (g *customGCMWrapper) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
++	return g.aead.Seal(dst, nonce, plaintext, additionalData)
++}
++
++func (g *customGCMWrapper) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
++	return g.aead.Open(dst, nonce, ciphertext, additionalData)
++}
++
+ // gcmFallback is only used for non-AES ciphers, which regrettably we
+ // theoretically support. It's a copy of the generic implementation from
+ // crypto/internal/fips140/aes/gcm/gcm_generic.go, refer to that file for more details.
 diff --git a/src/crypto/cipher/gcm_test.go b/src/crypto/cipher/gcm_test.go
 index e574822c9aa6f8..f32707146a369a 100644
 --- a/src/crypto/cipher/gcm_test.go

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -19,7 +19,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
  src/crypto/cipher/gcm.go                      |  58 +++++-
- src/crypto/cipher/gcm_test.go                 |   6 +-
+ src/crypto/cipher/gcm_test.go                 |  10 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
  src/crypto/dsa/dsa.go                         |  88 ++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1165 insertions(+), 95 deletions(-)
+ 86 files changed, 1169 insertions(+), 95 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -492,7 +492,7 @@ index 5580f96d55a0fb..07573084c55257 100644
  // theoretically support. It's a copy of the generic implementation from
  // crypto/internal/fips140/aes/gcm/gcm_generic.go, refer to that file for more details.
 diff --git a/src/crypto/cipher/gcm_test.go b/src/crypto/cipher/gcm_test.go
-index e574822c9aa6f8..abf0dfa3386dc4 100644
+index e574822c9aa6f8..5d9f27fb6b1931 100644
 --- a/src/crypto/cipher/gcm_test.go
 +++ b/src/crypto/cipher/gcm_test.go
 @@ -8,7 +8,6 @@ import (
@@ -511,7 +511,7 @@ index e574822c9aa6f8..abf0dfa3386dc4 100644
  	"io"
  	"reflect"
  	"testing"
-@@ -727,7 +727,7 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
+@@ -727,9 +727,13 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
  
  			// Test NewGCMWithRandomNonce.
  			t.Run("GCMWithRandomNonce", func(t *testing.T) {
@@ -519,8 +519,14 @@ index e574822c9aa6f8..abf0dfa3386dc4 100644
 +				if _, ok := block.(*wrapper); ok || goexperiment.BoringCrypto {
  					t.Skip("NewGCMWithRandomNonce requires an AES block cipher")
  				}
++				a, _ := cipher.NewGCMWithRandomNonce(block)
++				if a.NonceSize() != 0 {
++					t.Errorf("NewGCMWithRandomNonce returned AEAD with non-zero nonce size: %d", a.NonceSize())
++				}
  				cryptotest.TestAEAD(t, func() (cipher.AEAD, error) { return cipher.NewGCMWithRandomNonce(block) })
-@@ -752,7 +752,7 @@ func TestGCMExtraMethods(t *testing.T) {
+ 			})
+ 		})
+@@ -752,7 +756,7 @@ func TestGCMExtraMethods(t *testing.T) {
  		})
  		t.Run("NewGCMWithRandomNonce", func(t *testing.T) {
  			block := newCipher(make([]byte, 16))

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,8 +18,8 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  55 ++++-
- src/crypto/cipher/gcm_test.go                 |  13 +-
+ src/crypto/cipher/gcm.go                      |  58 +++++-
+ src/crypto/cipher/gcm_test.go                 |   6 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
  src/crypto/dsa/dsa.go                         |  88 ++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1169 insertions(+), 95 deletions(-)
+ 86 files changed, 1165 insertions(+), 95 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..8d048c95ad0512 100644
+index 5580f96d55a0fb..07573084c55257 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,6 +93,15 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -414,10 +414,10 @@ index 5580f96d55a0fb..8d048c95ad0512 100644
  	}
  
 -	gcm.SealWithRandomNonce(g.GCM, nonce, ciphertext, plaintext, additionalData)
-+	if gc, ok := g.aead.(*gcm.GCM); ok {
-+		gcm.SealWithRandomNonce(gc, nonce, ciphertext, plaintext, additionalData)
-+	} else if gc, ok := g.aead.(randomNonceSealer); ok {
-+		gc.SealWithRandomNonce(ciphertext, nonce, plaintext, additionalData)
++	if aeadGCM, ok := g.aead.(*gcm.GCM); ok {
++		gcm.SealWithRandomNonce(aeadGCM, nonce, ciphertext, plaintext, additionalData)
++	} else if aeadGCM, ok := g.aead.(randomNonceSealer); ok {
++		aeadGCM.SealWithRandomNonce(ciphertext, nonce, plaintext, additionalData)
 +	} else {
 +		panic("cipher: NewGCMWithRandomNonce requires aes.Block")
 +	}
@@ -434,10 +434,13 @@ index 5580f96d55a0fb..8d048c95ad0512 100644
  	if err != nil {
  		return nil, err
  	}
-@@ -204,6 +220,10 @@ type gcmAble interface {
+@@ -204,6 +220,13 @@ type gcmAble interface {
  	NewGCM(nonceSize, tagSize int) (AEAD, error)
  }
  
++// randomnoncesealer is an interface implemented by AEADs that can seal
++// messages with a random nonce. This is used by NewGCMWithRandomNonce to
++// check if AEAD is implementing its own SealWithRandomNonce method.
 +type randomNonceSealer interface {
 +	SealWithRandomNonce(out, nonce, plaintext, additionalData []byte)
 +}
@@ -445,7 +448,7 @@ index 5580f96d55a0fb..8d048c95ad0512 100644
  func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	if tagSize < gcmMinimumTagSize || tagSize > gcmBlockSize {
  		return nil, errors.New("cipher: incorrect tag size given to GCM")
-@@ -212,7 +232,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -212,7 +235,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  		return nil, errors.New("cipher: the nonce can't have zero length")
  	}
  	if cipher, ok := cipher.(gcmAble); ok {
@@ -463,7 +466,7 @@ index 5580f96d55a0fb..8d048c95ad0512 100644
  	}
  	if cipher.BlockSize() != gcmBlockSize {
  		return nil, errors.New("cipher: NewGCM requires 128-bit block cipher")
-@@ -220,6 +249,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -220,6 +252,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	return &gcmFallback{cipher: cipher, nonceSize: nonceSize, tagSize: tagSize}, nil
  }
  
@@ -489,7 +492,7 @@ index 5580f96d55a0fb..8d048c95ad0512 100644
  // theoretically support. It's a copy of the generic implementation from
  // crypto/internal/fips140/aes/gcm/gcm_generic.go, refer to that file for more details.
 diff --git a/src/crypto/cipher/gcm_test.go b/src/crypto/cipher/gcm_test.go
-index e574822c9aa6f8..f32707146a369a 100644
+index e574822c9aa6f8..abf0dfa3386dc4 100644
 --- a/src/crypto/cipher/gcm_test.go
 +++ b/src/crypto/cipher/gcm_test.go
 @@ -8,7 +8,6 @@ import (
@@ -508,7 +511,7 @@ index e574822c9aa6f8..f32707146a369a 100644
  	"io"
  	"reflect"
  	"testing"
-@@ -727,9 +727,13 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
+@@ -727,7 +727,7 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
  
  			// Test NewGCMWithRandomNonce.
  			t.Run("GCMWithRandomNonce", func(t *testing.T) {
@@ -516,14 +519,8 @@ index e574822c9aa6f8..f32707146a369a 100644
 +				if _, ok := block.(*wrapper); ok || goexperiment.BoringCrypto {
  					t.Skip("NewGCMWithRandomNonce requires an AES block cipher")
  				}
-+				a, _ := cipher.NewGCMWithRandomNonce(block)
-+				if a.NonceSize() != 0 {
-+					t.Errorf("NewGCMWithRandomNonce returned AEAD with non-zero nonce size: %d", a.NonceSize())
-+				}
  				cryptotest.TestAEAD(t, func() (cipher.AEAD, error) { return cipher.NewGCMWithRandomNonce(block) })
- 			})
- 		})
-@@ -752,10 +756,13 @@ func TestGCMExtraMethods(t *testing.T) {
+@@ -752,7 +752,7 @@ func TestGCMExtraMethods(t *testing.T) {
  		})
  		t.Run("NewGCMWithRandomNonce", func(t *testing.T) {
  			block := newCipher(make([]byte, 16))
@@ -532,12 +529,6 @@ index e574822c9aa6f8..f32707146a369a 100644
  				t.Skip("NewGCMWithRandomNonce requires an AES block cipher")
  			}
  			a, _ := cipher.NewGCMWithRandomNonce(block)
-+			if a.NonceSize() != 0 {
-+				t.Errorf("NewGCMWithRandomNonce returned AEAD with non-zero nonce size: %d", a.NonceSize())
-+			}
- 			cryptotest.NoExtraMethods(t, &a)
- 		})
- 	})
 diff --git a/src/crypto/des/cipher.go b/src/crypto/des/cipher.go
 index 21303b384cf757..0d3c4f810cfd8f 100644
 --- a/src/crypto/des/cipher.go

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  15 +-
+ src/crypto/cipher/gcm.go                      |  19 +-
  src/crypto/cipher/gcm_test.go                 |  12 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1128 insertions(+), 95 deletions(-)
+ 86 files changed, 1132 insertions(+), 95 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,19 +381,23 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..c4ba3ae20395dd 100644
+index 5580f96d55a0fb..256234217507ae 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
-@@ -93,7 +93,7 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -93,7 +93,11 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  	c, ok := cipher.(*aes.Block)
  	if !ok {
 -		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
-+		return newGCMFallback(cipher, gcmStandardNonceSize, gcmTagSize)
++		g, err := newGCMFallback(cipher, gcmStandardNonceSize, gcmTagSize)
++		if err != nil {
++			return nil, err
++		}
++		return gcmWithRandomNonce{g}, nil
  	}
  	g, err := gcm.New(c, gcmStandardNonceSize, gcmTagSize)
  	if err != nil {
-@@ -103,7 +103,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
+@@ -103,7 +107,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
  }
  
  type gcmWithRandomNonce struct {
@@ -402,7 +406,7 @@ index 5580f96d55a0fb..c4ba3ae20395dd 100644
  }
  
  func (g gcmWithRandomNonce) NonceSize() int {
-@@ -157,7 +157,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
+@@ -157,7 +161,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
  		plaintext = ciphertext[:len(plaintext)]
  	}
  
@@ -418,7 +422,7 @@ index 5580f96d55a0fb..c4ba3ae20395dd 100644
  	return ret
  }
  
-@@ -190,7 +197,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
+@@ -190,7 +201,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
  		ciphertext = ciphertext[gcmStandardNonceSize:]
  	}
  

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  53 ++++-
+ src/crypto/cipher/gcm.go                      |  31 ++-
  src/crypto/cipher/gcm_test.go                 |  13 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1166 insertions(+), 96 deletions(-)
+ 86 files changed, 1144 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..cc759af19b116b 100644
+index 5580f96d55a0fb..d6f6a1538e782f 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,7 +93,14 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -443,7 +443,7 @@ index 5580f96d55a0fb..cc759af19b116b 100644
  func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	if tagSize < gcmMinimumTagSize || tagSize > gcmBlockSize {
  		return nil, errors.New("cipher: incorrect tag size given to GCM")
-@@ -212,7 +228,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -212,7 +228,12 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  		return nil, errors.New("cipher: the nonce can't have zero length")
  	}
  	if cipher, ok := cipher.(gcmAble); ok {
@@ -453,39 +453,10 @@ index 5580f96d55a0fb..cc759af19b116b 100644
 +			return nil, err
 +		}
 +
-+		if _, ok := g.(randomNonceSealer); ok {
-+			return &customGCMWrapper{g}, nil
-+		}
-+
 +		return g, nil
  	}
  	if cipher.BlockSize() != gcmBlockSize {
  		return nil, errors.New("cipher: NewGCM requires 128-bit block cipher")
-@@ -220,6 +245,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
- 	return &gcmFallback{cipher: cipher, nonceSize: nonceSize, tagSize: tagSize}, nil
- }
- 
-+// customGCMWrapper wraps an AEAD implementation to expose only the AEAD interface methods.
-+// This prevents extra exported methods from causing test failures in cryptotest.NoExtraMethods.
-+type customGCMWrapper struct {
-+	aead AEAD
-+}
-+
-+func (g *customGCMWrapper) NonceSize() int { return g.aead.NonceSize() }
-+
-+func (g *customGCMWrapper) Overhead() int { return g.aead.Overhead() }
-+
-+func (g *customGCMWrapper) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
-+	return g.aead.Seal(dst, nonce, plaintext, additionalData)
-+}
-+
-+func (g *customGCMWrapper) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
-+	return g.aead.Open(dst, nonce, ciphertext, additionalData)
-+}
-+
- // gcmFallback is only used for non-AES ciphers, which regrettably we
- // theoretically support. It's a copy of the generic implementation from
- // crypto/internal/fips140/aes/gcm/gcm_generic.go, refer to that file for more details.
 diff --git a/src/crypto/cipher/gcm_test.go b/src/crypto/cipher/gcm_test.go
 index e574822c9aa6f8..f32707146a369a 100644
 --- a/src/crypto/cipher/gcm_test.go

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm.go                      |  46 ++++-
+ src/crypto/cipher/gcm.go                      |  53 ++++-
  src/crypto/cipher/gcm_test.go                 |  12 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1158 insertions(+), 96 deletions(-)
+ 86 files changed, 1165 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..ec264badc5f415 100644
+index 5580f96d55a0fb..f82b95e2c85cb7 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,7 +93,14 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -409,23 +409,21 @@ index 5580f96d55a0fb..ec264badc5f415 100644
  }
  
  func (g gcmWithRandomNonce) NonceSize() int {
-@@ -157,7 +164,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
+@@ -157,7 +164,12 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
  		plaintext = ciphertext[:len(plaintext)]
  	}
  
 -	gcm.SealWithRandomNonce(g.GCM, nonce, ciphertext, plaintext, additionalData)
 +	if gc, ok := g.aead.(*gcm.GCM); ok {
 +		gcm.SealWithRandomNonce(gc, nonce, ciphertext, plaintext, additionalData)
-+	} else if gc, ok := g.aead.(interface {
-+		SealWithRandomNonce(nonce, out, plaintext, additionalData []byte)
-+	}); ok {
++	} else if gc, ok := g.aead.(randomNonceSealer); ok {
 +		gc.SealWithRandomNonce(nonce, ciphertext, plaintext, additionalData)
 +	}
 +
  	return ret
  }
  
-@@ -190,7 +204,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
+@@ -190,7 +202,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
  		ciphertext = ciphertext[gcmStandardNonceSize:]
  	}
  
@@ -434,7 +432,18 @@ index 5580f96d55a0fb..ec264badc5f415 100644
  	if err != nil {
  		return nil, err
  	}
-@@ -212,7 +226,11 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -204,6 +216,10 @@ type gcmAble interface {
+ 	NewGCM(nonceSize, tagSize int) (AEAD, error)
+ }
+ 
++type randomNonceSealer interface {
++	SealWithRandomNonce(nonce, out, plaintext, additionalData []byte)
++}
++
+ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+ 	if tagSize < gcmMinimumTagSize || tagSize > gcmBlockSize {
+ 		return nil, errors.New("cipher: incorrect tag size given to GCM")
+@@ -212,7 +228,16 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  		return nil, errors.New("cipher: the nonce can't have zero length")
  	}
  	if cipher, ok := cipher.(gcmAble); ok {
@@ -443,11 +452,16 @@ index 5580f96d55a0fb..ec264badc5f415 100644
 +		if err != nil {
 +			return nil, err
 +		}
-+		return &customGCMWrapper{aead: g}, nil
++
++		if _, ok := g.(randomNonceSealer); ok {
++			return &customGCMWrapper{g}, nil
++		}
++
++		return g, nil
  	}
  	if cipher.BlockSize() != gcmBlockSize {
  		return nil, errors.New("cipher: NewGCM requires 128-bit block cipher")
-@@ -220,6 +238,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+@@ -220,6 +245,24 @@ func newGCMFallback(cipher Block, nonceSize, tagSize int) (AEAD, error) {
  	return &gcmFallback{cipher: cipher, nonceSize: nonceSize, tagSize: tagSize}, nil
  }
  

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -19,7 +19,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
  src/crypto/cipher/gcm.go                      |  53 ++++-
- src/crypto/cipher/gcm_test.go                 |  12 +-
+ src/crypto/cipher/gcm_test.go                 |  15 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
  src/crypto/dsa/dsa.go                         |  88 ++++++++
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1165 insertions(+), 96 deletions(-)
+ 86 files changed, 1167 insertions(+), 97 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -487,7 +487,7 @@ index 5580f96d55a0fb..cc759af19b116b 100644
  // theoretically support. It's a copy of the generic implementation from
  // crypto/internal/fips140/aes/gcm/gcm_generic.go, refer to that file for more details.
 diff --git a/src/crypto/cipher/gcm_test.go b/src/crypto/cipher/gcm_test.go
-index e574822c9aa6f8..6a51981cb508e5 100644
+index e574822c9aa6f8..b14780fe885a27 100644
 --- a/src/crypto/cipher/gcm_test.go
 +++ b/src/crypto/cipher/gcm_test.go
 @@ -8,7 +8,6 @@ import (
@@ -498,12 +498,20 @@ index e574822c9aa6f8..6a51981cb508e5 100644
  	"crypto/internal/cryptotest"
  	"crypto/internal/fips140"
  	fipsaes "crypto/internal/fips140/aes"
-@@ -727,9 +726,13 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
+@@ -17,6 +16,7 @@ import (
+ 	"encoding/hex"
+ 	"errors"
+ 	"fmt"
++	"internal/goexperiment"
+ 	"io"
+ 	"reflect"
+ 	"testing"
+@@ -727,15 +727,19 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
  
  			// Test NewGCMWithRandomNonce.
  			t.Run("GCMWithRandomNonce", func(t *testing.T) {
 -				if _, ok := block.(*wrapper); ok || boring.Enabled {
-+				if _, ok := block.(*wrapper); ok {
++				if _, ok := block.(*wrapper); ok || goexperiment.BoringCrypto {
  					t.Skip("NewGCMWithRandomNonce requires an AES block cipher")
  				}
 +				a, _ := cipher.NewGCMWithRandomNonce(block)
@@ -513,12 +521,19 @@ index e574822c9aa6f8..6a51981cb508e5 100644
  				cryptotest.TestAEAD(t, func() (cipher.AEAD, error) { return cipher.NewGCMWithRandomNonce(block) })
  			})
  		})
-@@ -752,10 +755,13 @@ func TestGCMExtraMethods(t *testing.T) {
+ 	}
+ }
+-
++z
+ func TestGCMExtraMethods(t *testing.T) {
+ 	testAllImplementations(t, func(t *testing.T, newCipher func([]byte) cipher.Block) {
+ 		t.Run("NewGCM", func(t *testing.T) {
+@@ -752,10 +756,13 @@ func TestGCMExtraMethods(t *testing.T) {
  		})
  		t.Run("NewGCMWithRandomNonce", func(t *testing.T) {
  			block := newCipher(make([]byte, 16))
 -			if _, ok := block.(*wrapper); ok || boring.Enabled {
-+			if _, ok := block.(*wrapper); ok {
++			if _, ok := block.(*wrapper); ok || goexperiment.BoringCrypto {
  				t.Skip("NewGCMWithRandomNonce requires an AES block cipher")
  			}
  			a, _ := cipher.NewGCMWithRandomNonce(block)

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -18,7 +18,8 @@ Subject: [PATCH] Use crypto backends
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
  src/crypto/cipher/ctr_aes_test.go             |   2 +-
- src/crypto/cipher/gcm_test.go                 |   2 +-
+ src/crypto/cipher/gcm.go                      |  15 +-
+ src/crypto/cipher/gcm_test.go                 |  12 +-
  src/crypto/des/cipher.go                      |   7 +
  src/crypto/dsa/boring.go                      | 113 ++++++++++
  src/crypto/dsa/dsa.go                         |  88 ++++++++
@@ -89,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 85 files changed, 1109 insertions(+), 89 deletions(-)
+ 86 files changed, 1128 insertions(+), 95 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -115,10 +116,10 @@ index f0e3575637c62a..9eab3b4e66e60b 100644
  package main
  
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 596036fce9f7f1..3e4b8d9e5e3903 100644
+index b50f3342fe8714..e2099ee5eff6ba 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1534,6 +1534,19 @@ func cmdbootstrap() {
+@@ -1538,6 +1538,19 @@ func cmdbootstrap() {
  	xprintf("Building Go toolchain2 using go_bootstrap and Go toolchain1.\n")
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
@@ -139,7 +140,7 @@ index 596036fce9f7f1..3e4b8d9e5e3903 100644
  	// No need to enable PGO for toolchain2.
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index e939768a2f4809..3197a8b81c2886 100644
+index d335e4cfbce468..542b16e1f1f18a 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -710,7 +710,7 @@ func (t *tester) registerTests() {
@@ -379,19 +380,95 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	"crypto/internal/cryptotest"
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
+diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
+index 5580f96d55a0fb..c4ba3ae20395dd 100644
+--- a/src/crypto/cipher/gcm.go
++++ b/src/crypto/cipher/gcm.go
+@@ -93,7 +93,7 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
+ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
+ 	c, ok := cipher.(*aes.Block)
+ 	if !ok {
+-		return nil, errors.New("cipher: NewGCMWithRandomNonce requires aes.Block")
++		return newGCMFallback(cipher, gcmStandardNonceSize, gcmTagSize)
+ 	}
+ 	g, err := gcm.New(c, gcmStandardNonceSize, gcmTagSize)
+ 	if err != nil {
+@@ -103,7 +103,7 @@ func NewGCMWithRandomNonce(cipher Block) (AEAD, error) {
+ }
+ 
+ type gcmWithRandomNonce struct {
+-	*gcm.GCM
++	aead AEAD
+ }
+ 
+ func (g gcmWithRandomNonce) NonceSize() int {
+@@ -157,7 +157,14 @@ func (g gcmWithRandomNonce) Seal(dst, nonce, plaintext, additionalData []byte) [
+ 		plaintext = ciphertext[:len(plaintext)]
+ 	}
+ 
+-	gcm.SealWithRandomNonce(g.GCM, nonce, ciphertext, plaintext, additionalData)
++	if gc, ok := g.aead.(*gcm.GCM); ok {
++		gcm.SealWithRandomNonce(gc, nonce, ciphertext, plaintext, additionalData)
++	} else if gc, ok := g.aead.(interface {
++		SealWithRandomNonce(nonce, out, plaintext, additionalData []byte)
++	}); ok {
++		gc.SealWithRandomNonce(nonce, ciphertext, plaintext, additionalData)
++	}
++
+ 	return ret
+ }
+ 
+@@ -190,7 +197,7 @@ func (g gcmWithRandomNonce) Open(dst, nonce, ciphertext, additionalData []byte)
+ 		ciphertext = ciphertext[gcmStandardNonceSize:]
+ 	}
+ 
+-	_, err := g.GCM.Open(out[:0], nonce, ciphertext, additionalData)
++	_, err := g.aead.Open(out[:0], nonce, ciphertext, additionalData)
+ 	if err != nil {
+ 		return nil, err
+ 	}
 diff --git a/src/crypto/cipher/gcm_test.go b/src/crypto/cipher/gcm_test.go
-index e574822c9aa6f8..cf121d9e5f654d 100644
+index e574822c9aa6f8..6a51981cb508e5 100644
 --- a/src/crypto/cipher/gcm_test.go
 +++ b/src/crypto/cipher/gcm_test.go
-@@ -8,7 +8,7 @@ import (
+@@ -8,7 +8,6 @@ import (
  	"bytes"
  	"crypto/aes"
  	"crypto/cipher"
 -	"crypto/internal/boring"
-+	boring "crypto/internal/backend"
  	"crypto/internal/cryptotest"
  	"crypto/internal/fips140"
  	fipsaes "crypto/internal/fips140/aes"
+@@ -727,9 +726,13 @@ func testGCMAEAD(t *testing.T, newCipher func(key []byte) cipher.Block) {
+ 
+ 			// Test NewGCMWithRandomNonce.
+ 			t.Run("GCMWithRandomNonce", func(t *testing.T) {
+-				if _, ok := block.(*wrapper); ok || boring.Enabled {
++				if _, ok := block.(*wrapper); ok {
+ 					t.Skip("NewGCMWithRandomNonce requires an AES block cipher")
+ 				}
++				a, _ := cipher.NewGCMWithRandomNonce(block)
++				if a.NonceSize() != 0 {
++					t.Errorf("NewGCMWithRandomNonce returned AEAD with non-zero nonce size: %d", a.NonceSize())
++				}
+ 				cryptotest.TestAEAD(t, func() (cipher.AEAD, error) { return cipher.NewGCMWithRandomNonce(block) })
+ 			})
+ 		})
+@@ -752,10 +755,13 @@ func TestGCMExtraMethods(t *testing.T) {
+ 		})
+ 		t.Run("NewGCMWithRandomNonce", func(t *testing.T) {
+ 			block := newCipher(make([]byte, 16))
+-			if _, ok := block.(*wrapper); ok || boring.Enabled {
++			if _, ok := block.(*wrapper); ok {
+ 				t.Skip("NewGCMWithRandomNonce requires an AES block cipher")
+ 			}
+ 			a, _ := cipher.NewGCMWithRandomNonce(block)
++			if a.NonceSize() != 0 {
++				t.Errorf("NewGCMWithRandomNonce returned AEAD with non-zero nonce size: %d", a.NonceSize())
++			}
+ 			cryptotest.NoExtraMethods(t, &a)
+ 		})
+ 	})
 diff --git a/src/crypto/des/cipher.go b/src/crypto/des/cipher.go
 index 21303b384cf757..0d3c4f810cfd8f 100644
 --- a/src/crypto/des/cipher.go
@@ -1318,7 +1395,7 @@ index 08d60933ef38b8..8840db05bde791 100644
  	"crypto/internal/fips140/aes"
  	"crypto/internal/fips140/aes/gcm"
 diff --git a/src/crypto/md5/md5.go b/src/crypto/md5/md5.go
-index a0384e175f31bd..f7aa6da36f02de 100644
+index dc586fb21787c9..7b7dc2f011bdf8 100644
 --- a/src/crypto/md5/md5.go
 +++ b/src/crypto/md5/md5.go
 @@ -12,6 +12,7 @@ package md5
@@ -1329,7 +1406,7 @@ index a0384e175f31bd..f7aa6da36f02de 100644
  	"crypto/internal/fips140only"
  	"errors"
  	"hash"
-@@ -104,6 +105,9 @@ func consumeUint32(b []byte) ([]byte, uint32) {
+@@ -109,6 +110,9 @@ func consumeUint32(b []byte) ([]byte, uint32) {
  // [encoding.BinaryUnmarshaler] to marshal and unmarshal the internal
  // state of the hash.
  func New() hash.Hash {
@@ -1339,7 +1416,7 @@ index a0384e175f31bd..f7aa6da36f02de 100644
  	d := new(digest)
  	d.Reset()
  	return d
-@@ -188,6 +192,12 @@ func (d *digest) checkSum() [Size]byte {
+@@ -198,6 +202,12 @@ func (d *digest) checkSum() [Size]byte {
  
  // Sum returns the MD5 checksum of the data.
  func Sum(data []byte) [Size]byte {
@@ -1353,7 +1430,7 @@ index a0384e175f31bd..f7aa6da36f02de 100644
  	d.Reset()
  	d.Write(data)
 diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
-index 2353ea85b54baf..f1d3668e6abff4 100644
+index c0bb15f05bac7c..1ef4f4e1471ada 100644
 --- a/src/crypto/md5/md5_test.go
 +++ b/src/crypto/md5/md5_test.go
 @@ -6,12 +6,14 @@ package md5
@@ -1381,7 +1458,7 @@ index 2353ea85b54baf..f1d3668e6abff4 100644
  			t.Errorf("could not marshal: %v", err)
  			continue
  		}
-@@ -157,6 +162,9 @@ func TestLarge(t *testing.T) {
+@@ -183,6 +188,9 @@ func TestExtraLarge(t *testing.T) {
  
  // Tests that blockGeneric (pure Go) and block (in assembly for amd64, 386, arm) match.
  func TestBlockGeneric(t *testing.T) {
@@ -1391,7 +1468,7 @@ index 2353ea85b54baf..f1d3668e6abff4 100644
  	gen, asm := New().(*digest), New().(*digest)
  	buf := make([]byte, BlockSize*20) // arbitrary factor
  	rand.Read(buf)
-@@ -204,10 +212,18 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+@@ -230,10 +238,18 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
  }
  
  func TestLargeHashes(t *testing.T) {
@@ -1410,7 +1487,7 @@ index 2353ea85b54baf..f1d3668e6abff4 100644
  			t.Errorf("test %d could not unmarshal: %v", i, err)
  			continue
  		}
-@@ -245,7 +261,7 @@ func TestMD5Hash(t *testing.T) {
+@@ -271,7 +287,7 @@ func TestMD5Hash(t *testing.T) {
  
  func TestExtraMethods(t *testing.T) {
  	h := New()
@@ -2042,7 +2119,7 @@ index 069938a22dbc5a..8d0e06b86f4359 100644
  	}
  	h := New224()
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index b3b4e77f578e60..23c4c7b4823f6c 100644
+index 38a7f25afb3fd1..9bbe4a86e1341f 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -8,11 +8,13 @@ package sha256
@@ -2069,7 +2146,7 @@ index b3b4e77f578e60..23c4c7b4823f6c 100644
  					t.Errorf("could not marshal: %v", err)
  					continue
  				}
-@@ -206,6 +211,9 @@ func TestMarshalTypeMismatch(t *testing.T) {
+@@ -256,6 +261,9 @@ func TestMarshalTypeMismatch(t *testing.T) {
  
  	state1, err := h1.(encoding.BinaryMarshaler).MarshalBinary()
  	if err != nil {
@@ -2079,7 +2156,7 @@ index b3b4e77f578e60..23c4c7b4823f6c 100644
  		t.Errorf("could not marshal: %v", err)
  	}
  
-@@ -275,10 +283,18 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
+@@ -325,10 +333,18 @@ func safeSum(h hash.Hash) (sum []byte, err error) {
  	return h.Sum(nil), nil
  }
  func TestLargeHashes(t *testing.T) {
@@ -2098,7 +2175,7 @@ index b3b4e77f578e60..23c4c7b4823f6c 100644
  			t.Errorf("test %d could not unmarshal: %v", i, err)
  			continue
  		}
-@@ -354,13 +370,13 @@ func TestExtraMethods(t *testing.T) {
+@@ -404,13 +420,13 @@ func TestExtraMethods(t *testing.T) {
  	t.Run("SHA-224", func(t *testing.T) {
  		cryptotest.TestAllImplementations(t, "sha256", func(t *testing.T) {
  			h := New224()
@@ -2294,7 +2371,7 @@ index 027bc22c33c921..eba08da985f832 100644
  package fipsonly
  
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
-index 30f2e2a2a2c43d..a25a29a2a26785 100644
+index bb5b7a042a7399..58e7320d3f166b 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
 @@ -11,11 +11,11 @@ import (
@@ -2328,7 +2405,7 @@ index 30f2e2a2a2c43d..a25a29a2a26785 100644
  
  	// If we did not load a session (hs.session == nil), but we did set a
 diff --git a/src/crypto/tls/handshake_client_tls13.go b/src/crypto/tls/handshake_client_tls13.go
-index 66dc76f72d6e6f..c8bb0c02d64afd 100644
+index 444c6f311ce1e3..bf52c619b2a1fc 100644
 --- a/src/crypto/tls/handshake_client_tls13.go
 +++ b/src/crypto/tls/handshake_client_tls13.go
 @@ -11,9 +11,9 @@ import (
@@ -2343,7 +2420,7 @@ index 66dc76f72d6e6f..c8bb0c02d64afd 100644
  	"hash"
  	"slices"
 diff --git a/src/crypto/tls/handshake_server.go b/src/crypto/tls/handshake_server.go
-index 507b69a0ed1471..86ef3f9c5b7f24 100644
+index 5be74e2967ffd4..0522e20589c2ff 100644
 --- a/src/crypto/tls/handshake_server.go
 +++ b/src/crypto/tls/handshake_server.go
 @@ -64,7 +64,15 @@ func (c *Conn) serverHandshake(ctx context.Context) error {
@@ -2364,7 +2441,7 @@ index 507b69a0ed1471..86ef3f9c5b7f24 100644
  
  	if err := hs.processClientHello(); err != nil {
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index ab0cff9e28454e..3981994fbee904 100644
+index fbdf55d46186cc..c69edb4336d6cc 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
 @@ -10,11 +10,12 @@ import (
@@ -2712,10 +2789,10 @@ index e7369542a73270..ff52175e4ac636 100644
  	}
  }
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index af62328edf5eca..09c16fd2db0b58 100644
+index 2e4b1fd1b370cc..adf9baf1a38705 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -540,7 +540,7 @@ var depsRules = `
+@@ -541,7 +541,7 @@ var depsRules = `
  	< crypto/internal/backend/internal/opensslsetup
  	< crypto/internal/backend/fips140;
  
@@ -2724,7 +2801,7 @@ index af62328edf5eca..09c16fd2db0b58 100644
  
  	crypto, hash !< FIPS;
  
-@@ -585,6 +585,7 @@ var depsRules = `
+@@ -586,6 +586,7 @@ var depsRules = `
  	  crypto/pbkdf2,
  	  crypto/ecdh,
  	  crypto/mlkem

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -381,7 +381,7 @@ index 33942467784ad3..0282ffa9fa23c8 100644
  	fipsaes "crypto/internal/fips140/aes"
  	"encoding/hex"
 diff --git a/src/crypto/cipher/gcm.go b/src/crypto/cipher/gcm.go
-index 5580f96d55a0fb..0113589bd7c7be 100644
+index 5580f96d55a0fb..8d048c95ad0512 100644
 --- a/src/crypto/cipher/gcm.go
 +++ b/src/crypto/cipher/gcm.go
 @@ -93,6 +93,15 @@ func newGCM(cipher Block, nonceSize, tagSize int) (AEAD, error) {
@@ -456,7 +456,7 @@ index 5580f96d55a0fb..0113589bd7c7be 100644
 +		}
 +
 +		if _, ok := g.(randomNonceSealer); ok {
-+			return &customGCMWrapper{g}, nil
++			return customGCMWrapper{g}, nil
 +		}
 +
 +		return g, err
@@ -473,15 +473,15 @@ index 5580f96d55a0fb..0113589bd7c7be 100644
 +	aead AEAD
 +}
 +
-+func (g *customGCMWrapper) NonceSize() int { return g.aead.NonceSize() }
++func (g customGCMWrapper) NonceSize() int { return g.aead.NonceSize() }
 +
-+func (g *customGCMWrapper) Overhead() int { return g.aead.Overhead() }
++func (g customGCMWrapper) Overhead() int { return g.aead.Overhead() }
 +
-+func (g *customGCMWrapper) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
++func (g customGCMWrapper) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 +	return g.aead.Seal(dst, nonce, plaintext, additionalData)
 +}
 +
-+func (g *customGCMWrapper) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
++func (g customGCMWrapper) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
 +	return g.aead.Open(dst, nonce, ciphertext, additionalData)
 +}
 +


### PR DESCRIPTION
Solves #1648
Currently type check is very strict at NewGCMWithRandomNonce, it only supports stdlib's aes.Block. This is causing a big issue because in Microsoft build of Go we are trying to use this function with our custom ciphers.  This PR aims to use less strict interface when possible, and also when FIPS 140-only mode is not enforced. 