### PR TITLE
Enable the `systemcrypto` goexperiment by default

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -139,7 +139,7 @@ See [the microsoft/go-images documentation][microsoft-go-images] for more inform
 ### Dockerfile env instruction
 
 > [!NOTE]
-> Since Go 1.25 `systemcrypto` is enabled by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
+> Since Go 1.25, `systemcrypto` is enabled by default on Linux and Windows. There is no need to manually enable using OpenSSL/CNG under the hood anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
 
 If you don't use the standard Go base images (e.g. your Dockerfile downloads the Microsoft build of Go manually), you can use an `env` instruction before the build instruction in your Dockerfile:
 
@@ -150,7 +150,7 @@ env GOEXPERIMENT=systemcrypto
 ### Modify the build command
 
 > [!NOTE]
-> Since Go 1.25 `systemcrypto` is enabled by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
+> Since Go 1.25, `systemcrypto` is enabled by default on Linux and Windows. There is no need to manually enable using OpenSSL/CNG under the hood anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
 
 Another approach that generally works for any build system is to modify the build command or build script. This section lists some helpful snippets to select a backend.
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -68,7 +68,7 @@ There are typically two goals that lead to this document. Creating a FIPS compli
 > 1.24 introduces `GODEBUG=fips140=on` as the preferred way to enable FIPS mode. See also [the Go 1.24 changelog](#go-124-feb-2025).
 
 > [!NOTE]
-> Since Go 1.25 `systemcrypto` is enabled by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
+> Since Go 1.25, `systemcrypto` is enabled by default on Linux and Windows. There is no need to manually enable using OpenSSL/CNG under the hood anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
 
 | Build-time config | Runtime config | Internal Microsoft crypto policy | FIPS behavior |
 | --- | --- | --- | --- |
@@ -95,7 +95,7 @@ The `GOEXPERIMENT` environment variable is used at build time to select a crypto
 
 - `systemcrypto` automatically selects the suggested crypto backend for the target platform
    - Prior to Go 1.21, this experiment is not available and the backend must be selected manually
-   - Since Go 1.25, this experiment es enabled automatically on Windows and Linux. It can be disabled in the usual way: setting `GOEXPERIMENT=nosystemcrypto`
+   - Since Go 1.25, this experiment is enabled automatically on Windows and Linux. It can be disabled like any other `GOEXPERIMENT`: setting `GOEXPERIMENT=nosystemcrypto`
 - `opensslcrypto` selects OpenSSL, for Linux
 - `cngcrypto` selects CNG, for Windows
 - Since 1.24, `darwincrypto` selects CommonCrypto & CryptoKit for macOS
@@ -446,7 +446,7 @@ This list of major changes is intended for quick reference and for access to his
 
 ### Go 1.25 (Aug 2025)
 
-- Enable the `systemcrypto` goexperiment by default behavior on Windows and Linux. To disable it, set `GOEXPERIMENT=nosystemcrypto`.
+- The `systemcrypto` goexperiment is now enabled by default on Windows and Linux. To disable it, set `GOEXPERIMENT=nosystemcrypto`.
 
 - Running `go version -m` on a binary which uses a system crypto backend now shows the `microsoft_systemcrypto=1` build setting.
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -68,7 +68,7 @@ There are typically two goals that lead to this document. Creating a FIPS compli
 > 1.24 introduces `GODEBUG=fips140=on` as the preferred way to enable FIPS mode. See also [the Go 1.24 changelog](#go-124-feb-2025).
 
 > [!NOTE]
-> Since Go 1.25 `systemcrypto` is by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
+> Since Go 1.25 `systemcrypto` is enabled by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
 
 | Build-time config | Runtime config | Internal Microsoft crypto policy | FIPS behavior |
 | --- | --- | --- | --- |
@@ -139,7 +139,7 @@ See [the microsoft/go-images documentation][microsoft-go-images] for more inform
 ### Dockerfile env instruction
 
 > [!NOTE]
-> Since Go 1.25 `systemcrypto` is by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
+> Since Go 1.25 `systemcrypto` is enabled by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
 
 If you don't use the standard Go base images (e.g. your Dockerfile downloads the Microsoft build of Go manually), you can use an `env` instruction before the build instruction in your Dockerfile:
 
@@ -150,7 +150,7 @@ env GOEXPERIMENT=systemcrypto
 ### Modify the build command
 
 > [!NOTE]
-> Since Go 1.25 `systemcrypto` is by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
+> Since Go 1.25 `systemcrypto` is enabled by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
 
 Another approach that generally works for any build system is to modify the build command or build script. This section lists some helpful snippets to select a backend.
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -67,6 +67,9 @@ There are typically two goals that lead to this document. Creating a FIPS compli
 >
 > 1.24 introduces `GODEBUG=fips140=on` as the preferred way to enable FIPS mode. See also [the Go 1.24 changelog](#go-124-feb-2025).
 
+> [!NOTE]
+> Since Go 1.25 `systemcrypto` is by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
+
 | Build-time config | Runtime config | Internal Microsoft crypto policy | FIPS behavior |
 | --- | --- | --- | --- |
 | Default | Default | Not compliant | Crypto usage is not FIPS compliant. |
@@ -74,6 +77,7 @@ There are typically two goals that lead to this document. Creating a FIPS compli
 | `GOEXPERIMENT=systemcrypto` | `GODEBUG=fips140=on` or `GOFIPS=1` | Compliant | Can be used to create a compliant app. Depending on platform, the app enables FIPS mode, ensures it is already enabled, or doesn't do any additional checks. The app panics if there is a problem. See [Usage: Runtime](#usage-runtime). |
 | `GOEXPERIMENT=systemcrypto` | `GO_OPENSSL_VERSION_OVERRIDE=1.1.1k-fips` | Compliant | Can be used to create a compliant app. If the app is built for Linux, `systemcrypto` chooses `opensslcrypto`, and the environment variable causes it to load `libcrypto.so.1.1.1k-fips` instead of using the automatic search behavior. This environment variable has no effect with `cngcrypto`. |
 | `GOEXPERIMENT=systemcrypto` and `-tags=requirefips` | Default | Compliant | Can be used to create a compliant app. The behavior is the same as `GODEBUG=fips140=on` and `GOFIPS=1`, but no runtime configuration is necessary. See [the `requirefips` section](#build-option-to-require-fips-mode) for more information on when this "locked-in" approach may be useful rather than the flexible approach. |
+| `GOEXPERIMENT=nosystemcrypto` | Default | Not compliant | Crypto usage is not FIPS compliant. |
 
 A [Docker base image](#dockerfile-base-image) is available that includes suitable build-time config in the environment.
 
@@ -89,8 +93,9 @@ Some configurations are invalid and intentionally result in a build error or run
 
 The `GOEXPERIMENT` environment variable is used at build time to select a cryptographic library backend. This modifies the Go runtime included in the program to use the specified platform-provided cryptographic library whenever it calls a Go standard library crypto API. The `GOEXPERIMENT` values that pick a crypto backend are:
 
-- *Recommended:* `systemcrypto` automatically selects the suggested crypto backend for the target platform
-  - Prior to Go 1.21, this alias is not available and the backend must be selected manually
+- `systemcrypto` automatically selects the suggested crypto backend for the target platform
+   - Prior to Go 1.21, this experiment is not available and the backend must be selected manually
+   - Since Go 1.25, this experiment es enabled automatically on Windows and Linux. It can be disabled in the usual way: setting `GOEXPERIMENT=nosystemcrypto`
 - `opensslcrypto` selects OpenSSL, for Linux
 - `cngcrypto` selects CNG, for Windows
 - Since 1.24, `darwincrypto` selects CommonCrypto & CryptoKit for macOS
@@ -133,6 +138,9 @@ See [the microsoft/go-images documentation][microsoft-go-images] for more inform
 
 ### Dockerfile env instruction
 
+> [!NOTE]
+> Since Go 1.25 `systemcrypto` is by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
+
 If you don't use the standard Go base images (e.g. your Dockerfile downloads the Microsoft build of Go manually), you can use an `env` instruction before the build instruction in your Dockerfile:
 
 ```dockerfile
@@ -140,6 +148,9 @@ env GOEXPERIMENT=systemcrypto
 ```
 
 ### Modify the build command
+
+> [!NOTE]
+> Since Go 1.25 `systemcrypto` is by default on Windows and Linux, there is no need to set it anymore. See also [the Go 1.25 changelog](#go-125-aug-2025).
 
 Another approach that generally works for any build system is to modify the build command or build script. This section lists some helpful snippets to select a backend.
 
@@ -434,6 +445,8 @@ A program running in FIPS mode can claim it is using a FIPS-certified cryptograp
 This list of major changes is intended for quick reference and for access to historical information about versions that are no longer supported. The behavior of all in-support versions are documented in the sections above with notes for version-specific differences where necessary.
 
 ### Go 1.25 (Aug 2025)
+
+- Enable the `systemcrypto` goexperiment by default behavior on Windows and Linux. To disable it, set `GOEXPERIMENT=nosystemcrypto`.
 
 - Running `go version -m` on a binary which uses a system crypto backend now shows the `microsoft_systemcrypto=1` build setting.
 

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -71,50 +71,50 @@ stages:
         # Individually enable buildandpack.
         # Could be determined based on inputs (if more are added) but the caller can just tell us.
         - ${{ if parameters.buildandpack }}:
-          - { os: linux, arch: amd64, config: buildandpack }
-          - { os: windows, arch: amd64, config: buildandpack }
-          - { os: linux, arch: arm, hostArch: amd64, config: buildandpack }
-          - { os: linux, arch: arm64, hostArch: amd64, config: buildandpack }
-          - { os: darwin, arch: amd64, config: buildandpack }
-          - { os: darwin, arch: arm64, hostArch: amd64, config: buildandpack }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: buildandpack }
+          - { experiment: nosystemcrypto, os: windows, arch: amd64, config: buildandpack }
+          - { experiment: nosystemcrypto, os: linux, arch: arm, hostArch: amd64, config: buildandpack }
+          - { experiment: nosystemcrypto, os: linux, arch: arm64, hostArch: amd64, config: buildandpack }
+          - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: buildandpack }
+          - { experiment: nosystemcrypto, os: darwin, arch: arm64, hostArch: amd64, config: buildandpack }
           - ${{ if parameters.includeArm64Host }}:
-            - { os: linux, arch: arm64, config: buildandpack }
+            - { experiment: nosystemcrypto, os: linux, arch: arm64, config: buildandpack }
         - ${{ if parameters.innerloop }}:
-          - { os: darwin, arch: amd64, config: devscript }
-          - { os: darwin, arch: amd64, config: test }
+          - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: devscript }
+          - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: test }
           - { experiment: systemcrypto, os: darwin, arch: amd64, config: test }
           - { experiment: systemcrypto, os: darwin, arch: amd64, config: test, fips: true }
-          # - { os: darwin, arch: arm64, config: devscript }
-          # - { os: darwin, arch: arm64, config: test }
+          # - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: devscript }
+          # - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: test }
           # - { experiment: systemcrypto, os: darwin, arch: arm64, config: test }
           # - { experiment: systemcrypto, os: darwin, arch: arm64, config: test, fips: true }
-          - { os: linux, arch: amd64, config: devscript }
-          - { os: linux, arch: amd64, config: test }
-          - { os: linux, arch: amd64, config: test, distro: ubuntu }
-          - { os: linux, arch: amd64, config: test, distro: azurelinux3 }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: devscript }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: test }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
           - { experiment: systemcrypto, os: linux, arch: amd64, config: test }
           - { experiment: systemcrypto, os: linux, arch: amd64, config: test, fips: true }
           - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
           - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
           - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true }
