### PR TITLE
Move backend error files to the `crypto` package

### DIFF
--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement crypto/internal/backend
 
 ---
  .gitignore                                    |   2 +
- src/cmd/dist/test.go                          |   6 +
+ src/cmd/dist/test.go                          |   7 +
  .../backend/allocryptofallback_off.go         |   9 +
  .../internal/backend/allocryptofallback_on.go |   9 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
@@ -50,7 +50,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2704 insertions(+), 4 deletions(-)
+ 46 files changed, 2705 insertions(+), 4 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -107,7 +107,7 @@ index c6512e64a4ef39..b3b01db73b009d 100644
  # For files created by specific development environment (e.g. editor),
  # use alternative ways to exclude files from git.
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index d335e4cfbce468..786dcdf971dbb1 100644
+index d335e4cfbce468..7e362c80be609a 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -847,6 +847,11 @@ func (t *tester) registerTests() {
@@ -122,7 +122,15 @@ index d335e4cfbce468..786dcdf971dbb1 100644
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
  				variant:   "pie_internal",
-@@ -865,6 +870,7 @@ func (t *tester) registerTests() {
+@@ -855,6 +860,7 @@ func (t *tester) registerTests() {
+ 				ldflags:   "-linkmode=internal",
+ 				env:       []string{"CGO_ENABLED=0"},
+ 				pkg:       "reflect",
++				tags:      tags,
+ 			})
+ 		t.registerTest("internal linking, -buildmode=pie",
+ 			&goTest{
+@@ -865,6 +871,7 @@ func (t *tester) registerTests() {
  				env:       []string{"CGO_ENABLED=0"},
  				pkg:       "crypto/internal/fips140test",
  				runTests:  "TestFIPSCheck",

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -5,15 +5,7 @@ Subject: [PATCH] Implement crypto/internal/backend
 
 ---
  .gitignore                                    |   2 +
- .../compile/internal/loopvar/loopvar_test.go  |   2 +-
- src/cmd/compile/internal/ssa/fmahash_test.go  |   2 +-
- src/cmd/dist/test.go                          |   7 +
- src/cmd/internal/obj/x86/pcrelative_test.go   |   2 +-
- src/cmd/internal/testdir/testdir_test.go      |  12 +
- src/cmd/link/internal/ld/ld_test.go           |   2 +-
- src/cmd/link/internal/ld/stackcheck_test.go   |   2 +-
- src/cmd/link/link_test.go                     |   4 +-
- src/cmd/vet/vet_test.go                       |   2 +-
+ src/cmd/dist/test.go                          |   6 +
  .../backend/allocryptofallback_off.go         |   9 +
  .../internal/backend/allocryptofallback_on.go |   9 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
@@ -57,8 +49,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../zbackenderrsystemcrypto_nobackend.go      |  16 +
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
- src/syscall/exec_linux_test.go                |   2 +-
- 54 files changed, 2725 insertions(+), 12 deletions(-)
+ 45 files changed, 2703 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -114,34 +105,8 @@ index c6512e64a4ef39..b3b01db73b009d 100644
  # This file includes artifacts of Go build that should not be checked in.
  # For files created by specific development environment (e.g. editor),
  # use alternative ways to exclude files from git.
-diff --git a/src/cmd/compile/internal/loopvar/loopvar_test.go b/src/cmd/compile/internal/loopvar/loopvar_test.go
-index b19962f0fd4023..ce018311a35d7d 100644
---- a/src/cmd/compile/internal/loopvar/loopvar_test.go
-+++ b/src/cmd/compile/internal/loopvar/loopvar_test.go
-@@ -189,7 +189,7 @@ func TestLoopVarHashes(t *testing.T) {
- 		// -trimpath is necessary so we get the same answer no matter where the
- 		// Go repository is checked out. This is not normally a concern since people
- 		// do not normally rely on the meaning of specific hashes.
--		cmd := testenv.Command(t, gocmd, "run", "-trimpath", root)
-+		cmd := testenv.Command(t, gocmd, "run", "-trimpath", "-tags=allowcryptofallback", root)
- 		cmd.Env = append(cmd.Env, "GOCOMPILEDEBUG=loopvarhash="+hash, "HOME="+tmpdir)
- 		cmd.Dir = filepath.Join("testdata", "inlines")
- 
-diff --git a/src/cmd/compile/internal/ssa/fmahash_test.go b/src/cmd/compile/internal/ssa/fmahash_test.go
-index c563d5b8d9d01b..ed063d7ded8fd9 100644
---- a/src/cmd/compile/internal/ssa/fmahash_test.go
-+++ b/src/cmd/compile/internal/ssa/fmahash_test.go
-@@ -33,7 +33,7 @@ func TestFmaHash(t *testing.T) {
- 	tmpdir := t.TempDir()
- 	source := filepath.Join("testdata", "fma.go")
- 	output := filepath.Join(tmpdir, "fma.exe")
--	cmd := testenv.Command(t, gocmd, "build", "-o", output, source)
-+	cmd := testenv.Command(t, gocmd, "build", "-o", output, "-tags=allowcryptofallback", source)
- 	// The hash-dependence on file path name is dodged by specifying "all hashes ending in 1" plus "all hashes ending in 0"
- 	// i.e., all hashes.  This will print all the FMAs; this test is only interested in one of them (that should appear near the end).
- 	cmd.Env = append(cmd.Env, "GOCOMPILEDEBUG=fmahash=1/0", "GOOS=linux", "GOARCH=arm64", "HOME="+tmpdir)
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index d335e4cfbce468..7e362c80be609a 100644
+index d335e4cfbce468..786dcdf971dbb1 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -847,6 +847,11 @@ func (t *tester) registerTests() {
@@ -156,15 +121,7 @@ index d335e4cfbce468..7e362c80be609a 100644
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
  				variant:   "pie_internal",
-@@ -855,6 +860,7 @@ func (t *tester) registerTests() {
- 				ldflags:   "-linkmode=internal",
- 				env:       []string{"CGO_ENABLED=0"},
- 				pkg:       "reflect",
-+				tags:      tags,
- 			})
- 		t.registerTest("internal linking, -buildmode=pie",
- 			&goTest{
-@@ -865,6 +871,7 @@ func (t *tester) registerTests() {
+@@ -865,6 +870,7 @@ func (t *tester) registerTests() {
  				env:       []string{"CGO_ENABLED=0"},
  				pkg:       "crypto/internal/fips140test",
  				runTests:  "TestFIPSCheck",
@@ -172,110 +129,6 @@ index d335e4cfbce468..7e362c80be609a 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-diff --git a/src/cmd/internal/obj/x86/pcrelative_test.go b/src/cmd/internal/obj/x86/pcrelative_test.go
-index 1ca9ea22cf7182..3cf10b0933abc0 100644
---- a/src/cmd/internal/obj/x86/pcrelative_test.go
-+++ b/src/cmd/internal/obj/x86/pcrelative_test.go
-@@ -56,7 +56,7 @@ func objdumpOutput(t *testing.T, mname, source string) []byte {
- 	}
- 
- 	cmd := testenv.Command(t,
--		testenv.GoToolPath(t), "build", "-o",
-+		testenv.GoToolPath(t), "build", "-tags=allowcryptofallback", "-o",
- 		filepath.Join(tmpdir, "output"))
- 
- 	cmd.Env = append(os.Environ(),
-diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index 7e7867d83f9c47..d593aaa5f7adb5 100644
---- a/src/cmd/internal/testdir/testdir_test.go
-+++ b/src/cmd/internal/testdir/testdir_test.go
-@@ -280,6 +280,10 @@ func (t test) expectFail() bool {
- 		failureSets = append(failureSets, types2Failures32Bit)
- 	}
- 
-+	if strings.Contains(goExperiment, "boringcrypto") {
-+		failureSets = append(failureSets, boringFailures)
-+	}
-+
- 	testName := path.Join(t.dir, t.goFile) // Test name is '/'-separated.
- 
- 	for _, set := range failureSets {
-@@ -1864,6 +1868,14 @@ var types2Failures32Bit = setOf(
- 	"fixedbugs/issue23305.go", // large untyped int passed to println (32-bit)
- )
- 
-+// List of files that fail with boringcrypto due
-+// to it not supporting 32-bit architectures.
-+var boringFailures = setOf(
-+	"codegen/copy.go",
-+	"codegen/memcombine.go",
-+	"codegen/stack.go",
-+)
-+
- // In all of these cases, the 1.17 compiler reports reasonable errors, but either the
- // 1.17 or 1.18 compiler report extra errors, so we can't match correctly on both. We
- // now set the patterns to match correctly on all the 1.18 errors.
-diff --git a/src/cmd/link/internal/ld/ld_test.go b/src/cmd/link/internal/ld/ld_test.go
-index c954ab6bca7294..d455f4ecd2edbd 100644
---- a/src/cmd/link/internal/ld/ld_test.go
-+++ b/src/cmd/link/internal/ld/ld_test.go
-@@ -417,7 +417,7 @@ func d()
- 	if err := os.WriteFile(filepath.Join(tmpDir, "x.go"), []byte(main), 0644); err != nil {
- 		t.Fatalf("failed to write main: %v\n", err)
- 	}
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal")
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal", "-tags=allowcryptofallback")
- 	cmd.Dir = tmpDir
- 	cmd.Env = append(os.Environ(), "GOARCH=riscv64", "GOOS=linux")
- 	out, err := cmd.CombinedOutput()
-diff --git a/src/cmd/link/internal/ld/stackcheck_test.go b/src/cmd/link/internal/ld/stackcheck_test.go
-index dd7e20528f0959..693d4ca473f95a 100644
---- a/src/cmd/link/internal/ld/stackcheck_test.go
-+++ b/src/cmd/link/internal/ld/stackcheck_test.go
-@@ -19,7 +19,7 @@ func TestStackCheckOutput(t *testing.T) {
- 	testenv.MustHaveGoBuild(t)
- 	t.Parallel()
- 
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-o", os.DevNull, "./testdata/stackcheck")
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-tags=allowcryptofallback", "-o", os.DevNull, "./testdata/stackcheck")
- 	// The rules for computing frame sizes on all of the
- 	// architectures are complicated, so just do this on amd64.
- 	cmd.Env = append(os.Environ(), "GOARCH=amd64", "GOOS=linux")
-diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
-index 53c4ee77fed4b4..43effb152f63f5 100644
---- a/src/cmd/link/link_test.go
-+++ b/src/cmd/link/link_test.go
-@@ -167,7 +167,7 @@ TEXT ·x(SB),0,$0
-         MOVD ·zero(SB), AX
-         RET
- `)
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "build")
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-tags=allowcryptofallback")
- 	cmd.Dir = tmpdir
- 	cmd.Env = append(os.Environ(),
- 		"GOARCH=amd64", "GOOS=linux", "GOPATH="+filepath.Join(tmpdir, "_gopath"))
-@@ -370,7 +370,7 @@ func TestMachOBuildVersion(t *testing.T) {
- 	}
- 
- 	exe := filepath.Join(tmpdir, "main")
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal", "-o", exe, src)
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "build", "-ldflags=-linkmode=internal", "-tags=allowcryptofallback", "-o", exe, src)
- 	cmd.Env = append(os.Environ(),
- 		"CGO_ENABLED=0",
- 		"GOOS=darwin",
-diff --git a/src/cmd/vet/vet_test.go b/src/cmd/vet/vet_test.go
-index 54eabca938c3a9..56546c413b330c 100644
---- a/src/cmd/vet/vet_test.go
-+++ b/src/cmd/vet/vet_test.go
-@@ -38,7 +38,7 @@ func vetPath(t testing.TB) string {
- }
- 
- func vetCmd(t *testing.T, arg, pkg string) *exec.Cmd {
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "vet", "-vettool="+vetPath(t), arg, path.Join("cmd/vet/testdata", pkg))
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "vet", "-tags=allowcryptofallback", "-vettool="+vetPath(t), arg, path.Join("cmd/vet/testdata", pkg))
- 	cmd.Env = os.Environ()
- 	return cmd
- }
 diff --git a/src/crypto/internal/backend/allocryptofallback_off.go b/src/crypto/internal/backend/allocryptofallback_off.go
 new file mode 100644
 index 00000000000000..7718cc02f48556
@@ -3264,16 +3117,3 @@ index 831ee67afc952d..d2f00d57c10286 100644
 +func crypto_backend_runtime_arg0() string {
 +	return boring_runtime_arg0()
 +}
-diff --git a/src/syscall/exec_linux_test.go b/src/syscall/exec_linux_test.go
-index 69d49169446d1c..9c16f665d4a223 100644
---- a/src/syscall/exec_linux_test.go
-+++ b/src/syscall/exec_linux_test.go
-@@ -299,7 +299,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
- 		}
- 	})
- 
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-tags=allowcryptofallback", "-o", x, "syscall")
- 	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
- 	if o, err := cmd.CombinedOutput(); err != nil {
- 		t.Fatalf("%v: %v\n%s", cmd, err, o)

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -49,7 +49,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../zbackenderrsystemcrypto_nobackend.go      |  16 +
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2703 insertions(+), 3 deletions(-)
+ src/syscall/exec_linux_test.go                |   2 +-
+ 46 files changed, 2704 insertions(+), 4 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -3117,3 +3118,16 @@ index 831ee67afc952d..d2f00d57c10286 100644
 +func crypto_backend_runtime_arg0() string {
 +	return boring_runtime_arg0()
 +}
+diff --git a/src/syscall/exec_linux_test.go b/src/syscall/exec_linux_test.go
+index 69d49169446d1c..9c16f665d4a223 100644
+--- a/src/syscall/exec_linux_test.go
++++ b/src/syscall/exec_linux_test.go
+@@ -299,7 +299,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
+ 		}
+ 	})
+ 
+-	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
++	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-tags=allowcryptofallback", "-o", x, "syscall")
+ 	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
+ 	if o, err := cmd.CombinedOutput(); err != nil {
+ 		t.Fatalf("%v: %v\n%s", cmd, err, o)

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -18,7 +18,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../internal/backend/allocryptofallback_on.go |   9 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
- .../internal/backend/backendgen_test.go       | 280 +++++++++++++
+ .../internal/backend/backendgen_test.go       | 278 +++++++++++++
  src/crypto/internal/backend/bbig/big.go       |  17 +
  .../internal/backend/bbig/big_boring.go       |  12 +
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
@@ -43,22 +43,22 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
  src/crypto/internal/backend/openssl_linux.go  | 339 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
+ src/crypto/zbackenderrconflict_boring_cng.go  |  17 +
+ .../zbackenderrconflict_boring_darwin.go      |  17 +
+ .../zbackenderrconflict_boring_openssl.go     |  17 +
+ src/crypto/zbackenderrconflict_cng_darwin.go  |  17 +
+ src/crypto/zbackenderrconflict_cng_openssl.go |  17 +
+ .../zbackenderrconflict_darwin_openssl.go     |  17 +
+ src/crypto/zbackenderrnofallback_boring.go    |  20 +
+ src/crypto/zbackenderrnofallback_cng.go       |  20 +
+ src/crypto/zbackenderrnofallback_darwin.go    |  20 +
+ src/crypto/zbackenderrnofallback_openssl.go   |  20 +
+ .../zbackenderrrequirefips_nosystemcrypto.go  |  17 +
+ .../zbackenderrsystemcrypto_nobackend.go      |  16 +
  src/go/build/deps_test.go                     |  27 +-
- .../backenderr_gen_conflict_boring_cng.go     |  17 +
- .../backenderr_gen_conflict_boring_darwin.go  |  17 +
- .../backenderr_gen_conflict_boring_openssl.go |  17 +
- .../backenderr_gen_conflict_cng_darwin.go     |  17 +
- .../backenderr_gen_conflict_cng_openssl.go    |  17 +
- .../backenderr_gen_conflict_darwin_openssl.go |  17 +
- .../backenderr_gen_nofallback_boring.go       |  20 +
- src/runtime/backenderr_gen_nofallback_cng.go  |  20 +
- .../backenderr_gen_nofallback_darwin.go       |  20 +
- .../backenderr_gen_nofallback_openssl.go      |  20 +
- ...ckenderr_gen_requirefips_nosystemcrypto.go |  17 +
- .../backenderr_gen_systemcrypto_nobackend.go  |  16 +
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 54 files changed, 2727 insertions(+), 12 deletions(-)
+ 54 files changed, 2725 insertions(+), 12 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -88,18 +88,18 @@ Subject: [PATCH] Implement crypto/internal/backend
  create mode 100644 src/crypto/internal/backend/nobackend.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/crypto/internal/backend/stub.s
- create mode 100644 src/runtime/backenderr_gen_conflict_boring_cng.go
- create mode 100644 src/runtime/backenderr_gen_conflict_boring_darwin.go
- create mode 100644 src/runtime/backenderr_gen_conflict_boring_openssl.go
- create mode 100644 src/runtime/backenderr_gen_conflict_cng_darwin.go
- create mode 100644 src/runtime/backenderr_gen_conflict_cng_openssl.go
- create mode 100644 src/runtime/backenderr_gen_conflict_darwin_openssl.go
- create mode 100644 src/runtime/backenderr_gen_nofallback_boring.go
- create mode 100644 src/runtime/backenderr_gen_nofallback_cng.go
- create mode 100644 src/runtime/backenderr_gen_nofallback_darwin.go
- create mode 100644 src/runtime/backenderr_gen_nofallback_openssl.go
- create mode 100644 src/runtime/backenderr_gen_requirefips_nosystemcrypto.go
- create mode 100644 src/runtime/backenderr_gen_systemcrypto_nobackend.go
+ create mode 100644 src/crypto/zbackenderrconflict_boring_cng.go
+ create mode 100644 src/crypto/zbackenderrconflict_boring_darwin.go
+ create mode 100644 src/crypto/zbackenderrconflict_boring_openssl.go
+ create mode 100644 src/crypto/zbackenderrconflict_cng_darwin.go
+ create mode 100644 src/crypto/zbackenderrconflict_cng_openssl.go
+ create mode 100644 src/crypto/zbackenderrconflict_darwin_openssl.go
+ create mode 100644 src/crypto/zbackenderrnofallback_boring.go
+ create mode 100644 src/crypto/zbackenderrnofallback_cng.go
+ create mode 100644 src/crypto/zbackenderrnofallback_darwin.go
+ create mode 100644 src/crypto/zbackenderrnofallback_openssl.go
+ create mode 100644 src/crypto/zbackenderrrequirefips_nosystemcrypto.go
+ create mode 100644 src/crypto/zbackenderrsystemcrypto_nobackend.go
 
 diff --git a/.gitignore b/.gitignore
 index c6512e64a4ef39..b3b01db73b009d 100644
@@ -370,10 +370,10 @@ index 00000000000000..acf0113bbefb6c
 +//go:generate go test -run TestGenerated -fix
 diff --git a/src/crypto/internal/backend/backendgen_test.go b/src/crypto/internal/backend/backendgen_test.go
 new file mode 100644
-index 00000000000000..1da2926a7b960f
+index 00000000000000..063e0bb4948236
 --- /dev/null
 +++ b/src/crypto/internal/backend/backendgen_test.go
-@@ -0,0 +1,280 @@
+@@ -0,0 +1,278 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -395,13 +395,13 @@ index 00000000000000..1da2926a7b960f
 +
 +var fix = flag.Bool("fix", false, "if true, update the generated files to the wanted value")
 +
-+const runtimePackageDir = "../../../runtime"
++const cryptoPackageDir = "../../../crypto"
 +
 +// backendErrPrefix is the prefix of the generated backend error files. Any file
-+// in the runtime package with this prefix will be considered a backend error
++// in the crypto package with this prefix will be considered a backend error
 +// file, so it's important that this prefix is unique or this generator may
 +// delete unexpected files.
-+const backendErrPrefix = "backenderr_gen_"
++const backendErrPrefix = "zbackenderr"
 +
 +const generateInstruction = "run 'go generate crypto/internal/backend' to fix"
 +
@@ -471,29 +471,27 @@ index 00000000000000..1da2926a7b960f
 +// The error files are Go files that detect issues with the backend selection
 +// and report an error at compile time.
 +//
-+// The issue detection files are placed in the runtime package rather than the
++// The issue detection files are placed in the crypto package rather than the
 +// crypto/internal/backend package to make sure these helpful errors will show
 +// up. If the files were in the backend package, DuplicateDecl and other errors
 +// would show up first, causing these informative errors to be skipped because
-+// there are too many total errors already reported. The errors would also show
-+// up if we put the files in the crypto package rather than the runtime package.
-+// (Crypto is imported before the backend backage, so the errors would show up.)
-+// However, then these errors would show up only if the Go program is using
-+// crypto. This could cause a confusing situation: if the user has a
-+// misconfigured backend and doesn't use crypto in their Go app, they will not
-+// get any errors. If they start using crypto later, they would only then get an
-+// error, but the cause would be much less apparent.
++// there are too many total errors already reported.
++//
++// Issues will only be detected if the binary uses a crypto package, else
++// the issue dection files will not be built and the errors will not be reported.
++// That done on purpose to avoid putting unnecessary restrictions on applications
++// that do not use crypto, like for example requiring cgo.
 +func TestGeneratedBackendErrorFiles(t *testing.T) {
 +	// Chip away at a list of files that should come from this generator.
 +	// Any remaining are unexpected.
 +	existingFiles := make(map[string]struct{})
-+	entries, err := os.ReadDir(runtimePackageDir)
++	entries, err := os.ReadDir(cryptoPackageDir)
 +	if err != nil {
 +		t.Fatal(err)
 +	}
 +	for _, e := range entries {
 +		if strings.HasPrefix(e.Name(), backendErrPrefix) && strings.HasSuffix(e.Name(), ".go") {
-+			existingFiles[filepath.Join(runtimePackageDir, e.Name())] = struct{}{}
++			existingFiles[filepath.Join(cryptoPackageDir, e.Name())] = struct{}{}
 +		}
 +	}
 +
@@ -530,7 +528,7 @@ index 00000000000000..1da2926a7b960f
 +func testConflict(t *testing.T, a, b string) string {
 +	return testErrorFile(
 +		t,
-+		filepath.Join(runtimePackageDir, backendErrPrefix+"conflict_"+a+"_"+b+".go"),
++		filepath.Join(cryptoPackageDir, backendErrPrefix+"conflict_"+a+"_"+b+".go"),
 +		"//go:build goexperiment."+a+"crypto && goexperiment."+b+"crypto",
 +		"The "+a+" and "+b+" backends are both enabled, but they are mutually exclusive.",
 +		"Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.")
@@ -548,7 +546,7 @@ index 00000000000000..1da2926a7b960f
 +	}
 +	return testErrorFile(
 +		t,
-+		filepath.Join(runtimePackageDir, backendErrPrefix+"nofallback_"+backend.name+".go"),
++		filepath.Join(cryptoPackageDir, backendErrPrefix+"nofallback_"+backend.name+".go"),
 +		"//go:build "+c.String(),
 +		"The "+expTag.String()+" tag is specified, but other tags required to enable that backend were not met.",
 +		"Required build tags:",
@@ -566,7 +564,7 @@ index 00000000000000..1da2926a7b960f
 +	}
 +	return testErrorFile(
 +		t,
-+		filepath.Join(runtimePackageDir, backendErrPrefix+"systemcrypto_nobackend.go"),
++		filepath.Join(cryptoPackageDir, backendErrPrefix+"systemcrypto_nobackend.go"),
 +		constraint,
 +		"The systemcrypto feature is enabled, but it was unable to enable an appropriate crypto backend for the target GOOS.")
 +}
@@ -574,7 +572,7 @@ index 00000000000000..1da2926a7b960f
 +func testRequireFIPSWithoutBackend(t *testing.T) string {
 +	return testErrorFile(
 +		t,
-+		filepath.Join(runtimePackageDir, backendErrPrefix+"requirefips_nosystemcrypto.go"),
++		filepath.Join(cryptoPackageDir, backendErrPrefix+"requirefips_nosystemcrypto.go"),
 +		"//go:build requirefips && !goexperiment.systemcrypto",
 +		"The requirefips tag is enabled, but no crypto backend is enabled.",
 +		"A crypto backend is required to enable FIPS mode.")
@@ -589,7 +587,7 @@ index 00000000000000..1da2926a7b960f
 +// license that can be found in the LICENSE file.
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "` + backendErrPrefix + `".`
-+	c := header + "\n\n" + constraint + "\n\npackage runtime\n\nfunc init() {\n\t`\n"
++	c := header + "\n\n" + constraint + "\n\npackage crypto\n\nfunc init() {\n\t`\n"
 +	for _, m := range message {
 +		c += "\t" + m + "\n"
 +	}
@@ -2905,6 +2903,293 @@ index 00000000000000..5e4b436554d44d
 +// Having this assembly file keeps the go command
 +// from complaining about the missing body
 +// (because the implementation might be here).
+diff --git a/src/crypto/zbackenderrconflict_boring_cng.go b/src/crypto/zbackenderrconflict_boring_cng.go
+new file mode 100644
+index 00000000000000..03aa67a60bd92b
+--- /dev/null
++++ b/src/crypto/zbackenderrconflict_boring_cng.go
+@@ -0,0 +1,17 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.boringcrypto && goexperiment.cngcrypto
++
++package crypto
++
++func init() {
++	`
++	The boring and cng backends are both enabled, but they are mutually exclusive.
++	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrconflict_boring_darwin.go b/src/crypto/zbackenderrconflict_boring_darwin.go
+new file mode 100644
+index 00000000000000..fa463937e0453a
+--- /dev/null
++++ b/src/crypto/zbackenderrconflict_boring_darwin.go
+@@ -0,0 +1,17 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.boringcrypto && goexperiment.darwincrypto
++
++package crypto
++
++func init() {
++	`
++	The boring and darwin backends are both enabled, but they are mutually exclusive.
++	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrconflict_boring_openssl.go b/src/crypto/zbackenderrconflict_boring_openssl.go
+new file mode 100644
+index 00000000000000..ba99c374422357
+--- /dev/null
++++ b/src/crypto/zbackenderrconflict_boring_openssl.go
+@@ -0,0 +1,17 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.boringcrypto && goexperiment.opensslcrypto
++
++package crypto
++
++func init() {
++	`
++	The boring and openssl backends are both enabled, but they are mutually exclusive.
++	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrconflict_cng_darwin.go b/src/crypto/zbackenderrconflict_cng_darwin.go
+new file mode 100644
+index 00000000000000..046f94d615efa7
+--- /dev/null
++++ b/src/crypto/zbackenderrconflict_cng_darwin.go
+@@ -0,0 +1,17 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.cngcrypto && goexperiment.darwincrypto
++
++package crypto
++
++func init() {
++	`
++	The cng and darwin backends are both enabled, but they are mutually exclusive.
++	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrconflict_cng_openssl.go b/src/crypto/zbackenderrconflict_cng_openssl.go
+new file mode 100644
+index 00000000000000..11070cf8303a8c
+--- /dev/null
++++ b/src/crypto/zbackenderrconflict_cng_openssl.go
+@@ -0,0 +1,17 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.cngcrypto && goexperiment.opensslcrypto
++
++package crypto
++
++func init() {
++	`
++	The cng and openssl backends are both enabled, but they are mutually exclusive.
++	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrconflict_darwin_openssl.go b/src/crypto/zbackenderrconflict_darwin_openssl.go
+new file mode 100644
+index 00000000000000..8d16f2133615bb
+--- /dev/null
++++ b/src/crypto/zbackenderrconflict_darwin_openssl.go
+@@ -0,0 +1,17 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.darwincrypto && goexperiment.opensslcrypto
++
++package crypto
++
++func init() {
++	`
++	The darwin and openssl backends are both enabled, but they are mutually exclusive.
++	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrnofallback_boring.go b/src/crypto/zbackenderrnofallback_boring.go
+new file mode 100644
+index 00000000000000..f3f5d73b4ec1e6
+--- /dev/null
++++ b/src/crypto/zbackenderrnofallback_boring.go
+@@ -0,0 +1,20 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.boringcrypto && !(goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan) && !allowcryptofallback
++
++package crypto
++
++func init() {
++	`
++	The goexperiment.boringcrypto tag is specified, but other tags required to enable that backend were not met.
++	Required build tags:
++	  goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan
++	Please check your build environment and build command for a reason one or more of these tags weren't specified.
++	
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrnofallback_cng.go b/src/crypto/zbackenderrnofallback_cng.go
+new file mode 100644
+index 00000000000000..50198a70ebb639
+--- /dev/null
++++ b/src/crypto/zbackenderrnofallback_cng.go
+@@ -0,0 +1,20 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.cngcrypto && !(goexperiment.cngcrypto && windows && (amd64 || arm64)) && !allowcryptofallback
++
++package crypto
++
++func init() {
++	`
++	The goexperiment.cngcrypto tag is specified, but other tags required to enable that backend were not met.
++	Required build tags:
++	  goexperiment.cngcrypto && windows && (amd64 || arm64)
++	Please check your build environment and build command for a reason one or more of these tags weren't specified.
++	
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrnofallback_darwin.go b/src/crypto/zbackenderrnofallback_darwin.go
+new file mode 100644
+index 00000000000000..8b4c2a0b549e46
+--- /dev/null
++++ b/src/crypto/zbackenderrnofallback_darwin.go
+@@ -0,0 +1,20 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.darwincrypto && !(goexperiment.darwincrypto && darwin && cgo) && !allowcryptofallback
++
++package crypto
++
++func init() {
++	`
++	The goexperiment.darwincrypto tag is specified, but other tags required to enable that backend were not met.
++	Required build tags:
++	  goexperiment.darwincrypto && darwin && cgo
++	Please check your build environment and build command for a reason one or more of these tags weren't specified.
++	
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrnofallback_openssl.go b/src/crypto/zbackenderrnofallback_openssl.go
+new file mode 100644
+index 00000000000000..5f137d23b6bc97
+--- /dev/null
++++ b/src/crypto/zbackenderrnofallback_openssl.go
+@@ -0,0 +1,20 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.opensslcrypto && !(goexperiment.opensslcrypto && linux && cgo) && !allowcryptofallback
++
++package crypto
++
++func init() {
++	`
++	The goexperiment.opensslcrypto tag is specified, but other tags required to enable that backend were not met.
++	Required build tags:
++	  goexperiment.opensslcrypto && linux && cgo
++	Please check your build environment and build command for a reason one or more of these tags weren't specified.
++	
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrrequirefips_nosystemcrypto.go b/src/crypto/zbackenderrrequirefips_nosystemcrypto.go
+new file mode 100644
+index 00000000000000..91bede3aa030a5
+--- /dev/null
++++ b/src/crypto/zbackenderrrequirefips_nosystemcrypto.go
+@@ -0,0 +1,17 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build requirefips && !goexperiment.systemcrypto
++
++package crypto
++
++func init() {
++	`
++	The requirefips tag is enabled, but no crypto backend is enabled.
++	A crypto backend is required to enable FIPS mode.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrsystemcrypto_nobackend.go b/src/crypto/zbackenderrsystemcrypto_nobackend.go
+new file mode 100644
+index 00000000000000..919c4d8ffa3740
+--- /dev/null
++++ b/src/crypto/zbackenderrsystemcrypto_nobackend.go
+@@ -0,0 +1,16 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build goexperiment.systemcrypto && !goexperiment.boringcrypto && !goexperiment.cngcrypto && !goexperiment.darwincrypto && !goexperiment.opensslcrypto
++
++package crypto
++
++func init() {
++	`
++	The systemcrypto feature is enabled, but it was unable to enable an appropriate crypto backend for the target GOOS.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index 3ad0b0a3f2f465..2e4b1fd1b370cc 100644
 --- a/src/go/build/deps_test.go
@@ -2966,293 +3251,6 @@ index 3ad0b0a3f2f465..2e4b1fd1b370cc 100644
  	< crypto/rand
  	< crypto/ed25519 # depends on crypto/rand.Reader
  	< encoding/asn1
-diff --git a/src/runtime/backenderr_gen_conflict_boring_cng.go b/src/runtime/backenderr_gen_conflict_boring_cng.go
-new file mode 100644
-index 00000000000000..361db2a962d60f
---- /dev/null
-+++ b/src/runtime/backenderr_gen_conflict_boring_cng.go
-@@ -0,0 +1,17 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.boringcrypto && goexperiment.cngcrypto
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The boring and cng backends are both enabled, but they are mutually exclusive.
-+	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_conflict_boring_darwin.go b/src/runtime/backenderr_gen_conflict_boring_darwin.go
-new file mode 100644
-index 00000000000000..6c48a4e50fa72e
---- /dev/null
-+++ b/src/runtime/backenderr_gen_conflict_boring_darwin.go
-@@ -0,0 +1,17 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.boringcrypto && goexperiment.darwincrypto
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The boring and darwin backends are both enabled, but they are mutually exclusive.
-+	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_conflict_boring_openssl.go b/src/runtime/backenderr_gen_conflict_boring_openssl.go
-new file mode 100644
-index 00000000000000..91fac35011b24c
---- /dev/null
-+++ b/src/runtime/backenderr_gen_conflict_boring_openssl.go
-@@ -0,0 +1,17 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.boringcrypto && goexperiment.opensslcrypto
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The boring and openssl backends are both enabled, but they are mutually exclusive.
-+	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_conflict_cng_darwin.go b/src/runtime/backenderr_gen_conflict_cng_darwin.go
-new file mode 100644
-index 00000000000000..2e82a5cff034b7
---- /dev/null
-+++ b/src/runtime/backenderr_gen_conflict_cng_darwin.go
-@@ -0,0 +1,17 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.cngcrypto && goexperiment.darwincrypto
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The cng and darwin backends are both enabled, but they are mutually exclusive.
-+	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_conflict_cng_openssl.go b/src/runtime/backenderr_gen_conflict_cng_openssl.go
-new file mode 100644
-index 00000000000000..bf44084570bbbc
---- /dev/null
-+++ b/src/runtime/backenderr_gen_conflict_cng_openssl.go
-@@ -0,0 +1,17 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.cngcrypto && goexperiment.opensslcrypto
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The cng and openssl backends are both enabled, but they are mutually exclusive.
-+	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_conflict_darwin_openssl.go b/src/runtime/backenderr_gen_conflict_darwin_openssl.go
-new file mode 100644
-index 00000000000000..90f4361e28cd94
---- /dev/null
-+++ b/src/runtime/backenderr_gen_conflict_darwin_openssl.go
-@@ -0,0 +1,17 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.darwincrypto && goexperiment.opensslcrypto
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The darwin and openssl backends are both enabled, but they are mutually exclusive.
-+	Please make sure only one crypto backend experiment is enabled by GOEXPERIMENT or '-tags'.
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_nofallback_boring.go b/src/runtime/backenderr_gen_nofallback_boring.go
-new file mode 100644
-index 00000000000000..08926e5f836698
---- /dev/null
-+++ b/src/runtime/backenderr_gen_nofallback_boring.go
-@@ -0,0 +1,20 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.boringcrypto && !(goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan) && !allowcryptofallback
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The goexperiment.boringcrypto tag is specified, but other tags required to enable that backend were not met.
-+	Required build tags:
-+	  goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan
-+	Please check your build environment and build command for a reason one or more of these tags weren't specified.
-+	
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_nofallback_cng.go b/src/runtime/backenderr_gen_nofallback_cng.go
-new file mode 100644
-index 00000000000000..f8e36f8c8406af
---- /dev/null
-+++ b/src/runtime/backenderr_gen_nofallback_cng.go
-@@ -0,0 +1,20 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.cngcrypto && !(goexperiment.cngcrypto && windows && (amd64 || arm64)) && !allowcryptofallback
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The goexperiment.cngcrypto tag is specified, but other tags required to enable that backend were not met.
-+	Required build tags:
-+	  goexperiment.cngcrypto && windows && (amd64 || arm64)
-+	Please check your build environment and build command for a reason one or more of these tags weren't specified.
-+	
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_nofallback_darwin.go b/src/runtime/backenderr_gen_nofallback_darwin.go
-new file mode 100644
-index 00000000000000..bcca3e1a5a548d
---- /dev/null
-+++ b/src/runtime/backenderr_gen_nofallback_darwin.go
-@@ -0,0 +1,20 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.darwincrypto && !(goexperiment.darwincrypto && darwin && cgo) && !allowcryptofallback
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The goexperiment.darwincrypto tag is specified, but other tags required to enable that backend were not met.
-+	Required build tags:
-+	  goexperiment.darwincrypto && darwin && cgo
-+	Please check your build environment and build command for a reason one or more of these tags weren't specified.
-+	
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_nofallback_openssl.go b/src/runtime/backenderr_gen_nofallback_openssl.go
-new file mode 100644
-index 00000000000000..c88593ad85fc76
---- /dev/null
-+++ b/src/runtime/backenderr_gen_nofallback_openssl.go
-@@ -0,0 +1,20 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.opensslcrypto && !(goexperiment.opensslcrypto && linux && cgo) && !allowcryptofallback
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The goexperiment.opensslcrypto tag is specified, but other tags required to enable that backend were not met.
-+	Required build tags:
-+	  goexperiment.opensslcrypto && linux && cgo
-+	Please check your build environment and build command for a reason one or more of these tags weren't specified.
-+	
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_requirefips_nosystemcrypto.go b/src/runtime/backenderr_gen_requirefips_nosystemcrypto.go
-new file mode 100644
-index 00000000000000..1c015dd2b08972
---- /dev/null
-+++ b/src/runtime/backenderr_gen_requirefips_nosystemcrypto.go
-@@ -0,0 +1,17 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build requirefips && !goexperiment.systemcrypto
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The requirefips tag is enabled, but no crypto backend is enabled.
-+	A crypto backend is required to enable FIPS mode.
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
-diff --git a/src/runtime/backenderr_gen_systemcrypto_nobackend.go b/src/runtime/backenderr_gen_systemcrypto_nobackend.go
-new file mode 100644
-index 00000000000000..95be7ad8d38cae
---- /dev/null
-+++ b/src/runtime/backenderr_gen_systemcrypto_nobackend.go
-@@ -0,0 +1,16 @@
-+// Copyright 2023 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "backenderr_gen_".
-+
-+//go:build goexperiment.systemcrypto && !goexperiment.boringcrypto && !goexperiment.cngcrypto && !goexperiment.darwincrypto && !goexperiment.opensslcrypto
-+
-+package runtime
-+
-+func init() {
-+	`
-+	The systemcrypto feature is enabled, but it was unable to enable an appropriate crypto backend for the target GOOS.
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
 diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
 index 831ee67afc952d..d2f00d57c10286 100644
 --- a/src/runtime/runtime_boring.go


### PR DESCRIPTION
We will soon enable `systemcrypto` by default (see #1352). We currently require cgo to be enabled when building with systemcrypto on Linux and Darwin, even when applications don't use crypto at all. That made sense when systemcrypto was opt-in, as it makes the behavior more consistent.

Now that systemcrypto will be the default, that restriction puts an unnecessary burden on applications that don't use crypto. For example, they can't set `CGO_ENABLE=0` and they can't cross-compile without manually setting `CGO_ENABLED=1` (as cgo is automatically disabled when cross-compiling).

To avoid this pain we better only require cgo if crypto is really used.

Note that most of the `allowcryptofallback` build tag used in tests can be removed thanks to this change.

While here, I've changed the backend error files name prefix from `backenderr_gen_` to `zbackenderr`. Starting autogenerated files with a `z` is more idiomatic.