### PR TITLE
Add `microsoft_systemcrypto` setting

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -437,7 +437,9 @@ This list of major changes is intended for quick reference and for access to his
 
 - Running `go version -m` on a binary which uses a system crypto backend now shows the `microsoft_systemcrypto=1` build setting.
 
- - It is now possible to build a binary that doesn't depend on a crypto package using invalid configurations, for example `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto`.
+ - The build-time backend compatibility check now only runs when a crypto package is required for the build.
+   - If your app doesn't depend on a crypto package, you may, for example, use `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto`.
+   - If your app doesn't use a crypto package and you make a change that introduces a crypto package dependency, you will only encounter a compatibility check failure after the change. The change may be in your transitive dependencies: for example, depending on a new module that uses `crypto/sha256` may trigger the compatibility check. This is undesirable, but it's necessary to enable flexibility.
 
 - `GOFIPS=0` support has been removed. It now has no effect.
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -306,7 +306,7 @@ Most programs aren't expected to use these options. Determining FIPS mode at run
 
 ### Build option to use Go crypto if the backend compatibility check fails
 
-When building a Go program with a crypto backend, the build will check that the build environment and target are compatible with that backend. If not, the build will fail with an error. For example, a common unsupported build configuration is `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=opensslcrypto`. The OpenSSL backend requires cgo, so the build fails:
+When building a Go program that imports a `crypto` package with a crypto backend, the build will check that the build environment and target are compatible with that backend. If not, the build will fail with an error. For example, a common unsupported build configuration is `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=opensslcrypto`. The OpenSSL backend requires cgo, so the build fails:
 
 ```
 # runtime

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -435,6 +435,10 @@ This list of major changes is intended for quick reference and for access to his
 
 ### Go 1.25 (Aug 2025)
 
+- Running `go version -m` on a binary which uses a system crypto backend now shows the `microsoft_systemcrypto=1` build setting.
+
+ - It is now possible to build a binary that doesn't depend on a crypto package using invalid configurations, for example `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto`.
+
 - `GOFIPS=0` support has been removed. It now has no effect.
 
 - `GOEXPERIMENT=allowcryptofallback` has been downgraded to the `allowcryptofallback` build tag. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -317,11 +317,12 @@ When building a Go program that imports a `crypto` package with a crypto backend
         Please check your build environment and build command for a reason one or more of these tags weren't specified.
 ```
 
-We recommend one of these fixes:
+We recommend fixing the build environment to allow the crypto backend to be used. (Enable cgo.)
 
-- Fix the build environment to allow the crypto backend to be used. (Enable cgo.)
+These are other fixes that may be used on a case-by-case basis:
+
 - Remove `GOEXPERIMENT` entirely. This intentionally doesn't comply with the internal Microsoft crypto policy or FIPS, so for builds within Microsoft, this should only be done under a documented exception.
-
+- Refactor the code to not use a `crypto` package. For example, when computing a hash for not cryptographic purposes, there are several alternatives in the Go standard library that don't require a crypto backend, such as `hash/fnv` or `hash/maphash`.
 
 > [!IMPORTANT]
 > Individual crypto calls may fall back to standard Go crypto at runtime if the selected backend doesn't support an API or the arguments used. See the [FIPS User Guide](UserGuide.md) for more information.

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -306,7 +306,7 @@ Most programs aren't expected to use these options. Determining FIPS mode at run
 
 ### Build option to use Go crypto if the backend compatibility check fails
 
