### PR TITLE
Add Clone interface for hashes in backends

### DIFF
--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -7,16 +7,16 @@ Subject: [PATCH] Implement crypto/internal/backend
  .gitignore                                    |   2 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
- .../internal/backend/backendgen_test.go       | 284 ++++++++++++
+ .../internal/backend/backendgen_test.go       | 284 +++++++++++++
  src/crypto/internal/backend/bbig/big.go       |  17 +
  .../internal/backend/bbig/big_boring.go       |  12 +
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
  src/crypto/internal/backend/boring_linux.go   | 287 +++++++++++++
- src/crypto/internal/backend/cng_windows.go    | 379 ++++++++++++++++
- src/crypto/internal/backend/common.go         |  59 +++
- src/crypto/internal/backend/darwin_darwin.go  | 404 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 368 ++++++++++++++++
+ src/crypto/internal/backend/common.go         |  74 ++++
+ src/crypto/internal/backend/darwin_darwin.go  | 401 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/internal/backend/fips140/darwin.go |  11 +
@@ -30,7 +30,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../opensslsetup/opensslsetup_test.go         |  92 ++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 246 +++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 361 ++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 350 +++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |  27 +-
  .../exp_allowcryptofallback_off.go            |   9 +
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2822 insertions(+), 3 deletions(-)
+ 45 files changed, 2812 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -847,10 +847,10 @@ index 00000000000000..48d44ec1723ab6
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..69c01d72178c2c
+index 00000000000000..f38aadd523d30c
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,379 @@
+@@ -0,0 +1,368 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -901,48 +901,37 @@ index 00000000000000..69c01d72178c2c
 +func SupportsRSAOAEPLabel(label []byte) bool     { return true }
 +func SupportsPKCS1v15Hash(hash crypto.Hash) bool { return true }
 +
-+// Wrapper types to handle Clone method with panic on error
-+type hashWrapper struct {
-+    hash.Hash
-+    cloner interface{ Clone() (hash.Hash, error) }
-+}
-+
 +func (h *hashWrapper) Clone() (hash.Hash, error) {
-+    cloned, err := h.cloner.Clone()
-+    if err != nil {
-+        panic("cngcrypto: clone failed: " + err.Error())
-+    }
-+    return wrapHash(cloned), nil
-+}
-+
-+func wrapHash(h hash.Hash) *hashWrapper {
-+    cloner, ok := h.(interface{ Clone() (hash.Hash, error) })
-+    if !ok {
-+        panic("cngcrypto: hash does not implement Clone() (hash.Hash, error)")
-+    }
-+    return &hashWrapper{Hash: h, cloner: cloner}
++	switch cloner := any(h.Hash).(type) {
++	case *hashWrapper:
++		return cloner.Clone()
++	case interface{ Clone() hash.Hash }:
++		return wrapHash(cloner.Clone()), nil
++	default:
++		panic("cngcrypto: hash does not implement Clone()")
++	}
 +}
 +
 +func NewMD5() hash.Hash {
-+    return wrapHash(cng.NewMD5())
++	return wrapHash(cng.NewMD5())
 +}
 +
 +func NewSHA1() hash.Hash {
-+    return wrapHash(cng.NewSHA1())
++	return wrapHash(cng.NewSHA1())
 +}
 +
 +func NewSHA224() hash.Hash { panic("cngcrypto: not available") }
 +
 +func NewSHA256() hash.Hash {
-+    return wrapHash(cng.NewSHA256())
++	return wrapHash(cng.NewSHA256())
 +}
 +
 +func NewSHA384() hash.Hash {
-+    return wrapHash(cng.NewSHA384())
++	return wrapHash(cng.NewSHA384())
 +}
 +
 +func NewSHA512() hash.Hash {
-+    return wrapHash(cng.NewSHA512())
++	return wrapHash(cng.NewSHA512())
 +}
 +
 +func MD5(p []byte) (sum [16]byte)        { return cng.MD5(p) }
@@ -1232,10 +1221,10 @@ index 00000000000000..69c01d72178c2c
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..9436b00381aaf8
+index 00000000000000..28661912ee5d05
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,74 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1245,6 +1234,7 @@ index 00000000000000..9436b00381aaf8
 +import (
 +	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
++	"hash"
 +	"internal/goexperiment"
 +	"runtime"
 +)
@@ -1295,12 +1285,26 @@ index 00000000000000..9436b00381aaf8
 +		}
 +	}
 +}
