### PR TITLE
Downgrade `GOEXPERIMENT=allowcryptofallback` to a build tag

### DIFF
--- a/eng/_util/buildutil/buildutil.go
+++ b/eng/_util/buildutil/buildutil.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 )
 
 // Retry runs f until it succeeds or the attempt limit is reached.
@@ -85,26 +84,31 @@ func GetEnvOrDefault(varName, defaultValue string) (string, error) {
 	return v, nil
 }
 
+// SetEnv sets an env var and logs it. Panics if it doesn't succeed.
+func SetEnv(key, value string) {
+	fmt.Printf("Setting env '%s' to '%s'\n", key, value)
+	if err := os.Setenv(key, value); err != nil {
+		panic(err)
+	}
+}
+
+// AppendEnv sets the given environment variable to the given value, or if the
+// environment variable is already set, appends sep and then the given value.
+func AppendEnv(key, value, sep string) {
+	if v, ok := os.LookupEnv(key); ok {
+		value = v + sep + value
+	}
+	SetEnv(key, value)
+}
+
 // AppendExperimentEnv sets the GOEXPERIMENT env var to the given value, or if GOEXPERIMENT is
 // already set, appends a comma separator and then the given value.
 func AppendExperimentEnv(experiment string) {
-	// If the experiment enables a crypto backend, allow fallback to Go crypto. Go turns off cgo
-	// and/or cross-builds in various situations during the build/tests, so we need to allow for it.
-	if strings.Contains(experiment, "opensslcrypto") ||
-		strings.Contains(experiment, "cngcrypto") ||
-		strings.Contains(experiment, "boringcrypto") ||
-		strings.Contains(experiment, "darwincrypto") ||
-		strings.Contains(experiment, "systemcrypto") {
+	AppendEnv("GOEXPERIMENT", experiment, ",")
 
-		experiment += ",allowcryptofallback"
-	}
-	if v, ok := os.LookupEnv("GOEXPERIMENT"); ok {
-		experiment = v + "," + experiment
-	}
-	fmt.Printf("Setting GOEXPERIMENT: %v\n", experiment)
-	if err := os.Setenv("GOEXPERIMENT", experiment); err != nil {
-		panic(err)
-	}
+	// Allow fallback to Go crypto. Go turns off cgo and/or cross-builds in various situations during
+	// the build/tests, so we need to allow for it.
+	AppendEnv("GOFLAGS", "-tags=allowcryptofallback", " ")
 }
 
 // UnassignGOROOT unsets the GOROOT env var if it is set.

