### PR TITLE
Use `skipfipscheck` instead of `allowcryptofallback` (sometimes)

### DIFF
--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -11,7 +11,6 @@ information about the behavior.
 Includes new tests in "build_test.go" and "buildbackend_test.go" to help
 maintain this feature. For more information, see the test files.
 ---
- src/cmd/dist/build.go                         |  6 ++
  src/cmd/go/internal/modindex/build.go         | 58 ++++++++++++-
  src/cmd/go/internal/modindex/build_test.go    | 73 ++++++++++++++++
  src/go/build/build.go                         | 58 ++++++++++++-
@@ -29,7 +28,7 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 ++++
- 18 files changed, 369 insertions(+), 4 deletions(-)
+ 17 files changed, 363 insertions(+), 4 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/main.go
@@ -45,23 +44,6 @@ maintain this feature. For more information, see the test files.
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_on.go
 
-diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index b50f3342fe8714..75629c2a6bd9ba 100644
---- a/src/cmd/dist/build.go
-+++ b/src/cmd/dist/build.go
-@@ -1539,6 +1539,12 @@ func cmdbootstrap() {
- 	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
- 	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
- 	os.Setenv("GOEXPERIMENT", goexperiment)
-+	// Build the Go toolchain with "-tags=allowcryptofallback". This
-+	// allows toolchains not built with "GOEXPERIMENT=systemcrypto" to be used
-+	// when GODEBUG=fips140=on is set. For example, when running
-+	// "GODEBUG=fips140=on go test ./..." or "GODEBUG=fips140=on go run .".
-+	// Shadow goexperiment so that the global variable is not modified.
-+	os.Setenv("GOFLAGS", "-tags=allowcryptofallback")
- 	// No need to enable PGO for toolchain2.
- 	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
- 	if debug {
 diff --git a/src/cmd/go/internal/modindex/build.go b/src/cmd/go/internal/modindex/build.go
 index d7e09fed25f43a..10614d17e62453 100644
 --- a/src/cmd/go/internal/modindex/build.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -127,7 +127,7 @@ index b50f3342fe8714..23a7f132788ebc 100644
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index d335e4cfbce468..7e362c80be609a 100644
+index d335e4cfbce468..f8abfe6f62216f 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -847,6 +847,11 @@ func (t *tester) registerTests() {
@@ -137,7 +137,7 @@ index d335e4cfbce468..7e362c80be609a 100644
 +		var tags []string
 +		if goos != "windows" {
 +			// Linux and macOS don't support systemcrypto with CGO_ENABLED=0.
-+			tags = append(tags, "allowcryptofallback")
++			tags = append(tags, "allowcryptofallback,skipfipscheck")
 +		}
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -3,14 +3,19 @@ From: qmuntal <qmuntaldiaz@microsoft.com>
 Date: Wed, 15 Jan 2025 16:32:26 +0100
 Subject: [PATCH] Implement crypto/internal/backend
 
+Implement the supporting code for using the crypto backends,
+but without using them yet.
+
+Update the Go toolchain build settings so that it uses the
+desired goexperiments and build tags.
 ---
  .gitignore                                    |   2 +
- src/cmd/dist/build.go                         |   6 +
+ src/cmd/dist/build.go                         |   5 +
  src/cmd/dist/test.go                          |  17 +-
- src/cmd/go/systemcrypto_test.go               |  92 +++++
+ src/cmd/go/systemcrypto_test.go               |  97 +++++
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
- .../internal/backend/backendgen_test.go       | 278 +++++++++++++
+ .../internal/backend/backendgen_test.go       | 288 ++++++++++++++
  src/crypto/internal/backend/bbig/big.go       |  17 +
  .../internal/backend/bbig/big_boring.go       |  12 +
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
@@ -48,11 +53,12 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/zbackenderrnofallback_darwin.go    |  20 +
  src/crypto/zbackenderrnofallback_openssl.go   |  20 +
  .../zbackenderrrequirefips_nosystemcrypto.go  |  17 +
+ .../zbackenderrrequirefips_skipfipscheck.go   |  16 +
  .../zbackenderrsystemcrypto_nobackend.go      |  16 +
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 48 files changed, 2829 insertions(+), 8 deletions(-)
+ 49 files changed, 2859 insertions(+), 8 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
@@ -94,6 +100,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  create mode 100644 src/crypto/zbackenderrnofallback_darwin.go
  create mode 100644 src/crypto/zbackenderrnofallback_openssl.go
  create mode 100644 src/crypto/zbackenderrrequirefips_nosystemcrypto.go
+ create mode 100644 src/crypto/zbackenderrrequirefips_skipfipscheck.go
  create mode 100644 src/crypto/zbackenderrsystemcrypto_nobackend.go
 
 diff --git a/.gitignore b/.gitignore
@@ -110,31 +117,30 @@ index c6512e64a4ef39..b3b01db73b009d 100644
  # For files created by specific development environment (e.g. editor),
  # use alternative ways to exclude files from git.
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index b50f3342fe8714..23a7f132788ebc 100644
+index b50f3342fe8714..3d3dde18a6562b 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1539,6 +1539,12 @@ func cmdbootstrap() {
+@@ -1539,6 +1539,11 @@ func cmdbootstrap() {
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
  	os.Setenv("GOEXPERIMENT", goexperiment)
-+	// Build the Go toolchain with "-tags=allowcryptofallback,skipfipscheck". This
++	// Build the Go toolchain with "-tags=allowcryptofallback,ms_skipfipscheck". This
 +	// allows toolchains not built with the systemcrypto goexperiment to be used
 +	// when GODEBUG=fips140=on is set. For example, when running
 +	// "GODEBUG=fips140=on go test ./..." or "GODEBUG=fips140=on go run .".
-+	// Shadow goexperiment so that the global variable is not modified.
-+	os.Setenv("GOFLAGS", "-tags=allowcryptofallback,skipfipscheck")
++	os.Setenv("GOFLAGS", "-tags=allowcryptofallback,ms_skipfipscheck")
  	// No need to enable PGO for toolchain2.
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index d335e4cfbce468..b4ba0ad8210a94 100644
+index d335e4cfbce468..5663aa3286a816 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
  		}
  	}
  
-+	tags := []string{"-tags=allowcryptofallback,skipfipscheck"}
++	tags := []string{"-tags=allowcryptofallback,ms_skipfipscheck"}
 +
  	if t.rebuild {
  		t.out("Building packages and commands.")
@@ -164,7 +170,7 @@ index d335e4cfbce468..b4ba0ad8210a94 100644
 +		var tags []string
 +		if goos != "windows" {
 +			// Linux and macOS don't support systemcrypto with CGO_ENABLED=0.
-+			tags = append(tags, "allowcryptofallback,skipfipscheck")
++			tags = append(tags, "allowcryptofallback,ms_skipfipscheck")
 +		}
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
@@ -187,10 +193,10 @@ index d335e4cfbce468..b4ba0ad8210a94 100644
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
-index 00000000000000..5fc1c487b6ffe1
+index 00000000000000..9bc2e228fee3a6
 --- /dev/null
 +++ b/src/cmd/go/systemcrypto_test.go
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,97 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -264,7 +270,7 @@ index 00000000000000..5fc1c487b6ffe1
 +
 +func TestSystemCryptoFIPS(t *testing.T) {
 +	// Test different go commands with GODEBUG=fips140=on
-+	// to exercise the skipfipscheck build tag.
++	// to exercise the ms_skipfipscheck build tag.
 +	if goexperiment.BoringCrypto {
 +		t.Skip("BoringCrypto doesn't support GODEBUG=fips140=on")
 +	}
@@ -275,13 +281,18 @@ index 00000000000000..5fc1c487b6ffe1
 +	nonCryptoFile := writeFile(t, fileWithoutCrypto)
 +
 +	// Build should always succeed given that the go toolchain
-+	// is built with the skipfipscheck build tag.
++	// is built with the ms_skipfipscheck build tag.
 +	execGoTool(t, "build", env, cryptoFile)
 +	execGoTool(t, "build", env, nonCryptoFile)
 +
 +	// Run should always succeed if the target go package
 +	// doesn't use crypto.
 +	execGoTool(t, "run", env, nonCryptoFile)
++
++	// Run may or may not fail if the target go package uses crypto,
++	// because while the toolchain was built with ms_skipfipscheck, the
++	// target program was not. Failure depends on system crypto mode
++	// and presence of system-provided crypto, and it can't be tested here.
 +}
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644
@@ -347,10 +358,10 @@ index 00000000000000..acf0113bbefb6c
 +//go:generate go test -run TestGenerated -fix
 diff --git a/src/crypto/internal/backend/backendgen_test.go b/src/crypto/internal/backend/backendgen_test.go
 new file mode 100644
-index 00000000000000..063e0bb4948236
+index 00000000000000..647d9f0b871aff
 --- /dev/null
 +++ b/src/crypto/internal/backend/backendgen_test.go
-@@ -0,0 +1,278 @@
+@@ -0,0 +1,288 @@
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -485,6 +496,8 @@ index 00000000000000..063e0bb4948236
 +	delete(existingFiles, f)
 +	f = testRequireFIPSWithoutBackend(t)
 +	delete(existingFiles, f)
++	f = testRequireFIPSWithSkipFIPSCheck(t)
++	delete(existingFiles, f)
 +
 +	for f := range existingFiles {
 +		if *fix {
@@ -553,6 +566,14 @@ index 00000000000000..063e0bb4948236
 +		"//go:build requirefips && !goexperiment.systemcrypto",
 +		"The requirefips tag is enabled, but no crypto backend is enabled.",
 +		"A crypto backend is required to enable FIPS mode.")
++}
++
++func testRequireFIPSWithSkipFIPSCheck(t *testing.T) string {
++	return testErrorFile(
++		t,
++		filepath.Join(cryptoPackageDir, backendErrPrefix+"requirefips_skipfipscheck.go"),
++		"//go:build requirefips && ms_skipfipscheck",
++		"The requirefips tag is enabled but conflicts with the ms_skipfipscheck tag.")
 +}
 +
 +// testErrorFile checks/generates a Go file with a given build constraint that
@@ -1886,7 +1907,7 @@ index 00000000000000..8a2efe2346e84c
 +}
 diff --git a/src/crypto/internal/backend/fips140/fips140.go b/src/crypto/internal/backend/fips140/fips140.go
 new file mode 100644
-index 00000000000000..c623233633daec
+index 00000000000000..1bf7c3b7d63da8
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/fips140.go
 @@ -0,0 +1,70 @@
@@ -1936,7 +1957,7 @@ index 00000000000000..c623233633daec
 +	if isRequireFIPS {
 +		if isSkipFIPSCheck {
 +			panic("the 'requirefips' build tag is enabled, but it conflicts " +
-+				"with the 'skipfipscheck' build tag")
++				"with the 'ms_skipfipscheck' build tag")
 +		}
 +		message = "requirefips tag set"
 +		enabled = true
@@ -2101,7 +2122,7 @@ index 00000000000000..a8ff666b6d182e
 +}
 diff --git a/src/crypto/internal/backend/fips140/skipfipscheck_off.go b/src/crypto/internal/backend/fips140/skipfipscheck_off.go
 new file mode 100644
-index 00000000000000..e279bb4820cbc1
+index 00000000000000..f60b10dfa3aaf3
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/skipfipscheck_off.go
 @@ -0,0 +1,9 @@
@@ -2109,14 +2130,14 @@ index 00000000000000..e279bb4820cbc1
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !skipfipscheck
++//go:build !ms_skipfipscheck
 +
 +package fips140
 +
 +const isSkipFIPSCheck = false
 diff --git a/src/crypto/internal/backend/fips140/skipfipscheck_on.go b/src/crypto/internal/backend/fips140/skipfipscheck_on.go
 new file mode 100644
-index 00000000000000..8509e61c588df7
+index 00000000000000..d3d39fd77f98db
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/skipfipscheck_on.go
 @@ -0,0 +1,9 @@
@@ -2124,7 +2145,7 @@ index 00000000000000..8509e61c588df7
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build skipfipscheck
++//go:build ms_skipfipscheck
 +
 +package fips140
 +
@@ -3192,6 +3213,28 @@ index 00000000000000..91bede3aa030a5
 +	`
 +	The requirefips tag is enabled, but no crypto backend is enabled.
 +	A crypto backend is required to enable FIPS mode.
++	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
++	`
++}
+diff --git a/src/crypto/zbackenderrrequirefips_skipfipscheck.go b/src/crypto/zbackenderrrequirefips_skipfipscheck.go
+new file mode 100644
+index 00000000000000..8ba88a888eb8c0
+--- /dev/null
++++ b/src/crypto/zbackenderrrequirefips_skipfipscheck.go
+@@ -0,0 +1,16 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file is generated by crypto/internal/backend. DO NOT EDIT. DO NOT manually create files with the prefix "zbackenderr".
++
++//go:build requirefips && ms_skipfipscheck
++
++package crypto
++
++func init() {
++	`
++	The requirefips tag is enabled but conflicts with the ms_skipfipscheck tag.
 +	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 +	`
 +}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -5,9 +5,9 @@ Subject: [PATCH] Implement crypto/internal/backend
 
 ---
  .gitignore                                    |   2 +
+ src/cmd/dist/build.go                         |   6 +
  src/cmd/dist/test.go                          |   7 +
- .../backend/allocryptofallback_off.go         |   9 +
- .../internal/backend/allocryptofallback_on.go |   9 +
+ .../go/testdata/script/build_systemcrypto.txt |  18 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
  .../internal/backend/backendgen_test.go       | 278 +++++++++++++
@@ -16,24 +16,26 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/boring_linux.go   | 287 ++++++++++++++
- src/crypto/internal/backend/cng_windows.go    | 344 ++++++++++++++++
- src/crypto/internal/backend/common.go         |  58 +++
- src/crypto/internal/backend/darwin_darwin.go  | 367 ++++++++++++++++++
- src/crypto/internal/backend/fips140/boring.go |  11 +
- src/crypto/internal/backend/fips140/cng.go    |  33 ++
- src/crypto/internal/backend/fips140/darwin.go |  11 +
- .../internal/backend/fips140/fips140.go       |  47 +++
+ src/crypto/internal/backend/boring_linux.go   | 294 ++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 345 ++++++++++++++++
+ src/crypto/internal/backend/common.go         |  46 +++
+ src/crypto/internal/backend/darwin_darwin.go  | 372 ++++++++++++++++++
+ src/crypto/internal/backend/fips140/boring.go |  13 +
+ src/crypto/internal/backend/fips140/cng.go    |  35 ++
+ src/crypto/internal/backend/fips140/darwin.go |  13 +
+ .../internal/backend/fips140/fips140.go       |  70 ++++
  .../internal/backend/fips140/isrequirefips.go |   9 +
  .../internal/backend/fips140/norequirefips.go |   9 +
- .../backend/fips140/nosystemcrypto.go         |  11 +
- .../internal/backend/fips140/openssl_cgo.go   |  57 +++
- .../internal/backend/fips140/openssl_nocgo.go |  15 +
+ .../backend/fips140/nosystemcrypto.go         |  13 +
+ .../internal/backend/fips140/openssl_cgo.go   |  59 +++
+ .../internal/backend/fips140/openssl_nocgo.go |  17 +
+ .../backend/fips140/skipfipscheck_off.go      |   9 +
+ .../backend/fips140/skipfipscheck_on.go       |   9 +
  .../internal/opensslsetup/opensslsetup.go     |  70 ++++
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
- src/crypto/internal/backend/nobackend.go      | 246 ++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 334 ++++++++++++++++
+ src/crypto/internal/backend/nobackend.go      | 253 ++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 332 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/crypto/zbackenderrconflict_boring_cng.go  |  17 +
  .../zbackenderrconflict_boring_darwin.go      |  17 +
@@ -50,9 +52,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2684 insertions(+), 4 deletions(-)
- create mode 100644 src/crypto/internal/backend/allocryptofallback_off.go
- create mode 100644 src/crypto/internal/backend/allocryptofallback_on.go
+ 48 files changed, 2749 insertions(+), 4 deletions(-)
+ create mode 100644 src/cmd/go/testdata/script/build_systemcrypto.txt
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -74,6 +75,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  create mode 100644 src/crypto/internal/backend/fips140/nosystemcrypto.go
  create mode 100644 src/crypto/internal/backend/fips140/openssl_cgo.go
  create mode 100644 src/crypto/internal/backend/fips140/openssl_nocgo.go
+ create mode 100644 src/crypto/internal/backend/fips140/skipfipscheck_off.go
+ create mode 100644 src/crypto/internal/backend/fips140/skipfipscheck_on.go
  create mode 100644 src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go
  create mode 100644 src/crypto/internal/backend/internal/opensslsetup/opensslsetup_test.go
  create mode 100644 src/crypto/internal/backend/internal/opensslsetup/stub.go
@@ -106,6 +109,23 @@ index c6512e64a4ef39..b3b01db73b009d 100644
  # This file includes artifacts of Go build that should not be checked in.
  # For files created by specific development environment (e.g. editor),
  # use alternative ways to exclude files from git.
+diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
+index b50f3342fe8714..23a7f132788ebc 100644
+--- a/src/cmd/dist/build.go
++++ b/src/cmd/dist/build.go
+@@ -1539,6 +1539,12 @@ func cmdbootstrap() {
+ 	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
+ 	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
+ 	os.Setenv("GOEXPERIMENT", goexperiment)
++	// Build the Go toolchain with "-tags=allowcryptofallback,skipfipscheck". This
++	// allows toolchains not built with "GOEXPERIMENT=systemcrypto" to be used
++	// when GODEBUG=fips140=on is set. For example, when running
++	// "GODEBUG=fips140=on go test ./..." or "GODEBUG=fips140=on go run .".
++	// Shadow goexperiment so that the global variable is not modified.
++	os.Setenv("GOFLAGS", "-tags=allowcryptofallback,skipfipscheck")
+ 	// No need to enable PGO for toolchain2.
+ 	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
+ 	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
 index d335e4cfbce468..7e362c80be609a 100644
 --- a/src/cmd/dist/test.go
@@ -138,36 +158,31 @@ index d335e4cfbce468..7e362c80be609a 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-diff --git a/src/crypto/internal/backend/allocryptofallback_off.go b/src/crypto/internal/backend/allocryptofallback_off.go
+diff --git a/src/cmd/go/testdata/script/build_systemcrypto.txt b/src/cmd/go/testdata/script/build_systemcrypto.txt
 new file mode 100644
-index 00000000000000..7718cc02f48556
+index 00000000000000..b795e27f6d75e8
 --- /dev/null
-+++ b/src/crypto/internal/backend/allocryptofallback_off.go
-@@ -0,0 +1,9 @@
-+// Copyright 2025 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
++++ b/src/cmd/go/testdata/script/build_systemcrypto.txt
+@@ -0,0 +1,18 @@
++# "GODEBUG=fips140=on go build" should always succeed, 
++# even if the toolchain is not build with systemcrypto
++# or the system doesn't support FIPS mode.
++env GODEBUG=fips140=on
++go build main.go 
 +
-+//go:build !allowcryptofallback
++-- main.go --
 +
-+package backend
++package main
 +
-+const allowCryptoFallback = false
-diff --git a/src/crypto/internal/backend/allocryptofallback_on.go b/src/crypto/internal/backend/allocryptofallback_on.go
-new file mode 100644
-index 00000000000000..fc30aba8ad8228
---- /dev/null
-+++ b/src/crypto/internal/backend/allocryptofallback_on.go
-@@ -0,0 +1,9 @@
-+// Copyright 2025 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
++import (
++	"crypto/sha256"
++	"fmt"
++)
 +
-+//go:build allowcryptofallback
-+
-+package backend
-+
-+const allowCryptoFallback = true
++func main() {
++	fmt.Println(sha256.Sum256([]byte("Hello, World!")))
++}
+\ No newline at end of file
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644
 index 00000000000000..c2c06d3bff8c74
@@ -611,10 +626,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..48d44ec1723ab6
+index 00000000000000..1d6ec4eef5a5b4
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
-@@ -0,0 +1,287 @@
+@@ -0,0 +1,294 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -629,9 +644,16 @@ index 00000000000000..48d44ec1723ab6
 +import (
 +	"crypto"
 +	"crypto/cipher"
++	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring"
 +	"hash"
 +)
++
++func init() {
++	if err := fips140.Check(func() bool { return true }); err != nil {
++		panic(err)
++	}
++}
 +
 +const Enabled = true
 +
@@ -904,10 +926,10 @@ index 00000000000000..48d44ec1723ab6
 +}
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..7a89cfb5d2f596
+index 00000000000000..448311cbfd3f10
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,344 @@
+@@ -0,0 +1,345 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -930,23 +952,24 @@ index 00000000000000..7a89cfb5d2f596
 +	"github.com/microsoft/go-crypto-winnative/cng"
 +)
 +
