### PR TITLE
Remove `GOFIPS=0` support

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -81,7 +81,6 @@ Some configurations are invalid and intentionally result in a build error or run
 
 | Build-time config | Runtime config | Behavior |
 | --- | --- | --- |
-| `GOEXPERIMENT=systemcrypto` and `-tags=requirefips` | `GOFIPS=0` | The app panics due to the conflict between build-time and runtime configuration. |
 | `-tags=requirefips` | | The build fails. A crypto backend must be specified to enable FIPS features. |
 | `GOEXPERIMENT=cngcrypto,opensslcrypto` | | The build fails. Only one crypto backend can be enabled at a time. |
 | `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto` | | The build fails. Cgo is required to use the OpenSSL backend. <br/> Prior to Go 1.21 the build would succeed but use standard Go crypto, making the app non-compliant. |
@@ -222,7 +221,6 @@ To set FIPS mode preference on Linux, use one of the following options. The firs
 
 - Explicitly enable it by setting the environment variable `GODEBUG=fips140=on`.
 - Explicitly enable it by setting the environment variable `GOFIPS=1`.
-- Explicitly disable it by setting the environment variable `GOFIPS=0`.
 - Implicitly enable it by booting the Linux Kernel in FIPS mode.
   - The Linux Kernel's FIPS mode sets the content of `/proc/sys/crypto/fips_enabled` to `1`. The Go runtime reads this file.
 
@@ -305,8 +303,6 @@ Most programs aren't expected to use these options. Determining FIPS mode at run
 - Dependence on environment variables like `GODEBUG` and `GOFIPS` in any way may be undesirable.
 - The program's documentation can state it will always run in FIPS mode without any nuance about environment variables.
 - If the program is used by someone unfamiliar with the system they're configuring, the panic will help catch mistakes before they become a problem.
-
-We chose to make a FIPS-only Go program panic if `GOFIPS=0` rather than silently ignoring the setting. This helps avoid a surprise if a user of such program sets `GOFIPS=0` and expects it to turn off FIPS mode.
 
 ### Build option to use Go crypto if the backend compatibility check fails
 
@@ -438,6 +434,8 @@ A program running in FIPS mode can claim it is using a FIPS-certified cryptograp
 This list of major changes is intended for quick reference and for access to historical information about versions that are no longer supported. The behavior of all in-support versions are documented in the sections above with notes for version-specific differences where necessary.
 
 ### Go 1.25 (Aug 2025)
+
+- `GOFIPS=0` support has been removed. It now has no effect.
 
 - `GOEXPERIMENT=allowcryptofallback` has been downgraded to the `allowcryptofallback` build tag. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
 

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -23,7 +23,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/internal/backend/fips140/darwin.go |  11 +
- .../internal/backend/fips140/fips140.go       |  63 +++
+ .../internal/backend/fips140/fips140.go       |  52 +++
  .../internal/backend/fips140/isrequirefips.go |   9 +
  .../internal/backend/fips140/norequirefips.go |   9 +
  .../backend/fips140/nosystemcrypto.go         |  11 +
@@ -33,7 +33,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 339 ++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 334 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/crypto/zbackenderrconflict_boring_cng.go  |  17 +
  .../zbackenderrconflict_boring_darwin.go      |  17 +
@@ -50,7 +50,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2705 insertions(+), 4 deletions(-)
+ 46 files changed, 2689 insertions(+), 4 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -1764,10 +1764,10 @@ index 00000000000000..ef5af5d956163e
 +}
 diff --git a/src/crypto/internal/backend/fips140/fips140.go b/src/crypto/internal/backend/fips140/fips140.go
 new file mode 100644
-index 00000000000000..7e5dd9b1544940
+index 00000000000000..49eb8b71ae1bb4
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/fips140.go
-@@ -0,0 +1,63 @@
+@@ -0,0 +1,52 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1789,13 +1789,6 @@ index 00000000000000..7e5dd9b1544940
 +
 +var enabled bool
 +