++
++type cloneHash interface {
++	hash.Hash
++	// Clone returns a separate Hash instance with the same state as h.
++	Clone() (hash.Hash, error)
++}
++
++type hashWrapper struct {
++	hash.Hash
++}
++
++func wrapHash(h hash.Hash) *hashWrapper {
++	return &hashWrapper{h}
++}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..c4d8b5bcaf3719
+index 00000000000000..3f96b825c527aa
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
-@@ -0,0 +1,404 @@
+@@ -0,0 +1,401 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1361,44 +1365,30 @@ index 00000000000000..c4d8b5bcaf3719
 +	return false
 +}
 +
-+// Wrapper types to handle Clone method with panic on error
-+type hashWrapper struct {
-+    hash.Hash
-+    cloner interface{ Clone() (hash.Hash, error) }
-+}
-+
 +func (h *hashWrapper) Clone() (hash.Hash, error) {
-+    cloned, err := h.cloner.Clone()
-+    if err != nil {
-+        panic("cryptobackend: clone failed: " + err.Error())
-+    }
-+    return wrapHash(cloned), nil
-+}
-+
-+func wrapHash(h hash.Hash) *hashWrapper {
-+    cloner, ok := h.(interface{ Clone() (hash.Hash, error) })
-+    if !ok {
-+        panic("cryptobackend: hash does not implement Clone() (hash.Hash, error)")
-+    }
-+    return &hashWrapper{Hash: h, cloner: cloner}
++	cloned, err := h.cloner.Clone()
++	if err != nil {
++		panic("cryptobackend: clone failed: " + err.Error())
++	}
++	return wrapHash(cloned), nil
 +}
 +
 +func NewMD5() hash.Hash {
-+    return wrapHash(xcrypto.NewMD5())
++	return wrapHash(xcrypto.NewMD5())
 +}
 +
 +func NewSHA1() hash.Hash {
-+    return wrapHash(xcrypto.NewSHA1())
++	return wrapHash(xcrypto.NewSHA1())
 +}
 +
 +func NewSHA224() hash.Hash { panic("cryptobackend: not available") }
 +
 +func NewSHA256() hash.Hash {
-+    return wrapHash(xcrypto.NewSHA256())
++	return wrapHash(xcrypto.NewSHA256())
 +}
 +
 +func NewSHA384() hash.Hash {
-+    return wrapHash(xcrypto.NewSHA384())
++	return wrapHash(xcrypto.NewSHA384())
 +}
 +
 +func NewSHA512() hash.Hash {
@@ -1413,6 +1403,17 @@ index 00000000000000..c4d8b5bcaf3719
 +func SHA512(p []byte) (sum [64]byte)     { return xcrypto.SHA512(p) }
 +func SHA512_224(p []byte) (sum [28]byte) { panic("cryptobackend: not available") }
 +func SHA512_256(p []byte) (sum [32]byte) { panic("cryptobackend: not available") }
++
++func (h *hashWrapper) Clone() (hash.Hash, error) {
++	switch cloner := any(h.Hash).(type) {
++	case *hashWrapper:
++		return cloner.Clone()
++	case interface{ Clone() hash.Hash }:
++		return wrapHash(cloner.Clone()), nil
++	default:
++		panic("cryptobackend: hash does not implement Clone()")
++	}
++}
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 +	return xcrypto.NewHMAC(h, key)
@@ -2422,10 +2423,10 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..dd04a0b5eff91f
+index 00000000000000..4f2fa3b2a175c0
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,361 @@
+@@ -0,0 +1,350 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2486,26 +2487,15 @@ index 00000000000000..dd04a0b5eff91f
 +func SupportsRSAOAEPLabel(label []byte) bool     { return true }
 +func SupportsPKCS1v15Hash(hash crypto.Hash) bool { return true }
 +
-+// Wrapper types to handle Clone method with panic on error
-+type hashWrapper struct {
-+    hash.Hash
-+    cloner interface{ Clone() (hash.Hash, error) }
-+}
-+
 +func (h *hashWrapper) Clone() (hash.Hash, error) {
-+    cloned, err := h.cloner.Clone()
-+    if err != nil {
-+        panic("opensslcrypto: clone failed: " + err.Error())
-+    }
-+    return wrapHash(cloned), nil
-+}
-+
-+func wrapHash(h hash.Hash) *hashWrapper {
-+    cloner, ok := h.(interface{ Clone() (hash.Hash, error) })
-+    if !ok {
-+        panic("opensslcrypto: hash does not implement Clone() (hash.Hash, error)")
-+    }
-+    return &hashWrapper{Hash: h, cloner: cloner}
++	switch cloner := any(h.Hash).(type) {
++	case *hashWrapper:
++		return cloner.Clone()
++	case interface{ Clone() hash.Hash }:
++		return wrapHash(cloner.Clone()), nil
++	default:
++		panic("opensslcrypto: hash does not implement Clone()")
++	}
 +}
 +
 +func NewMD5() hash.Hash        { return wrapHash(openssl.NewMD5()) }

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -7,16 +7,16 @@ Subject: [PATCH] Implement crypto/internal/backend
  .gitignore                                    |   2 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
- .../internal/backend/backendgen_test.go       | 284 ++++++++++++++
+ .../internal/backend/backendgen_test.go       | 284 ++++++++++++
  src/crypto/internal/backend/bbig/big.go       |  17 +
  .../internal/backend/bbig/big_boring.go       |  12 +
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/boring_linux.go   | 287 ++++++++++++++
- src/crypto/internal/backend/cng_windows.go    | 344 ++++++++++++++++
+ src/crypto/internal/backend/boring_linux.go   | 287 +++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 379 ++++++++++++++++
  src/crypto/internal/backend/common.go         |  59 +++
- src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
+ src/crypto/internal/backend/darwin_darwin.go  | 404 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/internal/backend/fips140/darwin.go |  11 +
@@ -26,11 +26,11 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../backend/fips140/nosystemcrypto.go         |  11 +
  .../internal/backend/fips140/openssl_cgo.go   |  57 +++
  .../internal/backend/fips140/openssl_nocgo.go |  15 +
- .../internal/opensslsetup/opensslsetup.go     |  70 ++++
- .../opensslsetup/opensslsetup_test.go         |  92 +++++
+ .../internal/opensslsetup/opensslsetup.go     |  70 +++
+ .../opensslsetup/opensslsetup_test.go         |  92 ++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
- src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 339 ++++++++++++++++
+ src/crypto/internal/backend/nobackend.go      | 246 +++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 361 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |  27 +-
  .../exp_allowcryptofallback_off.go            |   9 +
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2728 insertions(+), 3 deletions(-)
+ 45 files changed, 2822 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -847,10 +847,10 @@ index 00000000000000..48d44ec1723ab6
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..6abb6ff007c99f
+index 00000000000000..69c01d72178c2c
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,344 @@
+@@ -0,0 +1,379 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -901,14 +901,49 @@ index 00000000000000..6abb6ff007c99f
 +func SupportsRSAOAEPLabel(label []byte) bool     { return true }
 +func SupportsPKCS1v15Hash(hash crypto.Hash) bool { return true }
 +
-+func NewMD5() hash.Hash        { return cng.NewMD5() }
-+func NewSHA1() hash.Hash       { return cng.NewSHA1() }
-+func NewSHA224() hash.Hash     { panic("cngcrypto: not available") }
-+func NewSHA256() hash.Hash     { return cng.NewSHA256() }
-+func NewSHA384() hash.Hash     { return cng.NewSHA384() }
-+func NewSHA512() hash.Hash     { return cng.NewSHA512() }
-+func NewSHA512_224() hash.Hash { panic("cngcrypto: not available") }
-+func NewSHA512_256() hash.Hash { panic("cngcrypto: not available") }
++// Wrapper types to handle Clone method with panic on error
++type hashWrapper struct {
++    hash.Hash
++    cloner interface{ Clone() (hash.Hash, error) }
++}
++
++func (h *hashWrapper) Clone() (hash.Hash, error) {
++    cloned, err := h.cloner.Clone()
++    if err != nil {
++        panic("cngcrypto: clone failed: " + err.Error())
++    }
++    return wrapHash(cloned), nil
++}
++
++func wrapHash(h hash.Hash) *hashWrapper {
++    cloner, ok := h.(interface{ Clone() (hash.Hash, error) })
++    if !ok {
++        panic("cngcrypto: hash does not implement Clone() (hash.Hash, error)")
++    }
++    return &hashWrapper{Hash: h, cloner: cloner}
++}
++
++func NewMD5() hash.Hash {
++    return wrapHash(cng.NewMD5())
++}
++
++func NewSHA1() hash.Hash {
++    return wrapHash(cng.NewSHA1())
++}
++
++func NewSHA224() hash.Hash { panic("cngcrypto: not available") }
++
++func NewSHA256() hash.Hash {
++    return wrapHash(cng.NewSHA256())
++}
++
++func NewSHA384() hash.Hash {
++    return wrapHash(cng.NewSHA384())
++}
++
++func NewSHA512() hash.Hash {
++    return wrapHash(cng.NewSHA512())
++}
 +
 +func MD5(p []byte) (sum [16]byte)        { return cng.MD5(p) }
 +func SHA1(p []byte) (sum [20]byte)       { return cng.SHA1(p) }
@@ -1262,10 +1297,10 @@ index 00000000000000..9436b00381aaf8
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..0c374baf8d3f80
+index 00000000000000..c4d8b5bcaf3719
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
-@@ -0,0 +1,367 @@
+@@ -0,0 +1,404 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1326,12 +1361,49 @@ index 00000000000000..0c374baf8d3f80
 +	return false
 +}
 +
