### PR TITLE
Remove network isolation feature disable setting

### DIFF
--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -30,10 +30,6 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    featureFlags:
-      # Network Isolation causes standard library DNS net tests on Windows to fail.
-      # See https://github.com/microsoft/go-lab/issues/206
-      disableNetworkIsolation: true
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal


### PR DESCRIPTION
The team who works on the Network Isolation DNS proxy fixed some issues based on the Go tests. 🎉 

Tested this branch with https://dev.azure.com/dnceng/internal/_build/results?buildId=2713619&view=results, and although it isn't a clean build yet, the network tests that were failing did pass.

Note that this change alone **doesn't** isolate the build from the network.

* Reverts #1668 
* Fixes https://github.com/microsoft/go-lab/issues/206

IMO there is not a significant need to backport the revert. It wouldn't hurt, but Network Isolation is not isolating yet, and the main branch is sufficient to let NI do whatever experiments/data collection they need to do. We may need to do a slow rollout or backport of actual build isolation in the future, but it's not certain how that will work.