-When building a Go program that imports a `crypto` package with a crypto backend, the build will check that the build environment and target are compatible with that backend. If not, the build will fail with an error. For example, a common unsupported build configuration is `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=opensslcrypto`. The OpenSSL backend requires cgo, so the build fails:
+When building a Go program that imports a `crypto` package, the build will check that the build environment and target are compatible with the crypto backend being used, if any. If it's incompatible, the build will fail with an error. For example, a common unsupported build configuration is `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=opensslcrypto`. The OpenSSL backend requires cgo, so the build fails:
 
 ```
 # runtime
@@ -322,7 +322,7 @@ We recommend fixing the build environment to allow the crypto backend to be used
 These are other fixes that may be used on a case-by-case basis:
 
 - Remove `GOEXPERIMENT` entirely. This intentionally doesn't comply with the internal Microsoft crypto policy or FIPS, so for builds within Microsoft, this should only be done under a documented exception.
-- Refactor the code to not use a `crypto` package. For example, when computing a hash for not cryptographic purposes, there are several alternatives in the Go standard library that don't require a crypto backend, such as `hash/fnv` or `hash/maphash`.
+- Refactor the code to not use a `crypto` package. For example, when computing a hash for non-cryptographic purposes, there are several alternatives in the Go standard library that don't require a crypto backend, such as `hash/fnv` or `hash/maphash`.
 
 > [!IMPORTANT]
 > Individual crypto calls may fall back to standard Go crypto at runtime if the selected backend doesn't support an API or the arguments used. See the [FIPS User Guide](UserGuide.md) for more information.

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -12,7 +12,8 @@ desired goexperiments and build tags.
  .gitignore                                    |   2 +
  src/cmd/dist/build.go                         |   5 +
  src/cmd/dist/test.go                          |  17 +-
- src/cmd/go/systemcrypto_test.go               |  97 +++++
+ src/cmd/go/internal/load/pkg.go               |   6 +
+ src/cmd/go/systemcrypto_test.go               | 146 +++++++
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
  .../internal/backend/backendgen_test.go       | 288 ++++++++++++++
@@ -58,7 +59,7 @@ desired goexperiments and build tags.
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 49 files changed, 2859 insertions(+), 8 deletions(-)
+ 50 files changed, 2914 insertions(+), 8 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
@@ -191,12 +192,29 @@ index d335e4cfbce468..5663aa3286a816 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
+diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
+index e913f9885234fd..123a77518106c5 100644
+--- a/src/cmd/go/internal/load/pkg.go
++++ b/src/cmd/go/internal/load/pkg.go
+@@ -2412,6 +2412,12 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
+ 			buildmode = "archive"
+ 		}
+ 	}
++	if cfg.Experiment.SystemCrypto ||
++		cfg.Experiment.OpenSSLCrypto ||
++		cfg.Experiment.CNGCrypto ||
++		cfg.Experiment.DarwinCrypto {
++		appendSetting("microsoft_systemcrypto", "1")
++	}
+ 	appendSetting("-buildmode", buildmode)
+ 	appendSetting("-compiler", cfg.BuildContext.Compiler)
+ 	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
-index 00000000000000..9bc2e228fee3a6
+index 00000000000000..68311f8e33099a
 --- /dev/null
 +++ b/src/cmd/go/systemcrypto_test.go
-@@ -0,0 +1,97 @@
+@@ -0,0 +1,146 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -208,6 +226,7 @@ index 00000000000000..9bc2e228fee3a6
 +	"internal/testenv"
 +	"os"
 +	"path/filepath"
++	"runtime"
 +	"strings"
 +	"testing"
 +)
@@ -237,21 +256,20 @@ index 00000000000000..9bc2e228fee3a6
 +}
 +`
 +
-+func execGoTool(t *testing.T, command string, env []string, args ...string) {
++func execGoTool(t *testing.T, allowFail bool, env []string, args ...string) (bool, string) {
 +	t.Helper()
-+	cmdArgs := []string{command}
-+	if command == "build" {
-+		out := filepath.Join(t.TempDir(), "out")
-+		cmdArgs = append(cmdArgs, "-o", out)
-+	}
-+	cmdArgs = append(cmdArgs, args...)
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), cmdArgs...)
++	cmd := testenv.Command(t, testenv.GoToolPath(t), args...)
 +	cmd = testenv.CleanCmdEnv(cmd)
 +	cmd.Env = append(cmd.Env, env...)
 +	out, err := cmd.CombinedOutput()
++	sout := strings.TrimSpace(string(out))
 +	if err != nil {
++		if allowFail {
++			return false, sout
++		}
 +		t.Fatalf("go build failed: %v\n%s", err, out)
 +	}
++	return true, sout
 +}
 +
 +// writeFile creates a temporary file with the given content and returns its path.
@@ -268,6 +286,11 @@ index 00000000000000..9bc2e228fee3a6
 +	return name
 +}
 +