-+func NewMD5() hash.Hash    { return xcrypto.NewMD5() }
-+func NewSHA1() hash.Hash   { return xcrypto.NewSHA1() }
++// Wrapper types to handle Clone method with panic on error
++type hashWrapper struct {
++    hash.Hash
++    cloner interface{ Clone() (hash.Hash, error) }
++}
++
++func (h *hashWrapper) Clone() (hash.Hash, error) {
++    cloned, err := h.cloner.Clone()
++    if err != nil {
++        panic("cryptobackend: clone failed: " + err.Error())
++    }
++    return wrapHash(cloned), nil
++}
++
++func wrapHash(h hash.Hash) *hashWrapper {
++    cloner, ok := h.(interface{ Clone() (hash.Hash, error) })
++    if !ok {
++        panic("cryptobackend: hash does not implement Clone() (hash.Hash, error)")
++    }
++    return &hashWrapper{Hash: h, cloner: cloner}
++}
++
++func NewMD5() hash.Hash {
++    return wrapHash(xcrypto.NewMD5())
++}
++
++func NewSHA1() hash.Hash {
++    return wrapHash(xcrypto.NewSHA1())
++}
++
 +func NewSHA224() hash.Hash { panic("cryptobackend: not available") }
-+func NewSHA256() hash.Hash { return xcrypto.NewSHA256() }
-+func NewSHA384() hash.Hash { return xcrypto.NewSHA384() }
-+func NewSHA512() hash.Hash { return xcrypto.NewSHA512() }
++
++func NewSHA256() hash.Hash {
++    return wrapHash(xcrypto.NewSHA256())
++}
++
++func NewSHA384() hash.Hash {
++    return wrapHash(xcrypto.NewSHA384())
++}
++
++func NewSHA512() hash.Hash {
++	return wrapHash(xcrypto.NewSHA512())
++}
 +
 +func MD5(p []byte) (sum [16]byte)        { return xcrypto.MD5(p) }
 +func SHA1(p []byte) (sum [20]byte)       { return xcrypto.SHA1(p) }