-+// Enabled controls whether FIPS crypto is enabled.
-+const Enabled = true
-+
-+type BigInt = cng.BigInt
-+
 +func init() {
-+	if fips140.Enabled() {
++	fn := func() bool {
 +		enabled, err := cng.FIPS()
 +		if err != nil {
 +			panic("cngcrypto: unknown FIPS mode: " + err.Error())
 +		}
-+		if !enabled {
-+			panic("cngcrypto: not in FIPS mode")
-+		}
++		return enabled
++	}
++	if err := fips140.Check(fn); err != nil {
++		panic("cngcrypto: " + err.Error())
 +	}
 +	sig.BoringCrypto()
 +}
++
++// Enabled controls whether FIPS crypto is enabled.
++const Enabled = true
++
++type BigInt = cng.BigInt
 +
 +const RandReader = cng.RandReader
 +
@@ -1254,10 +1277,10 @@ index 00000000000000..7a89cfb5d2f596
 +}
 diff --git a/src/crypto/internal/backend/common.go b/src/crypto/internal/backend/common.go
 new file mode 100644
-index 00000000000000..9dec441fa63856
+index 00000000000000..a9682181ffa154
 --- /dev/null
 +++ b/src/crypto/internal/backend/common.go
-@@ -0,0 +1,58 @@
+@@ -0,0 +1,46 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1265,21 +1288,9 @@ index 00000000000000..9dec441fa63856
 +package backend
 +
 +import (
-+	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
 +	"runtime"
 +)