++func outPath(t *testing.T) string {
++	t.Helper()
++	return filepath.Join(t.TempDir(), "out")
++}
++
 +func TestSystemCryptoFIPS(t *testing.T) {
 +	// Test different go commands with GODEBUG=fips140=on
 +	// to exercise the ms_skipfipscheck build tag.
@@ -282,17 +305,61 @@ index 00000000000000..9bc2e228fee3a6
 +
 +	// Build should always succeed given that the go toolchain
 +	// is built with the ms_skipfipscheck build tag.
-+	execGoTool(t, "build", env, cryptoFile)
-+	execGoTool(t, "build", env, nonCryptoFile)
++	execGoTool(t, false, env, "build", "-o", outPath(t), cryptoFile)
++	execGoTool(t, false, env, "build", "-o", outPath(t), nonCryptoFile)
 +
 +	// Run should always succeed if the target go package
 +	// doesn't use crypto.
-+	execGoTool(t, "run", env, nonCryptoFile)
++	execGoTool(t, false, env, "run", nonCryptoFile)
 +
 +	// Run may or may not fail if the target go package uses crypto,
 +	// because while the toolchain was built with ms_skipfipscheck, the
 +	// target program was not. Failure depends on system crypto mode
 +	// and presence of system-provided crypto, and it can't be tested here.
++}
++
++func TestSystemCryptoSetting(t *testing.T) {
++	t.Parallel()
++	file := writeFile(t, fileWithCrypto)
++
++	type testCase struct {
++		enabled bool
++		exp     string
++	}
++	tests := []testCase{
++		{false, ""},
++		{false, "nosystemcrypto"},
++		{true, "systemcrypto"},
++	}
++	switch runtime.GOOS {
++	case "linux":
++		tests = append(tests, testCase{true, "opensslcrypto"})
++	case "windows":
++		tests = append(tests, testCase{true, "cngcrypto"})
++	case "darwin":
++		tests = append(tests, testCase{true, "darwincrypto"})
++	}
++	for _, tt := range tests {
++		t.Run(tt.exp, func(t *testing.T) {
++			t.Parallel()
++			out := outPath(t)
++
++			// Build the binary with the specified GOEXPERIMENT.
++			fail, _ := execGoTool(t, true, []string{"GOEXPERIMENT=" + tt.exp}, "build", "-o", out, file)
++			if fail && tt.enabled {
++				t.Skip("skipping test because GOEXPERIMENT not supported by the current toolchain")
++			}
++
++			// Check that the binary has the correct settings.
++			_, settings := execGoTool(t, false, nil, "version", "-m", out)
++			hashSetting := strings.Contains(settings, "microsoft_systemcrypto=1")
++			if tt.enabled && !hashSetting {
++				t.Errorf("expected microsoft_systemcrypto=1 in settings, got %v", settings)
++			} else if !tt.enabled && hashSetting {
++				t.Errorf("expected microsoft_systemcrypto=1 not to be in settings, got %v", settings)
++			}
++		})
++	}
 +}
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  src/cmd/dist/build.go                         |   5 +
  src/cmd/dist/test.go                          |  17 +-
  src/cmd/go/internal/load/pkg.go               |   6 +
- src/cmd/go/systemcrypto_test.go               | 146 +++++++
+ src/cmd/go/systemcrypto_test.go               | 148 +++++++
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
  .../internal/backend/backendgen_test.go       | 288 ++++++++++++++
@@ -59,7 +59,7 @@ desired goexperiments and build tags.
  src/go/build/deps_test.go                     |  27 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 50 files changed, 2914 insertions(+), 8 deletions(-)
+ 50 files changed, 2916 insertions(+), 8 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
@@ -211,10 +211,10 @@ index e913f9885234fd..123a77518106c5 100644
  	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
-index 00000000000000..68311f8e33099a
+index 00000000000000..385226588b5dcc
 --- /dev/null
 +++ b/src/cmd/go/systemcrypto_test.go
-@@ -0,0 +1,146 @@
+@@ -0,0 +1,148 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -327,7 +327,6 @@ index 00000000000000..68311f8e33099a
 +		exp     string
 +	}
 +	tests := []testCase{
-+		{false, ""},
 +		{false, "nosystemcrypto"},
 +		{true, "systemcrypto"},
 +	}
@@ -335,7 +334,10 @@ index 00000000000000..68311f8e33099a
 +	case "linux":
 +		tests = append(tests, testCase{true, "opensslcrypto"})
 +	case "windows":
-+		tests = append(tests, testCase{true, "cngcrypto"})
++		switch runtime.GOARCH {
++		case "amd64", "arm64":
++			tests = append(tests, testCase{true, "cngcrypto"})
++		}
 +	case "darwin":
 +		tests = append(tests, testCase{true, "darwincrypto"})
 +	}


### PR DESCRIPTION
It is not trivial to determine if a given Go binary uses systemcrypto or not, as it depends on multiple build settings. It would be even more difficult after #1352.

We can solve this issue by extending  the build info hardcoded in a Go binary to also contain whether systemcrypto is enabled. 

Example:

```
go version -m ./main
./main: go1.25-devel_04738e85ef2 Thu Jun 12 12:49:08 2025 +0200
        path    command-line-arguments
        build   microsoft_systemcrypto=1 // <----- New setting
        build   -buildmode=exe
        build   -compiler=gc
        build   CGO_ENABLED=1
        build   CGO_CFLAGS=
        build   CGO_CPPFLAGS=
        build   CGO_CXXFLAGS=
        build   CGO_LDFLAGS=
        build   GOARCH=arm64
        build   GOOS=darwin
        build   GOARM64=v8.0
```

For #1352.
Closes #1706.
Closes #963.