### PR TITLE
For CodeQL, rebuild existing Go build: no bootstrap

### DIFF
--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -73,20 +73,14 @@ extends:
         configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
 
     stages:
-      - template: /eng/pipeline/stages/pool.yml@self
+      - template: /eng/pipeline/stages/shorthand-builders-to-builders.yml@self
         parameters:
-          inner:
-            template: run-codeql.yml
-            parameters:
-              builder: { os: linux, hostArch: amd64, arch: amd64, config: codeql_inner }
-              official: true
-              goBuildID: $(resources.pipeline.build.runID)
-
-      - template: /eng/pipeline/stages/pool.yml@self
-        parameters:
-          inner:
-            template: run-codeql.yml
-            parameters:
-              builder: { os: linux, hostArch: amd64, arch: amd64, config: codeql_outer }
-              official: true
-              goBuildID: $(resources.pipeline.build.runID)
+          jobsTemplate: builders-to-stages.yml
+          jobsParameters:
+            official: true
+          shorthandBuilders:
+            # CodeQL doesn't submit the scan to both the outer repo
+            # (microsoft-go) and inner repo (microsoft-go-mirror).
+            # Use two jobs to submit two scans.
+            - { os: linux, arch: amd64, config: codeql_outer }
+            - { os: linux, arch: amd64, config: codeql_inner }

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -73,14 +73,20 @@ extends:
         configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
 
     stages:
-      - template: /eng/pipeline/stages/shorthand-builders-to-builders.yml@self
+      - template: /eng/pipeline/stages/pool.yml@self
         parameters:
-          jobsTemplate: builders-to-stages.yml
-          jobsParameters:
-            official: true
-          shorthandBuilders:
-            # CodeQL doesn't submit the scan to both the outer repo
-            # (microsoft-go) and inner repo (microsoft-go-mirror).
-            # Use two jobs to submit two scans.
-            - { os: linux, arch: amd64, config: codeql_outer }
-            - { os: linux, arch: amd64, config: codeql_inner }
+          inner:
+            template: run-codeql.yml
+            parameters:
+              builder: { os: linux, hostArch: amd64, arch: amd64, config: codeql_inner }
+              official: true
+              goBuildID: $(resources.pipeline.build.runID)
+
+      - template: /eng/pipeline/stages/pool.yml@self
+        parameters:
+          inner:
+            template: run-codeql.yml
+            parameters:
+              builder: { os: linux, hostArch: amd64, arch: amd64, config: codeql_outer }
+              official: true
+              goBuildID: $(resources.pipeline.build.runID)

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -32,21 +32,26 @@ stages:
         - template: pool.yml
           parameters:
             inner:
-              template: run-stage.yml
-              parameters:
-                builder: ${{ builder }}
-                createSourceArchive: ${{ parameters.createSourceArchive }}
-                releaseVersion: ${{ parameters.releaseVersion }}
-                official: ${{ parameters.official }}
-                createSymbols: ${{ parameters.createSymbols }}
-                # Attempt to retry the build on Windows to mitigate flakiness:
-                # "Access Denied" during EXE copying and general flakiness during tests.
-                ${{ if eq(builder.os, 'windows') }}:
-                  retryAttempts: [1, 2, 3, 4, "FINAL"]
-                # Attempt to retry the build on macOS to mitigate flakiness:
-                # "read: connection reset by peer" in cmd/go tests
-                ${{ if eq(builder.os, 'darwin') }}:
-                  retryAttempts: [1, 2, "FINAL"]
+              ${{ if startsWith(builder.config, 'codeql') }}:
+                template: run-codeql.yml
+                parameters:
+                  builder: ${{ builder }}
+              ${{ else }}:
+                template: run-stage.yml
+                parameters:
+                  builder: ${{ builder }}
+                  createSourceArchive: ${{ parameters.createSourceArchive }}
+                  releaseVersion: ${{ parameters.releaseVersion }}
+                  official: ${{ parameters.official }}
+                  createSymbols: ${{ parameters.createSymbols }}
+                  # Attempt to retry the build on Windows to mitigate flakiness:
+                  # "Access Denied" during EXE copying and general flakiness during tests.
+                  ${{ if eq(builder.os, 'windows') }}:
+                    retryAttempts: [1, 2, 3, 4, "FINAL"]
+                  # Attempt to retry the build on macOS to mitigate flakiness:
+                  # "read: connection reset by peer" in cmd/go tests
+                  ${{ if eq(builder.os, 'darwin') }}:
+                    retryAttempts: [1, 2, "FINAL"]
 
     - ${{ if eq(parameters.sign, true) }}:
       - template: pool.yml

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -34,24 +34,22 @@ stages:
             inner:
               ${{ if startsWith(builder.config, 'codeql') }}:
                 template: run-codeql.yml
