### PR TITLE
Set `goexperiment.SystemCrypto` when any crypto backend is enabled

### DIFF
--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -82,25 +82,25 @@ stages:
         - ${{ if parameters.innerloop }}:
           - { os: darwin, arch: amd64, config: devscript }
           - { os: darwin, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: darwin, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: darwin, arch: amd64, config: test, fips: true }
+          - { experiment: darwincrypto, os: darwin, arch: amd64, config: test }
+          - { experiment: darwincrypto, os: darwin, arch: amd64, config: test, fips: true }
           # - { os: darwin, arch: arm64, config: devscript }
           # - { os: darwin, arch: arm64, config: test }
-          # - { experiment: systemcrypto, os: darwin, arch: arm64, config: test }
-          # - { experiment: systemcrypto, os: darwin, arch: arm64, config: test, fips: true }
+          # - { experiment: darwincrypto, os: darwin, arch: arm64, config: test }
+          # - { experiment: darwincrypto, os: darwin, arch: arm64, config: test, fips: true }
           - { os: linux, arch: amd64, config: devscript }
           - { os: linux, arch: amd64, config: test }
           - { os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: linux, arch: amd64, config: test, distro: azurelinux3 }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, fips: true }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, fips: true }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true }
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: windows, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: windows, arch: amd64, config: test, fips: true }
+          - { experiment: cngcrypto, os: windows, arch: amd64, config: test }
+          - { experiment: cngcrypto, os: windows, arch: amd64, config: test, fips: true }
           # Test that buildandpack works on Windows x86-32, but don't release it.
           - { os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if parameters.outerloop }}:
@@ -114,9 +114,9 @@ stages:
           - { os: linux, arch: amd64, config: regabi }
           - { os: linux, arch: amd64, config: ssacheck }
           - { os: linux, arch: amd64, config: staticlockranking }
-          # - { experiment: systemcrypto, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: longtest }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: race }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: regabi }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: ssacheck }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: staticlockranking }
+          # - { experiment: opensslcrypto, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: longtest }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: race }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: regabi }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: ssacheck }
+          - { experiment: opensslcrypto, os: linux, arch: amd64, config: staticlockranking }

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -82,25 +82,25 @@ stages:
         - ${{ if parameters.innerloop }}:
           - { os: darwin, arch: amd64, config: devscript }
           - { os: darwin, arch: amd64, config: test }
-          - { experiment: darwincrypto, os: darwin, arch: amd64, config: test }
-          - { experiment: darwincrypto, os: darwin, arch: amd64, config: test, fips: true }
+          - { experiment: systemcrypto, os: darwin, arch: amd64, config: test }
+          - { experiment: systemcrypto, os: darwin, arch: amd64, config: test, fips: true }
           # - { os: darwin, arch: arm64, config: devscript }
           # - { os: darwin, arch: arm64, config: test }
-          # - { experiment: darwincrypto, os: darwin, arch: arm64, config: test }
-          # - { experiment: darwincrypto, os: darwin, arch: arm64, config: test, fips: true }
+          # - { experiment: systemcrypto, os: darwin, arch: arm64, config: test }
+          # - { experiment: systemcrypto, os: darwin, arch: arm64, config: test, fips: true }
           - { os: linux, arch: amd64, config: devscript }
           - { os: linux, arch: amd64, config: test }
           - { os: linux, arch: amd64, config: test, distro: ubuntu }
           - { os: linux, arch: amd64, config: test, distro: azurelinux3 }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, fips: true }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true }
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: test }
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, fips: true }
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true }
           - { os: windows, arch: amd64, config: devscript }
           - { os: windows, arch: amd64, config: test }
-          - { experiment: cngcrypto, os: windows, arch: amd64, config: test }
-          - { experiment: cngcrypto, os: windows, arch: amd64, config: test, fips: true }
+          - { experiment: systemcrypto, os: windows, arch: amd64, config: test }
+          - { experiment: systemcrypto, os: windows, arch: amd64, config: test, fips: true }
           # Test that buildandpack works on Windows x86-32, but don't release it.
           - { os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if parameters.outerloop }}:
@@ -114,9 +114,9 @@ stages:
           - { os: linux, arch: amd64, config: regabi }
           - { os: linux, arch: amd64, config: ssacheck }
           - { os: linux, arch: amd64, config: staticlockranking }
-          # - { experiment: opensslcrypto, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: longtest }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: race }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: regabi }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: ssacheck }
-          - { experiment: opensslcrypto, os: linux, arch: amd64, config: staticlockranking }
+          # - { experiment: systemcrypto, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: longtest }
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: race }
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: regabi }
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: ssacheck }
+          - { experiment: systemcrypto, os: linux, arch: amd64, config: staticlockranking }

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -19,7 +19,7 @@ maintain this feature. For more information, see the test files.
  .../testdata/backendtags_openssl/openssl.go   |  3 +
  .../build/testdata/backendtags_system/main.go |  3 +
  .../backendtags_system/systemcrypto.go        |  3 +