-          - { os: windows, arch: amd64, config: devscript }
-          - { os: windows, arch: amd64, config: test }
+          - { experiment: nosystemcrypto, os: windows, arch: amd64, config: devscript }
+          - { experiment: nosystemcrypto, os: windows, arch: amd64, config: test }
           - { experiment: systemcrypto, os: windows, arch: amd64, config: test }
           - { experiment: systemcrypto, os: windows, arch: amd64, config: test, fips: true }
           - { experiment: ms_tls_config_schannel, os: windows, arch: amd64, config: test }
           # Test that buildandpack works on Windows x86-32, but don't release it.
-          - { os: windows, hostArch: amd64, arch: 386, config: buildandpack }
+          - { experiment: nosystemcrypto, os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if parameters.outerloop }}:
           # Upstream builders.
-          # - { os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
-          - { os: linux, arch: amd64, config: longtest }
-          - { os: linux, arch: amd64, config: nocgo }
-          - { os: linux, arch: amd64, config: noopt }
-          - { os: linux, arch: amd64, config: race }
-          # - { os: linux, arch: amd64, config: racecompile } https://github.com/microsoft/go/issues/54
-          - { os: linux, arch: amd64, config: regabi }
-          - { os: linux, arch: amd64, config: ssacheck }
-          - { os: linux, arch: amd64, config: staticlockranking }
+          # - { experiment: nosystemcrypto, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: longtest }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: nocgo }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: noopt }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: race }
+          # - { os: experiment: nosystemcrypto, linux, arch: amd64, config: racecompile } https://github.com/microsoft/go/issues/54
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: regabi }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: ssacheck }
+          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: staticlockranking }
           # - { experiment: systemcrypto, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
           - { experiment: systemcrypto, os: linux, arch: amd64, config: longtest }
           - { experiment: systemcrypto, os: linux, arch: amd64, config: race }

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -71,14 +71,14 @@ stages:
         # Individually enable buildandpack.
         # Could be determined based on inputs (if more are added) but the caller can just tell us.
         - ${{ if parameters.buildandpack }}:
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: buildandpack }
-          - { experiment: nosystemcrypto, os: windows, arch: amd64, config: buildandpack }
-          - { experiment: nosystemcrypto, os: linux, arch: arm, hostArch: amd64, config: buildandpack }
-          - { experiment: nosystemcrypto, os: linux, arch: arm64, hostArch: amd64, config: buildandpack }
-          - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: buildandpack }
-          - { experiment: nosystemcrypto, os: darwin, arch: arm64, hostArch: amd64, config: buildandpack }
+          - { os: linux, arch: amd64, config: buildandpack }
+          - { os: windows, arch: amd64, config: buildandpack }
+          - { os: linux, arch: arm, hostArch: amd64, config: buildandpack }
+          - { os: linux, arch: arm64, hostArch: amd64, config: buildandpack }
+          - { os: darwin, arch: amd64, config: buildandpack }
+          - { os: darwin, arch: arm64, hostArch: amd64, config: buildandpack }
           - ${{ if parameters.includeArm64Host }}:
-            - { experiment: nosystemcrypto, os: linux, arch: arm64, config: buildandpack }
+            - { os: linux, arch: arm64, config: buildandpack }
         - ${{ if parameters.innerloop }}:
           - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: devscript }
           - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: test }

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -19,7 +19,7 @@ maintain this feature. For more information, see the test files.
  .../testdata/backendtags_openssl/openssl.go   |  3 +
  .../build/testdata/backendtags_system/main.go |  3 +
  .../backendtags_system/systemcrypto.go        |  3 +
- src/internal/buildcfg/exp.go                  | 15 ++++
+ src/internal/buildcfg/exp.go                  | 28 +++++++
  .../goexperiment/exp_cngcrypto_off.go         |  8 ++
  src/internal/goexperiment/exp_cngcrypto_on.go |  8 ++
  .../goexperiment/exp_darwincrypto_off.go      |  8 ++
@@ -29,7 +29,7 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 ++++
- 18 files changed, 374 insertions(+), 4 deletions(-)
+ 18 files changed, 387 insertions(+), 4 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/main.go
@@ -387,10 +387,37 @@ index 00000000000000..eb8a026982259c
 +
 +package main
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index e36ec08a5b0232..c1bd89cf694bea 100644
+index 689ca8ce58a6f2..9b3bafd0fc6cd9 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
-@@ -126,6 +126,14 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -67,6 +67,18 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+ 		regabiSupported = true
+ 	}
+ 
++	// These are the goos/goarch combinations where systemcrypto is
++	// enabled by default.
++	var systemCryptoSupported bool
++	switch goos {
++	case "windows":
++		systemCryptoSupported = goarch == "amd64" || goarch == "arm64"
++	case "linux":
++		systemCryptoSupported = true
++	case "darwin":
++		// darwincrypto is still experimental.
++	}
++
+ 	// Older versions (anything before V16) of dsymutil don't handle
+ 	// the .debug_rnglists section in DWARF5. See
+ 	// https://github.com/golang/go/issues/26379#issuecomment-2677068742
+@@ -85,6 +97,7 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+ 		SwissMap:        true,
+ 		SyncHashTrieMap: true,
+ 		Dwarf5:          dwarf5Supported,
++		SystemCrypto:    systemCryptoSupported,
+ 	}
+ 
+ 	// Start with the statically enabled set of experiments.
+@@ -126,6 +139,14 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  				// to build with any experiment flags.
  				flags.Flags = goexperiment.Flags{}
  				continue