-+// Disabled reports whether FIPS 140 mode is disabled by using GOFIPS or GOLANG_FIPS.
-+func Disabled() bool {
-+	return disabled
-+}
-+
-+var disabled bool
-+
 +// Message is a human-readable message about how [Enabled] was set.
 +var Message string
 +
@@ -1815,11 +1808,7 @@ index 00000000000000..7e5dd9b1544940
 +		Message = "system FIPS mode"
 +		value = "1"
 +	}
-+	if value == "1" {
-+		enabled = true
-+	} else if value == "0" {
-+		disabled = true
-+	}
++	enabled = value == "1"
 +	if isRequireFIPS {
 +		if disabled {
 +			panic("the 'requirefips' build tag is enabled, but it conflicts " +
@@ -2406,10 +2395,10 @@ index 00000000000000..dc8513b535f19b
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..ac656468e3ed32
+index 00000000000000..89a5fe5d170c41
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,339 @@
+@@ -0,0 +1,334 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2450,11 +2439,6 @@ index 00000000000000..ac656468e3ed32
 +			// - In OpenSSL 1, the active engine supports FIPS mode, but it is not enabled.
 +			// - In OpenSSL 3, the provider used by default doesn't match the `fips=yes` query.
 +			panic("opensslcrypto: FIPS mode requested (" + fips140.Message + ") but not available in " + openssl.VersionText())
-+		}
-+	} else if fips140.Disabled() {
-+		// TODO: Remove this block when GOFIPS=0 is no longer supported.
-+		if openssl.FIPS() {
-+			panic("opensslcrypto: FIPS mode explicitly disabled (" + fips140.Message + ") but enabled in " + openssl.VersionText())
 +		}
 +	}
 +	sig.BoringCrypto()

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -23,7 +23,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/fips140/boring.go |  11 +
  src/crypto/internal/backend/fips140/cng.go    |  33 ++
  src/crypto/internal/backend/fips140/darwin.go |  11 +
- .../internal/backend/fips140/fips140.go       |  52 +++
+ .../internal/backend/fips140/fips140.go       |  47 +++
  .../internal/backend/fips140/isrequirefips.go |   9 +
  .../internal/backend/fips140/norequirefips.go |   9 +
  .../backend/fips140/nosystemcrypto.go         |  11 +
@@ -50,7 +50,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2689 insertions(+), 4 deletions(-)
+ 46 files changed, 2684 insertions(+), 4 deletions(-)
  create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
  create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
@@ -1764,10 +1764,10 @@ index 00000000000000..ef5af5d956163e
 +}
 diff --git a/src/crypto/internal/backend/fips140/fips140.go b/src/crypto/internal/backend/fips140/fips140.go
 new file mode 100644
-index 00000000000000..49eb8b71ae1bb4
+index 00000000000000..b11251ad4c6c9c
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/fips140.go
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,47 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1810,11 +1810,6 @@ index 00000000000000..49eb8b71ae1bb4
 +	}
 +	enabled = value == "1"
 +	if isRequireFIPS {
-+		if disabled {
-+			panic("the 'requirefips' build tag is enabled, but it conflicts " +
-+				"with the " + Message + "=" + value +
-+				" which would disable FIPS mode")
-+		}
 +		Message = "requirefips tag set"
 +		enabled = true
 +		return


### PR DESCRIPTION
In Go 1.24 release notes we announced that the `GOFIPS` environment variable was deprecated and that it would be made no-opt in Go 1.25. Upstream's `GODEBUG=fips140=on` should be used instead.

This PR removes support for `GOFIPS=0`, which basically nobody is using. There are still several 1P code bases using `GOFIPS=1`, so we better keep it around until they migrate to the new setting (may have to ping those teams so they are aware of this).

I've also removed almost all occurrences of `GOFIPS=0` in the documentation, except for the notice that it is now unsupported.