- src/internal/buildcfg/exp.go                  | 16 ++++
+ src/internal/buildcfg/exp.go                  | 15 ++++
  .../goexperiment/exp_cngcrypto_off.go         |  8 ++
  src/internal/goexperiment/exp_cngcrypto_on.go |  8 ++
  .../goexperiment/exp_darwincrypto_off.go      |  8 ++
@@ -29,7 +29,7 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 ++++
- 18 files changed, 375 insertions(+), 4 deletions(-)
+ 18 files changed, 374 insertions(+), 4 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/main.go
@@ -387,17 +387,16 @@ index 00000000000000..eb8a026982259c
 +
 +package main
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index e36ec08a5b0232..54feb2905b859f 100644
+index e36ec08a5b0232..c1bd89cf694bea 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
-@@ -126,6 +126,15 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -126,6 +126,14 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  				// to build with any experiment flags.
  				flags.Flags = goexperiment.Flags{}
  				continue
 +			} else if f == "nosystemcrypto" {
-+				// GOEXPERIMENT=nosystemcrypto disables all system crypto
-+				// experiments. This is used by cmd/dist, which doesn't know
-+				// how to build with any system crypto flags.
++				// GOEXPERIMENT=nosystemcrypto disables all system
++				// crypto experiments.
 +				flags.Flags.OpenSSLCrypto = false
 +				flags.Flags.CNGCrypto = false
 +				flags.Flags.DarwinCrypto = false
@@ -406,7 +405,7 @@ index e36ec08a5b0232..54feb2905b859f 100644
  			}
  			val := true
  			if strings.HasPrefix(f, "no") {
-@@ -139,6 +148,10 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -139,6 +147,10 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  		}
  	}
  
@@ -417,7 +416,7 @@ index e36ec08a5b0232..54feb2905b859f 100644
  	if regabiAlwaysOn {
  		flags.RegabiWrappers = true
  		flags.RegabiArgs = true
-@@ -152,6 +165,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -152,6 +164,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.RegabiArgs && !flags.RegabiWrappers {
  		return nil, fmt.Errorf("GOEXPERIMENT regabiargs requires regabiwrappers")
  	}

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -19,7 +19,7 @@ maintain this feature. For more information, see the test files.
  .../testdata/backendtags_openssl/openssl.go   |  3 +
  .../build/testdata/backendtags_system/main.go |  3 +
  .../backendtags_system/systemcrypto.go        |  3 +
- src/internal/buildcfg/exp.go                  |  3 +
+ src/internal/buildcfg/exp.go                  | 16 ++++
  .../goexperiment/exp_cngcrypto_off.go         |  8 ++
  src/internal/goexperiment/exp_cngcrypto_on.go |  8 ++
  .../goexperiment/exp_darwincrypto_off.go      |  8 ++
@@ -29,7 +29,7 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 ++++
- 18 files changed, 362 insertions(+), 4 deletions(-)
+ 18 files changed, 375 insertions(+), 4 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/main.go
@@ -387,10 +387,37 @@ index 00000000000000..eb8a026982259c
 +
 +package main
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index e36ec08a5b0232..e30e156089847c 100644
+index e36ec08a5b0232..54feb2905b859f 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
-@@ -152,6 +152,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -126,6 +126,15 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+ 				// to build with any experiment flags.
+ 				flags.Flags = goexperiment.Flags{}
+ 				continue
++			} else if f == "nosystemcrypto" {
++				// GOEXPERIMENT=nosystemcrypto disables all system crypto
++				// experiments. This is used by cmd/dist, which doesn't know
++				// how to build with any system crypto flags.
++				flags.Flags.OpenSSLCrypto = false
++				flags.Flags.CNGCrypto = false
++				flags.Flags.DarwinCrypto = false
++				flags.Flags.SystemCrypto = false
++				continue
+ 			}
+ 			val := true
+ 			if strings.HasPrefix(f, "no") {
+@@ -139,6 +148,10 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+ 		}
+ 	}
+ 
++	if flags.OpenSSLCrypto || flags.CNGCrypto || flags.DarwinCrypto {
++		flags.SystemCrypto = true
++	}
++
+ 	if regabiAlwaysOn {
+ 		flags.RegabiWrappers = true
+ 		flags.RegabiArgs = true
+@@ -152,6 +165,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.RegabiArgs && !flags.RegabiWrappers {
  		return nil, fmt.Errorf("GOEXPERIMENT regabiargs requires regabiwrappers")
  	}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -11,8 +11,8 @@ desired goexperiments and build tags.
 ---
  .gitignore                                    |   2 +
  src/cmd/dist/build.go                         |   5 +
- src/cmd/dist/test.go                          |  22 +-
- src/cmd/go/internal/load/pkg.go               |   6 +
+ src/cmd/dist/test.go                          |  17 +-
+ src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/systemcrypto_test.go               | 144 +++++++
  src/crypto/internal/backend/backend_test.go   |  30 ++
  src/crypto/internal/backend/backendgen.go     |  20 +
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/go/build/deps_test.go                     |  30 +-
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 43 files changed, 2529 insertions(+), 9 deletions(-)
+ 43 files changed, 2521 insertions(+), 9 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/backendgen.go
@@ -191,17 +191,14 @@ index aa09d1eba34be8..c2adb959460ac2 100644
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
 diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
-index e913f9885234fd..123a77518106c5 100644
+index e913f9885234fd..ef331980a816a3 100644
 --- a/src/cmd/go/internal/load/pkg.go
 +++ b/src/cmd/go/internal/load/pkg.go
-@@ -2412,6 +2412,12 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
+@@ -2412,6 +2412,9 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
  			buildmode = "archive"
  		}
  	}
