### PR TITLE
Remove `allowcryptofallback`

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -437,15 +437,15 @@ This list of major changes is intended for quick reference and for access to his
 
 - Running `go version -m` on a binary which uses a system crypto backend now shows the `microsoft_systemcrypto=1` build setting.
 
- - The build-time backend compatibility check now only runs when a crypto package is required for the build.
-   - If your app doesn't depend on a crypto package, you may, for example, use `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto`.
-   - If your app doesn't use a crypto package and you make a change that introduces a crypto package dependency, you will only encounter a compatibility check failure after the change. The change may be in your transitive dependencies: for example, depending on a new module that uses `crypto/sha256` may trigger the compatibility check. This is undesirable, but it's necessary to enable flexibility.
+- The build-time backend compatibility check now only runs when a crypto package is required for the build.
+  - If your app doesn't depend on a crypto package, you may, for example, use `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto`.
+  - If your app doesn't use a crypto package and you make a change that introduces a crypto package dependency, you will only encounter a compatibility check failure after the change. The change may be in your transitive dependencies: for example, depending on a new module that uses `crypto/sha256` may trigger the compatibility check. This is undesirable, but it's necessary to enable flexibility.
 
 - `GOFIPS=0` support has been removed. It now has no effect.
 
 - `GOEXPERIMENT=boringcrypto` support has been removed.
 
-- `GOEXPERIMENT=allowcryptofallback` has been downgraded to the `allowcryptofallback` build tag. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
+- `GOEXPERIMENT=allowcryptofallback` has removed. Instead, if it's necessary to opt out from using a system crypto backend, use `GOEXPERIMENT=nosystemcrypto`. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
 
 ### Go 1.24 (Feb 2025)
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -443,9 +443,9 @@ This list of major changes is intended for quick reference and for access to his
 
 - `GOFIPS=0` support has been removed. It now has no effect.
 
-- `GOEXPERIMENT=boringcrypto` support has been removed.
+- `GOEXPERIMENT=boringcrypto` has been removed.
 
-- `GOEXPERIMENT=allowcryptofallback` has removed. Instead, if it's necessary to opt out from using a system crypto backend, use `GOEXPERIMENT=nosystemcrypto`. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
+- `GOEXPERIMENT=allowcryptofallback` has been removed. Instead, if it's necessary to opt out from using a system crypto backend, use `GOEXPERIMENT=nosystemcrypto`. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
 
 ### Go 1.24 (Feb 2025)
 

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/dist/build.go                         |  11 +
- src/cmd/dist/test.go                          |  47 ++-
+ src/cmd/dist/test.go                          |  49 ++-
  src/cmd/go/go_test.go                         |   4 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2208 insertions(+), 17 deletions(-)