-                parameters:
-                  builder: ${{ builder }}
               ${{ else }}:
                 template: run-stage.yml
-                parameters:
-                  builder: ${{ builder }}
-                  createSourceArchive: ${{ parameters.createSourceArchive }}
-                  releaseVersion: ${{ parameters.releaseVersion }}
-                  official: ${{ parameters.official }}
-                  createSymbols: ${{ parameters.createSymbols }}
-                  # Attempt to retry the build on Windows to mitigate flakiness:
-                  # "Access Denied" during EXE copying and general flakiness during tests.
-                  ${{ if eq(builder.os, 'windows') }}:
-                    retryAttempts: [1, 2, 3, 4, "FINAL"]
-                  # Attempt to retry the build on macOS to mitigate flakiness:
-                  # "read: connection reset by peer" in cmd/go tests
-                  ${{ if eq(builder.os, 'darwin') }}:
-                    retryAttempts: [1, 2, "FINAL"]
+              parameters:
+                builder: ${{ builder }}
+                createSourceArchive: ${{ parameters.createSourceArchive }}
+                releaseVersion: ${{ parameters.releaseVersion }}
+                official: ${{ parameters.official }}
+                createSymbols: ${{ parameters.createSymbols }}
+                # Attempt to retry the build on Windows to mitigate flakiness:
+                # "Access Denied" during EXE copying and general flakiness during tests.
+                ${{ if eq(builder.os, 'windows') }}:
+                  retryAttempts: [1, 2, 3, 4, "FINAL"]
+                # Attempt to retry the build on macOS to mitigate flakiness:
+                # "read: connection reset by peer" in cmd/go tests
+                ${{ if eq(builder.os, 'darwin') }}:
+                  retryAttempts: [1, 2, "FINAL"]
 
     - ${{ if eq(parameters.sign, true) }}:
       - template: pool.yml

--- a/eng/pipeline/stages/run-codeql.yml
+++ b/eng/pipeline/stages/run-codeql.yml
@@ -31,6 +31,16 @@ parameters:
     type: object
     default: ["FINAL"]
 
+  - name: osArchList
+    type: object
+    default:
+      - { os: 'linux', arch: 'amd64' }
+      - { os: 'windows', arch: 'amd64' }
+      - { os: 'linux', arch: 'arm' }
+      - { os: 'linux', arch: 'arm64' }
+      - { os: 'darwin', arch: 'amd64' }
+      - { os: 'darwin', arch: 'arm64' }
+
 stages:
   - stage: ${{ parameters.builder.id }}
     # For display name, try for readability. Use some parameters set by
@@ -87,14 +97,30 @@ stages:
               ls "$(Pipeline.Workspace)/Binaries Signed/go"
             displayName: Extract Microsoft build of Go (linux-amd64)
 
-          - bash: |
-              "$(GoExecutable)" version
-            displayName: Show Go version
+          - ${{ each c in parameters.osArchList }}:
+            - bash: |
+                set -eux
+                export GOOS=${{ c.os }}
+                export GOARCH=${{ c.arch }}
 
-          - bash: |
-              "$(GoExecutable)" build std
-            displayName: Build std
+                # Static binary workaround for CodeQL and Go 1.21 and higher
+                # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/onboarding/language-compiled#go-121-and-higher-on-linux
 
-          - bash: |
-              "$(GoExecutable)" build cmd/...
-            displayName: Build cmd
+                WORKAROUND_DIR=$AGENT_TEMPDIRECTORY/codeql-go-tracing-${{ c.os }}-${{ c.arch }}
+                mkdir "${WORKAROUND_DIR}"
+                WHICH_GO="$(GoExecutable)"
+
+                cat > "${WORKAROUND_DIR}/go" <<EOF
+                #!/bin/bash
+                exec "$WHICH_GO" "\$@"
+                EOF
+
+                chmod 755 "${WORKAROUND_DIR}/go"
+                export PATH="${WORKAROUND_DIR}:${PATH}"
+
+                # Build Go itself.
+                go build std
+                go build cmd/...
+                # Build our infra tools.
+                ( cd eng/_util/ && go build ./... )
+              displayName: Build ${{ c.os }}-${{ c.arch }}