-+	if cfg.Experiment.SystemCrypto ||
-+		cfg.Experiment.OpenSSLCrypto ||
-+		cfg.Experiment.CNGCrypto ||
-+		cfg.Experiment.DarwinCrypto {
++	if cfg.Experiment.SystemCrypto {
 +		appendSetting("microsoft_systemcrypto", "1")
 +	}
  	appendSetting("-buildmode", buildmode)

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -2823,7 +2823,7 @@ index e7369542a73270..ff52175e4ac636 100644
  	}
  }
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 8477ba131082a8..23d4c9a0f8204d 100644
+index eddaf170772e19..dbd96efb9a7dce 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -517,7 +517,7 @@ var depsRules = `
@@ -2843,9 +2843,8 @@ index 8477ba131082a8..23d4c9a0f8204d 100644
 +
  	crypto !< FIPS;
  
- 	crypto, hash !< FIPS;
- 
-@@ -585,6 +585,7 @@ var depsRules = `
+ 	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
+@@ -584,6 +586,7 @@ var depsRules = `
  	  crypto/pbkdf2,
  	  crypto/ecdh,
  	  crypto/mlkem

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -227,7 +227,7 @@ index 4aaf46b5d0f0dc..ec58a217400caa 100644
  
  go list -f '{{.Dir}}' vendor/golang.org/x/net/http2/hpack
 diff --git a/src/cmd/link/internal/ld/config.go b/src/cmd/link/internal/ld/config.go
-index b2d4ad7cb0e7f6..2859879041ff8f 100644
+index b2d4ad7cb0e7f6..f5b109fc6cc069 100644
 --- a/src/cmd/link/internal/ld/config.go
 +++ b/src/cmd/link/internal/ld/config.go
 @@ -7,6 +7,7 @@ package ld
@@ -244,7 +244,7 @@ index b2d4ad7cb0e7f6..2859879041ff8f 100644
  		switch buildcfg.GOOS + "/" + buildcfg.GOARCH {
 +		case "darwin/amd64":
 +			// We can't link against the static object file when using no_pie
-+			if goexperiment.DarwinCrypto || goexperiment.SystemCrypto {
++			if goexperiment.SystemCrypto {
 +				*mode = BuildModePIE
 +			} else {
 +				*mode = BuildModeExe
@@ -2823,7 +2823,7 @@ index e7369542a73270..ff52175e4ac636 100644
  	}
  }
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index eddaf170772e19..dbd96efb9a7dce 100644
+index 8477ba131082a8..23d4c9a0f8204d 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -517,7 +517,7 @@ var depsRules = `
@@ -2843,8 +2843,9 @@ index eddaf170772e19..dbd96efb9a7dce 100644
 +
  	crypto !< FIPS;
  
- 	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
-@@ -584,6 +586,7 @@ var depsRules = `
+ 	crypto, hash !< FIPS;
+ 
+@@ -585,6 +585,7 @@ var depsRules = `
  	  crypto/pbkdf2,
  	  crypto/ecdh,
  	  crypto/mlkem


### PR DESCRIPTION
We currently make the `goexperiment.systemcrypto` build tag evaluate to true when any backend is enabled. This PR extends this idea to `goexperiment.SystemCrypto`.

The main benefit is that it is easier to use `goexperiment.SystemCrypto` than `goexperiment.OpenSSLCrypto || goexperiment.CNGCrypto || goexperiment.DarwinCrypto`. This pattern is not used much for now, but I'll start using it more in follow-up PRs.

This doesn't change any user-visibly behavior.