@@ -2350,10 +2422,10 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..ac656468e3ed32
+index 00000000000000..dd04a0b5eff91f
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,339 @@
+@@ -0,0 +1,361 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2414,14 +2486,36 @@ index 00000000000000..ac656468e3ed32
 +func SupportsRSAOAEPLabel(label []byte) bool     { return true }
 +func SupportsPKCS1v15Hash(hash crypto.Hash) bool { return true }
 +
-+func NewMD5() hash.Hash        { return openssl.NewMD5() }
-+func NewSHA1() hash.Hash       { return openssl.NewSHA1() }
-+func NewSHA224() hash.Hash     { return openssl.NewSHA224() }
-+func NewSHA256() hash.Hash     { return openssl.NewSHA256() }
-+func NewSHA384() hash.Hash     { return openssl.NewSHA384() }
-+func NewSHA512() hash.Hash     { return openssl.NewSHA512() }
-+func NewSHA512_224() hash.Hash { return openssl.NewSHA512_224() }
-+func NewSHA512_256() hash.Hash { return openssl.NewSHA512_256() }
++// Wrapper types to handle Clone method with panic on error
++type hashWrapper struct {
++    hash.Hash
++    cloner interface{ Clone() (hash.Hash, error) }
++}
++
++func (h *hashWrapper) Clone() (hash.Hash, error) {
++    cloned, err := h.cloner.Clone()
++    if err != nil {
++        panic("opensslcrypto: clone failed: " + err.Error())
++    }
++    return wrapHash(cloned), nil
++}
++
++func wrapHash(h hash.Hash) *hashWrapper {
++    cloner, ok := h.(interface{ Clone() (hash.Hash, error) })
++    if !ok {
++        panic("opensslcrypto: hash does not implement Clone() (hash.Hash, error)")
++    }
++    return &hashWrapper{Hash: h, cloner: cloner}
++}
++
++func NewMD5() hash.Hash        { return wrapHash(openssl.NewMD5()) }
++func NewSHA1() hash.Hash       { return wrapHash(openssl.NewSHA1()) }
++func NewSHA224() hash.Hash     { return wrapHash(openssl.NewSHA224()) }
++func NewSHA256() hash.Hash     { return wrapHash(openssl.NewSHA256()) }
++func NewSHA384() hash.Hash     { return wrapHash(openssl.NewSHA384()) }
++func NewSHA512() hash.Hash     { return wrapHash(openssl.NewSHA512()) }
++func NewSHA512_224() hash.Hash { return wrapHash(openssl.NewSHA512_224()) }
++func NewSHA512_256() hash.Hash { return wrapHash(openssl.NewSHA512_256()) }
 +
 +func MD5(p []byte) (sum [16]byte)        { return openssl.MD5(p) }
 +func SHA1(p []byte) (sum [20]byte)       { return openssl.SHA1(p) }

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -15,7 +15,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/backend/bbig/big_openssl.go      |  12 +
  src/crypto/internal/backend/boring_linux.go   | 287 +++++++++++++
  src/crypto/internal/backend/cng_windows.go    | 368 ++++++++++++++++