@@ -405,7 +432,7 @@ index e36ec08a5b0232..c1bd89cf694bea 100644
  			}
  			val := true
  			if strings.HasPrefix(f, "no") {
-@@ -139,6 +147,10 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -139,6 +160,10 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  		}
  	}
  
@@ -416,7 +443,7 @@ index e36ec08a5b0232..c1bd89cf694bea 100644
  	if regabiAlwaysOn {
  		flags.RegabiWrappers = true
  		flags.RegabiArgs = true
-@@ -152,6 +164,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -152,6 +177,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.RegabiArgs && !flags.RegabiWrappers {
  		return nil, fmt.Errorf("GOEXPERIMENT regabiargs requires regabiwrappers")
  	}
@@ -539,7 +566,7 @@ index 00000000000000..fcd4cb9da0d162
 +const SystemCrypto = true
 +const SystemCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index ceff24193d89a5..6b4289503d57ae 100644
+index 63a338883991e0..04f8fce2dfed03 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,24 @@ type Flags struct {

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -18,7 +18,7 @@ desired goexperiments and build tags.
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/cfg/cfg.go                |  13 +
  src/cmd/go/internal/load/pkg.go               |   3 +
- src/cmd/go/internal/tool/tool.go              |   7 +
+ src/cmd/go/internal/tool/tool.go              |   9 +-
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
@@ -55,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2254 insertions(+), 22 deletions(-)
+ 46 files changed, 2255 insertions(+), 23 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -374,7 +374,7 @@ index 3e691abe41f702..b799031d598892 100644
  	tg.parallel()
  	defer tg.cleanup()
 diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
-index a4edd854f1d35a..3efe51984c2566 100644
+index a4edd854f1d35a..a0672ced2ca107 100644
 --- a/src/cmd/go/internal/cfg/cfg.go
 +++ b/src/cmd/go/internal/cfg/cfg.go
 @@ -19,6 +19,7 @@ import (
@@ -390,16 +390,16 @@ index a4edd854f1d35a..3efe51984c2566 100644
  	// This will also update the BuildContext's tool tags to include the new
  	// experiment tags.
 +	//
-+	// Remove systemcrypto from the RawGOEXPERIMENT and add instead
++	// Remove systemcrypto from the RawGOEXPERIMENT and add
 +	// nosystemcrypto so that the tool is built without systemcrypto,
-+	// as the rest of the toolchain.
++	// like the rest of the toolchain.
 +	goexp := strings.Split(RawGOEXPERIMENT, ",")
 +	goexp = slices.DeleteFunc(goexp, func(s string) bool {
 +		return s == "systemcrypto" || s == "nosystemcrypto" || s == ""
 +	})
 +	goexp = append(goexp, "nosystemcrypto")
 +	RawGOEXPERIMENT = strings.Join(goexp, ",")
-+	// Set the ms_skipfipscheck build tag, as the rest of the toolchain.
++	// Set the ms_skipfipscheck build tag, like the rest of the toolchain.
 +	BuildContext.BuildTags = append(BuildContext.BuildTags, "ms_skipfipscheck")
  	computeExperiment()
  }
@@ -419,7 +419,7 @@ index 1f791546f90088..d20890b4e70fae 100644
  	appendSetting("-compiler", cfg.BuildContext.Compiler)
  	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
 diff --git a/src/cmd/go/internal/tool/tool.go b/src/cmd/go/internal/tool/tool.go
-index 16e1a4f47f49c0..38688015d5a704 100644
+index 16e1a4f47f49c0..6c16293cd8deb0 100644
 --- a/src/cmd/go/internal/tool/tool.go
 +++ b/src/cmd/go/internal/tool/tool.go
 @@ -281,6 +281,10 @@ func buildAndRunBuiltinTool(ctx context.Context, toolName, tool string, args []s
@@ -433,16 +433,19 @@ index 16e1a4f47f49c0..38688015d5a704 100644
  
  	// Ignore go.mod and go.work: we don't need them, and we want to be able
  	// to run the tool even if there's an issue with the module or workspace the
-@@ -288,6 +292,9 @@ func buildAndRunBuiltinTool(ctx context.Context, toolName, tool string, args []s
+@@ -288,8 +292,11 @@ func buildAndRunBuiltinTool(ctx context.Context, toolName, tool string, args []s
  	modload.RootMode = modload.NoRoot
  
  	runFunc := func(b *work.Builder, ctx context.Context, a *work.Action) error {
 +		// Now that the tool is built, revert the GOEXPERIMENT
 +		// environment variable to the original value.
-+		os.Setenv("GOEXPERIMENT", originalGOEXPERIMENT)
++		env := []string{"GOEXPERIMENT=" + originalGOEXPERIMENT}
  		cmdline := str.StringList(a.Deps[0].BuiltTarget(), a.Args)
- 		return runBuiltTool(toolName, nil, cmdline)
+-		return runBuiltTool(toolName, nil, cmdline)
++		return runBuiltTool(toolName, env, cmdline)
  	}
+ 
+ 	buildAndRunTool(ctx, tool, args, runFunc)
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
 index 00000000000000..5ee9c2e050cf24

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,8 +13,8 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/compile/script_test.go                |   8 +
- src/cmd/dist/build.go                         |  13 +
- src/cmd/dist/test.go                          |  44 ++-
+ src/cmd/dist/build.go                         |  17 +
+ src/cmd/dist/test.go                          |  45 ++-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2209 insertions(+), 17 deletions(-)
+ 43 files changed, 2214 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -157,28 +157,32 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 024050c2dd70c4..ad7a09918c38c2 100644
+index 024050c2dd70c4..1291bb632d2f7e 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1387,6 +1387,14 @@ func toolenv() []string {
- 		// still have full paths for stack traces for compiler crashes and the like.
- 		env = append(env, "GOFLAGS=-trimpath -ldflags=-w -gcflags=cmd/...=-dwarf=false")
- 	}
-+	// Remove systemcrypto from GOEXPERIMENT: to favor portability, the
-+	// Microsoft build of Go should not use it. Go only uses crypto packages
-+	// for non-crypto purposes, such as generating build IDs.
+@@ -1390,6 +1390,17 @@ func toolenv() []string {
+ 	return env
+ }
+ 
++// disableSystemCrypto removes systemcrypto from GOEXPERIMENT: to favor portability,
++// the Microsoft build of Go should not use it. Go only uses crypto packages
++// for non-crypto purposes, such as generating build IDs.
++func disableSystemCrypto() {
 +	goexp := os.Getenv("GOEXPERIMENT")
 +	if goexp != "" {
 +		goexp += ","
 +	}
-+	env = append(env, "GOEXPERIMENT="+goexp+"nosystemcrypto")
- 	return env
- }
++	os.Setenv("GOEXPERIMENT", goexp+"nosystemcrypto")
++}
++
+ var (
+ 	toolchain = []string{"cmd/asm", "cmd/cgo", "cmd/compile", "cmd/link", "cmd/preprofile"}
  
-@@ -1548,6 +1556,11 @@ func cmdbootstrap() {
+@@ -1548,6 +1559,12 @@ func cmdbootstrap() {
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
  	os.Setenv("GOEXPERIMENT", goexperiment)
++	disableSystemCrypto()
 +	// Build the Go toolchain with "-tags=ms_skipfipscheck". This
 +	// allows toolchains not built with the systemcrypto goexperiment to be used
 +	// when GODEBUG=fips140=on is set. For example, when running
@@ -188,13 +192,14 @@ index 024050c2dd70c4..ad7a09918c38c2 100644
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aa09d1eba34be8..c3f3a8324c507c 100644
+index aa09d1eba34be8..e037970d95cba2 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -156,10 +156,12 @@ func (t *tester) run() {
+@@ -156,10 +156,13 @@ func (t *tester) run() {
  		}
  	}
  
++	disableSystemCrypto()
 +	tags := []string{"-tags=ms_skipfipscheck"}
 +
  	if t.rebuild {
@@ -205,7 +210,7 @@ index aa09d1eba34be8..c3f3a8324c507c 100644
  	}
  
  	if !t.listMode {
-@@ -176,9 +178,9 @@ func (t *tester) run() {
+@@ -176,9 +179,9 @@ func (t *tester) run() {
  			// and virtualization we usually start with a clean GOCACHE, so we would
  			// end up rebuilding large parts of the standard library that aren't
  			// otherwise relevant to the actual set of packages under test.
@@ -218,7 +223,7 @@ index aa09d1eba34be8..c3f3a8324c507c 100644
  		}
  	}
  
-@@ -749,11 +751,18 @@ func (t *tester) registerTests() {
+@@ -749,11 +752,18 @@ func (t *tester) registerTests() {
  			variant: "jsonv2",
  			env:     []string{"GOEXPERIMENT=jsonv2"},
  			pkg:     "encoding/json/...",
@@ -238,7 +243,7 @@ index aa09d1eba34be8..c3f3a8324c507c 100644
  		t.registerTest("GOOS=ios on darwin/amd64",
  			&goTest{
  				variant:  "amd64ios",
-@@ -863,14 +872,21 @@ func (t *tester) registerTests() {
+@@ -863,14 +873,21 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
@@ -261,7 +266,7 @@ index aa09d1eba34be8..c3f3a8324c507c 100644
  			})
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
-@@ -878,9 +894,10 @@ func (t *tester) registerTests() {
+@@ -878,9 +895,10 @@ func (t *tester) registerTests() {
  				timeout:   60 * time.Second,
  				buildmode: "pie",
  				ldflags:   "-linkmode=internal",
@@ -273,7 +278,7 @@ index aa09d1eba34be8..c3f3a8324c507c 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-@@ -897,15 +914,22 @@ func (t *tester) registerTests() {
+@@ -897,15 +915,22 @@ func (t *tester) registerTests() {
  
  	if t.extLink() && !t.compileOnly {
  		if goos != "android" { // Android does not support non-PIE linking
@@ -297,7 +302,7 @@ index aa09d1eba34be8..c3f3a8324c507c 100644
  				})
  		}
  		if t.externalLinkPIE() && !disablePIE {
-@@ -984,7 +1008,9 @@ func (t *tester) registerTests() {
+@@ -984,7 +1009,9 @@ func (t *tester) registerTests() {
  		t.registerRaceTests()
  	}
  

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -16,7 +16,7 @@ desired goexperiments and build tags.
  src/cmd/dist/build.go                         |  29 +-
  src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |  11 +
- src/cmd/go/internal/cfg/cfg.go                |  13 +
+ src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/internal/tool/tool.go              |   9 +-
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
@@ -55,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2255 insertions(+), 23 deletions(-)
+ 46 files changed, 2258 insertions(+), 23 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -374,36 +374,39 @@ index 3e691abe41f702..b799031d598892 100644
  	tg.parallel()
  	defer tg.cleanup()
 diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
-index a4edd854f1d35a..a0672ced2ca107 100644
+index a4edd854f1d35a..10ee92536b96cd 100644
 --- a/src/cmd/go/internal/cfg/cfg.go
 +++ b/src/cmd/go/internal/cfg/cfg.go
 @@ -19,6 +19,7 @@ import (
  	"os"
  	"path/filepath"
  	"runtime"
-+	"slices"
++	"runtime/debug"
  	"strings"
  	"sync"
  	"time"
-@@ -232,6 +233,18 @@ func ForceHost() {
+@@ -229,6 +230,21 @@ func ForceHost() {
+ 	BuildContext = defaultContext()
+ 	// Call SetGOROOT to properly set the GOROOT on the new context.
+ 	SetGOROOT(Getenv("GOROOT"), false)
++	// The Microsoft build of Go might be built with non-default
++	// GOEXPERIMENT and BuildTags, so we need to get them from
++	// the build info.
++	bi, ok := debug.ReadBuildInfo()
++	if !ok {
++		panic("missing build info")
++	}
++	for _, s := range bi.Settings {
++		switch s.Key {
++		case "-tags":
++			BuildContext.BuildTags = strings.Split(s.Value, ",")
++		case "GOEXPERIMENT":
++			RawGOEXPERIMENT = s.Value
++		}
++	}
  	// Recompute experiments: the settings determined depend on GOOS and GOARCH.
  	// This will also update the BuildContext's tool tags to include the new
  	// experiment tags.
-+	//
-+	// Remove systemcrypto from the RawGOEXPERIMENT and add
-+	// nosystemcrypto so that the tool is built without systemcrypto,
-+	// like the rest of the toolchain.
-+	goexp := strings.Split(RawGOEXPERIMENT, ",")
-+	goexp = slices.DeleteFunc(goexp, func(s string) bool {
-+		return s == "systemcrypto" || s == "nosystemcrypto" || s == ""
-+	})
-+	goexp = append(goexp, "nosystemcrypto")
-+	RawGOEXPERIMENT = strings.Join(goexp, ",")
-+	// Set the ms_skipfipscheck build tag, like the rest of the toolchain.
-+	BuildContext.BuildTags = append(BuildContext.BuildTags, "ms_skipfipscheck")
- 	computeExperiment()
- }
- 
 diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
 index 1f791546f90088..d20890b4e70fae 100644
 --- a/src/cmd/go/internal/load/pkg.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -21,6 +21,7 @@ desired goexperiments and build tags.
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
  src/cmd/internal/testdir/testdir_test.go      |   7 +
+ src/cmd/link/internal/ld/main.go              |  14 +-
  src/cmd/link/link_test.go                     |   8 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/bbig/big.go       |  17 +
@@ -52,7 +53,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2222 insertions(+), 21 deletions(-)
+ 44 files changed, 2235 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -576,6 +577,38 @@ index 483a9ec33c6798..fad922e3f844ab 100644
  	common := testCommon{
  		gorootTestDir: filepath.Join(testenv.GOROOT(t), "test"),
  		runoutputGate: make(chan bool, *runoutputLimit),
+diff --git a/src/cmd/link/internal/ld/main.go b/src/cmd/link/internal/ld/main.go
+index 6a684890be0a03..09554a60b23471 100644
+--- a/src/cmd/link/internal/ld/main.go
++++ b/src/cmd/link/internal/ld/main.go
+@@ -44,6 +44,7 @@ import (
+ 	"os"
+ 	"runtime"
+ 	"runtime/pprof"
++	"slices"
+ 	"strconv"
+ 	"strings"
+ )
+@@ -187,7 +188,18 @@ func Main(arch *sys.Arch, theArch Arch) {
+ 
+ 	buildVersion := buildcfg.Version
+ 	if goexperiment := buildcfg.Experiment.String(); goexperiment != "" {
+-		buildVersion += " X:" + goexperiment
++		// buildVersion is intended to contain non-default experiment flags.
++		// The Microsoft build of Go default behavior is to set the
++		// nosystemcrypto experiments, so we don't include it in the buildVersion string.
++		// This is also important because runtime.Version() gets the value from
++		// the buildVersion string, and many code out there, e.g. the standard library
++		// go/version package, doesn't expect the version to contain experiments.
++		goexperiment = strings.Join(slices.DeleteFunc(strings.Split(goexperiment, ","), func(s string) bool {
++			return s == "nosystemcrypto"
++		}), ",")
++		if goexperiment != "" {
++			buildVersion += " X:" + goexperiment
++		}
+ 	}
+ 	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
+ 
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
 index 2fe32600f1d6c7..f84cbdc5ee25f0 100644
 --- a/src/cmd/link/link_test.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -17,6 +17,7 @@ desired goexperiments and build tags.
  src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/load/pkg.go               |   3 +
+ src/cmd/go/internal/tool/tool.go              |  10 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
@@ -53,7 +54,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 44 files changed, 2234 insertions(+), 22 deletions(-)
+ 45 files changed, 2244 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -385,6 +386,27 @@ index 1f791546f90088..d20890b4e70fae 100644
  	appendSetting("-buildmode", buildmode)
  	appendSetting("-compiler", cfg.BuildContext.Compiler)
  	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
+diff --git a/src/cmd/go/internal/tool/tool.go b/src/cmd/go/internal/tool/tool.go
+index 16e1a4f47f49c0..4a8f63f21c73cd 100644
+--- a/src/cmd/go/internal/tool/tool.go
++++ b/src/cmd/go/internal/tool/tool.go
+@@ -280,6 +280,16 @@ func loadModTool(ctx context.Context, name string) string {
+ func buildAndRunBuiltinTool(ctx context.Context, toolName, tool string, args []string) {
+ 	// Override GOOS and GOARCH for the build to build the tool using
+ 	// the same GOOS and GOARCH as this go command.
++	//
++	// Remove systemcrypto from the RawGOEXPERIMENT and add nosystemcrypto
++	// to the GOEXPERIMENT environment variable, so that the tool
++	// is built without systemcrypto, as the rest of the toolchain.
++	goexp := strings.Split(cfg.RawGOEXPERIMENT, ",")
++	goexp = slices.DeleteFunc(goexp, func(s string) bool {
++		return s == "systemcrypto" || s == ""
++	})
++	goexp = append(goexp, "nosystemcrypto")
++	cfg.RawGOEXPERIMENT = strings.Join(goexp, ",")
+ 	cfg.ForceHost()
+ 
+ 	// Ignore go.mod and go.work: we don't need them, and we want to be able
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
 index 00000000000000..5ee9c2e050cf24

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -16,7 +16,7 @@ desired goexperiments and build tags.
  src/cmd/dist/build.go                         |  29 +-
  src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |  11 +
- src/cmd/go/internal/cfg/cfg.go                |  18 +-
+ src/cmd/go/internal/cfg/cfg.go                |  12 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
@@ -51,10 +51,10 @@ desired goexperiments and build tags.
  src/crypto/internal/backend/stub.s            |  10 +
  src/crypto/systemcrypto_nocgo.go              |  15 +
  src/go/build/deps_test.go                     |  32 +-
- src/internal/buildcfg/exp.go                  |  55 +++
+ src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 45 files changed, 2249 insertions(+), 26 deletions(-)
+ 45 files changed, 2246 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -373,7 +373,7 @@ index 3e691abe41f702..b799031d598892 100644
  	tg.parallel()
  	defer tg.cleanup()
 diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
-index a4edd854f1d35a..33719a4a009f12 100644
+index a4edd854f1d35a..2214338adf86a0 100644
 --- a/src/cmd/go/internal/cfg/cfg.go
 +++ b/src/cmd/go/internal/cfg/cfg.go
 @@ -19,6 +19,7 @@ import (
@@ -384,11 +384,10 @@ index a4edd854f1d35a..33719a4a009f12 100644
  	"strings"
  	"sync"
  	"time"
-@@ -232,7 +233,16 @@ func ForceHost() {
+@@ -232,6 +233,17 @@ func ForceHost() {
  	// Recompute experiments: the settings determined depend on GOOS and GOARCH.
  	// This will also update the BuildContext's tool tags to include the new
  	// experiment tags.
--	computeExperiment()
 +	//
 +	// Remove systemcrypto from the RawGOEXPERIMENT and add instead
 +	// nosystemcrypto so that the tool is built without systemcrypto,
@@ -398,25 +397,11 @@ index a4edd854f1d35a..33719a4a009f12 100644
 +		return s == "systemcrypto" || s == "nosystemcrypto" || s == ""
 +	})
 +	goexp = append(goexp, "nosystemcrypto")
-+	computeExperiment(strings.Join(goexp, ","))
++	RawGOEXPERIMENT = strings.Join(goexp, ",")
++	os.Setenv("GOEXPERIMENT", RawGOEXPERIMENT)
+ 	computeExperiment()
  }
  
- // SetGOROOT sets GOROOT and associated variables to the given values.
-@@ -297,11 +307,11 @@ var (
- )
- 
- func init() {
--	computeExperiment()
-+	computeExperiment(RawGOEXPERIMENT)
- }
- 
--func computeExperiment() {
--	Experiment, ExperimentErr = buildcfg.ParseGOEXPERIMENT(Goos, Goarch, RawGOEXPERIMENT)
-+func computeExperiment(goexp string) {
-+	Experiment, ExperimentErr = buildcfg.ParseGOEXPERIMENT(Goos, Goarch, goexp)
- 	if ExperimentErr != nil {
- 		return
- 	}
 diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
 index 1f791546f90088..d20890b4e70fae 100644
 --- a/src/cmd/go/internal/load/pkg.go
@@ -2800,7 +2785,7 @@ index 9b7613a62b5a31..1997d90f2f20ba 100644
  	< crypto/rand
  	< crypto/ed25519 # depends on crypto/rand.Reader
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index 9b3bafd0fc6cd9..da8260eaed4d1c 100644
+index 9b3bafd0fc6cd9..b7cc2bdfa6ffd9 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
 @@ -5,11 +5,14 @@
@@ -2818,15 +2803,7 @@ index 9b3bafd0fc6cd9..da8260eaed4d1c 100644
  )
  
  // ExperimentFlags represents a set of GOEXPERIMENT flags relative to a baseline
-@@ -77,6 +80,7 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
- 		systemCryptoSupported = true
- 	case "darwin":
- 		// darwincrypto is still experimental.
-+		systemCryptoSupported = true
- 	}
- 
- 	// Older versions (anything before V16) of dsymutil don't handle
-@@ -180,6 +184,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -180,6 +183,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.BoringCrypto {
  		return nil, fmt.Errorf("GOEXPERIMENT boringcrypto is not supported in the Microsoft build of Go")
  	}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -14,7 +14,7 @@ desired goexperiments and build tags.
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  29 +-
- src/cmd/dist/test.go                          |  45 ++-
+ src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2222 insertions(+), 21 deletions(-)
+ 43 files changed, 2221 insertions(+), 21 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -214,14 +214,13 @@ index 024050c2dd70c4..a3ae7ef562cace 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aa09d1eba34be8..e037970d95cba2 100644
+index aa09d1eba34be8..c3f3a8324c507c 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -156,10 +156,13 @@ func (t *tester) run() {
+@@ -156,10 +156,12 @@ func (t *tester) run() {
  		}
  	}
  
-+	disableSystemCrypto()
 +	tags := []string{"-tags=ms_skipfipscheck"}
 +
  	if t.rebuild {
@@ -232,7 +231,7 @@ index aa09d1eba34be8..e037970d95cba2 100644
  	}
  
  	if !t.listMode {
-@@ -176,9 +179,9 @@ func (t *tester) run() {
+@@ -176,9 +178,9 @@ func (t *tester) run() {
  			// and virtualization we usually start with a clean GOCACHE, so we would
  			// end up rebuilding large parts of the standard library that aren't
  			// otherwise relevant to the actual set of packages under test.
@@ -245,7 +244,7 @@ index aa09d1eba34be8..e037970d95cba2 100644
  		}
  	}
  
-@@ -749,11 +752,18 @@ func (t *tester) registerTests() {
+@@ -749,11 +751,18 @@ func (t *tester) registerTests() {
  			variant: "jsonv2",
  			env:     []string{"GOEXPERIMENT=jsonv2"},
  			pkg:     "encoding/json/...",
@@ -265,7 +264,7 @@ index aa09d1eba34be8..e037970d95cba2 100644
  		t.registerTest("GOOS=ios on darwin/amd64",
  			&goTest{
  				variant:  "amd64ios",
-@@ -863,14 +873,21 @@ func (t *tester) registerTests() {
+@@ -863,14 +872,21 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
@@ -288,7 +287,7 @@ index aa09d1eba34be8..e037970d95cba2 100644
  			})
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
-@@ -878,9 +895,10 @@ func (t *tester) registerTests() {
+@@ -878,9 +894,10 @@ func (t *tester) registerTests() {
  				timeout:   60 * time.Second,
  				buildmode: "pie",
  				ldflags:   "-linkmode=internal",
@@ -300,7 +299,7 @@ index aa09d1eba34be8..e037970d95cba2 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-@@ -897,15 +915,22 @@ func (t *tester) registerTests() {
+@@ -897,15 +914,22 @@ func (t *tester) registerTests() {
  
  	if t.extLink() && !t.compileOnly {
  		if goos != "android" { // Android does not support non-PIE linking
@@ -324,7 +323,7 @@ index aa09d1eba34be8..e037970d95cba2 100644
  				})
  		}
  		if t.externalLinkPIE() && !disablePIE {
-@@ -984,7 +1009,9 @@ func (t *tester) registerTests() {
+@@ -984,7 +1008,9 @@ func (t *tester) registerTests() {
  		t.registerRaceTests()
  	}
  

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -15,7 +15,7 @@ desired goexperiments and build tags.
  src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  29 +-
  src/cmd/dist/test.go                          |  44 ++-
- src/cmd/go/go_test.go                         |  12 +
+ src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
@@ -53,7 +53,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 44 files changed, 2235 insertions(+), 22 deletions(-)
+ 44 files changed, 2234 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -336,7 +336,7 @@ index aa09d1eba34be8..c3f3a8324c507c 100644
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
-index 3e691abe41f702..fffd1b42f67b92 100644
+index 3e691abe41f702..b799031d598892 100644
 --- a/src/cmd/go/go_test.go
 +++ b/src/cmd/go/go_test.go
 @@ -14,6 +14,7 @@ import (
@@ -347,7 +347,7 @@ index 3e691abe41f702..fffd1b42f67b92 100644
  	"internal/platform"
  	"internal/testenv"
  	"io"
-@@ -111,6 +112,14 @@ func TestMain(m *testing.M) {
+@@ -111,6 +112,13 @@ func TestMain(m *testing.M) {
  		if v := os.Getenv("TESTGO_TOOLCHAIN_VERSION"); v != "" {
  			work.ToolchainVersion = v
  		}
@@ -358,11 +358,10 @@ index 3e691abe41f702..fffd1b42f67b92 100644
 +		// but it instead calls the test binary with CMDGO_TEST_RUN_MAIN=1,
 +		// which can be built with systemcrypto.
 +		work.ToolchainVersion = strings.ReplaceAll(work.ToolchainVersion, " X:systemcrypto", "")
-+		work.ToolchainVersion = strings.ReplaceAll(work.ToolchainVersion, " X:nosystemcrypto", "")
  
  		if testGOROOT := os.Getenv("TESTGO_GOROOT"); testGOROOT != "" {
  			// Disallow installs to the GOROOT from which testgo was built.
-@@ -1861,6 +1870,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
+@@ -1861,6 +1869,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
  }
  
  func TestGoEnv(t *testing.T) {

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -15,7 +15,7 @@ desired goexperiments and build tags.
  src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  29 +-
  src/cmd/dist/test.go                          |  44 ++-
- src/cmd/go/go_test.go                         |  11 +
+ src/cmd/go/go_test.go                         |  12 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2221 insertions(+), 21 deletions(-)
+ 43 files changed, 2222 insertions(+), 21 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -335,7 +335,7 @@ index aa09d1eba34be8..c3f3a8324c507c 100644
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
-index 3e691abe41f702..b799031d598892 100644
+index 3e691abe41f702..fffd1b42f67b92 100644
 --- a/src/cmd/go/go_test.go
 +++ b/src/cmd/go/go_test.go
 @@ -14,6 +14,7 @@ import (
@@ -346,7 +346,7 @@ index 3e691abe41f702..b799031d598892 100644
  	"internal/platform"
  	"internal/testenv"
  	"io"
-@@ -111,6 +112,13 @@ func TestMain(m *testing.M) {
+@@ -111,6 +112,14 @@ func TestMain(m *testing.M) {
  		if v := os.Getenv("TESTGO_TOOLCHAIN_VERSION"); v != "" {
  			work.ToolchainVersion = v
  		}
@@ -357,10 +357,11 @@ index 3e691abe41f702..b799031d598892 100644
 +		// but it instead calls the test binary with CMDGO_TEST_RUN_MAIN=1,
 +		// which can be built with systemcrypto.
 +		work.ToolchainVersion = strings.ReplaceAll(work.ToolchainVersion, " X:systemcrypto", "")
++		work.ToolchainVersion = strings.ReplaceAll(work.ToolchainVersion, " X:nosystemcrypto", "")
  
  		if testGOROOT := os.Getenv("TESTGO_GOROOT"); testGOROOT != "" {
  			// Disallow installs to the GOROOT from which testgo was built.
-@@ -1861,6 +1869,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
+@@ -1861,6 +1870,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
  }
  
  func TestGoEnv(t *testing.T) {

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/compile/script_test.go                |   8 +
- src/cmd/dist/build.go                         |  11 +
+ src/cmd/dist/build.go                         |  13 +
  src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/load/pkg.go               |   3 +
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2207 insertions(+), 17 deletions(-)
+ 43 files changed, 2209 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -157,23 +157,25 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 024050c2dd70c4..3c82b7436d10bf 100644
+index 024050c2dd70c4..ad7a09918c38c2 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1387,6 +1387,12 @@ func toolenv() []string {
+@@ -1387,6 +1387,14 @@ func toolenv() []string {
  		// still have full paths for stack traces for compiler crashes and the like.
  		env = append(env, "GOFLAGS=-trimpath -ldflags=-w -gcflags=cmd/...=-dwarf=false")
  	}
-+	if goexp := os.Getenv("GOEXPERIMENT"); goexp != "" {
-+		// Remove systemcrypto from GOEXPERIMENT: to favor portability, the
-+		// Microsoft build of Go should not use it. Go only uses crypto packages
-+		// for non-crypto purposes, such as generating build IDs.
-+		env = append(env, "GOEXPERIMENT="+goexp+",nosystemcrypto")
++	// Remove systemcrypto from GOEXPERIMENT: to favor portability, the
++	// Microsoft build of Go should not use it. Go only uses crypto packages
++	// for non-crypto purposes, such as generating build IDs.
++	goexp := os.Getenv("GOEXPERIMENT")
++	if goexp != "" {
++		goexp += ","
 +	}
++	env = append(env, "GOEXPERIMENT="+goexp+"nosystemcrypto")
  	return env
  }
  
-@@ -1548,6 +1554,11 @@ func cmdbootstrap() {
+@@ -1548,6 +1556,11 @@ func cmdbootstrap() {
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
  	os.Setenv("GOEXPERIMENT", goexperiment)
@@ -343,7 +345,7 @@ index 3e691abe41f702..b799031d598892 100644
  	tg.parallel()
  	defer tg.cleanup()
 diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
-index e913f9885234fd..ef331980a816a3 100644
+index 1f791546f90088..d20890b4e70fae 100644
 --- a/src/cmd/go/internal/load/pkg.go
 +++ b/src/cmd/go/internal/load/pkg.go
 @@ -2412,6 +2412,9 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
@@ -2693,7 +2695,7 @@ index 9b7613a62b5a31..1997d90f2f20ba 100644
  	< crypto/rand
  	< crypto/ed25519 # depends on crypto/rand.Reader
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index bba73cfab9a108..11ffdf2213dc7b 100644
+index 9b3bafd0fc6cd9..b7cc2bdfa6ffd9 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
 @@ -5,11 +5,14 @@
@@ -2711,7 +2713,7 @@ index bba73cfab9a108..11ffdf2213dc7b 100644
  )
  
  // ExperimentFlags represents a set of GOEXPERIMENT flags relative to a baseline
-@@ -167,6 +170,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -180,6 +183,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.BoringCrypto {
  		return nil, fmt.Errorf("GOEXPERIMENT boringcrypto is not supported in the Microsoft build of Go")
  	}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -16,8 +16,8 @@ desired goexperiments and build tags.
  src/cmd/dist/build.go                         |  29 +-
  src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |  11 +
+ src/cmd/go/internal/cfg/cfg.go                |  18 +-
  src/cmd/go/internal/load/pkg.go               |   3 +
- src/cmd/go/internal/tool/tool.go              |  10 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
@@ -51,10 +51,10 @@ desired goexperiments and build tags.
  src/crypto/internal/backend/stub.s            |  10 +
  src/crypto/systemcrypto_nocgo.go              |  15 +
  src/go/build/deps_test.go                     |  32 +-
- src/internal/buildcfg/exp.go                  |  54 +++
+ src/internal/buildcfg/exp.go                  |  55 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 45 files changed, 2244 insertions(+), 22 deletions(-)
+ 45 files changed, 2249 insertions(+), 26 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -372,6 +372,51 @@ index 3e691abe41f702..b799031d598892 100644
  	tg := testgo(t)
  	tg.parallel()
  	defer tg.cleanup()
+diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
+index a4edd854f1d35a..33719a4a009f12 100644
+--- a/src/cmd/go/internal/cfg/cfg.go
++++ b/src/cmd/go/internal/cfg/cfg.go
+@@ -19,6 +19,7 @@ import (
+ 	"os"
+ 	"path/filepath"
+ 	"runtime"
++	"slices"
+ 	"strings"
+ 	"sync"
+ 	"time"
+@@ -232,7 +233,16 @@ func ForceHost() {
+ 	// Recompute experiments: the settings determined depend on GOOS and GOARCH.
+ 	// This will also update the BuildContext's tool tags to include the new
+ 	// experiment tags.
+-	computeExperiment()
++	//
++	// Remove systemcrypto from the RawGOEXPERIMENT and add instead
++	// nosystemcrypto so that the tool is built without systemcrypto,
++	// as the rest of the toolchain.
++	goexp := strings.Split(RawGOEXPERIMENT, ",")
++	goexp = slices.DeleteFunc(goexp, func(s string) bool {
++		return s == "systemcrypto" || s == "nosystemcrypto" || s == ""
++	})
++	goexp = append(goexp, "nosystemcrypto")
++	computeExperiment(strings.Join(goexp, ","))
+ }
+ 
+ // SetGOROOT sets GOROOT and associated variables to the given values.
+@@ -297,11 +307,11 @@ var (
+ )
+ 
+ func init() {
+-	computeExperiment()
++	computeExperiment(RawGOEXPERIMENT)
+ }
+ 
+-func computeExperiment() {
+-	Experiment, ExperimentErr = buildcfg.ParseGOEXPERIMENT(Goos, Goarch, RawGOEXPERIMENT)
++func computeExperiment(goexp string) {
++	Experiment, ExperimentErr = buildcfg.ParseGOEXPERIMENT(Goos, Goarch, goexp)
+ 	if ExperimentErr != nil {
+ 		return
+ 	}
 diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
 index 1f791546f90088..d20890b4e70fae 100644
 --- a/src/cmd/go/internal/load/pkg.go
@@ -386,27 +431,6 @@ index 1f791546f90088..d20890b4e70fae 100644
  	appendSetting("-buildmode", buildmode)
  	appendSetting("-compiler", cfg.BuildContext.Compiler)
  	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
-diff --git a/src/cmd/go/internal/tool/tool.go b/src/cmd/go/internal/tool/tool.go
-index 16e1a4f47f49c0..4a8f63f21c73cd 100644
---- a/src/cmd/go/internal/tool/tool.go
-+++ b/src/cmd/go/internal/tool/tool.go
-@@ -280,6 +280,16 @@ func loadModTool(ctx context.Context, name string) string {
- func buildAndRunBuiltinTool(ctx context.Context, toolName, tool string, args []string) {
- 	// Override GOOS and GOARCH for the build to build the tool using
- 	// the same GOOS and GOARCH as this go command.
-+	//
-+	// Remove systemcrypto from the RawGOEXPERIMENT and add nosystemcrypto
-+	// to the GOEXPERIMENT environment variable, so that the tool
-+	// is built without systemcrypto, as the rest of the toolchain.
-+	goexp := strings.Split(cfg.RawGOEXPERIMENT, ",")
-+	goexp = slices.DeleteFunc(goexp, func(s string) bool {
-+		return s == "systemcrypto" || s == ""
-+	})
-+	goexp = append(goexp, "nosystemcrypto")
-+	cfg.RawGOEXPERIMENT = strings.Join(goexp, ",")
- 	cfg.ForceHost()
- 
- 	// Ignore go.mod and go.work: we don't need them, and we want to be able
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
 index 00000000000000..5ee9c2e050cf24
@@ -2776,7 +2800,7 @@ index 9b7613a62b5a31..1997d90f2f20ba 100644
  	< crypto/rand
  	< crypto/ed25519 # depends on crypto/rand.Reader
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index 9b3bafd0fc6cd9..b7cc2bdfa6ffd9 100644
+index 9b3bafd0fc6cd9..da8260eaed4d1c 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
 @@ -5,11 +5,14 @@
@@ -2794,7 +2818,15 @@ index 9b3bafd0fc6cd9..b7cc2bdfa6ffd9 100644
  )
  
  // ExperimentFlags represents a set of GOEXPERIMENT flags relative to a baseline
-@@ -180,6 +183,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -77,6 +80,7 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+ 		systemCryptoSupported = true
+ 	case "darwin":
+ 		// darwincrypto is still experimental.
++		systemCryptoSupported = true
+ 	}
+ 
+ 	// Older versions (anything before V16) of dsymutil don't handle
+@@ -180,6 +184,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.BoringCrypto {
  		return nil, fmt.Errorf("GOEXPERIMENT boringcrypto is not supported in the Microsoft build of Go")
  	}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -16,8 +16,9 @@ desired goexperiments and build tags.
  src/cmd/dist/build.go                         |  29 +-
  src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |  11 +
- src/cmd/go/internal/cfg/cfg.go                |  12 +
+ src/cmd/go/internal/cfg/cfg.go                |  11 +
  src/cmd/go/internal/load/pkg.go               |   3 +
+ src/cmd/go/internal/tool/tool.go              |   7 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
@@ -54,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 45 files changed, 2246 insertions(+), 22 deletions(-)
+ 46 files changed, 2252 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -373,7 +374,7 @@ index 3e691abe41f702..b799031d598892 100644
  	tg.parallel()
  	defer tg.cleanup()
 diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
-index a4edd854f1d35a..2214338adf86a0 100644
+index a4edd854f1d35a..f082588cb75549 100644
 --- a/src/cmd/go/internal/cfg/cfg.go
 +++ b/src/cmd/go/internal/cfg/cfg.go
 @@ -19,6 +19,7 @@ import (
@@ -384,7 +385,7 @@ index a4edd854f1d35a..2214338adf86a0 100644
  	"strings"
  	"sync"
  	"time"
-@@ -232,6 +233,17 @@ func ForceHost() {
+@@ -232,6 +233,16 @@ func ForceHost() {
  	// Recompute experiments: the settings determined depend on GOOS and GOARCH.
  	// This will also update the BuildContext's tool tags to include the new
  	// experiment tags.
@@ -398,7 +399,6 @@ index a4edd854f1d35a..2214338adf86a0 100644
 +	})
 +	goexp = append(goexp, "nosystemcrypto")
 +	RawGOEXPERIMENT = strings.Join(goexp, ",")
-+	os.Setenv("GOEXPERIMENT", RawGOEXPERIMENT)
  	computeExperiment()
  }
  
@@ -416,6 +416,31 @@ index 1f791546f90088..d20890b4e70fae 100644
  	appendSetting("-buildmode", buildmode)
  	appendSetting("-compiler", cfg.BuildContext.Compiler)
  	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
+diff --git a/src/cmd/go/internal/tool/tool.go b/src/cmd/go/internal/tool/tool.go
+index 16e1a4f47f49c0..38688015d5a704 100644
+--- a/src/cmd/go/internal/tool/tool.go
++++ b/src/cmd/go/internal/tool/tool.go
+@@ -281,6 +281,10 @@ func buildAndRunBuiltinTool(ctx context.Context, toolName, tool string, args []s
+ 	// Override GOOS and GOARCH for the build to build the tool using
+ 	// the same GOOS and GOARCH as this go command.
+ 	cfg.ForceHost()
++	// The tool might build some additional packages, set the GOEXPERIMENT
++	// environment variable to the one we just computed in cfg.ForceHost.
++	originalGOEXPERIMENT := os.Getenv("GOEXPERIMENT")
++	os.Setenv("GOEXPERIMENT", cfg.RawGOEXPERIMENT)
+ 
+ 	// Ignore go.mod and go.work: we don't need them, and we want to be able
+ 	// to run the tool even if there's an issue with the module or workspace the
+@@ -288,6 +292,9 @@ func buildAndRunBuiltinTool(ctx context.Context, toolName, tool string, args []s
+ 	modload.RootMode = modload.NoRoot
+ 
+ 	runFunc := func(b *work.Builder, ctx context.Context, a *work.Action) error {
++		// Now that the tool is built, revert the GOEXPERIMENT
++		// environment variable to the original value.
++		os.Setenv("GOEXPERIMENT", originalGOEXPERIMENT)
+ 		cmdline := str.StringList(a.Deps[0].BuiltTarget(), a.Args)
+ 		return runBuiltTool(toolName, nil, cmdline)
+ 	}
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
 index 00000000000000..5ee9c2e050cf24

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/compile/script_test.go                |   8 +
- src/cmd/dist/build.go                         |  23 ++
+ src/cmd/dist/build.go                         |  29 +-
  src/cmd/dist/test.go                          |  45 ++-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/load/pkg.go               |   3 +
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2220 insertions(+), 17 deletions(-)
+ 43 files changed, 2222 insertions(+), 21 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -157,38 +157,38 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 024050c2dd70c4..e39be4bef50022 100644
+index 024050c2dd70c4..a3ae7ef562cace 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1390,6 +1390,23 @@ func toolenv() []string {
- 	return env
- }
- 
-+// disableSystemCrypto removes systemcrypto from GOEXPERIMENT: to favor portability,
-+// the Microsoft build of Go should not use it. Go only uses crypto packages
-+// for non-crypto purposes, such as generating build IDs.
-+func disableSystemCrypto() {
-+	goexp := strings.Split(os.Getenv("GOEXPERIMENT"), ",")
-+	if len(goexp) == 1 && goexp[0] == "" {
-+		goexp = nil
-+	}
-+	goexp = slices.DeleteFunc(goexp, func(s string) bool {
-+		return s == "systemcrypto"
-+	})
-+	if !slices.Contains(goexp, "nosystemcrypto") {
-+		goexp = append(goexp, "nosystemcrypto")
-+	}
-+	os.Setenv("GOEXPERIMENT", strings.Join(goexp, ","))
+@@ -1387,7 +1387,23 @@ func toolenv() []string {
+ 		// still have full paths for stack traces for compiler crashes and the like.
+ 		env = append(env, "GOFLAGS=-trimpath -ldflags=-w -gcflags=cmd/...=-dwarf=false")
+ 	}
+-	return env
++	return toolchainGOEXPERIMENT(env)
 +}
 +
- var (
- 	toolchain = []string{"cmd/asm", "cmd/cgo", "cmd/compile", "cmd/link", "cmd/preprofile"}
++// toolchainGOEXPERIMENT appends a GOEXPERIMENT to env
++// that contains all the experiments from the current
++// environment, but with "systemcrypto" removed and
++// "nosystemcrypto" added. This is used when building
++// the Microsoft build of Go to favor portability.
++// Go only uses crypto packages for non-crypto purposes,
++// such as generating build IDs.
++func toolchainGOEXPERIMENT(env []string) []string {
++	goexp := strings.Split(os.Getenv("GOEXPERIMENT"), ",")
++	goexp = slices.DeleteFunc(goexp, func(s string) bool {
++		return s == "systemcrypto" || s == "nosystemcrypto" || s == ""
++	})
++	goexp = append(goexp, "nosystemcrypto")
++	return append(env, "GOEXPERIMENT="+strings.Join(goexp, ","))
+ }
  
-@@ -1548,6 +1565,12 @@ func cmdbootstrap() {
+ var (
+@@ -1548,6 +1564,11 @@ func cmdbootstrap() {
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
  	os.Setenv("GOEXPERIMENT", goexperiment)
-+	disableSystemCrypto()
 +	// Build the Go toolchain with "-tags=ms_skipfipscheck". This
 +	// allows toolchains not built with the systemcrypto goexperiment to be used
 +	// when GODEBUG=fips140=on is set. For example, when running
@@ -197,6 +197,22 @@ index 024050c2dd70c4..e39be4bef50022 100644
  	// No need to enable PGO for toolchain2.
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
+@@ -1629,12 +1650,12 @@ func cmdbootstrap() {
+ 		os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
+ 		xprintf("Building packages and commands for target, %s/%s.\n", goos, goarch)
+ 	}
+-	goInstall(nil, goBootstrap, "std")
++	goInstall(toolchainGOEXPERIMENT(nil), goBootstrap, "std")
+ 	goInstall(toolenv(), goBootstrap, toolsToInstall...)
+ 	checkNotStale(toolenv(), goBootstrap, toolchain...)
+-	checkNotStale(nil, goBootstrap, "std")
++	checkNotStale(toolchainGOEXPERIMENT(nil), goBootstrap, "std")
+ 	checkNotStale(toolenv(), goBootstrap, toolsToInstall...)
+-	checkNotStale(nil, gorootBinGo, "std")
++	checkNotStale(toolchainGOEXPERIMENT(nil), gorootBinGo, "std")
+ 	checkNotStale(toolenv(), gorootBinGo, toolsToInstall...)
+ 	if debug {
+ 		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
 index aa09d1eba34be8..e037970d95cba2 100644
 --- a/src/cmd/dist/test.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -422,7 +422,7 @@ index 1f791546f90088..d20890b4e70fae 100644
  	appendSetting("-compiler", cfg.BuildContext.Compiler)
  	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
 diff --git a/src/cmd/go/internal/tool/tool.go b/src/cmd/go/internal/tool/tool.go
-index 16e1a4f47f49c0..6c16293cd8deb0 100644
+index 16e1a4f47f49c0..f987e499da4c15 100644
 --- a/src/cmd/go/internal/tool/tool.go
 +++ b/src/cmd/go/internal/tool/tool.go
 @@ -281,6 +281,10 @@ func buildAndRunBuiltinTool(ctx context.Context, toolName, tool string, args []s
@@ -442,7 +442,7 @@ index 16e1a4f47f49c0..6c16293cd8deb0 100644
  	runFunc := func(b *work.Builder, ctx context.Context, a *work.Action) error {
 +		// Now that the tool is built, revert the GOEXPERIMENT
 +		// environment variable to the original value.
-+		env := []string{"GOEXPERIMENT=" + originalGOEXPERIMENT}
++		env := append(os.Environ(), "GOEXPERIMENT="+originalGOEXPERIMENT)
  		cmdline := str.StringList(a.Deps[0].BuiltTarget(), a.Args)
 -		return runBuiltTool(toolName, nil, cmdline)
 +		return runBuiltTool(toolName, env, cmdline)

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -16,7 +16,7 @@ desired goexperiments and build tags.
  src/cmd/dist/build.go                         |  29 +-
  src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |  11 +
- src/cmd/go/internal/cfg/cfg.go                |  11 +
+ src/cmd/go/internal/cfg/cfg.go                |  13 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/internal/tool/tool.go              |   7 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
@@ -55,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2252 insertions(+), 22 deletions(-)
+ 46 files changed, 2254 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -374,7 +374,7 @@ index 3e691abe41f702..b799031d598892 100644
  	tg.parallel()
  	defer tg.cleanup()
 diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
-index a4edd854f1d35a..f082588cb75549 100644
+index a4edd854f1d35a..3efe51984c2566 100644
 --- a/src/cmd/go/internal/cfg/cfg.go
 +++ b/src/cmd/go/internal/cfg/cfg.go
 @@ -19,6 +19,7 @@ import (
@@ -385,7 +385,7 @@ index a4edd854f1d35a..f082588cb75549 100644
  	"strings"
  	"sync"
  	"time"
-@@ -232,6 +233,16 @@ func ForceHost() {
+@@ -232,6 +233,18 @@ func ForceHost() {
  	// Recompute experiments: the settings determined depend on GOOS and GOARCH.
  	// This will also update the BuildContext's tool tags to include the new
  	// experiment tags.
@@ -399,6 +399,8 @@ index a4edd854f1d35a..f082588cb75549 100644
 +	})
 +	goexp = append(goexp, "nosystemcrypto")
 +	RawGOEXPERIMENT = strings.Join(goexp, ",")
++	// Set the ms_skipfipscheck build tag, as the rest of the toolchain.
++	BuildContext.BuildTags = append(BuildContext.BuildTags, "ms_skipfipscheck")
  	computeExperiment()
  }
  

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/compile/script_test.go                |   8 +
- src/cmd/dist/build.go                         |  17 +
+ src/cmd/dist/build.go                         |  23 ++
  src/cmd/dist/test.go                          |  45 ++-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/load/pkg.go               |   3 +
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2214 insertions(+), 17 deletions(-)
+ 43 files changed, 2220 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -157,10 +157,10 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 024050c2dd70c4..1291bb632d2f7e 100644
+index 024050c2dd70c4..e39be4bef50022 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1390,6 +1390,17 @@ func toolenv() []string {
+@@ -1390,6 +1390,23 @@ func toolenv() []string {
  	return env
  }
  
@@ -168,17 +168,23 @@ index 024050c2dd70c4..1291bb632d2f7e 100644
 +// the Microsoft build of Go should not use it. Go only uses crypto packages
 +// for non-crypto purposes, such as generating build IDs.
 +func disableSystemCrypto() {
-+	goexp := os.Getenv("GOEXPERIMENT")
-+	if goexp != "" {
-+		goexp += ","
++	goexp := strings.Split(os.Getenv("GOEXPERIMENT"), ",")
++	if len(goexp) == 1 && goexp[0] == "" {
++		goexp = nil
 +	}
-+	os.Setenv("GOEXPERIMENT", goexp+"nosystemcrypto")
++	goexp = slices.DeleteFunc(goexp, func(s string) bool {
++		return s == "systemcrypto"
++	})
++	if !slices.Contains(goexp, "nosystemcrypto") {
++		goexp = append(goexp, "nosystemcrypto")
++	}
++	os.Setenv("GOEXPERIMENT", strings.Join(goexp, ","))
 +}
 +
  var (
  	toolchain = []string{"cmd/asm", "cmd/cgo", "cmd/compile", "cmd/link", "cmd/preprofile"}
  
-@@ -1548,6 +1559,12 @@ func cmdbootstrap() {
+@@ -1548,6 +1565,12 @@ func cmdbootstrap() {
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
  	os.Setenv("GOEXPERIMENT", goexperiment)


### PR DESCRIPTION
As agreed in #1352, we should make `GOEXPERIMENT=systemcrypto` the default behavior. Users can opt-out from it using `GOEXPERIMENT=nosystemcrypto`.

Note that `systemcrypto` is only enabled by default on Windows and Linux. `darwincrypto` is still experimental, therefore this PR doesn't enable `systemcrypto` by default on `darwin`.

Closes #1352.