### PR TITLE
Use nosystemcrypto instead of nocryptofallback

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -439,7 +439,11 @@ This list of major changes is intended for quick reference and for access to his
 
 ### Go 1.25 (Aug 2025)
 
-- `GOEXPERIMENT=allowcryptofallback` has been downgraded to the `allowcryptofallback` build tag. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
+- Running `go version -m` on a binary which uses a system crypto backend now shows the `microsoft_systemcrypto=1` build setting.
+
+- `GOEXPERIMENT=allowcryptofallback` has been removed. It was an internal mechanism that was not intended for use when building a Go application. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
+
+- It is now possible to build a binary that doesn't depend on a crypto package using invalid configurations, for example `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto`.
 
 ### Go 1.24 (Feb 2025)
 

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -11,7 +11,6 @@ information about the behavior.
 Includes new tests in "build_test.go" and "buildbackend_test.go" to help
 maintain this feature. For more information, see the test files.
 ---
- src/cmd/dist/build.go                         |  6 ++
  src/cmd/go/internal/modindex/build.go         | 58 ++++++++++++-
  src/cmd/go/internal/modindex/build_test.go    | 73 ++++++++++++++++
  src/go/build/build.go                         | 58 ++++++++++++-
@@ -29,7 +28,7 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 ++++
- 18 files changed, 369 insertions(+), 4 deletions(-)
+ 17 files changed, 363 insertions(+), 4 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/main.go
@@ -45,23 +44,6 @@ maintain this feature. For more information, see the test files.
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_on.go
 
-diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index b50f3342fe8714..75629c2a6bd9ba 100644
---- a/src/cmd/dist/build.go
-+++ b/src/cmd/dist/build.go
-@@ -1539,6 +1539,12 @@ func cmdbootstrap() {
- 	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
- 	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
- 	os.Setenv("GOEXPERIMENT", goexperiment)
-+	// Build the Go toolchain with "-tags=allowcryptofallback". This
-+	// allows toolchains not built with "GOEXPERIMENT=systemcrypto" to be used
-+	// when GODEBUG=fips140=on is set. For example, when running
-+	// "GODEBUG=fips140=on go test ./..." or "GODEBUG=fips140=on go run .".
-+	// Shadow goexperiment so that the global variable is not modified.
-+	os.Setenv("GOFLAGS", "-tags=allowcryptofallback")
- 	// No need to enable PGO for toolchain2.
- 	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
- 	if debug {
 diff --git a/src/cmd/go/internal/modindex/build.go b/src/cmd/go/internal/modindex/build.go
 index d7e09fed25f43a..10614d17e62453 100644
 --- a/src/cmd/go/internal/modindex/build.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement crypto/internal/backend
 
 ---
  .gitignore                                    |   2 +
- src/cmd/dist/build.go                         |   5 +
+ src/cmd/dist/build.go                         |  19 +-
  src/cmd/dist/test.go                          |   9 +-
  src/cmd/go/internal/load/pkg.go               |   3 +
  .../go/testdata/script/build_systemcrypto.txt |  35 ++
@@ -54,7 +54,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 50 files changed, 2758 insertions(+), 7 deletions(-)
+ 50 files changed, 2771 insertions(+), 8 deletions(-)
  create mode 100644 src/cmd/go/testdata/script/build_systemcrypto.txt
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
@@ -112,13 +112,27 @@ index c6512e64a4ef39..b3b01db73b009d 100644
  # For files created by specific development environment (e.g. editor),
  # use alternative ways to exclude files from git.
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index b50f3342fe8714..fb61daf8160a5b 100644
+index b50f3342fe8714..a327e0a50e0d74 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1539,6 +1539,11 @@ func cmdbootstrap() {
+@@ -1538,7 +1538,24 @@ func cmdbootstrap() {
+ 	xprintf("Building Go toolchain2 using go_bootstrap and Go toolchain1.\n")
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
- 	os.Setenv("GOEXPERIMENT", goexperiment)
+-	os.Setenv("GOEXPERIMENT", goexperiment)
++	//
++	// The Go toolchain does not use crypto for security. Disable systemcrypto
++	// to favor portability.
++	var goexpSlice []string
++	if goexperiment != "" {
++		goexpSlice = strings.Split(goexperiment, ",")
++		goexpSlice = slices.DeleteFunc(goexpSlice, func(exp string) bool {
++			return exp == "systemcrypto" || exp == "opensslcrypto" ||
++				exp == "cngcrypto" || exp == "darwincrypto" || exp == "boringcrypto"
++		})
++	}
++	goexpSlice = append(goexpSlice, "nosystemcrypto")
++	os.Setenv("GOEXPERIMENT", strings.Join(goexpSlice, ","))
 +	// Set the norequirefips to allow using the toolchain when it is
 +	// not built with a systemcrypto backend and GODEBUG=fips140=on is set.
 +	// For example, when runnings "GODEBUG=fips140=on go test ./..." or

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement crypto/internal/backend
 ---
  .gitignore                                    |   2 +
  src/cmd/dist/build.go                         |  19 +-
- src/cmd/dist/test.go                          |   9 +-
+ src/cmd/dist/test.go                          |  16 +-
  src/cmd/go/internal/load/pkg.go               |   3 +
  .../go/testdata/script/build_systemcrypto.txt |  35 ++
  src/cmd/link/internal/ld/main.go              |  15 +-
@@ -54,7 +54,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 50 files changed, 2775 insertions(+), 8 deletions(-)
+ 50 files changed, 2781 insertions(+), 9 deletions(-)
  create mode 100644 src/cmd/go/testdata/script/build_systemcrypto.txt
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
@@ -142,7 +142,7 @@ index b50f3342fe8714..a327e0a50e0d74 100644
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index d335e4cfbce468..a80815006a5377 100644
+index d335e4cfbce468..e169f14170c413 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -847,13 +847,18 @@ func (t *tester) registerTests() {
@@ -174,6 +174,26 @@ index d335e4cfbce468..a80815006a5377 100644
  				pkg:       "crypto/internal/fips140test",
  				runTests:  "TestFIPSCheck",
  			})
+@@ -881,13 +886,18 @@ func (t *tester) registerTests() {
+ 
+ 	if t.extLink() && !t.compileOnly {
+ 		if goos != "android" { // Android does not support non-PIE linking
++			var extraEnvs []string
++			if goos == "darwin" {
++				// macOS don't support systemcrypto with non-PIE linking.
++				extraEnvs = append(extraEnvs, "GOEXPERIMENT=nosystemcrypto", "GOFLAGS=-tags=norequirefips")
++			}
+ 			t.registerTest("external linking, -buildmode=exe",
+ 				&goTest{
+ 					variant:   "exe_external",
+ 					timeout:   60 * time.Second,
+ 					buildmode: "exe",
+ 					ldflags:   "-linkmode=external",
+-					env:       []string{"CGO_ENABLED=1"},
++					env:       append([]string{"CGO_ENABLED=1"}, extraEnvs...),
+ 					pkg:       "crypto/internal/fips140test",
+ 					runTests:  "TestFIPSCheck",
+ 				})
 diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
 index e913f9885234fd..ef331980a816a3 100644
 --- a/src/cmd/go/internal/load/pkg.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -5,12 +5,14 @@ Subject: [PATCH] Implement crypto/internal/backend
 
 ---
  .gitignore                                    |   2 +
- src/cmd/dist/test.go                          |   7 +
- .../backend/allocryptofallback_off.go         |   9 +
- .../internal/backend/allocryptofallback_on.go |   9 +
+ src/cmd/dist/build.go                         |  19 +-
+ src/cmd/dist/test.go                          |   9 +-
+ src/cmd/go/internal/load/pkg.go               |   3 +
+ .../go/testdata/script/build_systemcrypto.txt |  35 ++
+ src/cmd/link/internal/ld/main.go              |  11 +-
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
- .../internal/backend/backendgen_test.go       | 278 +++++++++++++
+ .../internal/backend/backendgen_test.go       | 274 +++++++++++++
  src/crypto/internal/backend/bbig/big.go       |  17 +
  .../internal/backend/bbig/big_boring.go       |  12 +
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
@@ -33,6 +35,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
+ .../internal/backend/norequirefips_off.go     |   9 +
+ .../internal/backend/norequirefips_on.go      |  13 +
  src/crypto/internal/backend/openssl_linux.go  | 339 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/crypto/zbackenderrconflict_boring_cng.go  |  17 +
@@ -50,9 +54,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2705 insertions(+), 4 deletions(-)
- create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
- create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
+ 50 files changed, 2771 insertions(+), 8 deletions(-)
+ create mode 100644 src/cmd/go/testdata/script/build_systemcrypto.txt
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -78,6 +81,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  create mode 100644 src/crypto/internal/backend/internal/opensslsetup/opensslsetup_test.go
  create mode 100644 src/crypto/internal/backend/internal/opensslsetup/stub.go
  create mode 100644 src/crypto/internal/backend/nobackend.go
+ create mode 100644 src/crypto/internal/backend/norequirefips_off.go
+ create mode 100644 src/crypto/internal/backend/norequirefips_on.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/crypto/internal/backend/stub.s
  create mode 100644 src/crypto/zbackenderrconflict_boring_cng.go
@@ -106,68 +111,154 @@ index c6512e64a4ef39..b3b01db73b009d 100644
  # This file includes artifacts of Go build that should not be checked in.
  # For files created by specific development environment (e.g. editor),
  # use alternative ways to exclude files from git.
+diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
+index b50f3342fe8714..cee3ff2d1543f6 100644
+--- a/src/cmd/dist/build.go
++++ b/src/cmd/dist/build.go
+@@ -1538,7 +1538,24 @@ func cmdbootstrap() {
+ 	xprintf("Building Go toolchain2 using go_bootstrap and Go toolchain1.\n")
+ 	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
+ 	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
+-	os.Setenv("GOEXPERIMENT", goexperiment)
++	//
++	// The Go toolchain does not use crypto for security. Disable systemcrypto
++	// to favor portability.
++	var goexpSlice []string
++	if goexperiment != "" {
++		goexpSlice = strings.Split(goexperiment, ",")
++		goexpSlice = slices.DeleteFunc(goexpSlice, func(exp string) bool {
++			return exp == "systemcrypto" || exp == "opensslcrypto" ||
++				exp == "cngcrypto" || exp == "darwincrypto" || exp == "boringcrypto"
++		})
++	}
++	goexpSlice = append(goexpSlice, "nosystemcrypto")
++	os.Setenv("GOEXPERIMENT", strings.Join(goexpSlice, ","))
++	// Set the norequirefips to allow using the toolchain when it is
++	// not built with a systemcrypto backend and GODEBUG=fips140=on is set.
++	// For example, when runnings "GODEBUG=fips140=on go test ./..." or
++	// "GODEBUG=fips140=on go run .".
++	os.Setenv("GOFLAGS", "-tags=norequirefips")
+ 	// No need to enable PGO for toolchain2.
+ 	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
+ 	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index d335e4cfbce468..7e362c80be609a 100644
+index d335e4cfbce468..27102ba00b27a2 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -847,6 +847,11 @@ func (t *tester) registerTests() {
+@@ -847,13 +847,18 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
-+		var tags []string
++		var extraEnvs []string
 +		if goos != "windows" {
 +			// Linux and macOS don't support systemcrypto with CGO_ENABLED=0.
-+			tags = append(tags, "allowcryptofallback")
++			extraEnvs = append(extraEnvs, "GOEXPERIMENT=nosystemcrypto")
 +		}
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
  				variant:   "pie_internal",
-@@ -855,6 +860,7 @@ func (t *tester) registerTests() {
+ 				timeout:   60 * time.Second,
+ 				buildmode: "pie",
  				ldflags:   "-linkmode=internal",
- 				env:       []string{"CGO_ENABLED=0"},
+-				env:       []string{"CGO_ENABLED=0"},
++				env:       append([]string{"CGO_ENABLED=0"}, extraEnvs...),
  				pkg:       "reflect",
-+				tags:      tags,
  			})
  		t.registerTest("internal linking, -buildmode=pie",
- 			&goTest{
-@@ -865,6 +871,7 @@ func (t *tester) registerTests() {
- 				env:       []string{"CGO_ENABLED=0"},
+@@ -862,7 +867,7 @@ func (t *tester) registerTests() {
+ 				timeout:   60 * time.Second,
+ 				buildmode: "pie",
+ 				ldflags:   "-linkmode=internal",
+-				env:       []string{"CGO_ENABLED=0"},
++				env:       append([]string{"CGO_ENABLED=0"}, extraEnvs...),
  				pkg:       "crypto/internal/fips140test",
  				runTests:  "TestFIPSCheck",
-+				tags:      tags,
  			})
- 		// Also test a cgo package.
- 		if t.cgoEnabled && t.internalLink() && !disablePIE {
-diff --git a/src/crypto/internal/backend/allocryptofallback_off.go b/src/crypto/internal/backend/allocryptofallback_off.go
+diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
+index e913f9885234fd..ef331980a816a3 100644
+--- a/src/cmd/go/internal/load/pkg.go
++++ b/src/cmd/go/internal/load/pkg.go
+@@ -2412,6 +2412,9 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
+ 			buildmode = "archive"
+ 		}
+ 	}
++	if cfg.Experiment.SystemCrypto {
++		appendSetting("microsoft_systemcrypto", "1")
++	}
+ 	appendSetting("-buildmode", buildmode)
+ 	appendSetting("-compiler", cfg.BuildContext.Compiler)
+ 	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
+diff --git a/src/cmd/go/testdata/script/build_systemcrypto.txt b/src/cmd/go/testdata/script/build_systemcrypto.txt
 new file mode 100644
-index 00000000000000..7718cc02f48556
+index 00000000000000..3ae8fbfa3ccad3
 --- /dev/null
-+++ b/src/crypto/internal/backend/allocryptofallback_off.go
-@@ -0,0 +1,9 @@
-+// Copyright 2025 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
++++ b/src/cmd/go/testdata/script/build_systemcrypto.txt
+@@ -0,0 +1,35 @@
++[GOOS:windows] [GOARCH:386] skip
++[!GOOS:windows] [!GOOS:linux] [!GOOS:darwin] skip
++[!cgo] skip
 +
-+//go:build !allowcryptofallback
++# Default behavior depends on GOEXPERIMENT.
++go build -o main.exe main.go
++go version -m main.exe
++[!GOEXPERIMENT:nosystemcrypto] stdout microsoft_systemcrypto=1
++[GOEXPERIMENT:nosystemcrypto] ! stdout microsoft_systemcrypto=1
 +
-+package backend
++# Explicit systemcrypto should set it
++# in the version and in GOEXPERIMENT.
++env GOEXPERIMENT=systemcrypto
++go build -o main.exe main.go
++go version -m main.exe
++stdout microsoft_systemcrypto=1
 +
-+const allowCryptoFallback = false
-diff --git a/src/crypto/internal/backend/allocryptofallback_on.go b/src/crypto/internal/backend/allocryptofallback_on.go
-new file mode 100644
-index 00000000000000..fc30aba8ad8228
---- /dev/null
-+++ b/src/crypto/internal/backend/allocryptofallback_on.go
-@@ -0,0 +1,9 @@
-+// Copyright 2025 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
++# Explictly disable systemcrypto.
++env GOEXPERIMENT=nosystemcrypto
++go build -o main.exe main.go
++go version -m main.exe
++! stdout microsoft_systemcrypto=1
 +
-+//go:build allowcryptofallback
++-- main.go --
 +
-+package backend
++package main
 +
-+const allowCryptoFallback = true
++import (
++	"crypto/sha256"
++	"fmt"
++)
++
++func main() {
++	fmt.Println(sha256.Sum256([]byte("Hello, World!")))
++}
+\ No newline at end of file
+diff --git a/src/cmd/link/internal/ld/main.go b/src/cmd/link/internal/ld/main.go
+index 6a684890be0a03..0d3f6a51b69e58 100644
+--- a/src/cmd/link/internal/ld/main.go
++++ b/src/cmd/link/internal/ld/main.go
+@@ -44,6 +44,7 @@ import (
+ 	"os"
+ 	"runtime"
+ 	"runtime/pprof"
++	"slices"
+ 	"strconv"
+ 	"strings"
+ )
+@@ -187,7 +188,15 @@ func Main(arch *sys.Arch, theArch Arch) {
+ 
+ 	buildVersion := buildcfg.Version
+ 	if goexperiment := buildcfg.Experiment.String(); goexperiment != "" {
+-		buildVersion += " X:" + goexperiment
++		// systemcrypt is managed an experiment for historical reasons,
++		// but it is really not an experiment, but a consolidated feature.
++		// Don't report it in the build version.
++		goexperiment = strings.Join(slices.DeleteFunc(strings.Split(goexperiment, ","), func(s string) bool {
++			return s == "nosystemcrypto" || s == "systemcrypto"
++		}), ",")
++		if goexperiment != "" {
++			buildVersion += " X:" + goexperiment
++		}
+ 	}
+ 	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
+ 
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644
 index 00000000000000..c2c06d3bff8c74
@@ -232,10 +323,10 @@ index 00000000000000..acf0113bbefb6c
 +//go:generate go test -run TestGenerated -fix
 diff --git a/src/crypto/internal/backend/backendgen_test.go b/src/crypto/internal/backend/backendgen_test.go
 new file mode 100644
-index 00000000000000..063e0bb4948236
+index 00000000000000..e973a0f23c919a
 --- /dev/null
 +++ b/src/crypto/internal/backend/backendgen_test.go
-@@ -0,0 +1,278 @@
+@@ -0,0 +1,274 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -398,13 +489,9 @@ index 00000000000000..063e0bb4948236
 +
 +func testPreventUnintendedFallback(t *testing.T, backend *backend) string {
 +	expTag := &constraint.TagExpr{Tag: "goexperiment." + backend.name + "crypto"}
-+	optOutTag := &constraint.TagExpr{Tag: "allowcryptofallback"}
 +	c := constraint.AndExpr{
-+		X: &constraint.AndExpr{
-+			X: expTag,
-+			Y: &constraint.NotExpr{X: backend.constraint},
-+		},
-+		Y: &constraint.NotExpr{X: optOutTag},
++		X: expTag,
++		Y: &constraint.NotExpr{X: backend.constraint},
 +	}
 +	return testErrorFile(
 +		t,
@@ -1254,7 +1341,7 @@ index 00000000000000..7a89cfb5d2f596
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..9dec441fa63856
+index 00000000000000..38f69d09f62f62
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
 @@ -0,0 +1,58 @@
@@ -1271,7 +1358,7 @@ index 00000000000000..9dec441fa63856
 +)
 +
 +func init() {
-+	if !allowCryptoFallback && fips140.Enabled() {
++	if !noRequireFIPS && fips140.Enabled() {
 +		if !Enabled {
 +			if runtime.GOOS != "linux" && runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 +				panic("FIPS mode requested (" + fips140.Message + ") but no crypto backend is supported on " + runtime.GOOS)
@@ -2404,6 +2491,40 @@ index 00000000000000..dc8513b535f19b
 +func VerifyDSA(pub *PublicKeyDSA, hashed []byte, r, s BigInt, encodeSignature func(r, s BigInt) ([]byte, error)) bool {
 +	panic("cryptobackend: not available")
 +}
+diff --git a/src/crypto/internal/backend/norequirefips_off.go b/src/crypto/internal/backend/norequirefips_off.go
+new file mode 100644
+index 00000000000000..00a7c8a34913bd
+--- /dev/null
++++ b/src/crypto/internal/backend/norequirefips_off.go
+@@ -0,0 +1,9 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !norequirefips
++
++package backend
++
++const noRequireFIPS = false
+diff --git a/src/crypto/internal/backend/norequirefips_on.go b/src/crypto/internal/backend/norequirefips_on.go
+new file mode 100644
+index 00000000000000..a20c1d4ce323fe
+--- /dev/null
++++ b/src/crypto/internal/backend/norequirefips_on.go
+@@ -0,0 +1,13 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build norequirefips
++
++package backend
++
++// noRequireFIPS should only be set to true when building
++// the Go toolchain, where it is necessary to allow
++// running it with GODEBUG=FIPS140=1 even when the toolchain
++// is built with GOEXPERIMENT=noopensslcrypto.
++const noRequireFIPS = true
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
 index 00000000000000..ac656468e3ed32
@@ -2905,7 +3026,7 @@ index 00000000000000..8d16f2133615bb
 +}
 diff --git a/src/crypto/zbackenderrnofallback_boring.go b/src/crypto/zbackenderrnofallback_boring.go
 new file mode 100644
-index 00000000000000..f3f5d73b4ec1e6
+index 00000000000000..7ee6d5d271e128
 --- /dev/null
 +++ b/src/crypto/zbackenderrnofallback_boring.go
 @@ -0,0 +1,20 @@
@@ -2915,7 +3036,7 @@ index 00000000000000..f3f5d73b4ec1e6
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
 +
-+//go:build goexperiment.boringcrypto && !(goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan) && !allowcryptofallback
++//go:build goexperiment.boringcrypto && !(goexperiment.boringcrypto && linux && cgo && (amd64 || arm64) && !android && !msan)
 +
 +package crypto
 +
@@ -2931,7 +3052,7 @@ index 00000000000000..f3f5d73b4ec1e6
 +}
 diff --git a/src/crypto/zbackenderrnofallback_cng.go b/src/crypto/zbackenderrnofallback_cng.go
 new file mode 100644
-index 00000000000000..50198a70ebb639
+index 00000000000000..b6706c775d8146
 --- /dev/null
 +++ b/src/crypto/zbackenderrnofallback_cng.go
 @@ -0,0 +1,20 @@
@@ -2941,7 +3062,7 @@ index 00000000000000..50198a70ebb639
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
 +
-+//go:build goexperiment.cngcrypto && !(goexperiment.cngcrypto && windows && (amd64 || arm64)) && !allowcryptofallback
++//go:build goexperiment.cngcrypto && !(goexperiment.cngcrypto && windows && (amd64 || arm64))
 +
 +package crypto
 +
@@ -2957,7 +3078,7 @@ index 00000000000000..50198a70ebb639
 +}
 diff --git a/src/crypto/zbackenderrnofallback_darwin.go b/src/crypto/zbackenderrnofallback_darwin.go
 new file mode 100644
-index 00000000000000..8b4c2a0b549e46
+index 00000000000000..9438ab0db29f2e
 --- /dev/null
 +++ b/src/crypto/zbackenderrnofallback_darwin.go
 @@ -0,0 +1,20 @@
@@ -2967,7 +3088,7 @@ index 00000000000000..8b4c2a0b549e46
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
 +
-+//go:build goexperiment.darwincrypto && !(goexperiment.darwincrypto && darwin && cgo) && !allowcryptofallback
++//go:build goexperiment.darwincrypto && !(goexperiment.darwincrypto && darwin && cgo)
 +
 +package crypto
 +
@@ -2983,7 +3104,7 @@ index 00000000000000..8b4c2a0b549e46
 +}
 diff --git a/src/crypto/zbackenderrnofallback_openssl.go b/src/crypto/zbackenderrnofallback_openssl.go
 new file mode 100644
-index 00000000000000..5f137d23b6bc97
+index 00000000000000..004f5cfba4e74f
 --- /dev/null
 +++ b/src/crypto/zbackenderrnofallback_openssl.go
 @@ -0,0 +1,20 @@
@@ -2993,7 +3114,7 @@ index 00000000000000..5f137d23b6bc97
 +
 +// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
 +
-+//go:build goexperiment.opensslcrypto && !(goexperiment.opensslcrypto && linux && cgo) && !allowcryptofallback
++//go:build goexperiment.opensslcrypto && !(goexperiment.opensslcrypto && linux && cgo)
 +
 +package crypto
 +
@@ -3127,15 +3248,15 @@ index 831ee67afc952d..d2f00d57c10286 100644
 +	return boring_runtime_arg0()
 +}
 diff --git a/src/syscall/exec_linux_test.go b/src/syscall/exec_linux_test.go
-index 69d49169446d1c..9c16f665d4a223 100644
+index 69d49169446d1c..e6d344ff67a8aa 100644
 --- a/src/syscall/exec_linux_test.go
 +++ b/src/syscall/exec_linux_test.go
-@@ -299,7 +299,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
- 		}
+@@ -300,7 +300,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
  	})
  
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-tags=allowcryptofallback", "-o", x, "syscall")
- 	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
+ 	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
+-	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
++	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0", "GOEXPERIMENT=nosystemcrypto")
  	if o, err := cmd.CombinedOutput(); err != nil {
  		t.Fatalf("%v: %v\n%s", cmd, err, o)
+ 	}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/cmd/dist/test.go                          |   9 +-
  src/cmd/go/internal/load/pkg.go               |   3 +
  .../go/testdata/script/build_systemcrypto.txt |  35 ++
- src/cmd/link/internal/ld/main.go              |  11 +-
+ src/cmd/link/internal/ld/main.go              |  15 +-
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
  .../internal/backend/backendgen_test.go       | 274 +++++++++++++
@@ -54,7 +54,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 50 files changed, 2771 insertions(+), 8 deletions(-)
+ 50 files changed, 2775 insertions(+), 8 deletions(-)
  create mode 100644 src/cmd/go/testdata/script/build_systemcrypto.txt
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
@@ -231,7 +231,7 @@ index 00000000000000..3ae8fbfa3ccad3
 +}
 \ No newline at end of file
 diff --git a/src/cmd/link/internal/ld/main.go b/src/cmd/link/internal/ld/main.go
-index 6a684890be0a03..0d3f6a51b69e58 100644
+index 6a684890be0a03..4d84fc9bd08984 100644
 --- a/src/cmd/link/internal/ld/main.go
 +++ b/src/cmd/link/internal/ld/main.go
 @@ -44,6 +44,7 @@ import (
@@ -242,7 +242,7 @@ index 6a684890be0a03..0d3f6a51b69e58 100644
  	"strconv"
  	"strings"
  )
-@@ -187,7 +188,15 @@ func Main(arch *sys.Arch, theArch Arch) {
+@@ -187,7 +188,19 @@ func Main(arch *sys.Arch, theArch Arch) {
  
  	buildVersion := buildcfg.Version
  	if goexperiment := buildcfg.Experiment.String(); goexperiment != "" {
@@ -250,8 +250,12 @@ index 6a684890be0a03..0d3f6a51b69e58 100644
 +		// systemcrypt is managed an experiment for historical reasons,
 +		// but it is really not an experiment, but a consolidated feature.
 +		// Don't report it in the build version.
++		var cryptoBackends = [...]string{"systemcrypto", "opensslcrypto", "cngcrypto", "darwincrypto", "boringcrypto"}
 +		goexperiment = strings.Join(slices.DeleteFunc(strings.Split(goexperiment, ","), func(s string) bool {
-+			return s == "nosystemcrypto" || s == "systemcrypto"
++			if slices.Contains(cryptoBackends[:], s) {
++				return true
++			}
++			return strings.HasPrefix(s, "no") && slices.Contains(cryptoBackends[:], s[2:])
 +		}), ",")
 +		if goexperiment != "" {
 +			buildVersion += " X:" + goexperiment

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -142,7 +142,7 @@ index b50f3342fe8714..a327e0a50e0d74 100644
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index d335e4cfbce468..27102ba00b27a2 100644
+index d335e4cfbce468..a80815006a5377 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -847,13 +847,18 @@ func (t *tester) registerTests() {
@@ -152,7 +152,7 @@ index d335e4cfbce468..27102ba00b27a2 100644
 +		var extraEnvs []string
 +		if goos != "windows" {
 +			// Linux and macOS don't support systemcrypto with CGO_ENABLED=0.
-+			extraEnvs = append(extraEnvs, "GOEXPERIMENT=nosystemcrypto")
++			extraEnvs = append(extraEnvs, "GOEXPERIMENT=nosystemcrypto", "GOFLAGS=-tags=norequirefips")
 +		}
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement crypto/internal/backend
 
 ---
  .gitignore                                    |   2 +
- src/cmd/dist/build.go                         |  19 +-
+ src/cmd/dist/build.go                         |   5 +
  src/cmd/dist/test.go                          |   9 +-
  src/cmd/go/internal/load/pkg.go               |   3 +
  .../go/testdata/script/build_systemcrypto.txt |  35 ++
@@ -54,7 +54,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 50 files changed, 2771 insertions(+), 8 deletions(-)
+ 50 files changed, 2758 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/go/testdata/script/build_systemcrypto.txt
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
@@ -112,27 +112,13 @@ index c6512e64a4ef39..b3b01db73b009d 100644
  # For files created by specific development environment (e.g. editor),
  # use alternative ways to exclude files from git.
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index b50f3342fe8714..cee3ff2d1543f6 100644
+index b50f3342fe8714..fb61daf8160a5b 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1538,7 +1538,24 @@ func cmdbootstrap() {
- 	xprintf("Building Go toolchain2 using go_bootstrap and Go toolchain1.\n")
+@@ -1539,6 +1539,11 @@ func cmdbootstrap() {
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
--	os.Setenv("GOEXPERIMENT", goexperiment)
-+	//
-+	// The Go toolchain does not use crypto for security. Disable systemcrypto
-+	// to favor portability.
-+	var goexpSlice []string
-+	if goexperiment != "" {
-+		goexpSlice = strings.Split(goexperiment, ",")
-+		goexpSlice = slices.DeleteFunc(goexpSlice, func(exp string) bool {
-+			return exp == "systemcrypto" || exp == "opensslcrypto" ||
-+				exp == "cngcrypto" || exp == "darwincrypto" || exp == "boringcrypto"
-+		})
-+	}
-+	goexpSlice = append(goexpSlice, "nosystemcrypto")
-+	os.Setenv("GOEXPERIMENT", strings.Join(goexpSlice, ","))
+ 	os.Setenv("GOEXPERIMENT", goexperiment)
 +	// Set the norequirefips to allow using the toolchain when it is
 +	// not built with a systemcrypto backend and GODEBUG=fips140=on is set.
 +	// For example, when runnings "GODEBUG=fips140=on go test ./..." or


### PR DESCRIPTION
`nocryptofallback` is a hack with a misleading name that does too many things: allow building the toolchain with cgo disabled, help to Microsoft Go toolchain pass the Go test suite, and allow the toolchain to not fail if it hasn't been built with a system crypto backend and `GODEBUG=fips140=1` is set.

The first and second jobs can already be achieved by using `GOEXPERIMENT=nosystemcrypto`, which disables the systemcrypto experiment. This PR uses this flag instead of `allowcryptofallback` in the few tests that don't support running with `GOEXPERIMENT=systemcrypto` (mainly because cgo is disabled and crypto is imported).

The third job should be achieved by a build tag with a name that is more specific. Here I've proposed `norequirefips`, but I'm open to suggestions. I've kept this build tag out of the documentation because nobody else should be using it.

This PR also adds makes go version -m to report whether systemcrypto is enabled. It goes in the direction of moving away from managing the systemcrypto as an experiment, which has always been a bit misleading. Example:

```
go version -m ./main
./main: go1.25-devel_04738e85ef2 Thu Jun 12 12:49:08 2025 +0200
        path    command-line-arguments
        build   microsoft_systemcrypto=1
        build   -buildmode=exe
        build   -compiler=gc
        build   CGO_ENABLED=1
        build   CGO_CFLAGS=
        build   CGO_CPPFLAGS=
        build   CGO_CXXFLAGS=
        build   CGO_LDFLAGS=
        build   GOARCH=arm64
        build   GOOS=darwin
        build   GOARM64=v8.0
```

Updates #1352.
Closes #1706.