-+
-+func init() {
-+	if !allowCryptoFallback && fips140.Enabled() {
-+		if !Enabled {
-+			if runtime.GOOS != "linux" && runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-+				panic("FIPS mode requested (" + fips140.Message + ") but no crypto backend is supported on " + runtime.GOOS)
-+			}
-+			panic("FIPS mode requested (" + fips140.Message + ") but no supported crypto backend is enabled")
-+		}
-+	}
-+}
 +
 +// Unreachable marks code that should be unreachable
 +// when backend is in use.
@@ -1318,10 +1329,10 @@ index 00000000000000..9dec441fa63856
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..0c374baf8d3f80
+index 00000000000000..fea0f284de2439
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
-@@ -0,0 +1,367 @@
+@@ -0,0 +1,372 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1336,6 +1347,7 @@ index 00000000000000..0c374baf8d3f80
 +import (
 +	"crypto"
 +	"crypto/cipher"
++	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
 +	"crypto/internal/fips140/nistec"
 +	"errors"
@@ -1345,14 +1357,18 @@ index 00000000000000..0c374baf8d3f80
 +	"github.com/microsoft/go-crypto-darwin/xcrypto"
 +)
 +
++func init() {
++	// Darwin is considered FIPS compliant.
++	if err := fips140.Check(func() bool { return true }); err != nil {
++		panic("darwincrypto: " + err.Error())
++	}
++	sig.BoringCrypto()
++}
++
 +// Enabled controls whether FIPS crypto is enabled.
 +const Enabled = true
 +
 +type BigInt = xcrypto.BigInt