--- a/eng/pipeline/stages/run-codeql.yml
+++ b/eng/pipeline/stages/run-codeql.yml
@@ -9,14 +9,27 @@ parameters:
   - name: builder
     type: object
 
-  - name: official
+  - name: createSourceArchive # Ignored
     type: boolean
+    default: false
+
+  - name: createSymbols # Ignored
+    type: boolean
+    default: false
+
+  - name: releaseVersion # Ignored
+    type: string
+    default: 'nil'
 
   - name: pool
     type: object
 
-  - name: goBuildID
-    type: string
+  - name: official # Ignored
+    type: boolean
+
+  - name: retryAttempts # Ignored
+    type: object
+    default: ["FINAL"]
 
 stages:
   - stage: ${{ parameters.builder.id }}
@@ -57,7 +70,7 @@ stages:
 
           - template: ../steps/download-signed-binaries-task.yml
             parameters:
-              runID: ${{ parameters.goBuildID }}
+              runID: $(resources.pipeline.build.runID)
 
           - bash: |
               set -eux

--- a/eng/pipeline/stages/run-codeql.yml
+++ b/eng/pipeline/stages/run-codeql.yml
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This job runs a builder for any OS.
+
+parameters:
+  # { id, os, arch, hostArch, config, distro?, experiment?, fips?, broken? }
+  - name: builder
+    type: object
+
+  - name: official
+    type: boolean
+
+  - name: pool
+    type: object
+
+  - name: goBuildID
+    type: string
+
+stages:
+  - stage: ${{ parameters.builder.id }}
+    # For display name, try for readability. Use some parameters set by
+    # shorthand-builders-to-builders.yml that let us add some formatting.
+    displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.fipsAcronym }}
+    dependsOn: []
+    jobs:
+      - job: ${{ parameters.builder.id }}
+        displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.fipsAcronym }}
+        workspace:
+          clean: all
+
+        # Validation for complex inputs.
+        ${{ if startsWith(parameters.builder.config, 'codeql') }}:
+          ${{ if not(or(eq(parameters.builder.config, 'codeql_inner'), eq(parameters.builder.config, 'codeql_outer'))) }}:
+            'The CodeQL configuration must include "_inner" or "_outer" suffix': error
+
+        # Allow CodeQL to take a while. https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#other-issues
+        timeoutInMinutes: 420
+
+        pool: ${{ parameters.pool }}
+
+        variables:
+          - ${{ if eq(parameters.builder.config, 'codeql_inner') }}:
+            # Manually specify the repository being scanned by this job because
+            # CodeQL can't detect the inner repository (the submodule)
+            # automatically. See https://stackoverflow.microsoft.com/a/368419
+            - name: Codeql.ADO.Build.Repository.Provider
+              value: override
+            - name: Codeql.ADO.Build.Repository.Uri
+              value: https://dev.azure.com/dnceng/internal/_git/microsoft-go-mirror
+          - name: GoExecutable
+            value: '$(Pipeline.Workspace)/Binaries Signed/go/bin/go'
+
+        steps:
+          - template: ../steps/checkout-unix-task.yml
+
+          - template: ../steps/download-signed-binaries-task.yml
+            parameters:
+              runID: ${{ parameters.goBuildID }}
+
+          - bash: |
+              set -eux
+
+              for f in "$(Pipeline.Workspace)/Binaries Signed/"go*.linux-amd64.tar.gz; do
+                if [ "${found:-}" ]; then
+                  echo "Found multiple Go binaries in Binaries Signed: $found and $f"
+                  exit 1
+                fi
+                found=$f
+              done
+
+              tar -xf "$found" -C "$(Pipeline.Workspace)/Binaries Signed"
+              ls "$(Pipeline.Workspace)/Binaries Signed/go"
+            displayName: Extract Microsoft build of Go (linux-amd64)
+
+          - bash: |
+              "$(GoExecutable)" version
+            displayName: Show Go version
+
+          - bash: |
+              "$(GoExecutable)" build std
+            displayName: Build std
+
+          - bash: |
+              "$(GoExecutable)" build cmd/...
+            displayName: Build cmd


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/213

Fixes CodeQL scans. First, simplifies: instead of building the toolchain the normal way (bootstrap compilers, etc.), just download the build we did earlier and re-run the stdlib, cmd, and _util builds. Do so targeting all supported platforms. This directs CodeQL to the right place and ends up with all our Go files in the submitted database.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2733888&view=results
Submitted https://codeql.microsoft.com/job/b9f6f885-df80-4825-ab70-2233aba10c75