--- a/eng/_util/buildutil/buildutil.go
+++ b/eng/_util/buildutil/buildutil.go
@@ -105,10 +105,6 @@ func AppendEnv(key, value, sep string) {
 // already set, appends a comma separator and then the given value.
 func AppendExperimentEnv(experiment string) {
 	AppendEnv("GOEXPERIMENT", experiment, ",")
-
-	// Allow fallback to Go crypto. Go turns off cgo and/or cross-builds in various situations during
-	// the build/tests, so we need to allow for it.
-	AppendEnv("GOFLAGS", "-tags=allowcryptofallback", " ")
 }
 
 // UnassignGOROOT unsets the GOROOT env var if it is set.

--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -79,18 +79,18 @@ func main() {
 	// running tests:
 	switch config {
 	case "clang":
-		env("CC", "/usr/bin/clang-3.9")
+		buildutil.SetEnv("CC", "/usr/bin/clang-3.9")
 	case "longtest":
-		env("GO_TEST_SHORT", "false")
+		buildutil.SetEnv("GO_TEST_SHORT", "false")
 		timeoutScale *= 5
 	case "nocgo":
-		env("CGO_ENABLED", "0")
+		buildutil.SetEnv("CGO_ENABLED", "0")
 	case "noopt":
-		env("GO_GCFLAGS", "-N -l")
+		buildutil.SetEnv("GO_GCFLAGS", "-N -l")
 	case "regabi":
 		buildutil.AppendExperimentEnv("regabi")
 	case "ssacheck":
-		env("GO_GCFLAGS", "-d=ssa/check/on")
+		buildutil.SetEnv("GO_GCFLAGS", "-d=ssa/check/on")
 	case "staticlockranking":
 		buildutil.AppendExperimentEnv("staticlockranking")
 	}
@@ -102,7 +102,7 @@ func main() {
 	}
 
 	if timeoutScale != 1 {
-		env("GO_TEST_TIMEOUT_SCALE", strconv.Itoa(timeoutScale))
+		buildutil.SetEnv("GO_TEST_TIMEOUT_SCALE", strconv.Itoa(timeoutScale))
 	}
 
 	if err := buildutil.UnassignGOROOT(); err != nil {
@@ -150,7 +150,7 @@ func main() {
 		}
 
 		if *fipsMode {
-			envAppend("GODEBUG", "fips140=on")
+			buildutil.AppendEnv("GODEBUG", "fips140=on", ",")
 			// Enable system-wide FIPS if supported by the host platform.
 			restore, err := enableSystemWideFIPS()
 			if err != nil {
@@ -163,14 +163,14 @@ func main() {
 
 		// The tests read GO_BUILDER_NAME and make decisions based on it. For some configurations,
 		// we only need to set this env var.
-		env("GO_BUILDER_NAME", *builder)
+		buildutil.SetEnv("GO_BUILDER_NAME", *builder)
 
 		// The "fake" config "test" is a sentinel value that means we should omit the config part of
 		// the builder name. This lets us have a stable "{os}-{arch}-{config}" API (particularly
 		// useful when dealing with AzDO YAML limitations) while still being able to test e.g. the
 		// "linux-amd64" builder from upstream.
 		if config == "test" {
-			env("GO_BUILDER_NAME", goos+"-"+goarch)
+			buildutil.SetEnv("GO_BUILDER_NAME", goos+"-"+goarch)
 		}
 
 		cmdline := []string{
@@ -228,23 +228,6 @@ func main() {
 			}
 		}
 	}
-}
-
-// env sets an env var and logs it. Panics if it doesn't succeed.
-func env(key, value string) {
-	fmt.Printf("Setting env '%s' to '%s'\n", key, value)
-	if err := os.Setenv(key, value); err != nil {
-		panic(err)
-	}
-}
-
-// envAppend appends a value to an env var and logs it.
-// Panics if it doesn't succeed.
-func envAppend(key, value string) {
-	if v, ok := os.LookupEnv(key); ok {
-		value = v + "," + value
-	}
-	env(key, value)
 }
 
 func run(cmdline ...string) error {

--- a/eng/_util/cmd/run-builder/systemfips_linux.go
+++ b/eng/_util/cmd/run-builder/systemfips_linux.go
@@ -6,6 +6,8 @@ package main
 import (
 	"log"
 	"os"
+
+	"github.com/microsoft/go/_util/buildutil"
 )
 
 // enableSystemWideFIPS enables Mariner and Azure Linux 3 process-wide FIPS mode
@@ -18,7 +20,7 @@ func enableSystemWideFIPS() (restore func(), err error) {
 		return nil, nil
 	}
 
-	env("OPENSSL_FORCE_FIPS_MODE", "1")
+	buildutil.SetEnv("OPENSSL_FORCE_FIPS_MODE", "1")
 	log.Println("Enabled Mariner and Azure Linux 3 FIPS mode (OPENSSL_FORCE_FIPS_MODE).")
 
 	return func() {

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -84,7 +84,7 @@ Some configurations are invalid and intentionally result in a build error or run
 | `GOEXPERIMENT=systemcrypto` and `-tags=requirefips` | `GOFIPS=0` | The app panics due to the conflict between build-time and runtime configuration. |
 | `-tags=requirefips` | | The build fails. A crypto backend must be specified to enable FIPS features. |
 | `GOEXPERIMENT=cngcrypto,opensslcrypto` | | The build fails. Only one crypto backend can be enabled at a time. |
-| `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto` | | The build fails. Cgo is required to use the OpenSSL backend. <br/> Prior to Go 1.21 or if 
+| `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto` | | The build fails. Cgo is required to use the OpenSSL backend. <br/> Prior to Go 1.21 the build would succeed but use standard Go crypto, making the app non-compliant. |
 
 ## Usage: Build
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -50,7 +50,6 @@ These are described in the following sections in detail.
   - [`goexperiment.<backend>crypto` build tag](#usage-build)
   - [`requirefips` build tag](#build-option-to-require-fips-mode)
   - [`GOFIPS140=latest` environment variable](#build-option-to-require-fips-mode) (go1.24+)
-  - [`GOEXPERIMENT` `allowcryptofallback`](#build-option-to-use-go-crypto-if-the-backend-compatibility-check-fails)
   - [`import _ "crypto/tls/fipsonly"` source change](#tls-with-fips-compliant-settings)
 - Runtime configuration:
   - [`GOFIPS` environment variable](#usage-runtime)
@@ -85,7 +84,7 @@ Some configurations are invalid and intentionally result in a build error or run
 | `GOEXPERIMENT=systemcrypto` and `-tags=requirefips` | `GOFIPS=0` | The app panics due to the conflict between build-time and runtime configuration. |
 | `-tags=requirefips` | | The build fails. A crypto backend must be specified to enable FIPS features. |
 | `GOEXPERIMENT=cngcrypto,opensslcrypto` | | The build fails. Only one crypto backend can be enabled at a time. |
-| `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto` | | The build fails. Cgo is required to use the OpenSSL backend. <br/> Prior to Go 1.21 or if [`allowcryptofallback`](#build-option-to-use-go-crypto-if-the-backend-compatibility-check-fails) is enabled, the build would succeed but use standard Go crypto, making the app non-compliant. |
+| `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto` | | The build fails. Cgo is required to use the OpenSSL backend. <br/> Prior to Go 1.21 or if 
 
 ## Usage: Build
 
@@ -124,8 +123,6 @@ Setting the `goexperiment.<option>` build tag can be used as an alternative to s
 
 If a crypto backend is selected but isn't supported, the build fails.
 For example, attempting to use the OpenSSL backend without cgo enabled results in a build error.
-It's possible to dismiss the build error by using [the `allowcryptofallback` experiment](#build-option-to-use-go-crypto-if-the-backend-compatibility-check-fails), but this is dangerous.
-
 
 The next sections describe how to select a crypto backend in some common scenarios.
 
@@ -329,27 +326,9 @@ We recommend one of these fixes:
 - Fix the build environment to allow the crypto backend to be used. (Enable cgo.)
 - Remove `GOEXPERIMENT` entirely. This intentionally doesn't comply with the internal Microsoft crypto policy or FIPS, so for builds within Microsoft, this should only be done under a documented exception.
 
-Prior to Go 1.21, if the backend is not compatible with the build environment and target, the assigned backend is completely ignored and the standard Go crypto implementation is used by the built app. This is called *silent crypto backend fallback* and makes the built Go app noncompliant with internal Microsoft crypto policy and FIPS. For backward compatibility and exceptional cases, this behavior can be enabled in Go 1.21 and above using the `allowcryptofallback` experiment.
-
-We recommend against using `allowcryptofallback`. It makes it unclear whether or not the app is intended to be compliant, and could lead to accidental use of Go crypto in a context where FIPS compliance is expected.
 
 > [!IMPORTANT]
-> Even if `allowcryptofallback` is not enabled, a Go app may use Go standard library crypto and not be FIPS compliant.
 > Individual crypto calls may fall back to standard Go crypto at runtime if the selected backend doesn't support an API or the arguments used. See the [FIPS User Guide](UserGuide.md) for more information.
-
-This table shows an example of the fragile behavior that results from using `allowcryptofallback`:
-
-| Build-time config | Internal Microsoft crypto policy | FIPS behavior |
-| --- | --- | --- |
-| `GOOS=linux GOEXPERIMENT=systemcrypto,allowcryptofallback` | Compliant | *Not recommended,* but can be used to create a compliant app, as `allowcryptofallback` has no effect in this situation. |
-| `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto,allowcryptofallback` | Not compliant | Crypto usage is not FIPS compliant. `systemcrypto` on `linux` picks the OpenSSL backend. The backend requires cgo, so `CGO_ENABLED=0` would normally result in a build error. However, `allowcryptofallback` causes the Go standard library crypto to be used and ignores the error. |
-
-A scenario we expect is that a dev attempts to rebuild an open source Go app with an OpenSSL backend to start working towards FIPS compliance. A Dockerfile or other build script provided by the open source project may set `CGO_ENABLED=0` in a non-obvious way. With *silent crypto backend fallback*, the dev needs to notice that the OpenSSL backend isn't being used in some situations (e.g. `GODEBUG=fips140=on` and `GOFIPS=1` causes failure) and figure out why. If they don't notice, they may deliver an app that uses Go crypto without realizing it. The compatibility check makes it so this issue blocks the build and can't be missed.
-
-> [!NOTE]
-> In rare cases, it may be more practical to use `allowcryptofallback` than to remove the `GOEXPERIMENT`. For example, a generic build script that supports many platforms, some of which don't support crypto backends, may find it practical to use `GOEXPERIMENT=systemcrypto,allowcryptofallback` despite the risk of unclear or accidental fallback to Go crypto.
->
-> For example, `allowcryptofallback` plays an important role in the Microsoft build of Go build process. We have CI jobs that run the build and tests under the OpenSSL, CNG, and Boring crypto backends, but parts of the upstream build and tests disable cgo and run cross-builds. This would cause a failure because the backend can't be enabled, but by including `allowcryptofallback`, the build is allowed to continue and fall back to the Go standard library crypto implementation when necessary.
 
 ### Runtime OpenSSL version override
 
@@ -458,6 +437,10 @@ A program running in FIPS mode can claim it is using a FIPS-certified cryptograp
 
 This list of major changes is intended for quick reference and for access to historical information about versions that are no longer supported. The behavior of all in-support versions are documented in the sections above with notes for version-specific differences where necessary.
 
+### Go 1.25 (Aug 2025)
+
+- `GOEXPERIMENT=allowcryptofallback` has been downgraded to the `allowcryptofallback` build tag. Applications shouldn't be using it anymore, as it was a mechanism to facilitate migrating to Go 1.21. The build tag is still there for rare exceptions, please contact the Go team at Microsoft if you need to use it so we can help you migrate to the new behavior.
+
 ### Go 1.24 (Feb 2025)
 
 See the [Microsoft build of Go 1.24 FIPS changes](https://devblogs.microsoft.com/go/go-1-24-fips-update/) blog post for a summary of the Feb 2025 changes.
@@ -480,7 +463,7 @@ See the [Microsoft build of Go 1.24 FIPS changes](https://devblogs.microsoft.com
 
 - Adds build errors if a crypto backend is selected but not supported.
   - Before 1.21, selecting an unsupported backend causes *silent crypto backend fallback* and the built Go app will never use the crypto backend. This is generally not desirable because it can lead to accidental or unclear fallback to Go crypto.
-    - The old behavior can be enabled using the [`allowcryptofallback` experiment](#build-option-to-use-go-crypto-if-the-backend-compatibility-check-fails) if necessary, but it is not recommended.
+    - The old behavior can be enabled using `GOEXPERIMENT=allowcryptofallback` if necessary, but it is not recommended.
   - Individual crypto calls may still fall back to the Go standard library at runtime if the selected backend doesn't support an API or the arguments used. See the [FIPS User Guide](UserGuide.md) for more information. (This behavior is unaffected by this change.)
 - Adds [`systemcrypto` experiment alias](#usage-build).
 - Adds [`requirefips` build tag](#build-option-to-require-fips-mode).

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -439,7 +439,7 @@ This list of major changes is intended for quick reference and for access to his
 
 ### Go 1.25 (Aug 2025)
 
-- `GOEXPERIMENT=allowcryptofallback` has been downgraded to the `allowcryptofallback` build tag. Applications shouldn't be using it anymore, as it was a mechanism to facilitate migrating to Go 1.21. The build tag is still there for rare exceptions, please contact the Go team at Microsoft if you need to use it so we can help you migrate to the new behavior.
+- `GOEXPERIMENT=allowcryptofallback` has been downgraded to the `allowcryptofallback` build tag. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
 
 ### Go 1.24 (Feb 2025)
 

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -11,18 +11,15 @@ information about the behavior.
 Includes new tests in "build_test.go" and "buildbackend_test.go" to help
 maintain this feature. For more information, see the test files.
 ---
- src/cmd/dist/build.go                         | 13 +++
+ src/cmd/dist/build.go                         | 10 ++-
  src/cmd/go/internal/modindex/build.go         | 58 ++++++++++++-
  src/cmd/go/internal/modindex/build_test.go    | 73 ++++++++++++++++
- src/cmd/link/internal/ld/main.go              | 12 ++-
  src/go/build/build.go                         | 58 ++++++++++++-
  src/go/build/buildbackend_test.go             | 84 +++++++++++++++++++
  .../testdata/backendtags_openssl/main.go      |  3 +
  .../testdata/backendtags_openssl/openssl.go   |  3 +
  .../build/testdata/backendtags_system/main.go |  3 +
  .../backendtags_system/systemcrypto.go        |  3 +
- .../exp_allowcryptofallback_off.go            |  8 ++
- .../exp_allowcryptofallback_on.go             |  8 ++
  .../goexperiment/exp_cngcrypto_off.go         |  8 ++
  src/internal/goexperiment/exp_cngcrypto_on.go |  8 ++
  .../goexperiment/exp_darwincrypto_off.go      |  8 ++
@@ -31,16 +28,14 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_opensslcrypto_on.go      |  8 ++
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
- src/internal/goexperiment/flags.go            | 26 ++++++
- 21 files changed, 411 insertions(+), 5 deletions(-)
+ src/internal/goexperiment/flags.go            | 18 ++++
+ 18 files changed, 371 insertions(+), 6 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/main.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/openssl.go
  create mode 100644 src/go/build/testdata/backendtags_system/main.go
  create mode 100644 src/go/build/testdata/backendtags_system/systemcrypto.go
- create mode 100644 src/internal/goexperiment/exp_allowcryptofallback_off.go
- create mode 100644 src/internal/goexperiment/exp_allowcryptofallback_on.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_cngcrypto_on.go
  create mode 100644 src/internal/goexperiment/exp_darwincrypto_off.go
@@ -51,29 +46,35 @@ maintain this feature. For more information, see the test files.
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_on.go
 
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index b50f3342fe8714..5120c23556ebe3 100644
+index b50f3342fe8714..c4451b438bbf60 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1538,6 +1538,19 @@ func cmdbootstrap() {
+@@ -1538,9 +1538,15 @@ func cmdbootstrap() {
  	xprintf("Building Go toolchain2 using go_bootstrap and Go toolchain1.\n")
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
 +	//
-+	// Build the Go toolchain with "GOEXPERIMENT=allowcryptofallback". This
++	// Build the Go toolchain with "-tags=allowcryptofallback". This
 +	// allows toolchains not built with "GOEXPERIMENT=systemcrypto" to be used
 +	// when GODEBUG=fips140=on is set. For example, when running
 +	// "GODEBUG=fips140=on go test ./..." or "GODEBUG=fips140=on go run .".
 +	// Shadow goexperiment so that the global variable is not modified.
-+	goexperiment := goexperiment
-+	if !strings.Contains(goexperiment, "allowcryptofallback") {
-+		if goexperiment != "" {
-+			goexperiment += ","
-+		}
-+		goexperiment += "allowcryptofallback"
-+	}
  	os.Setenv("GOEXPERIMENT", goexperiment)
  	// No need to enable PGO for toolchain2.
- 	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
+-	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
++	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off", "-tags=allowcryptofallback"}, toolchain...)...)
+ 	if debug {
+ 		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
+ 		copyfile(pathf("%s/compile2", tooldir), pathf("%s/compile", tooldir), writeExec)
+@@ -1567,7 +1573,7 @@ func cmdbootstrap() {
+ 		xprintf("\n")
+ 	}
+ 	xprintf("Building Go toolchain3 using go_bootstrap and Go toolchain2.\n")
+-	goInstall(toolenv(), goBootstrap, append([]string{"-a"}, toolchain...)...)
++	goInstall(toolenv(), goBootstrap, append([]string{"-a", "-tags=allowcryptofallback"}, toolchain...)...)
+ 	if debug {
+ 		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
+ 		copyfile(pathf("%s/compile3", tooldir), pathf("%s/compile", tooldir), writeExec)
 diff --git a/src/cmd/go/internal/modindex/build.go b/src/cmd/go/internal/modindex/build.go
 index d7e09fed25f43a..10614d17e62453 100644
 --- a/src/cmd/go/internal/modindex/build.go
@@ -223,36 +224,6 @@ index 00000000000000..1756c5d027fee0
 +		})
 +	}
 +}
-diff --git a/src/cmd/link/internal/ld/main.go b/src/cmd/link/internal/ld/main.go
-index 6a684890be0a03..1dcc126b7a0440 100644
---- a/src/cmd/link/internal/ld/main.go
-+++ b/src/cmd/link/internal/ld/main.go
-@@ -44,6 +44,7 @@ import (
- 	"os"
- 	"runtime"
- 	"runtime/pprof"
-+	"slices"
- 	"strconv"
- 	"strings"
- )
-@@ -187,7 +188,16 @@ func Main(arch *sys.Arch, theArch Arch) {
- 
- 	buildVersion := buildcfg.Version
- 	if goexperiment := buildcfg.Experiment.String(); goexperiment != "" {
--		buildVersion += " X:" + goexperiment
-+		// buildVersion is intended to contain non-default experiment flags.
-+		// The Microsoft build of Go default behavior is to set the
-+		// allowcryptofallback experiment, so we don't include it in the
-+		// buildVersion string.
-+		goexperiment = strings.Join(slices.DeleteFunc(strings.Split(goexperiment, ","), func(s string) bool {
-+			return s == "allowcryptofallback"
-+		}), ",")
-+		if goexperiment != "" {
-+			buildVersion += " X:" + goexperiment
-+		}
- 	}
- 	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
- 
 diff --git a/src/go/build/build.go b/src/go/build/build.go
 index 50288fcec64141..44be2e6a4c580a 100644
 --- a/src/go/build/build.go
@@ -449,34 +420,6 @@ index 00000000000000..eb8a026982259c
 +//go:build goexperiment.systemcrypto
 +
 +package main
-diff --git a/src/internal/goexperiment/exp_allowcryptofallback_off.go b/src/internal/goexperiment/exp_allowcryptofallback_off.go
-new file mode 100644
-index 00000000000000..b8bdf689af6fb5
---- /dev/null
-+++ b/src/internal/goexperiment/exp_allowcryptofallback_off.go
-@@ -0,0 +1,8 @@
-+// Code generated by mkconsts.go. DO NOT EDIT.
-+
-+//go:build !goexperiment.allowcryptofallback
-+
-+package goexperiment
-+
-+const AllowCryptoFallback = false
-+const AllowCryptoFallbackInt = 0
-diff --git a/src/internal/goexperiment/exp_allowcryptofallback_on.go b/src/internal/goexperiment/exp_allowcryptofallback_on.go
-new file mode 100644
-index 00000000000000..d03c0284e949ba
---- /dev/null
-+++ b/src/internal/goexperiment/exp_allowcryptofallback_on.go
-@@ -0,0 +1,8 @@
-+// Code generated by mkconsts.go. DO NOT EDIT.
-+
-+//go:build goexperiment.allowcryptofallback
-+
-+package goexperiment
-+
-+const AllowCryptoFallback = true
-+const AllowCryptoFallbackInt = 1
 diff --git a/src/internal/goexperiment/exp_cngcrypto_off.go b/src/internal/goexperiment/exp_cngcrypto_off.go
 new file mode 100644
 index 00000000000000..eb879f94fa0c42
@@ -590,10 +533,10 @@ index 00000000000000..fcd4cb9da0d162
 +const SystemCrypto = true
 +const SystemCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index ceff24193d89a5..12fba96b868c9e 100644
+index ceff24193d89a5..6b4289503d57ae 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
-@@ -59,6 +59,32 @@ type Flags struct {
+@@ -59,6 +59,24 @@ type Flags struct {
  	PreemptibleLoops  bool
  	StaticLockRanking bool
  	BoringCrypto      bool
@@ -615,14 +558,6 @@ index ceff24193d89a5..12fba96b868c9e 100644
 +	// "any crypto backend is enabled", even if GOEXPERIMENT=systemcrypto is not
 +	// being used to build the Go program.
 +	SystemCrypto bool
-+
-+	// AllowCryptoFallback allows the use of pure Go crypto if a crypto backend
-+	// experiment is enabled but the backend's requirements are not met. This is
-+	// used during the Go build itself to allow running the test suite with a
-+	// backend experiment enabled. Some parts of the Go build (bootstrapping)
-+	// and parts of the test suite run without cgo, so
-+	// GOEXPERIMENT=opensslcrypto,allowcryptofallback must be used to succeed.
-+	AllowCryptoFallback bool
  
  	// Regabi is split into several sub-experiments that can be
  	// enabled individually. Not all combinations work.

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -11,7 +11,7 @@ information about the behavior.
 Includes new tests in "build_test.go" and "buildbackend_test.go" to help
 maintain this feature. For more information, see the test files.
 ---
- src/cmd/dist/build.go                         | 10 ++-
+ src/cmd/dist/build.go                         |  6 ++
  src/cmd/go/internal/modindex/build.go         | 58 ++++++++++++-
  src/cmd/go/internal/modindex/build_test.go    | 73 ++++++++++++++++
  src/go/build/build.go                         | 58 ++++++++++++-
@@ -29,7 +29,7 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 ++++
- 18 files changed, 371 insertions(+), 6 deletions(-)
+ 18 files changed, 369 insertions(+), 4 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/main.go
@@ -46,35 +46,23 @@ maintain this feature. For more information, see the test files.
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_on.go
 
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index b50f3342fe8714..c4451b438bbf60 100644
+index b50f3342fe8714..f1ca86bc13105a 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1538,9 +1538,15 @@ func cmdbootstrap() {
- 	xprintf("Building Go toolchain2 using go_bootstrap and Go toolchain1.\n")
+@@ -1539,7 +1539,13 @@ func cmdbootstrap() {
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
-+	//
+ 	os.Setenv("GOEXPERIMENT", goexperiment)
 +	// Build the Go toolchain with "-tags=allowcryptofallback". This
 +	// allows toolchains not built with "GOEXPERIMENT=systemcrypto" to be used
 +	// when GODEBUG=fips140=on is set. For example, when running
 +	// "GODEBUG=fips140=on go test ./..." or "GODEBUG=fips140=on go run .".
 +	// Shadow goexperiment so that the global variable is not modified.
- 	os.Setenv("GOEXPERIMENT", goexperiment)
  	// No need to enable PGO for toolchain2.
--	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
-+	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off", "-tags=allowcryptofallback"}, toolchain...)...)
++	os.Setenv("GOFLAGS", "-tags=allowcryptofallback")
+ 	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
- 		copyfile(pathf("%s/compile2", tooldir), pathf("%s/compile", tooldir), writeExec)
-@@ -1567,7 +1573,7 @@ func cmdbootstrap() {
- 		xprintf("\n")
- 	}
- 	xprintf("Building Go toolchain3 using go_bootstrap and Go toolchain2.\n")
--	goInstall(toolenv(), goBootstrap, append([]string{"-a"}, toolchain...)...)
-+	goInstall(toolenv(), goBootstrap, append([]string{"-a", "-tags=allowcryptofallback"}, toolchain...)...)
- 	if debug {
- 		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
- 		copyfile(pathf("%s/compile3", tooldir), pathf("%s/compile", tooldir), writeExec)
 diff --git a/src/cmd/go/internal/modindex/build.go b/src/cmd/go/internal/modindex/build.go
 index d7e09fed25f43a..10614d17e62453 100644
 --- a/src/cmd/go/internal/modindex/build.go

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -46,10 +46,10 @@ maintain this feature. For more information, see the test files.
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_on.go
 
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index b50f3342fe8714..f1ca86bc13105a 100644
+index b50f3342fe8714..75629c2a6bd9ba 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1539,7 +1539,13 @@ func cmdbootstrap() {
+@@ -1539,6 +1539,12 @@ func cmdbootstrap() {
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
  	os.Setenv("GOEXPERIMENT", goexperiment)
@@ -58,11 +58,10 @@ index b50f3342fe8714..f1ca86bc13105a 100644
 +	// when GODEBUG=fips140=on is set. For example, when running
 +	// "GODEBUG=fips140=on go test ./..." or "GODEBUG=fips140=on go run .".
 +	// Shadow goexperiment so that the global variable is not modified.
- 	// No need to enable PGO for toolchain2.
 +	os.Setenv("GOFLAGS", "-tags=allowcryptofallback")
+ 	// No need to enable PGO for toolchain2.
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
- 		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/go/internal/modindex/build.go b/src/cmd/go/internal/modindex/build.go
 index d7e09fed25f43a..10614d17e62453 100644
 --- a/src/cmd/go/internal/modindex/build.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -5,9 +5,11 @@ Subject: [PATCH] Implement crypto/internal/backend
 
 ---
  .gitignore                                    |   2 +
+ .../backend/allocryptofallback_off.go         |   9 +
+ .../internal/backend/allocryptofallback_on.go |   9 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
- .../internal/backend/backendgen_test.go       | 284 ++++++++++++++
+ .../internal/backend/backendgen_test.go       | 280 +++++++++++++
  src/crypto/internal/backend/bbig/big.go       |  17 +
  .../internal/backend/bbig/big_boring.go       |  12 +
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
@@ -15,7 +17,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/backend/bbig/big_openssl.go      |  12 +
  src/crypto/internal/backend/boring_linux.go   | 287 ++++++++++++++
  src/crypto/internal/backend/cng_windows.go    | 344 ++++++++++++++++
- src/crypto/internal/backend/common.go         |  59 +++
+ src/crypto/internal/backend/common.go         |  58 +++
  src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
@@ -39,14 +41,16 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../backenderr_gen_conflict_cng_darwin.go     |  17 +
  .../backenderr_gen_conflict_cng_openssl.go    |  17 +
  .../backenderr_gen_conflict_darwin_openssl.go |  17 +
- .../backenderr_gen_nofallback_boring.go       |  24 ++
- src/runtime/backenderr_gen_nofallback_cng.go  |  24 ++
- .../backenderr_gen_nofallback_darwin.go       |  24 ++
- .../backenderr_gen_nofallback_openssl.go      |  24 ++
+ .../backenderr_gen_nofallback_boring.go       |  20 +
+ src/runtime/backenderr_gen_nofallback_cng.go  |  20 +
+ .../backenderr_gen_nofallback_darwin.go       |  20 +
+ .../backenderr_gen_nofallback_openssl.go      |  20 +
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 42 files changed, 2702 insertions(+), 3 deletions(-)
+ 44 files changed, 2699 insertions(+), 3 deletions(-)
+ create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
+ create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -100,6 +104,36 @@ index c6512e64a4ef39..b3b01db73b009d 100644
  # This file includes artifacts of Go build that should not be checked in.
  # For files created by specific development environment (e.g. editor),
  # use alternative ways to exclude files from git.
+diff --git a/src/crypto/internal/backend/allocryptofallback_off.go b/src/crypto/internal/backend/allocryptofallback_off.go
+new file mode 100644
+index 00000000000000..7718cc02f48556
+--- /dev/null
++++ b/src/crypto/internal/backend/allocryptofallback_off.go
+@@ -0,0 +1,9 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !allowcryptofallback
++
++package backend
++
++const allowCryptoFallback = false
+diff --git a/src/crypto/internal/backend/allocryptofallback_on.go b/src/crypto/internal/backend/allocryptofallback_on.go
+new file mode 100644
+index 00000000000000..fc30aba8ad8228
+--- /dev/null
++++ b/src/crypto/internal/backend/allocryptofallback_on.go
+@@ -0,0 +1,9 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build allowcryptofallback
++
++package backend
++
++const allowCryptoFallback = true
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644
 index 00000000000000..c2c06d3bff8c74
@@ -164,10 +198,10 @@ index 00000000000000..acf0113bbefb6c
 +//go:generate go test -run TestGenerated -fix
 diff --git a/src/crypto/internal/backend/backendgen_test.go b/src/crypto/internal/backend/backendgen_test.go
 new file mode 100644
-index 00000000000000..1ba948c8f207e5
+index 00000000000000..1da2926a7b960f
 --- /dev/null
 +++ b/src/crypto/internal/backend/backendgen_test.go
-@@ -0,0 +1,284 @@
+@@ -0,0 +1,280 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -332,7 +366,7 @@ index 00000000000000..1ba948c8f207e5
 +
 +func testPreventUnintendedFallback(t *testing.T, backend *backend) string {
 +	expTag := &constraint.TagExpr{Tag: "goexperiment." + backend.name + "crypto"}
-+	optOutTag := &constraint.TagExpr{Tag: "goexperiment.allowcryptofallback"}
++	optOutTag := &constraint.TagExpr{Tag: "allowcryptofallback"}
 +	c := constraint.AndExpr{
 +		X: &constraint.AndExpr{
 +			X: expTag,
@@ -348,10 +382,6 @@ index 00000000000000..1ba948c8f207e5
 +		"Required build tags:",
 +		"  "+backend.constraint.String(),
 +		"Please check your build environment and build command for a reason one or more of these tags weren't specified.",
-+		"",
-+		"If you only performed a Go toolset upgrade and didn't expect this error, your code was likely depending on fallback to Go standard library crypto.",
-+		"As of Go 1.21, Go crypto fallback is a build error. This helps prevent accidental fallback.",
-+		"Removing "+backend.name+"crypto will restore pre-1.21 behavior by intentionally using Go standard library crypto.",
 +		"")
 +}
 +
@@ -1192,10 +1222,10 @@ index 00000000000000..6abb6ff007c99f
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..9436b00381aaf8
+index 00000000000000..9dec441fa63856
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,58 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1205,12 +1235,11 @@ index 00000000000000..9436b00381aaf8
 +import (
 +	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
-+	"internal/goexperiment"
 +	"runtime"
 +)
 +
 +func init() {
-+	if !goexperiment.AllowCryptoFallback && fips140.Enabled() {
++	if !allowCryptoFallback && fips140.Enabled() {
 +		if !Enabled {
 +			if runtime.GOOS != "linux" && runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 +				panic("FIPS mode requested (" + fips140.Message + ") but no crypto backend is supported on " + runtime.GOOS)
@@ -2905,17 +2934,17 @@ index 00000000000000..90f4361e28cd94
 +}
 diff --git a/src/runtime/backenderr_gen_nofallback_boring.go b/src/runtime/backenderr_gen_nofallback_boring.go
 new file mode 100644
-index 00000000000000..6db0ed6dc09639
+index 00000000000000..08926e5f836698
 --- /dev/null
 +++ b/src/runtime/backenderr_gen_nofallback_boring.go
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,20 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
 +
-+//go:build goexperiment.boringcrypto && !(goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan) && !goexperiment.allowcryptofallback
++//go:build goexperiment.boringcrypto && !(goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan) && !allowcryptofallback
 +
 +package runtime
 +
@@ -2926,26 +2955,22 @@ index 00000000000000..6db0ed6dc09639
 +	  goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan
 +	Please check your build environment and build command for a reason one or more of these tags weren't specified.
 +	
-+	If you only performed a Go toolset upgrade and didn't expect this error, your code was likely depending on fallback to Go standard library crypto.
-+	As of Go 1.21, Go crypto fallback is a build error. This helps prevent accidental fallback.
-+	Removing boringcrypto will restore pre-1.21 behavior by intentionally using Go standard library crypto.
-+	
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`
 +}
 diff --git a/src/runtime/backenderr_gen_nofallback_cng.go b/src/runtime/backenderr_gen_nofallback_cng.go
 new file mode 100644
-index 00000000000000..ae7f798ea41225
+index 00000000000000..fcd86ebaa37814
 --- /dev/null
 +++ b/src/runtime/backenderr_gen_nofallback_cng.go
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,20 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
 +
-+//go:build goexperiment.cngcrypto && !(goexperiment.cngcrypto && windows) && !goexperiment.allowcryptofallback
++//go:build goexperiment.cngcrypto && !(goexperiment.cngcrypto && windows) && !allowcryptofallback
 +
 +package runtime
 +
@@ -2956,26 +2981,22 @@ index 00000000000000..ae7f798ea41225
 +	  goexperiment.cngcrypto && windows
 +	Please check your build environment and build command for a reason one or more of these tags weren't specified.
 +	
-+	If you only performed a Go toolset upgrade and didn't expect this error, your code was likely depending on fallback to Go standard library crypto.
-+	As of Go 1.21, Go crypto fallback is a build error. This helps prevent accidental fallback.
-+	Removing cngcrypto will restore pre-1.21 behavior by intentionally using Go standard library crypto.
-+	
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`
 +}
 diff --git a/src/runtime/backenderr_gen_nofallback_darwin.go b/src/runtime/backenderr_gen_nofallback_darwin.go
 new file mode 100644
-index 00000000000000..8a32f2cb25bda2
+index 00000000000000..bcca3e1a5a548d
 --- /dev/null
 +++ b/src/runtime/backenderr_gen_nofallback_darwin.go
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,20 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
 +
-+//go:build goexperiment.darwincrypto && !(goexperiment.darwincrypto && darwin && cgo) && !goexperiment.allowcryptofallback
++//go:build goexperiment.darwincrypto && !(goexperiment.darwincrypto && darwin && cgo) && !allowcryptofallback
 +
 +package runtime
 +
@@ -2986,26 +3007,22 @@ index 00000000000000..8a32f2cb25bda2
 +	  goexperiment.darwincrypto && darwin && cgo
 +	Please check your build environment and build command for a reason one or more of these tags weren't specified.
 +	
-+	If you only performed a Go toolset upgrade and didn't expect this error, your code was likely depending on fallback to Go standard library crypto.
-+	As of Go 1.21, Go crypto fallback is a build error. This helps prevent accidental fallback.
-+	Removing darwincrypto will restore pre-1.21 behavior by intentionally using Go standard library crypto.
-+	
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`
 +}
 diff --git a/src/runtime/backenderr_gen_nofallback_openssl.go b/src/runtime/backenderr_gen_nofallback_openssl.go
 new file mode 100644
-index 00000000000000..7e1679dfc37a23
+index 00000000000000..c88593ad85fc76
 --- /dev/null
 +++ b/src/runtime/backenderr_gen_nofallback_openssl.go
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,20 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
 +
-+//go:build goexperiment.opensslcrypto && !(goexperiment.opensslcrypto && linux && cgo) && !goexperiment.allowcryptofallback
++//go:build goexperiment.opensslcrypto && !(goexperiment.opensslcrypto && linux && cgo) && !allowcryptofallback
 +
 +package runtime
 +
@@ -3015,10 +3032,6 @@ index 00000000000000..7e1679dfc37a23
 +	Required build tags:
 +	  goexperiment.opensslcrypto && linux && cgo
 +	Please check your build environment and build command for a reason one or more of these tags weren't specified.
-+	
-+	If you only performed a Go toolset upgrade and didn't expect this error, your code was likely depending on fallback to Go standard library crypto.
-+	As of Go 1.21, Go crypto fallback is a build error. This helps prevent accidental fallback.
-+	Removing opensslcrypto will restore pre-1.21 behavior by intentionally using Go standard library crypto.
 +	
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -9,6 +9,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/cmd/compile/internal/ssa/fmahash_test.go  |   2 +-
  src/cmd/dist/test.go                          |   7 +
  src/cmd/internal/obj/x86/pcrelative_test.go   |   2 +-
+ src/cmd/internal/testdir/testdir_test.go      |  11 +
  src/cmd/link/internal/ld/ld_test.go           |   2 +-
  src/cmd/link/internal/ld/stackcheck_test.go   |   2 +-
  src/cmd/link/link_test.go                     |   4 +-
@@ -57,7 +58,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 53 files changed, 2715 insertions(+), 12 deletions(-)
+ 54 files changed, 2726 insertions(+), 12 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -184,6 +185,35 @@ index 1ca9ea22cf7182..3cf10b0933abc0 100644
  		filepath.Join(tmpdir, "output"))
  
  	cmd.Env = append(os.Environ(),
+diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
+index 7e7867d83f9c47..3e9c3d0ef7edf9 100644
+--- a/src/cmd/internal/testdir/testdir_test.go
++++ b/src/cmd/internal/testdir/testdir_test.go
+@@ -280,6 +280,10 @@ func (t test) expectFail() bool {
+ 		failureSets = append(failureSets, types2Failures32Bit)
+ 	}
+ 
++	if strings.Contains(goExperiment, "boringcrypto") {
++		failureSets = append(failureSets, boringFailures)
++	}
++
+ 	testName := path.Join(t.dir, t.goFile) // Test name is '/'-separated.
+ 
+ 	for _, set := range failureSets {
+@@ -1864,6 +1868,13 @@ var types2Failures32Bit = setOf(
+ 	"fixedbugs/issue23305.go", // large untyped int passed to println (32-bit)
+ )
+ 
++// List of files that fail with boringcrypto due
++// to it not supporting 32-bit architectures.
++var boringFailures = setOf(
++	"codegen/copy.go",
++	"codegen/memcombine.go",
++)
++
+ // In all of these cases, the 1.17 compiler reports reasonable errors, but either the
+ // 1.17 or 1.18 compiler report extra errors, so we can't match correctly on both. We
+ // now set the patterns to match correctly on all the 1.18 errors.
 diff --git a/src/cmd/link/internal/ld/ld_test.go b/src/cmd/link/internal/ld/ld_test.go
 index c954ab6bca7294..d455f4ecd2edbd 100644
 --- a/src/cmd/link/internal/ld/ld_test.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -7,6 +7,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .gitignore                                    |   2 +
  .../compile/internal/loopvar/loopvar_test.go  |   2 +-
  src/cmd/compile/internal/ssa/fmahash_test.go  |   2 +-
+ src/cmd/dist/test.go                          |   7 +
  src/cmd/internal/obj/x86/pcrelative_test.go   |   2 +-
  src/cmd/link/internal/ld/ld_test.go           |   2 +-
  src/cmd/link/internal/ld/stackcheck_test.go   |   2 +-
@@ -56,7 +57,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 52 files changed, 2708 insertions(+), 12 deletions(-)
+ 53 files changed, 2715 insertions(+), 12 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -138,6 +139,38 @@ index c563d5b8d9d01b..ed063d7ded8fd9 100644
  	// The hash-dependence on file path name is dodged by specifying "all hashes ending in 1" plus "all hashes ending in 0"
  	// i.e., all hashes.  This will print all the FMAs; this test is only interested in one of them (that should appear near the end).
  	cmd.Env = append(cmd.Env, "GOCOMPILEDEBUG=fmahash=1/0", "GOOS=linux", "GOARCH=arm64", "HOME="+tmpdir)
+diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
+index d335e4cfbce468..7e362c80be609a 100644
+--- a/src/cmd/dist/test.go
++++ b/src/cmd/dist/test.go
+@@ -847,6 +847,11 @@ func (t *tester) registerTests() {
+ 
+ 	// Test internal linking of PIE binaries where it is supported.
+ 	if t.internalLinkPIE() && !disablePIE {
++		var tags []string
++		if goos != "windows" {
++			// Linux and macOS don't support systemcrypto with CGO_ENABLED=0.
++			tags = append(tags, "allowcryptofallback")
++		}
+ 		t.registerTest("internal linking, -buildmode=pie",
+ 			&goTest{
+ 				variant:   "pie_internal",
+@@ -855,6 +860,7 @@ func (t *tester) registerTests() {
+ 				ldflags:   "-linkmode=internal",
+ 				env:       []string{"CGO_ENABLED=0"},
+ 				pkg:       "reflect",
++				tags:      tags,
+ 			})
+ 		t.registerTest("internal linking, -buildmode=pie",
+ 			&goTest{
+@@ -865,6 +871,7 @@ func (t *tester) registerTests() {
+ 				env:       []string{"CGO_ENABLED=0"},
+ 				pkg:       "crypto/internal/fips140test",
+ 				runTests:  "TestFIPSCheck",
++				tags:      tags,
+ 			})
+ 		// Also test a cgo package.
+ 		if t.cgoEnabled && t.internalLink() && !disablePIE {
 diff --git a/src/cmd/internal/obj/x86/pcrelative_test.go b/src/cmd/internal/obj/x86/pcrelative_test.go
 index 1ca9ea22cf7182..3cf10b0933abc0 100644
 --- a/src/cmd/internal/obj/x86/pcrelative_test.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -5,6 +5,13 @@ Subject: [PATCH] Implement crypto/internal/backend
 
 ---
  .gitignore                                    |   2 +
+ .../compile/internal/loopvar/loopvar_test.go  |   2 +-
+ src/cmd/compile/internal/ssa/fmahash_test.go  |   2 +-
+ src/cmd/internal/obj/x86/pcrelative_test.go   |   2 +-
+ src/cmd/link/internal/ld/ld_test.go           |   2 +-
+ src/cmd/link/internal/ld/stackcheck_test.go   |   2 +-
+ src/cmd/link/link_test.go                     |   4 +-
+ src/cmd/vet/vet_test.go                       |   2 +-
  .../backend/allocryptofallback_off.go         |   9 +
  .../internal/backend/allocryptofallback_on.go |   9 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
@@ -48,7 +55,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
- 44 files changed, 2699 insertions(+), 3 deletions(-)
+ src/syscall/exec_linux_test.go                |   2 +-
+ 52 files changed, 2708 insertions(+), 12 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -104,6 +112,106 @@ index c6512e64a4ef39..b3b01db73b009d 100644
  # This file includes artifacts of Go build that should not be checked in.
  # For files created by specific development environment (e.g. editor),
  # use alternative ways to exclude files from git.
+diff --git a/src/cmd/compile/internal/loopvar/loopvar_test.go b/src/cmd/compile/internal/loopvar/loopvar_test.go
+index b19962f0fd4023..ce018311a35d7d 100644
+--- a/src/cmd/compile/internal/loopvar/loopvar_test.go
++++ b/src/cmd/compile/internal/loopvar/loopvar_test.go
+@@ -189,7 +189,7 @@ func TestLoopVarHashes(t *testing.T) {
+ 		// -trimpath is necessary so we get the same answer no matter where the
+ 		// Go repository is checked out. This is not normally a concern since people
+ 		// do not normally rely on the meaning of specific hashes.
+-		cmd := testenv.Command(t, gocmd, "run", "-trimpath", root)
++		cmd := testenv.Command(t, gocmd, "run", "-trimpath", "-tags=allowcryptofallback", root)
+ 		cmd.Env = append(cmd.Env, "GOCOMPILEDEBUG=loopvarhash="+hash, "HOME="+tmpdir)
+ 		cmd.Dir = filepath.Join("testdata", "inlines")
+ 
+diff --git a/src/cmd/compile/internal/ssa/fmahash_test.go b/src/cmd/compile/internal/ssa/fmahash_test.go
+index c563d5b8d9d01b..ed063d7ded8fd9 100644
+--- a/src/cmd/compile/internal/ssa/fmahash_test.go
++++ b/src/cmd/compile/internal/ssa/fmahash_test.go
+@@ -33,7 +33,7 @@ func TestFmaHash(t *testing.T) {
+ 	tmpdir := t.TempDir()
+ 	source := filepath.Join("testdata", "fma.go")
+ 	output := filepath.Join(tmpdir, "fma.exe")
+-	cmd := testenv.Command(t, gocmd, "build", "-o", output, source)
++	cmd := testenv.Command(t, gocmd, "build", "-o", output, "-tags=allowcryptofallback", source)
+ 	// The hash-dependence on file path name is dodged by specifying "all hashes ending in 1" plus "all hashes ending in 0"
+ 	// i.e., all hashes.  This will print all the FMAs; this test is only interested in one of them (that should appear near the end).
+ 	cmd.Env = append(cmd.Env, "GOCOMPILEDEBUG=fmahash=1/0", "GOOS=linux", "GOARCH=arm64", "HOME="+tmpdir)
+diff --git a/src/cmd/internal/obj/x86/pcrelative_test.go b/src/cmd/internal/obj/x86/pcrelative_test.go
+index 1ca9ea22cf7182..3cf10b0933abc0 100644
+--- a/src/cmd/internal/obj/x86/pcrelative_test.go
++++ b/src/cmd/internal/obj/x86/pcrelative_test.go
+@@ -56,7 +56,7 @@ func objdumpOutput(t *testing.T, mname, source string) []byte {
+ 	}
+ 
+ 	cmd := testenv.Command(t,
+-		testenv.GoToolPath(t), "build", "-o",
++		testenv.GoToolPath(t), "build", "-tags=allowcryptofallback", "-o",
+ 		filepath.Join(tmpdir, "output"))
+ 
+ 	cmd.Env = append(os.Environ(),
+diff --git a/src/cmd/link/internal/ld/ld_test.go b/src/cmd/link/internal/ld/ld_test.go
+index c954ab6bca7294..d455f4ecd2edbd 100644
+--- a/src/cmd/link/internal/ld/ld_test.go
++++ b/src/cmd/link/internal/ld/ld_test.go
+@@ -417,7 +417,7 @@ func d()
+ 	if err := os.WriteFile(filepath.Join(tmpDir, "x.go"), []byte(main), 0644); err != nil {
+ 		t.Fatalf("failed to write main: %v\n", err)
+ 	}
+-	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal")
++	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal", "-tags=allowcryptofallback")
+ 	cmd.Dir = tmpDir
+ 	cmd.Env = append(os.Environ(), "GOARCH=riscv64", "GOOS=linux")
+ 	out, err := cmd.CombinedOutput()
+diff --git a/src/cmd/link/internal/ld/stackcheck_test.go b/src/cmd/link/internal/ld/stackcheck_test.go
+index dd7e20528f0959..693d4ca473f95a 100644
+--- a/src/cmd/link/internal/ld/stackcheck_test.go
++++ b/src/cmd/link/internal/ld/stackcheck_test.go
+@@ -19,7 +19,7 @@ func TestStackCheckOutput(t *testing.T) {
+ 	testenv.MustHaveGoBuild(t)
+ 	t.Parallel()
+ 
+-	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-o", os.DevNull, "./testdata/stackcheck")
++	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-tags=allowcryptofallback", "-o", os.DevNull, "./testdata/stackcheck")
+ 	// The rules for computing frame sizes on all of the
+ 	// architectures are complicated, so just do this on amd64.
+ 	cmd.Env = append(os.Environ(), "GOARCH=amd64", "GOOS=linux")
+diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
+index 53c4ee77fed4b4..43effb152f63f5 100644
+--- a/src/cmd/link/link_test.go
++++ b/src/cmd/link/link_test.go
+@@ -167,7 +167,7 @@ TEXT ·x(SB),0,$0
+         MOVD ·zero(SB), AX
+         RET
+ `)
+-	cmd := testenv.Command(t, testenv.GoToolPath(t), "build")
++	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-tags=allowcryptofallback")
+ 	cmd.Dir = tmpdir
+ 	cmd.Env = append(os.Environ(),
+ 		"GOARCH=amd64", "GOOS=linux", "GOPATH="+filepath.Join(tmpdir, "_gopath"))
+@@ -370,7 +370,7 @@ func TestMachOBuildVersion(t *testing.T) {
+ 	}
+ 
+ 	exe := filepath.Join(tmpdir, "main")
+-	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal", "-o", exe, src)
++	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal", "-tags=allowcryptofallback", "-o", exe, src)
+ 	cmd.Env = append(os.Environ(),
+ 		"CGO_ENABLED=0",
+ 		"GOOS=darwin",
+diff --git a/src/cmd/vet/vet_test.go b/src/cmd/vet/vet_test.go
+index 54eabca938c3a9..56546c413b330c 100644
+--- a/src/cmd/vet/vet_test.go
++++ b/src/cmd/vet/vet_test.go
+@@ -38,7 +38,7 @@ func vetPath(t testing.TB) string {
+ }
+ 
+ func vetCmd(t *testing.T, arg, pkg string) *exec.Cmd {
+-	cmd := testenv.Command(t, testenv.GoToolPath(t), "vet", "-vettool="+vetPath(t), arg, path.Join("cmd/vet/testdata", pkg))
++	cmd := testenv.Command(t, testenv.GoToolPath(t), "vet", "-tags=allowcryptofallback", "-vettool="+vetPath(t), arg, path.Join("cmd/vet/testdata", pkg))
+ 	cmd.Env = os.Environ()
+ 	return cmd
+ }
 diff --git a/src/crypto/internal/backend/allocryptofallback_off.go b/src/crypto/internal/backend/allocryptofallback_off.go
 new file mode 100644
 index 00000000000000..7718cc02f48556
@@ -3094,3 +3202,16 @@ index 831ee67afc952d..d2f00d57c10286 100644
 +func crypto_backend_runtime_arg0() string {
 +	return boring_runtime_arg0()
 +}
+diff --git a/src/syscall/exec_linux_test.go b/src/syscall/exec_linux_test.go
+index 69d49169446d1c..9c16f665d4a223 100644
+--- a/src/syscall/exec_linux_test.go
++++ b/src/syscall/exec_linux_test.go
+@@ -299,7 +299,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
+ 		}
+ 	})
+ 
+-	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
++	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-tags=allowcryptofallback", "-o", x, "syscall")
+ 	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
+ 	if o, err := cmd.CombinedOutput(); err != nil {
+ 		t.Fatalf("%v: %v\n%s", cmd, err, o)

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/cmd/compile/internal/ssa/fmahash_test.go  |   2 +-
  src/cmd/dist/test.go                          |   7 +
  src/cmd/internal/obj/x86/pcrelative_test.go   |   2 +-
- src/cmd/internal/testdir/testdir_test.go      |  11 +
+ src/cmd/internal/testdir/testdir_test.go      |  12 +
  src/cmd/link/internal/ld/ld_test.go           |   2 +-
  src/cmd/link/internal/ld/stackcheck_test.go   |   2 +-
  src/cmd/link/link_test.go                     |   4 +-
@@ -58,7 +58,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 54 files changed, 2726 insertions(+), 12 deletions(-)
+ 54 files changed, 2727 insertions(+), 12 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -186,7 +186,7 @@ index 1ca9ea22cf7182..3cf10b0933abc0 100644
  
  	cmd.Env = append(os.Environ(),
 diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index 7e7867d83f9c47..3e9c3d0ef7edf9 100644
+index 7e7867d83f9c47..d593aaa5f7adb5 100644
 --- a/src/cmd/internal/testdir/testdir_test.go
 +++ b/src/cmd/internal/testdir/testdir_test.go
 @@ -280,6 +280,10 @@ func (t test) expectFail() bool {
@@ -200,7 +200,7 @@ index 7e7867d83f9c47..3e9c3d0ef7edf9 100644
  	testName := path.Join(t.dir, t.goFile) // Test name is '/'-separated.
  
  	for _, set := range failureSets {
-@@ -1864,6 +1868,13 @@ var types2Failures32Bit = setOf(
+@@ -1864,6 +1868,14 @@ var types2Failures32Bit = setOf(
  	"fixedbugs/issue23305.go", // large untyped int passed to println (32-bit)
  )
  
@@ -209,6 +209,7 @@ index 7e7867d83f9c47..3e9c3d0ef7edf9 100644
 +var boringFailures = setOf(
 +	"codegen/copy.go",
 +	"codegen/memcombine.go",
++	"codegen/stack.go",
 +)
 +
  // In all of these cases, the 1.17 compiler reports reasonable errors, but either the


### PR DESCRIPTION
The `allowcryptofallback` was a mechanism to facilitate upgrading to Go 1.21. In that release we stopped falling back to go crypto by default, and the `allowcryptofallback` restored the old behavior (hurting compliance, ofc).

Go 1.21 is not supported anymore, so that use case is no longer relevant. I did a cursory search in GitHub and AzDO and found no real uses of `GOEXPERIMENT=allowcryptofallback` other than in this repo.

Given these facts, we can downgrade it to a simple build tag, which has less visibility. I've also removed most of the related mentions from our FIPS guide, as we were almost spending more time describing how to use `GOEXPERIMENT=allowcryptofallback` than explaining how to be compliant.

Note that our CI code no longer sets `allowcryptofallback` globally, but on a case by case basis. This mainly because build tags are not passed around as good as goexperiments in `go tool dist test`. Instead of making sure they are properly honored I took the approach of being explicit about which tests require `allowcryptofallback` so that we can fix them upstream.

This PR helps simplifying our code and docs in preparation for #1352.