-+
-+func init() {
-+	sig.BoringCrypto()
-+}
 +
 +const RandReader = xcrypto.RandReader
 +
@@ -1691,10 +1707,10 @@ index 00000000000000..0c374baf8d3f80
 +}
 diff --git a/src/crypto/internal/backend/fips140/boring.go b/src/crypto/internal/backend/fips140/boring.go
 new file mode 100644
-index 00000000000000..3b583dc0eb0235
+index 00000000000000..4a955f7d781022
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/boring.go
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,13 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1703,15 +1719,17 @@ index 00000000000000..3b583dc0eb0235
 +
 +package fips140
 +
++const backendEnabled = true
++
 +func systemFIPSMode() bool {
 +	return false
 +}
 diff --git a/src/crypto/internal/backend/fips140/cng.go b/src/crypto/internal/backend/fips140/cng.go
 new file mode 100644
-index 00000000000000..f769d15f94ab05
+index 00000000000000..e4a1ddeeb7dc09
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/cng.go
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,35 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1725,6 +1743,8 @@ index 00000000000000..f769d15f94ab05
 +	"syscall"
 +	"unsafe"
 +)
++
++const backendEnabled = true
 +
 +// Don't use github.com/microsoft/go-crypto-winnative here.
 +// The fips140 package should have minimal dependencies.