- src/crypto/internal/backend/common.go         |  74 ++++
+ src/crypto/internal/backend/common.go         |  68 +++
  src/crypto/internal/backend/darwin_darwin.go  | 401 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2812 insertions(+), 3 deletions(-)
+ 45 files changed, 2806 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -847,7 +847,7 @@ index 00000000000000..48d44ec1723ab6
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..f38aadd523d30c
+index 00000000000000..5f117156efa84c
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
 @@ -0,0 +1,368 @@
@@ -901,9 +901,9 @@ index 00000000000000..f38aadd523d30c
 +func SupportsRSAOAEPLabel(label []byte) bool     { return true }
 +func SupportsPKCS1v15Hash(hash crypto.Hash) bool { return true }
 +
-+func (h *hashWrapper) Clone() (hash.Hash, error) {
++func (h hashWrapper) Clone() (hash.Hash, error) {
 +	switch cloner := any(h.Hash).(type) {
-+	case *hashWrapper:
++	case hashWrapper:
 +		return cloner.Clone()
 +	case interface{ Clone() hash.Hash }:
 +		return wrapHash(cloner.Clone()), nil
@@ -1221,10 +1221,10 @@ index 00000000000000..f38aadd523d30c
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..28661912ee5d05
+index 00000000000000..c619a18b897320
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,68 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1286,22 +1286,16 @@ index 00000000000000..28661912ee5d05
 +	}
 +}
 +
-+type cloneHash interface {
-+	hash.Hash
-+	// Clone returns a separate Hash instance with the same state as h.
-+	Clone() (hash.Hash, error)
-+}
-+
 +type hashWrapper struct {
 +	hash.Hash
 +}
 +
-+func wrapHash(h hash.Hash) *hashWrapper {
-+	return &hashWrapper{h}
++func wrapHash(h hash.Hash) hashWrapper {
++	return hashWrapper{h}
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..3f96b825c527aa
+index 00000000000000..de0f9474aa6580
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
 @@ -0,0 +1,401 @@
@@ -1404,9 +1398,9 @@ index 00000000000000..3f96b825c527aa
 +func SHA512_224(p []byte) (sum [28]byte) { panic("cryptobackend: not available") }
 +func SHA512_256(p []byte) (sum [32]byte) { panic("cryptobackend: not available") }
 +
-+func (h *hashWrapper) Clone() (hash.Hash, error) {
++func (h hashWrapper) Clone() (hash.Hash, error) {
 +	switch cloner := any(h.Hash).(type) {
-+	case *hashWrapper:
++	case hashWrapper:
 +		return cloner.Clone()
 +	case interface{ Clone() hash.Hash }:
 +		return wrapHash(cloner.Clone()), nil
@@ -2423,7 +2417,7 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..4f2fa3b2a175c0
+index 00000000000000..64154d1954a7da
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,350 @@
@@ -2487,9 +2481,9 @@ index 00000000000000..4f2fa3b2a175c0
 +func SupportsRSAOAEPLabel(label []byte) bool     { return true }
 +func SupportsPKCS1v15Hash(hash crypto.Hash) bool { return true }
 +
-+func (h *hashWrapper) Clone() (hash.Hash, error) {
++func (h hashWrapper) Clone() (hash.Hash, error) {
 +	switch cloner := any(h.Hash).(type) {
-+	case *hashWrapper:
++	case hashWrapper:
 +		return cloner.Clone()
 +	case interface{ Clone() hash.Hash }:
 +		return wrapHash(cloner.Clone()), nil

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -14,9 +14,9 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
  src/crypto/internal/backend/boring_linux.go   | 287 +++++++++++++
- src/crypto/internal/backend/cng_windows.go    | 368 ++++++++++++++++
- src/crypto/internal/backend/common.go         |  68 +++
- src/crypto/internal/backend/darwin_darwin.go  | 393 ++++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 353 ++++++++++++++++
+ src/crypto/internal/backend/common.go         |  68 ++++
+ src/crypto/internal/backend/darwin_darwin.go  | 378 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/internal/backend/fips140/darwin.go |  11 +
@@ -27,9 +27,9 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/backend/fips140/openssl_cgo.go   |  57 +++
  .../internal/backend/fips140/openssl_nocgo.go |  15 +
  .../internal/opensslsetup/opensslsetup.go     |  70 ++++
- .../opensslsetup/opensslsetup_test.go         |  92 ++++
+ .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
- src/crypto/internal/backend/nobackend.go      | 246 +++++++++++
+ src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
  src/crypto/internal/backend/openssl_linux.go  | 350 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |  27 +-
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2798 insertions(+), 3 deletions(-)
+ 45 files changed, 2768 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -847,10 +847,10 @@ index 00000000000000..48d44ec1723ab6
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..5f117156efa84c
+index 00000000000000..523076ca2a490e
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,368 @@
+@@ -0,0 +1,353 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -912,27 +912,12 @@ index 00000000000000..5f117156efa84c
 +	}
 +}
 +
-+func NewMD5() hash.Hash {
-+	return wrapHash(cng.NewMD5())
-+}
-+
-+func NewSHA1() hash.Hash {
-+	return wrapHash(cng.NewSHA1())
-+}
-+
++func NewMD5() hash.Hash    { return wrapHash(cng.NewMD5()) }
++func NewSHA1() hash.Hash   { return wrapHash(cng.NewSHA1()) }
 +func NewSHA224() hash.Hash { panic("cngcrypto: not available") }
-+
-+func NewSHA256() hash.Hash {
-+	return wrapHash(cng.NewSHA256())
-+}
-+
-+func NewSHA384() hash.Hash {
-+	return wrapHash(cng.NewSHA384())
-+}
-+
-+func NewSHA512() hash.Hash {
-+	return wrapHash(cng.NewSHA512())
-+}
++func NewSHA256() hash.Hash { return wrapHash(cng.NewSHA256()) }
++func NewSHA384() hash.Hash { return wrapHash(cng.NewSHA384()) }
++func NewSHA512() hash.Hash { return wrapHash(cng.NewSHA512()) }
 +
 +func MD5(p []byte) (sum [16]byte)        { return cng.MD5(p) }
 +func SHA1(p []byte) (sum [20]byte)       { return cng.SHA1(p) }
@@ -944,7 +929,7 @@ index 00000000000000..5f117156efa84c
 +func SHA512_256(p []byte) (sum [32]byte) { panic("cngcrypto: not available") }
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
-+	return cng.NewHMAC(h, key)
++	return wrapHash(cng.NewHMAC(h, key))
 +}
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) {
@@ -1295,10 +1280,10 @@ index 00000000000000..c619a18b897320
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..7e761f3e141d57
+index 00000000000000..239de18b202fd8
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
-@@ -0,0 +1,393 @@
+@@ -0,0 +1,378 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1370,27 +1355,12 @@ index 00000000000000..7e761f3e141d57
 +	}
 +}
 +
-+func NewMD5() hash.Hash {
-+	return wrapHash(xcrypto.NewMD5())
-+}
-+
-+func NewSHA1() hash.Hash {
-+	return wrapHash(xcrypto.NewSHA1())
-+}
-+
++func NewMD5() hash.Hash    { return wrapHash(xcrypto.NewMD5()) }
++func NewSHA1() hash.Hash   { return wrapHash(xcrypto.NewSHA1()) }
 +func NewSHA224() hash.Hash { panic("cryptobackend: not available") }
-+
-+func NewSHA256() hash.Hash {
-+	return wrapHash(xcrypto.NewSHA256())
-+}
-+
-+func NewSHA384() hash.Hash {
-+	return wrapHash(xcrypto.NewSHA384())
-+}
-+
-+func NewSHA512() hash.Hash {
-+	return wrapHash(xcrypto.NewSHA512())
-+}
++func NewSHA256() hash.Hash { return wrapHash(xcrypto.NewSHA256()) }
++func NewSHA384() hash.Hash { return wrapHash(xcrypto.NewSHA384()) }
++func NewSHA512() hash.Hash { return wrapHash(xcrypto.NewSHA512()) }
 +
 +func MD5(p []byte) (sum [16]byte)        { return xcrypto.MD5(p) }
 +func SHA1(p []byte) (sum [20]byte)       { return xcrypto.SHA1(p) }
@@ -1402,7 +1372,7 @@ index 00000000000000..7e761f3e141d57
 +func SHA512_256(p []byte) (sum [32]byte) { panic("cryptobackend: not available") }
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
-+	return xcrypto.NewHMAC(h, key)
++	return wrapHash(xcrypto.NewHMAC(h, key))
 +}
 +
 +func NewAESCipher(key []byte) (cipher.Block, error) {
@@ -2409,7 +2379,7 @@ index 00000000000000..1675358749323f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..64154d1954a7da
+index 00000000000000..ef10f754877167
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,350 @@
@@ -2502,7 +2472,7 @@ index 00000000000000..64154d1954a7da
 +func SHA512_224(p []byte) (sum [28]byte) { return openssl.SHA512_224(p) }
 +func SHA512_256(p []byte) (sum [32]byte) { return openssl.SHA512_256(p) }
 +
-+func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return openssl.NewHMAC(h, key) }
++func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { return wrapHash(openssl.NewHMAC(h, key)) }
 +
 +func NewAESCipher(key []byte) (cipher.Block, error)   { return openssl.NewAESCipher(key) }
 +func NewGCMTLS(c cipher.Block) (cipher.AEAD, error)   { return openssl.NewGCMTLS(c) }

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -16,7 +16,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/boring_linux.go   | 287 +++++++++++++
  src/crypto/internal/backend/cng_windows.go    | 368 ++++++++++++++++
  src/crypto/internal/backend/common.go         |  68 +++
- src/crypto/internal/backend/darwin_darwin.go  | 401 ++++++++++++++++++
+ src/crypto/internal/backend/darwin_darwin.go  | 393 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/internal/backend/fips140/darwin.go |  11 +
@@ -26,11 +26,11 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../backend/fips140/nosystemcrypto.go         |  11 +
  .../internal/backend/fips140/openssl_cgo.go   |  57 +++
  .../internal/backend/fips140/openssl_nocgo.go |  15 +
- .../internal/opensslsetup/opensslsetup.go     |  70 +++
+ .../internal/opensslsetup/opensslsetup.go     |  70 ++++
  .../opensslsetup/opensslsetup_test.go         |  92 ++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 246 +++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 350 +++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 350 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/go/build/deps_test.go                     |  27 +-
  .../exp_allowcryptofallback_off.go            |   9 +
@@ -49,7 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2806 insertions(+), 3 deletions(-)
+ 45 files changed, 2798 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -1295,10 +1295,10 @@ index 00000000000000..c619a18b897320
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..de0f9474aa6580
+index 00000000000000..7e761f3e141d57
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
-@@ -0,0 +1,401 @@
+@@ -0,0 +1,393 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1359,12 +1359,15 @@ index 00000000000000..de0f9474aa6580
 +	return false
 +}
 +
-+func (h *hashWrapper) Clone() (hash.Hash, error) {
-+	cloned, err := h.cloner.Clone()
-+	if err != nil {
-+		panic("cryptobackend: clone failed: " + err.Error())
++func (h hashWrapper) Clone() (hash.Hash, error) {
++	switch cloner := any(h.Hash).(type) {
++	case hashWrapper:
++		return cloner.Clone()
++	case interface{ Clone() hash.Hash }:
++		return wrapHash(cloner.Clone()), nil
++	default:
++		panic("cryptobackend: hash does not implement Clone()")
 +	}
-+	return wrapHash(cloned), nil
 +}
 +
 +func NewMD5() hash.Hash {
@@ -1397,17 +1400,6 @@ index 00000000000000..de0f9474aa6580
 +func SHA512(p []byte) (sum [64]byte)     { return xcrypto.SHA512(p) }
 +func SHA512_224(p []byte) (sum [28]byte) { panic("cryptobackend: not available") }
 +func SHA512_256(p []byte) (sum [32]byte) { panic("cryptobackend: not available") }
-+
-+func (h hashWrapper) Clone() (hash.Hash, error) {
-+	switch cloner := any(h.Hash).(type) {
-+	case hashWrapper:
-+		return cloner.Clone()
-+	case interface{ Clone() hash.Hash }:
-+		return wrapHash(cloner.Clone()), nil
-+	default:
-+		panic("cryptobackend: hash does not implement Clone()")
-+	}
-+}
 +
 +func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 +	return xcrypto.NewHMAC(h, key)

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -40,6 +40,10 @@ Subject: [PATCH] Use crypto backends
  src/crypto/hkdf/hkdf_test.go                  |   2 +-
  src/crypto/hmac/hmac.go                       |   2 +-
  src/crypto/hmac/hmac_test.go                  |   2 +-
+ src/crypto/internal/backend/cng_windows.go    |   4 +-
+ src/crypto/internal/backend/common.go         |   7 +-
+ src/crypto/internal/backend/darwin_darwin.go  |   4 +-
+ src/crypto/internal/backend/openssl_linux.go  |   4 +-
  src/crypto/internal/cryptotest/allocations.go |   2 +-
  .../internal/cryptotest/implementations.go    |   2 +-
  src/crypto/internal/fips140test/acvp_test.go  |   6 +
@@ -90,7 +94,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1170 insertions(+), 95 deletions(-)
+ 90 files changed, 1181 insertions(+), 103 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -1346,6 +1350,70 @@ index 7accad763244a1..dd3211f2c37af3 100644
  	"crypto/internal/cryptotest"
  	"crypto/md5"
  	"crypto/sha1"
+diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
+index 523076ca2a490e..18d2c81ad6b5fd 100644
+--- a/src/crypto/internal/backend/cng_windows.go
++++ b/src/crypto/internal/backend/cng_windows.go
+@@ -48,9 +48,9 @@ func SupportsCurve(curve string) bool            { return true }
+ func SupportsRSAOAEPLabel(label []byte) bool     { return true }
+ func SupportsPKCS1v15Hash(hash crypto.Hash) bool { return true }
+ 
+-func (h hashWrapper) Clone() (hash.Hash, error) {
++func (h *hashWrapper) Clone() (hash.Hash, error) {
+ 	switch cloner := any(h.Hash).(type) {
+-	case hashWrapper:
++	case *hashWrapper:
+ 		return cloner.Clone()
+ 	case interface{ Clone() hash.Hash }:
+ 		return wrapHash(cloner.Clone()), nil
+diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
+index c619a18b897320..2436466a968d01 100644
+--- a/src/crypto/internal/backend/common.go
++++ b/src/crypto/internal/backend/common.go
+@@ -63,6 +63,9 @@ type hashWrapper struct {
+ 	hash.Hash
+ }
+ 
+-func wrapHash(h hash.Hash) hashWrapper {
+-	return hashWrapper{h}
++func wrapHash(h hash.Hash) *hashWrapper {
++	if h != nil {
++		return &hashWrapper{h}
++	}
++	return nil
+ }
+diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
+index 239de18b202fd8..0d9afa64179c8b 100644
+--- a/src/crypto/internal/backend/darwin_darwin.go
++++ b/src/crypto/internal/backend/darwin_darwin.go
+@@ -58,9 +58,9 @@ func SupportsPKCS1v15Hash(hash crypto.Hash) bool {
+ 	return false
+ }
+ 
+-func (h hashWrapper) Clone() (hash.Hash, error) {
++func (h *hashWrapper) Clone() (hash.Hash, error) {
+ 	switch cloner := any(h.Hash).(type) {
+-	case hashWrapper:
++	case *hashWrapper:
+ 		return cloner.Clone()
+ 	case interface{ Clone() hash.Hash }:
+ 		return wrapHash(cloner.Clone()), nil
+diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
+index ef10f754877167..5b824877741ff7 100644
+--- a/src/crypto/internal/backend/openssl_linux.go
++++ b/src/crypto/internal/backend/openssl_linux.go
+@@ -58,9 +58,9 @@ func SupportsCurve(curve string) bool            { return true }
+ func SupportsRSAOAEPLabel(label []byte) bool     { return true }
+ func SupportsPKCS1v15Hash(hash crypto.Hash) bool { return true }
+ 
+-func (h hashWrapper) Clone() (hash.Hash, error) {
++func (h *hashWrapper) Clone() (hash.Hash, error) {
+ 	switch cloner := any(h.Hash).(type) {
+-	case hashWrapper:
++	case *hashWrapper:
+ 		return cloner.Clone()
+ 	case interface{ Clone() hash.Hash }:
+ 		return wrapHash(cloner.Clone()), nil
 diff --git a/src/crypto/internal/cryptotest/allocations.go b/src/crypto/internal/cryptotest/allocations.go
 index 70055af70b42ec..3c4b4fbaa98ded 100644
 --- a/src/crypto/internal/cryptotest/allocations.go


### PR DESCRIPTION
Fixes #1681 
This PR introduces a Clone interface to our backend systems. This is to maintain compatibility with Go 1.25's newly introduced hash.Clone interface in the standard library.

Currently, our backend's Clone implementations don't return an error. Since the standard library's hash.Clone interface requires an error return, we now wrap the hash structures returned by our backends. This wrapper then includes a Clone method that correctly implements the hash.Clone interface, allowing us to incorporate the necessary error handling.