+ 43 files changed, 2210 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -160,7 +160,7 @@ index 024050c2dd70c4..be3a730af69c07 100644
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aa09d1eba34be8..b2e8fe9734b76e 100644
+index aa09d1eba34be8..b356aa44ff53fb 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -269,24 +269,26 @@ index aa09d1eba34be8..b2e8fe9734b76e 100644
  				})
  		}
  		if t.externalLinkPIE() && !disablePIE {
-@@ -985,6 +1009,12 @@ func (t *tester) registerTests() {
+@@ -985,6 +1009,13 @@ func (t *tester) registerTests() {
  	}
  
  	if goos != "android" && !t.iOS() {
-+		var env []string
++		var tags, env []string
 +		if goos == "darwin" {
 +			// cmd/internal/testdir uses -buildmode=exe on darwin,
 +			// which is not supported by darwincrypto.
++			tags = append(tags, "ms_skipfipscheck")
 +			env = append(env, "GOEXPERIMENT=nosystemcrypto")
 +		}
  		// Only start multiple test dir shards on builders,
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
-@@ -1007,6 +1037,7 @@ func (t *tester) registerTests() {
+@@ -1007,6 +1038,8 @@ func (t *tester) registerTests() {
  					pkg:         "cmd/internal/testdir",
  					testFlags:   []string{fmt.Sprintf("-shard=%d", shard), fmt.Sprintf("-shards=%d", nShards)},
  					runOnHost:   true,
 +					env:         env,
++					tags:        tags,
  				},
  			)
  		}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/dist/build.go                         |  11 +
- src/cmd/dist/test.go                          |  49 ++-
+ src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |   4 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2210 insertions(+), 17 deletions(-)
+ 43 files changed, 2204 insertions(+), 18 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -160,7 +160,7 @@ index 024050c2dd70c4..be3a730af69c07 100644
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aa09d1eba34be8..b356aa44ff53fb 100644
+index aa09d1eba34be8..c3f3a8324c507c 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -269,29 +269,17 @@ index aa09d1eba34be8..b356aa44ff53fb 100644
  				})
  		}
  		if t.externalLinkPIE() && !disablePIE {
-@@ -985,6 +1009,13 @@ func (t *tester) registerTests() {
+@@ -984,7 +1008,9 @@ func (t *tester) registerTests() {
+ 		t.registerRaceTests()
  	}
  
- 	if goos != "android" && !t.iOS() {
-+		var tags, env []string
-+		if goos == "darwin" {
-+			// cmd/internal/testdir uses -buildmode=exe on darwin,
-+			// which is not supported by darwincrypto.
-+			tags = append(tags, "ms_skipfipscheck")
-+			env = append(env, "GOEXPERIMENT=nosystemcrypto")
-+		}
+-	if goos != "android" && !t.iOS() {
++	// cmd/internal/testdir uses -buildmode=exe on darwin,
++	// which is not supported by darwincrypto.
++	if goos != "android" && !t.iOS() && !(strings.Contains(goexperiment, "systemcrypto") || strings.Contains(goexperiment, "darwincrypto")) {
  		// Only start multiple test dir shards on builders,
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
-@@ -1007,6 +1038,8 @@ func (t *tester) registerTests() {
- 					pkg:         "cmd/internal/testdir",
- 					testFlags:   []string{fmt.Sprintf("-shard=%d", shard), fmt.Sprintf("-shards=%d", nShards)},
- 					runOnHost:   true,
-+					env:         env,
-+					tags:        tags,
- 				},
- 			)
- 		}
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
 index 3e691abe41f702..2c4eed0bc575cf 100644
 --- a/src/cmd/go/go_test.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/dist/build.go                         |  11 +
- src/cmd/dist/test.go                          |  45 ++-
+ src/cmd/dist/test.go                          |  47 ++-
  src/cmd/go/go_test.go                         |   4 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2206 insertions(+), 17 deletions(-)
+ 43 files changed, 2208 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -160,7 +160,7 @@ index 024050c2dd70c4..be3a730af69c07 100644
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aa09d1eba34be8..2c49e2233ce84c 100644
+index aa09d1eba34be8..b2e8fe9734b76e 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -245,13 +245,14 @@ index aa09d1eba34be8..2c49e2233ce84c 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-@@ -897,13 +914,18 @@ func (t *tester) registerTests() {
+@@ -897,15 +914,22 @@ func (t *tester) registerTests() {
  
  	if t.extLink() && !t.compileOnly {
  		if goos != "android" { // Android does not support non-PIE linking
-+			var env []string
++			var tags, env []string
 +			if goos == "darwin" {
 +				// Darwincrypto doesn't support external linking.
++				tags = append(tags, "ms_skipfipscheck")
 +				env = append(env, "GOEXPERIMENT=nosystemcrypto")
 +			}
  			t.registerTest("external linking, -buildmode=exe",
@@ -264,8 +265,11 @@ index aa09d1eba34be8..2c49e2233ce84c 100644
 +					env:       append([]string{"CGO_ENABLED=1"}, env...),
  					pkg:       "crypto/internal/fips140test",
  					runTests:  "TestFIPSCheck",
++					tags:      tags,
  				})
-@@ -985,6 +1007,12 @@ func (t *tester) registerTests() {
+ 		}
+ 		if t.externalLinkPIE() && !disablePIE {
+@@ -985,6 +1009,12 @@ func (t *tester) registerTests() {
  	}
  
  	if goos != "android" && !t.iOS() {
@@ -278,7 +282,7 @@ index aa09d1eba34be8..2c49e2233ce84c 100644
  		// Only start multiple test dir shards on builders,
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
-@@ -1007,6 +1035,7 @@ func (t *tester) registerTests() {
+@@ -1007,6 +1037,7 @@ func (t *tester) registerTests() {
  					pkg:         "cmd/internal/testdir",
  					testFlags:   []string{fmt.Sprintf("-shard=%d", shard), fmt.Sprintf("-shards=%d", nShards)},
  					runOnHost:   true,

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -12,14 +12,15 @@ desired goexperiments and build tags.
  .gitignore                                    |   2 +
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
- src/cmd/dist/build.go                         |   5 +
- src/cmd/dist/test.go                          |  26 +-
+ src/cmd/dist/build.go                         |  11 +
+ src/cmd/dist/test.go                          |  38 +-
  src/cmd/go/go_test.go                         |   4 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
  src/cmd/internal/testdir/testdir_test.go      |   7 +
+ src/cmd/link/internal/ld/main.go              |  13 +-
  src/cmd/link/link_test.go                     |   8 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/bbig/big.go       |  17 +
@@ -51,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 42 files changed, 2172 insertions(+), 13 deletions(-)
+ 43 files changed, 2199 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -130,30 +131,43 @@ index e17a5402af818d..e83c4c5b79d11b 100644
  			err := lrdr.Next(&le)
  			if err == io.EOF {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 024050c2dd70c4..e8f388badaeb3c 100644
+index 024050c2dd70c4..be3a730af69c07 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1548,6 +1548,11 @@ func cmdbootstrap() {
+@@ -1387,6 +1387,12 @@ func toolenv() []string {
+ 		// still have full paths for stack traces for compiler crashes and the like.
+ 		env = append(env, "GOFLAGS=-trimpath -ldflags=-w -gcflags=cmd/...=-dwarf=false")
+ 	}
++	if goexp := os.Getenv("GOEXPERIMENT"); goexp != "" {
++		// Remove systemcrypto from GOEXPERIMENT, the Microsoft build of Go
++		// should not use it to favor portability. It only uses crypto packages
++		// for non-crypto purposes, such as generating build IDs.
++		env = append(env, "GOEXPERIMENT="+goexp+",nosystemcrypto")
++	}
+ 	return env
+ }
+ 
+@@ -1548,6 +1554,11 @@ func cmdbootstrap() {
  	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
  	os.Setenv("GOEXPERIMENT", goexperiment)
-+	// Build the Go toolchain with "-tags=allowcryptofallback,ms_skipfipscheck". This
++	// Build the Go toolchain with "-tags=ms_skipfipscheck". This
 +	// allows toolchains not built with the systemcrypto goexperiment to be used
 +	// when GODEBUG=fips140=on is set. For example, when running
 +	// "GODEBUG=fips140=on go test ./..." or "GODEBUG=fips140=on go run .".
-+	os.Setenv("GOFLAGS", "-tags=allowcryptofallback,ms_skipfipscheck")
++	os.Setenv("GOFLAGS", "-tags=ms_skipfipscheck")
  	// No need to enable PGO for toolchain2.
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aa09d1eba34be8..f4d720ab213eb1 100644
+index aa09d1eba34be8..fa7b7dd64ee3be 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
  		}
  	}
  
-+	tags := []string{"-tags=allowcryptofallback,ms_skipfipscheck"}
++	tags := []string{"-tags=ms_skipfipscheck"}
 +
  	if t.rebuild {
  		t.out("Building packages and commands.")
@@ -196,34 +210,61 @@ index aa09d1eba34be8..f4d720ab213eb1 100644
  		t.registerTest("GOOS=ios on darwin/amd64",
  			&goTest{
  				variant:  "amd64ios",
-@@ -863,6 +872,11 @@ func (t *tester) registerTests() {
+@@ -863,14 +872,21 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
-+		var tags []string
++		var tags, env []string
 +		if goos != "windows" {
 +			// Linux and macOS don't support systemcrypto with CGO_ENABLED=0.
-+			tags = append(tags, "allowcryptofallback,ms_skipfipscheck")
++			tags = append(tags, "ms_skipfipscheck")
++			env = append(env, "GOEXPERIMENT=nosystemcrypto")
 +		}
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
  				variant:   "pie_internal",
-@@ -871,6 +885,7 @@ func (t *tester) registerTests() {
+ 				timeout:   60 * time.Second,
+ 				buildmode: "pie",
  				ldflags:   "-linkmode=internal",
- 				env:       []string{"CGO_ENABLED=0"},
+-				env:       []string{"CGO_ENABLED=0"},
++				env:       append([]string{"CGO_ENABLED=0"}, env...),
  				pkg:       "reflect",
 +				tags:      tags,
  			})
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
-@@ -881,6 +896,7 @@ func (t *tester) registerTests() {
- 				env:       []string{"CGO_ENABLED=0"},
+@@ -878,9 +894,10 @@ func (t *tester) registerTests() {
+ 				timeout:   60 * time.Second,
+ 				buildmode: "pie",
+ 				ldflags:   "-linkmode=internal",
+-				env:       []string{"CGO_ENABLED=0"},
++				env:       append([]string{"CGO_ENABLED=0"}, env...),
  				pkg:       "crypto/internal/fips140test",
  				runTests:  "TestFIPSCheck",
 +				tags:      tags,
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
+@@ -897,13 +914,18 @@ func (t *tester) registerTests() {
+ 
+ 	if t.extLink() && !t.compileOnly {
+ 		if goos != "android" { // Android does not support non-PIE linking
++			var env []string
++			if goos == "darwin" {
++				// Darwincrypto doesn't support external linking.
++				env = append(env, "GOEXPERIMENT=nosystemcrypto")
++			}
+ 			t.registerTest("external linking, -buildmode=exe",
+ 				&goTest{
+ 					variant:   "exe_external",
+ 					timeout:   60 * time.Second,
+ 					buildmode: "exe",
+ 					ldflags:   "-linkmode=external",
+-					env:       []string{"CGO_ENABLED=1"},
++					env:       append([]string{"CGO_ENABLED=1"}, env...),
+ 					pkg:       "crypto/internal/fips140test",
+ 					runTests:  "TestFIPSCheck",
+ 				})
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
 index 3e691abe41f702..2c4eed0bc575cf 100644
 --- a/src/cmd/go/go_test.go
@@ -451,6 +492,37 @@ index 483a9ec33c6798..fad922e3f844ab 100644
  	common := testCommon{
  		gorootTestDir: filepath.Join(testenv.GOROOT(t), "test"),
  		runoutputGate: make(chan bool, *runoutputLimit),
+diff --git a/src/cmd/link/internal/ld/main.go b/src/cmd/link/internal/ld/main.go
+index 6a684890be0a03..1678bb5baf4aef 100644
+--- a/src/cmd/link/internal/ld/main.go
++++ b/src/cmd/link/internal/ld/main.go
+@@ -44,6 +44,7 @@ import (
+ 	"os"
+ 	"runtime"
+ 	"runtime/pprof"
++	"slices"
+ 	"strconv"
+ 	"strings"
+ )
+@@ -187,7 +188,17 @@ func Main(arch *sys.Arch, theArch Arch) {
+ 
+ 	buildVersion := buildcfg.Version
+ 	if goexperiment := buildcfg.Experiment.String(); goexperiment != "" {
+-		buildVersion += " X:" + goexperiment
++		// Don't report crypto experiments in build version.
++		// These are already reported in the buildInfo.
++		// If we don't do this, "go tool dist test" will always fail.
++		goexpList := strings.Split(goexperiment, ",")
++		goexpList = slices.DeleteFunc(goexpList, func(s string) bool {
++			return s == "systemcrypto" || s == "opensslcrypto" || s == "cngcrypto" || s == "darwincrypto"
++		})
++		goexperiment = strings.Join(goexpList, ",")
++		if goexperiment != "" {
++			buildVersion += " X:" + strings.Join(goexpList, ",")
++		}
+ 	}
+ 	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
+ 
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
 index 2fe32600f1d6c7..f84cbdc5ee25f0 100644
 --- a/src/cmd/link/link_test.go
@@ -2505,7 +2577,7 @@ index 00000000000000..5e4b436554d44d
 +// (because the implementation might be here).
 diff --git a/src/crypto/systemcrypto_nocgo.go b/src/crypto/systemcrypto_nocgo.go
 new file mode 100644
-index 00000000000000..99cf22dc13ef89
+index 00000000000000..13782a8241b99a
 --- /dev/null
 +++ b/src/crypto/systemcrypto_nocgo.go
 @@ -0,0 +1,15 @@
@@ -2513,7 +2585,7 @@ index 00000000000000..99cf22dc13ef89
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !cgo && (goexperiment.opensslcrypto || goexperiment.darwincrypto) && !allowcryptofallback
++//go:build !cgo && (goexperiment.opensslcrypto || goexperiment.darwincrypto)
 +
 +package crypto
 +
@@ -2687,15 +2759,15 @@ index 831ee67afc952d..d2f00d57c10286 100644
 +	return boring_runtime_arg0()
 +}
 diff --git a/src/syscall/exec_linux_test.go b/src/syscall/exec_linux_test.go
-index 69d49169446d1c..9c16f665d4a223 100644
+index 69d49169446d1c..e6d344ff67a8aa 100644
 --- a/src/syscall/exec_linux_test.go
 +++ b/src/syscall/exec_linux_test.go
-@@ -299,7 +299,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
- 		}
+@@ -300,7 +300,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
  	})
  
--	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
-+	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-tags=allowcryptofallback", "-o", x, "syscall")
- 	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
+ 	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
+-	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
++	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0", "GOEXPERIMENT=nosystemcrypto")
  	if o, err := cmd.CombinedOutput(); err != nil {
  		t.Fatalf("%v: %v\n%s", cmd, err, o)
+ 	}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -14,13 +14,12 @@ desired goexperiments and build tags.
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/dist/build.go                         |  11 +
  src/cmd/dist/test.go                          |  44 ++-
- src/cmd/go/go_test.go                         |   4 +
+ src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
  src/cmd/internal/testdir/testdir_test.go      |   7 +
- src/cmd/link/internal/ld/main.go              |  13 +-
  src/cmd/link/link_test.go                     |   8 +
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/bbig/big.go       |  17 +
@@ -52,7 +51,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2204 insertions(+), 18 deletions(-)
+ 42 files changed, 2199 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -131,7 +130,7 @@ index e17a5402af818d..e83c4c5b79d11b 100644
  			err := lrdr.Next(&le)
  			if err == io.EOF {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 024050c2dd70c4..be3a730af69c07 100644
+index 024050c2dd70c4..3c82b7436d10bf 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
 @@ -1387,6 +1387,12 @@ func toolenv() []string {
@@ -139,8 +138,8 @@ index 024050c2dd70c4..be3a730af69c07 100644
  		env = append(env, "GOFLAGS=-trimpath -ldflags=-w -gcflags=cmd/...=-dwarf=false")
  	}
 +	if goexp := os.Getenv("GOEXPERIMENT"); goexp != "" {
-+		// Remove systemcrypto from GOEXPERIMENT, the Microsoft build of Go
-+		// should not use it to favor portability. It only uses crypto packages
++		// Remove systemcrypto from GOEXPERIMENT: to favor portability, the
++		// Microsoft build of Go should not use it. Go only uses crypto packages
 +		// for non-crypto purposes, such as generating build IDs.
 +		env = append(env, "GOEXPERIMENT="+goexp+",nosystemcrypto")
 +	}
@@ -281,7 +280,7 @@ index aa09d1eba34be8..c3f3a8324c507c 100644
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
-index 3e691abe41f702..2c4eed0bc575cf 100644
+index 3e691abe41f702..b799031d598892 100644
 --- a/src/cmd/go/go_test.go
 +++ b/src/cmd/go/go_test.go
 @@ -14,6 +14,7 @@ import (
@@ -292,7 +291,21 @@ index 3e691abe41f702..2c4eed0bc575cf 100644
  	"internal/platform"
  	"internal/testenv"
  	"io"
-@@ -1861,6 +1862,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
+@@ -111,6 +112,13 @@ func TestMain(m *testing.M) {
+ 		if v := os.Getenv("TESTGO_TOOLCHAIN_VERSION"); v != "" {
+ 			work.ToolchainVersion = v
+ 		}
++		// Remove the " X:systemcrypto" suffix from the toolchain version,
++		// else it won't match the compiler version and the tests will fail.
++		// This happens because "go" invocations inside TestScript don't
++		// really call the go binary, which is never built with systemcrypto,
++		// but it instead calls the test binary with CMDGO_TEST_RUN_MAIN=1,
++		// which can be built with systemcrypto.
++		work.ToolchainVersion = strings.ReplaceAll(work.ToolchainVersion, " X:systemcrypto", "")
+ 
+ 		if testGOROOT := os.Getenv("TESTGO_GOROOT"); testGOROOT != "" {
+ 			// Disallow installs to the GOROOT from which testgo was built.
+@@ -1861,6 +1869,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
  }
  
  func TestGoEnv(t *testing.T) {
@@ -507,37 +520,6 @@ index 483a9ec33c6798..fad922e3f844ab 100644
  	common := testCommon{
  		gorootTestDir: filepath.Join(testenv.GOROOT(t), "test"),
  		runoutputGate: make(chan bool, *runoutputLimit),
-diff --git a/src/cmd/link/internal/ld/main.go b/src/cmd/link/internal/ld/main.go
-index 6a684890be0a03..1678bb5baf4aef 100644
---- a/src/cmd/link/internal/ld/main.go
-+++ b/src/cmd/link/internal/ld/main.go
-@@ -44,6 +44,7 @@ import (
- 	"os"
- 	"runtime"
- 	"runtime/pprof"
-+	"slices"
- 	"strconv"
- 	"strings"
- )
-@@ -187,7 +188,17 @@ func Main(arch *sys.Arch, theArch Arch) {
- 
- 	buildVersion := buildcfg.Version
- 	if goexperiment := buildcfg.Experiment.String(); goexperiment != "" {
--		buildVersion += " X:" + goexperiment
-+		// Don't report crypto experiments in build version.
-+		// These are already reported in the buildInfo.
-+		// If we don't do this, "go tool dist test" will always fail.
-+		goexpList := strings.Split(goexperiment, ",")
-+		goexpList = slices.DeleteFunc(goexpList, func(s string) bool {
-+			return s == "systemcrypto" || s == "opensslcrypto" || s == "cngcrypto" || s == "darwincrypto"
-+		})
-+		goexperiment = strings.Join(goexpList, ",")
-+		if goexperiment != "" {
-+			buildVersion += " X:" + strings.Join(goexpList, ",")
-+		}
- 	}
- 	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
- 
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
 index 2fe32600f1d6c7..f84cbdc5ee25f0 100644
 --- a/src/cmd/link/link_test.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/dist/build.go                         |  11 +
- src/cmd/dist/test.go                          |  38 +-
+ src/cmd/dist/test.go                          |  45 ++-
  src/cmd/go/go_test.go                         |   4 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2199 insertions(+), 17 deletions(-)
+ 43 files changed, 2206 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -160,7 +160,7 @@ index 024050c2dd70c4..be3a730af69c07 100644
  	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
  	if debug {
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aa09d1eba34be8..fa7b7dd64ee3be 100644
+index aa09d1eba34be8..2c49e2233ce84c 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -265,6 +265,27 @@ index aa09d1eba34be8..fa7b7dd64ee3be 100644
  					pkg:       "crypto/internal/fips140test",
  					runTests:  "TestFIPSCheck",
  				})
+@@ -985,6 +1007,12 @@ func (t *tester) registerTests() {
+ 	}
+ 
+ 	if goos != "android" && !t.iOS() {
++		var env []string
++		if goos == "darwin" {
++			// cmd/internal/testdir uses -buildmode=exe on darwin,
++			// which is not supported by darwincrypto.
++			env = append(env, "GOEXPERIMENT=nosystemcrypto")
++		}
+ 		// Only start multiple test dir shards on builders,
+ 		// where they get distributed to multiple machines.
+ 		// See issues 20141 and 31834.
+@@ -1007,6 +1035,7 @@ func (t *tester) registerTests() {
+ 					pkg:         "cmd/internal/testdir",
+ 					testFlags:   []string{fmt.Sprintf("-shard=%d", shard), fmt.Sprintf("-shards=%d", nShards)},
+ 					runOnHost:   true,
++					env:         env,
+ 				},
+ 			)
+ 		}
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
 index 3e691abe41f702..2c4eed0bc575cf 100644
 --- a/src/cmd/go/go_test.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -12,6 +12,7 @@ desired goexperiments and build tags.
  .gitignore                                    |   2 +
  .../compile/internal/logopt/logopt_test.go    |   6 +-
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
+ src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  11 +
  src/cmd/dist/test.go                          |  44 ++-
  src/cmd/go/go_test.go                         |  11 +
@@ -51,7 +52,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 42 files changed, 2199 insertions(+), 17 deletions(-)
+ 43 files changed, 2207 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -129,6 +130,32 @@ index e17a5402af818d..e83c4c5b79d11b 100644
  		for {
  			err := lrdr.Next(&le)
  			if err == io.EOF {
+diff --git a/src/cmd/compile/script_test.go b/src/cmd/compile/script_test.go
+index 0e32e0769ee2e2..eda2d576acc6c6 100644
+--- a/src/cmd/compile/script_test.go
++++ b/src/cmd/compile/script_test.go
+@@ -7,6 +7,7 @@ package main
+ import (
+ 	"cmd/internal/script/scripttest"
+ 	"flag"
++	"internal/goexperiment"
+ 	"internal/testenv"
+ 	"os"
+ 	"runtime"
+@@ -50,6 +51,13 @@ func TestScript(t *testing.T) {
+ 		// the installed linker with our test binary.
+ 		doReplacement = false
+ 	}
++	if goexperiment.SystemCrypto {
++		// If systemcrypto is enabled, we can't replace the compiler
++		// because the test binary is built with systemcrypto, but the
++		// compiler is not. This would cause a mismatch in the
++		// compiler version check in the script tests.
++		doReplacement = false
++	}
+ 	repls := []scripttest.ToolReplacement{}
+ 	if doReplacement {
+ 		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
 index 024050c2dd70c4..3c82b7436d10bf 100644
 --- a/src/cmd/dist/build.go


### PR DESCRIPTION
After #1723 `allowcryptofallback` is only used to allow building the Go toolchain when `CGO_ENABLED=0`.

We can get this same behavior by removing `systemcrypto` from the `GOEXPERIMENT` environment variable or by using `GOEXPERIMENT=nosystemcrypto`, so `allowcryptofallback` is not really necessary.

For #1352.