@@ -1747,10 +1767,10 @@ index 00000000000000..f769d15f94ab05
 +}
 diff --git a/src/crypto/internal/backend/fips140/darwin.go b/src/crypto/internal/backend/fips140/darwin.go
 new file mode 100644
-index 00000000000000..ef5af5d956163e
+index 00000000000000..8a2efe2346e84c
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/darwin.go
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,13 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1759,15 +1779,17 @@ index 00000000000000..ef5af5d956163e
 +
 +package fips140
 +
++const backendEnabled = true
++
 +func systemFIPSMode() bool {
 +	return false
 +}
 diff --git a/src/crypto/internal/backend/fips140/fips140.go b/src/crypto/internal/backend/fips140/fips140.go
 new file mode 100644
-index 00000000000000..b11251ad4c6c9c
+index 00000000000000..c623233633daec
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/fips140.go
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,70 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1775,7 +1797,9 @@ index 00000000000000..b11251ad4c6c9c
 +package fips140
 +
 +import (
++	"errors"
 +	"internal/godebug"
++	"runtime"
 +	"syscall"
 +)
 +
@@ -1789,8 +1813,8 @@ index 00000000000000..b11251ad4c6c9c
 +
 +var enabled bool
 +
-+// Message is a human-readable message about how [Enabled] was set.
-+var Message string
++// message is a human-readable message about how [Enabled] was set.
++var message string
 +
 +func init() {
 +	// TODO: Decide which environment variable to use.
@@ -1798,22 +1822,43 @@ index 00000000000000..b11251ad4c6c9c
 +	var ok bool
 +	value := fips140GODEBUG.Value()
 +	if value == "on" || value == "only" || value == "debug" {
-+		Message = "environment variable GODEBUG=fips140=" + value
++		message = "environment variable GODEBUG=fips140=" + value
 +		value = "1"
 +	} else if value, ok = syscall.Getenv("GOFIPS"); ok {
-+		Message = "environment variable GOFIPS"
++		message = "environment variable GOFIPS"
 +	} else if value, ok = syscall.Getenv("GOLANG_FIPS"); ok {
-+		Message = "environment variable GOLANG_FIPS"
++		message = "environment variable GOLANG_FIPS"
 +	} else if systemFIPSMode() {
-+		Message = "system FIPS mode"
++		message = "system FIPS mode"
 +		value = "1"
 +	}
 +	enabled = value == "1"
 +	if isRequireFIPS {
-+		Message = "requirefips tag set"
++		if isSkipFIPSCheck {
++			panic("the 'requirefips' build tag is enabled, but it conflicts " +
++				"with the 'skipfipscheck' build tag")
++		}
++		message = "requirefips tag set"
 +		enabled = true
-+		return
 +	}
++}
++
++// Check checks whether fips mode, as returned by fips(),
++// is valid given the current settings.
++func Check(fips func() bool) error {
++	if isSkipFIPSCheck || !enabled {
++		return nil
++	}
++	if !backendEnabled {
++		if runtime.GOOS != "linux" && runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
++			return errors.New("FIPS mode requested (" + message + ") but no crypto backend is supported on " + runtime.GOOS)
++		}
++		return errors.New("FIPS mode requested (" + message + ") but no supported crypto backend is enabled")
++	}
++	if !fips() {
++		return errors.New("FIPS mode requested (" + message + ") but not available")
++	}
++	return nil
 +}
 diff --git a/src/crypto/internal/backend/fips140/isrequirefips.go b/src/crypto/internal/backend/fips140/isrequirefips.go
 new file mode 100644
@@ -1849,10 +1894,10 @@ index 00000000000000..6f01b9a3524dee
 \ No newline at end of file
 diff --git a/src/crypto/internal/backend/fips140/nosystemcrypto.go b/src/crypto/internal/backend/fips140/nosystemcrypto.go
 new file mode 100644
-index 00000000000000..83691d7dd42d51
+index 00000000000000..289d6594eac54b
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/nosystemcrypto.go
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,13 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1861,15 +1906,17 @@ index 00000000000000..83691d7dd42d51
 +
 +package fips140
 +
++const backendEnabled = false
++
 +func systemFIPSMode() bool {
 +	return false
 +}
 diff --git a/src/crypto/internal/backend/fips140/openssl_cgo.go b/src/crypto/internal/backend/fips140/openssl_cgo.go
 new file mode 100644
-index 00000000000000..d9ea4e513db72d
+index 00000000000000..a24db78572f528
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/openssl_cgo.go
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,59 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1884,6 +1931,8 @@ index 00000000000000..d9ea4e513db72d
 +
 +	"github.com/golang-fips/openssl/v2"
 +)
++
++const backendEnabled = true
 +
 +// systemFIPSMode reports whether the system is in FIPS mode.
 +// It first checks the kernel, and if that is not available, it checks the
@@ -1929,10 +1978,10 @@ index 00000000000000..d9ea4e513db72d
 +}
 diff --git a/src/crypto/internal/backend/fips140/openssl_nocgo.go b/src/crypto/internal/backend/fips140/openssl_nocgo.go
 new file mode 100644
-index 00000000000000..60ed26591d05d8
+index 00000000000000..a8ff666b6d182e
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/openssl_nocgo.go
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,17 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1945,9 +1994,41 @@ index 00000000000000..60ed26591d05d8
 +
 +package fips140
 +
++const backendEnabled = true
++
 +func systemFIPSMode() bool {
 +	return false
 +}
+diff --git a/src/crypto/internal/backend/fips140/skipfipscheck_off.go b/src/crypto/internal/backend/fips140/skipfipscheck_off.go
+new file mode 100644
+index 00000000000000..e279bb4820cbc1
+--- /dev/null
++++ b/src/crypto/internal/backend/fips140/skipfipscheck_off.go
+@@ -0,0 +1,9 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !skipfipscheck
++
++package fips140
++
++const isSkipFIPSCheck = false
+diff --git a/src/crypto/internal/backend/fips140/skipfipscheck_on.go b/src/crypto/internal/backend/fips140/skipfipscheck_on.go
+new file mode 100644
+index 00000000000000..8509e61c588df7
+--- /dev/null
++++ b/src/crypto/internal/backend/fips140/skipfipscheck_on.go
+@@ -0,0 +1,9 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build skipfipscheck
++
++package fips140
++
++const isSkipFIPSCheck = true
 diff --git a/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go
 new file mode 100644
 index 00000000000000..c6c1f53e7452ab
@@ -2138,10 +2219,10 @@ index 00000000000000..3b92bfc5fbabf6
 +package opensslsetup
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..dc8513b535f19b
+index 00000000000000..6eea4e1c93b314
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,246 @@
+@@ -0,0 +1,253 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2155,8 +2236,15 @@ index 00000000000000..dc8513b535f19b
 +import (
 +	"crypto"
 +	"crypto/cipher"
++	"crypto/internal/backend/fips140"
 +	"hash"
 +)
++
++func init() {
++	if err := fips140.Check(func() bool { return false }); err != nil {
++		panic(err)
++	}
++}
 +
 +const Enabled = false
 +
@@ -2390,10 +2478,10 @@ index 00000000000000..dc8513b535f19b
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..89a5fe5d170c41
+index 00000000000000..02c3c67f822ae2
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,334 @@
+@@ -0,0 +1,332 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2422,19 +2510,17 @@ index 00000000000000..89a5fe5d170c41
 +type BigInt = openssl.BigInt
 +
 +func init() {
-+	if fips140.Enabled() {
-+		// Some distributions, e.g. Azure Linux 3, don't set the `fips=yes` property when running in FIPS mode,
-+		// but they configure OpenSSL to use a FIPS-compliant provider (in the case of Azure Linux 3, the SCOSSL provider).
-+		// In this cases, openssl.FIPS would return `false` and openssl.FIPSCapable would return `true`.
-+		// We don't care about the `fips=yes` property as long as the provider is FIPS-compliant, so use
-+		// openssl.FIPSCapable to determine whether FIPS mode is enabled.
-+		if !openssl.FIPSCapable() {
-+			// This path can be reached for the following reasons:
-+			// - In OpenSSL 1, the active engine doesn't support FIPS mode.
-+			// - In OpenSSL 1, the active engine supports FIPS mode, but it is not enabled.
-+			// - In OpenSSL 3, the provider used by default doesn't match the `fips=yes` query.
-+			panic("opensslcrypto: FIPS mode requested (" + fips140.Message + ") but not available in " + openssl.VersionText())
-+		}
++	// Some distributions, e.g. Azure Linux 3, don't set the `fips=yes` property when running in FIPS mode,
++	// but they configure OpenSSL to use a FIPS-compliant provider (in the case of Azure Linux 3, the SCOSSL provider).
++	// In this cases, openssl.FIPS would return `false` and openssl.FIPSCapable would return `true`.
++	// We don't care about the `fips=yes` property as long as the provider is FIPS-compliant, so use
++	// openssl.FIPSCapable to determine whether FIPS mode is enabled.
++	if err := fips140.Check(func() bool { return openssl.FIPSCapable() }); err != nil {
++		// This path can be reached for the following reasons:
++		// - In OpenSSL 1, the active engine doesn't support FIPS mode.
++		// - In OpenSSL 1, the active engine supports FIPS mode, but it is not enabled.
++		// - In OpenSSL 3, the provider used by default doesn't match the `fips=yes` query.
++		panic("opensslcrypto: " + err.Error() + ": " + openssl.VersionText())
 +	}
 +	sig.BoringCrypto()
 +}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -118,7 +118,7 @@ index b50f3342fe8714..23a7f132788ebc 100644
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
  	os.Setenv("GOEXPERIMENT", goexperiment)
 +	// Build the Go toolchain with "-tags=allowcryptofallback,skipfipscheck". This
-+	// allows toolchains not built with "GOEXPERIMENT=systemcrypto" to be used
++	// allows toolchains not built with the systemcrypto goexperiment to be used
 +	// when GODEBUG=fips140=on is set. For example, when running
 +	// "GODEBUG=fips140=on go test ./..." or "GODEBUG=fips140=on go run .".
 +	// Shadow goexperiment so that the global variable is not modified.
@@ -256,7 +256,7 @@ index 00000000000000..5fc1c487b6ffe1
 +		name = "main_test.go"
 +	}
 +	name = filepath.Join(t.TempDir(), name)
-+	if err := os.WriteFile(name, []byte(content), 0644); err != nil {
++	if err := os.WriteFile(name, []byte(content), 0o644); err != nil {
 +		t.Fatal(err)
 +	}
 +	return name
@@ -279,7 +279,7 @@ index 00000000000000..5fc1c487b6ffe1
 +	execGoTool(t, "build", env, cryptoFile)
 +	execGoTool(t, "build", env, nonCryptoFile)
 +
-+	// Run should always succed if the target go package
++	// Run should always succeed if the target go package
 +	// doesn't use crypto.
 +	execGoTool(t, "run", env, nonCryptoFile)
 +}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  .gitignore                                    |   2 +
  src/cmd/dist/build.go                         |   6 +
  src/cmd/dist/test.go                          |   7 +
- .../go/testdata/script/build_systemcrypto.txt |  18 +
+ src/cmd/go/systemcrypto_test.go               |  92 +++++
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
  .../internal/backend/backendgen_test.go       | 278 +++++++++++++
@@ -52,8 +52,8 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 48 files changed, 2749 insertions(+), 4 deletions(-)
- create mode 100644 src/cmd/go/testdata/script/build_systemcrypto.txt
+ 48 files changed, 2823 insertions(+), 4 deletions(-)
+ create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
  create mode 100644 src/crypto/internal/backend/backendgen_test.go
@@ -158,20 +158,28 @@ index d335e4cfbce468..7e362c80be609a 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-diff --git a/src/cmd/go/testdata/script/build_systemcrypto.txt b/src/cmd/go/testdata/script/build_systemcrypto.txt
+diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
-index 00000000000000..b795e27f6d75e8
+index 00000000000000..5fc1c487b6ffe1
 --- /dev/null
-+++ b/src/cmd/go/testdata/script/build_systemcrypto.txt
-@@ -0,0 +1,18 @@
-+# "GODEBUG=fips140=on go build" should always succeed, 
-+# even if the toolchain is not build with systemcrypto
-+# or the system doesn't support FIPS mode.
-+env GODEBUG=fips140=on
-+go build main.go 
++++ b/src/cmd/go/systemcrypto_test.go
+@@ -0,0 +1,92 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
 +
-+-- main.go --
++package main_test
 +
++import (
++	"internal/goexperiment"
++	"internal/testenv"
++	"os"
++	"path/filepath"
++	"strings"
++	"testing"
++)
++
++const fileWithCrypto = `
 +package main
 +
 +import (
@@ -182,7 +190,72 @@ index 00000000000000..b795e27f6d75e8
 +func main() {
 +	fmt.Println(sha256.Sum256([]byte("Hello, World!")))
 +}
-\ No newline at end of file
++`
++
++const fileWithoutCrypto = `
++package main
++
++import (
++	"fmt"
++)
++
++func main() {
++	fmt.Println("Hello, World!")
++}
++`
++
++func execGoTool(t *testing.T, command string, env []string, args ...string) {
++	t.Helper()
++	cmdArgs := []string{command}
++	if command == "build" {
++		out := filepath.Join(t.TempDir(), "out")
++		cmdArgs = append(cmdArgs, "-o", out)
++	}
++	cmdArgs = append(cmdArgs, args...)
++	cmd := testenv.Command(t, testenv.GoToolPath(t), cmdArgs...)
++	cmd = testenv.CleanCmdEnv(cmd)
++	cmd.Env = append(cmd.Env, env...)
++	out, err := cmd.CombinedOutput()
++	if err != nil {
++		t.Fatalf("go build failed: %v\n%s", err, out)
++	}
++}
++
++// writeFile creates a temporary file with the given content and returns its path.
++func writeFile(t *testing.T, content string) string {
++	t.Helper()
++	name := "main.go"
++	if strings.Contains(content, "testing") {
++		name = "main_test.go"
++	}
++	name = filepath.Join(t.TempDir(), name)
++	if err := os.WriteFile(name, []byte(content), 0644); err != nil {
++		t.Fatal(err)
++	}
++	return name
++}
++
++func TestSystemCryptoFIPS(t *testing.T) {
++	// Test different go commands with GODEBUG=fips140=on
++	// to exercise the skipfipscheck build tag.
++	if goexperiment.BoringCrypto {
++		t.Skip("BoringCrypto doesn't support GODEBUG=fips140=on")
++	}
++	t.Parallel()
++	env := []string{"GODEBUG=fips140=on"}
++
++	cryptoFile := writeFile(t, fileWithCrypto)
++	nonCryptoFile := writeFile(t, fileWithoutCrypto)
++
++	// Build should always succeed given that the go toolchain
++	// is built with the skipfipscheck build tag.
++	execGoTool(t, "build", env, cryptoFile)
++	execGoTool(t, "build", env, nonCryptoFile)
++
++	// Run should always succed if the target go package
++	// doesn't use crypto.
++	execGoTool(t, "run", env, nonCryptoFile)
++}
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644
 index 00000000000000..c2c06d3bff8c74

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement crypto/internal/backend
 ---
  .gitignore                                    |   2 +
  src/cmd/dist/build.go                         |   6 +
- src/cmd/dist/test.go                          |   7 +
+ src/cmd/dist/test.go                          |  17 +-
  src/cmd/go/systemcrypto_test.go               |  92 +++++
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
@@ -52,7 +52,7 @@ Subject: [PATCH] Implement crypto/internal/backend
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 48 files changed, 2823 insertions(+), 4 deletions(-)
+ 48 files changed, 2829 insertions(+), 8 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
@@ -127,10 +127,37 @@ index b50f3342fe8714..23a7f132788ebc 100644
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index d335e4cfbce468..f8abfe6f62216f 100644
+index d335e4cfbce468..b4ba0ad8210a94 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -847,6 +847,11 @@ func (t *tester) registerTests() {
+@@ -156,10 +156,12 @@ func (t *tester) run() {
+ 		}
+ 	}
+ 
++	tags := []string{"-tags=allowcryptofallback,skipfipscheck"}
++
+ 	if t.rebuild {
+ 		t.out("Building packages and commands.")
+ 		// Force rebuild the whole toolchain.
+-		goInstall(toolenv(), gorootBinGo, append([]string{"-a"}, toolchain...)...)
++		goInstall(toolenv(), gorootBinGo, append([]string{"-a"}, append(tags, toolchain...)...)...)
+ 	}
+ 
+ 	if !t.listMode {
+@@ -176,9 +178,9 @@ func (t *tester) run() {
+ 			// and virtualization we usually start with a clean GOCACHE, so we would
+ 			// end up rebuilding large parts of the standard library that aren't
+ 			// otherwise relevant to the actual set of packages under test.
+-			goInstall(toolenv(), gorootBinGo, toolchain...)
+-			goInstall(toolenv(), gorootBinGo, toolchain...)
+-			goInstall(toolenv(), gorootBinGo, "cmd")
++			goInstall(toolenv(), gorootBinGo, append(tags, toolchain...)...)
++			goInstall(toolenv(), gorootBinGo, append(tags, toolchain...)...)
++			goInstall(toolenv(), gorootBinGo, append(tags, "cmd")...)
+ 		}
+ 	}
+ 
+@@ -847,6 +849,11 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
@@ -142,7 +169,7 @@ index d335e4cfbce468..f8abfe6f62216f 100644
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
  				variant:   "pie_internal",
-@@ -855,6 +860,7 @@ func (t *tester) registerTests() {
+@@ -855,6 +862,7 @@ func (t *tester) registerTests() {
  				ldflags:   "-linkmode=internal",
  				env:       []string{"CGO_ENABLED=0"},
  				pkg:       "reflect",
@@ -150,7 +177,7 @@ index d335e4cfbce468..f8abfe6f62216f 100644
  			})
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
-@@ -865,6 +871,7 @@ func (t *tester) registerTests() {
+@@ -865,6 +873,7 @@ func (t *tester) registerTests() {
  				env:       []string{"CGO_ENABLED=0"},
  				pkg:       "crypto/internal/fips140test",
  				runTests:  "TestFIPSCheck",


### PR DESCRIPTION
`allowcryptofallback` is overriden with too many duties (and the name doesn't fit any of them). One of those duties is to allow executing the Go toolchain with `GODEBUG=fips140=on` even when the toolchain is not built with a system crypto backend or when the system doesn't support FIPS mode. This is because the user doesn't care about the toolchain being executed in FIPS mode (which is in fact not officially supported), but to run the binary built by the toolchain in FIPS mode.

This PR stops using the`allocryptofallback` build tag for this purpose, and starts using the new `skipfipscheck` build tag instead. This build tag is not documented as it is supposed to only be used by the Go toolchain (we might revisit this decision if there is a compelling 1P use case).