### PR TITLE
Support for excluding OS-disabled cipher suites in TLS handshake

### DIFF
--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -315,7 +315,7 @@ The TLS stack is implemented using native Go code but the crypto primitives are 
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
-On Windows, it is possible to restrict and reorder the cipher suites following the [Schannel preferences](https://learn.microsoft.com/en-us/windows/win32/secauthn/cipher-suites-in-schannel) by building with the `ms_schannelciphersuites` goexperiment enabled.
+On Windows, it is possible to restrict and reorder the cipher suites following the [Schannel preferences](https://learn.microsoft.com/en-us/windows/win32/secauthn/cipher-suites-in-schannel) by building with the `ms_tls_config_schannel` goexperiment enabled.
 
 ### Curves and Groups
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -315,6 +315,8 @@ The TLS stack is implemented using native Go code but the crypto primitives are 
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
+On Windows, it is possible to restrict and reorder the cipher suites following the [Schannel preferences](https://learn.microsoft.com/en-us/windows/win32/secauthn/cipher-suites-in-schannel) by building with the `ms_schannelciphersuites` goexperiment enabled.
+
 ### Curves and Groups
 
 Below are the supported [`tls.CurveIDs`](https://pkg.go.dev/crypto/tls#CurveID).

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -101,7 +101,7 @@ stages:
           - { os: windows, arch: amd64, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test, fips: true }
-          - { experiment: ms_schannelciphersuites, os: windows, arch: amd64, config: test }
+          - { experiment: ms_tls_config_schannel, os: windows, arch: amd64, config: test }
           # Test that buildandpack works on Windows x86-32, but don't release it.
           - { os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if parameters.outerloop }}:

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -101,6 +101,7 @@ stages:
           - { os: windows, arch: amd64, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test }
           - { experiment: cngcrypto, os: windows, arch: amd64, config: test, fips: true }
+          - { experiment: ms_schannelciphersuites, os: windows, arch: amd64, config: test }
           # Test that buildandpack works on Windows x86-32, but don't release it.
           - { os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if parameters.outerloop }}:

--- a/patches/0011-implement-ms_schannelsiphersuites-experiment.patch
+++ b/patches/0011-implement-ms_schannelsiphersuites-experiment.patch
@@ -1,0 +1,347 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: qmuntal <qmuntaldiaz@microsoft.com>
+Date: Thu, 3 Jul 2025 15:13:26 +0200
+Subject: [PATCH] implement ms_schannelsiphersuites experiment
+
+---
+ src/crypto/tls/cipher_suites_windows.go       | 74 +++++++++++++++++++
+ src/crypto/tls/cipher_suites_windows_test.go  | 67 +++++++++++++++++
+ src/crypto/tls/fips140_test.go                |  4 +
+ src/crypto/tls/tls_test.go                    |  8 ++
+ .../exp_ms_schannelciphersuites_off.go        |  8 ++
+ .../exp_ms_schannelciphersuites_on.go         |  8 ++
+ src/internal/goexperiment/flags.go            |  4 +
+ .../syscall/windows/security_windows.go       | 28 +++++++
+ .../syscall/windows/zsyscall_windows.go       | 16 ++++
+ 9 files changed, 217 insertions(+)
+ create mode 100644 src/crypto/tls/cipher_suites_windows.go
+ create mode 100644 src/crypto/tls/cipher_suites_windows_test.go
+ create mode 100644 src/internal/goexperiment/exp_ms_schannelciphersuites_off.go
+ create mode 100644 src/internal/goexperiment/exp_ms_schannelciphersuites_on.go
+
+diff --git a/src/crypto/tls/cipher_suites_windows.go b/src/crypto/tls/cipher_suites_windows.go
+new file mode 100644
+index 00000000000000..d9276b46fbadc9
+--- /dev/null
++++ b/src/crypto/tls/cipher_suites_windows.go
+@@ -0,0 +1,74 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build goexperiment.ms_schannelciphersuites
++
++package tls
++
++import (
++	"internal/syscall/windows"
++	"slices"
++	"unsafe"
++)
++
++func init() {
++	cipherSuitesSchannel, err := cipherSuitesSchannel()
++	if err != nil {
++		panic(err) // This should never happen, as Schannel is always available on Windows.
++	}
++	cipherSuitesPreferenceOrder = filterCipherSuites(cipherSuitesSchannel, cipherSuitesPreferenceOrder)
++	cipherSuitesPreferenceOrderNoAES = filterCipherSuites(cipherSuitesSchannel, cipherSuitesPreferenceOrderNoAES)
++	defaultCipherSuitesTLS13 = filterCipherSuites(cipherSuitesSchannel, defaultCipherSuitesTLS13)
++	defaultCipherSuitesTLS13NoAES = filterCipherSuites(cipherSuitesSchannel, defaultCipherSuitesTLS13NoAES)
++	allowedCipherSuitesFIPS = filterCipherSuites(cipherSuitesSchannel, allowedCipherSuitesFIPS)
++	allowedCipherSuitesTLS13FIPS = filterCipherSuites(cipherSuitesSchannel, allowedCipherSuitesTLS13FIPS)
++}
++
++func cipherSuiteID(name string) (uint16, bool) {
++	for _, c := range CipherSuites() {
++		if c.Name == name {
++			return c.ID, true
++		}
++	}
++	for _, c := range InsecureCipherSuites() {
++		if c.Name == name {
++			return c.ID, true
++		}
++	}
++	return 0, false
++}
++
++// cipherSuitesSchannel returns all the cipher suites that Schannel supports in preference order.
++func cipherSuitesSchannel() ([]uint16, error) {
++	// Get all the cipher suites that Schannel supports in preference order.
++	var size uint32
++	var funcs *windows.CRYPT_CONTEXT_FUNCTIONS
++	err := windows.BCryptEnumContextFunctions(windows.CRYPT_LOCAL, unsafe.SliceData(windows.SSL_CONTEXT[:]), windows.NCRYPT_SCHANNEL_INTERFACE, &size, &funcs)
++	if err != nil {
++		return nil, err
++	}
++	defer windows.BCryptFreeBuffer(unsafe.Pointer(funcs))
++
++	suites := make([]uint16, 0, funcs.Count) // order[i] will be the index of suites[i] in the Schannel list
++	for i := range funcs.Count {
++		name := windows.UTF16PtrToString(funcs.At(int(i)))
++		id, ok := cipherSuiteID(name)
++		if !ok {
++			continue // cipher suite not found in the provided list
++		}
++		suites = append(suites, id)
++	}
++	return suites, nil
++}
++
++// filterCipherSuites filters the provided cipher suites, removing those that are not in the allowed list.
++func filterCipherSuites(suites, allowed []uint16) []uint16 {
++	out := make([]uint16, 0, len(suites))
++	for _, suite := range suites {
++		if slices.Contains(allowed, suite) {
++			out = append(out, suite)
++		}
++	}
++	return out
++}
+diff --git a/src/crypto/tls/cipher_suites_windows_test.go b/src/crypto/tls/cipher_suites_windows_test.go
+new file mode 100644
+index 00000000000000..02e28482bb813b
+--- /dev/null
++++ b/src/crypto/tls/cipher_suites_windows_test.go
+@@ -0,0 +1,67 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build goexperiment.ms_schannelciphersuites
++
++package tls
++
++import (
++	"bytes"
++	"os/exec"
++	"testing"
++)
++
++func TestCipherSuitesSchannel(t *testing.T) {
++	cipherSuites, err := cipherSuitesSchannel()
++	if err != nil {
++		t.Fatal(err)
++	}
++	if len(cipherSuites) == 0 {
++		t.Fatal("cipherSuitesSchannel returned no cipher suites")
++	}
++
++	for _, suite := range cipherSuites {
++		if suite == 0 {
++			t.Fatal("cipherSuitesSchannel returned a 0 cipher suite")
++		}
++	}
++
++	// Check that all the cipher suites are present in the Get-TlsCipherSuite output.
++	output, err := exec.Command("powershell", "-Command", "Get-TlsCipherSuite").CombinedOutput()
++	if err != nil {
++		t.Fatalf("failed to get TLS cipher suites: %v\n%s", err, output)
++	}
++	for _, id := range cipherSuites {
++		name := CipherSuiteName(id)
++		if !bytes.Contains(output, []byte(name)) {
++			t.Errorf("cipher suite %s not found in PowerShell output", name)
++		}
++	}
++}
++
++func TestCipherSuitePreferenceSchannel(t *testing.T) {
++	// Schannel should prefer AES-256 over AES-128.
++	serverConfig := &Config{
++		CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384},
++		Certificates: testConfig.Certificates,
++		MaxVersion:   VersionTLS13,
++		GetConfigForClient: func(chi *ClientHelloInfo) (*Config, error) {
++			if chi.CipherSuites[0] != TLS_AES_256_GCM_SHA384 {
++				t.Error("the advertised order should not depend on Config.CipherSuites")
++			}
++			return nil, nil
++		},
++	}
++	clientConfig := &Config{
++		CipherSuites:       []uint16{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384},
++		InsecureSkipVerify: true,
++	}
++	state, _, err := testHandshake(t, clientConfig, serverConfig)
++	if err != nil {
++		t.Fatalf("handshake failed: %s", err)
++	}
++	if state.CipherSuite != TLS_AES_256_GCM_SHA384 {
++		t.Error("the preference order should not depend on Config.CipherSuites")
++	}
++}
+diff --git a/src/crypto/tls/fips140_test.go b/src/crypto/tls/fips140_test.go
+index 711ce750a71a93..c4a1834adf70b7 100644
+--- a/src/crypto/tls/fips140_test.go
++++ b/src/crypto/tls/fips140_test.go
+@@ -14,6 +14,7 @@ import (
+ 	"crypto/x509/pkix"
+ 	"encoding/pem"
+ 	"fmt"
++	"internal/goexperiment"
+ 	"internal/obscuretestdata"
+ 	"internal/testenv"
+ 	"math/big"
+@@ -174,6 +175,9 @@ func isFIPSSignatureScheme(alg SignatureScheme) bool {
+ }
+ 
+ func TestFIPSServerCipherSuites(t *testing.T) {
++	if goexperiment.MS_SchannelCipherSuites {
++		t.Skip("skipping Schannel cipher suite test")
++	}
+ 	serverConfig := testConfig.Clone()
+ 	serverConfig.Certificates = make([]Certificate, 1)
+ 
+diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
+index bfcc62ccfb8ba0..3f4da38fcde887 100644
+--- a/src/crypto/tls/tls_test.go
++++ b/src/crypto/tls/tls_test.go
+@@ -21,6 +21,7 @@ import (
+ 	"encoding/pem"
+ 	"errors"
+ 	"fmt"
++	"internal/goexperiment"
+ 	"internal/testenv"
+ 	"io"
+ 	"math"
+@@ -211,6 +212,10 @@ func skipFIPS(t *testing.T) {
+ 	if fips140tls.Required() {
+ 		t.Skip("skipping test in FIPS mode")
+ 	}
++	if goexperiment.MS_SchannelCipherSuites {
++		// Reuse the FIPS skip logic for Schannel.
++		t.Skip("skipping test in Schannel mode")
++	}
+ }
+ 
+ func TestDialTimeout(t *testing.T) {
+@@ -1545,6 +1550,9 @@ func TestClientHelloInfo_SupportsCertificate(t *testing.T) {
+ }
+ 
+ func TestCipherSuites(t *testing.T) {
++	if goexperiment.MS_SchannelCipherSuites {
++		t.Skip("Skipping CipherSuites test in MS_SchannelCipherSuites mode")
++	}
+ 	var lastID uint16
+ 	for _, c := range CipherSuites() {
+ 		if lastID > c.ID {
+diff --git a/src/internal/goexperiment/exp_ms_schannelciphersuites_off.go b/src/internal/goexperiment/exp_ms_schannelciphersuites_off.go
+new file mode 100644
+index 00000000000000..a3b7d02c464a9c
+--- /dev/null
++++ b/src/internal/goexperiment/exp_ms_schannelciphersuites_off.go
+@@ -0,0 +1,8 @@
++// Code generated by mkconsts.go. DO NOT EDIT.
++
++//go:build !goexperiment.ms_schannelciphersuites
++
++package goexperiment
++
++const MS_SchannelCipherSuites = false
++const MS_SchannelCipherSuitesInt = 0
+diff --git a/src/internal/goexperiment/exp_ms_schannelciphersuites_on.go b/src/internal/goexperiment/exp_ms_schannelciphersuites_on.go
+new file mode 100644
+index 00000000000000..e23dc6f2a6f361
+--- /dev/null
++++ b/src/internal/goexperiment/exp_ms_schannelciphersuites_on.go
+@@ -0,0 +1,8 @@
++// Code generated by mkconsts.go. DO NOT EDIT.
++
++//go:build goexperiment.ms_schannelciphersuites
++
++package goexperiment
++
++const MS_SchannelCipherSuites = true
++const MS_SchannelCipherSuitesInt = 1
+diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
+index 6b4289503d57ae..37455eab360f40 100644
+--- a/src/internal/goexperiment/flags.go
++++ b/src/internal/goexperiment/flags.go
+@@ -147,4 +147,8 @@ type Flags struct {
+ 
+ 	// GreenTeaGC enables the Green Tea GC implementation.
+ 	GreenTeaGC bool
++
++	// MS_SchannelCipherSuites enables the filtering and ordering of cipher suites
++	// according to the Windows Schannel settings.
++	MS_SchannelCipherSuites bool
+ }
+diff --git a/src/internal/syscall/windows/security_windows.go b/src/internal/syscall/windows/security_windows.go
+index f0ab52ac819baf..d6ef32c0e5c089 100644
+--- a/src/internal/syscall/windows/security_windows.go
++++ b/src/internal/syscall/windows/security_windows.go
+@@ -262,3 +262,31 @@ func GetSidSubAuthorityCount(sid *syscall.SID) uint8 {
+ 	defer runtime.KeepAlive(sid)
+ 	return *(*uint8)(unsafe.Pointer(getSidSubAuthorityCount(sid)))
+ }
++
++const (
++	CRYPT_LOCAL = 0x00000001
++
++	CRYPT_UM = 0x00000001
++
++	NCRYPT_SCHANNEL_INTERFACE = 0x00010002
++)
++
++var SSL_CONTEXT = [...]uint16{'S', 'S', 'L', 0}
++
++type CRYPT_CONTEXT_FUNCTIONS struct {
++	Count     uint32
++	Functions **uint16 // pointer to an array of pointers to null-terminated UTF-16 function names
++}
++
++func (ccf *CRYPT_CONTEXT_FUNCTIONS) At(i int) *uint16 {
++	if i < 0 || i >= int(ccf.Count) {
++		panic("index out of range")
++	}
++	if ccf.Functions == nil || *ccf.Functions == nil {
++		return nil
++	}
++	return *(**uint16)(unsafe.Add(unsafe.Pointer(ccf.Functions), uintptr(i)*unsafe.Sizeof(uintptr(0))))
++}
++
++//sys	BCryptFreeBuffer(buffer unsafe.Pointer) = bcrypt.BCryptFreeBuffer
++//sys	BCryptEnumContextFunctions(table uint32, context *uint16, iface uint32, bufferSize *uint32, buffer **CRYPT_CONTEXT_FUNCTIONS) (ntstatus error) = bcrypt.BCryptEnumContextFunctions
+diff --git a/src/internal/syscall/windows/zsyscall_windows.go b/src/internal/syscall/windows/zsyscall_windows.go
+index 90cf0b92a49bc4..db43b5da72f00e 100644
+--- a/src/internal/syscall/windows/zsyscall_windows.go
++++ b/src/internal/syscall/windows/zsyscall_windows.go
+@@ -38,6 +38,7 @@ func errnoErr(e syscall.Errno) error {
+ 
+ var (
+ 	modadvapi32         = syscall.NewLazyDLL(sysdll.Add("advapi32.dll"))
++	modbcrypt           = syscall.NewLazyDLL(sysdll.Add("bcrypt.dll"))
+ 	modbcryptprimitives = syscall.NewLazyDLL(sysdll.Add("bcryptprimitives.dll"))
+ 	modiphlpapi         = syscall.NewLazyDLL(sysdll.Add("iphlpapi.dll"))
+ 	modkernel32         = syscall.NewLazyDLL(sysdll.Add("kernel32.dll"))
+@@ -63,6 +64,8 @@ var (
+ 	procQueryServiceStatus                = modadvapi32.NewProc("QueryServiceStatus")
+ 	procRevertToSelf                      = modadvapi32.NewProc("RevertToSelf")
+ 	procSetTokenInformation               = modadvapi32.NewProc("SetTokenInformation")
++	procBCryptEnumContextFunctions        = modbcrypt.NewProc("BCryptEnumContextFunctions")
++	procBCryptFreeBuffer                  = modbcrypt.NewProc("BCryptFreeBuffer")
+ 	procProcessPrng                       = modbcryptprimitives.NewProc("ProcessPrng")
+ 	procGetAdaptersAddresses              = modiphlpapi.NewProc("GetAdaptersAddresses")
+ 	procCreateEventW                      = modkernel32.NewProc("CreateEventW")
+@@ -242,6 +245,19 @@ func SetTokenInformation(tokenHandle syscall.Token, tokenInformationClass uint32
+ 	return
+ }
+ 
++func BCryptEnumContextFunctions(table uint32, context *uint16, iface uint32, bufferSize *uint32, buffer **CRYPT_CONTEXT_FUNCTIONS) (ntstatus error) {
++	r0, _, _ := syscall.Syscall6(procBCryptEnumContextFunctions.Addr(), 5, uintptr(table), uintptr(unsafe.Pointer(context)), uintptr(iface), uintptr(unsafe.Pointer(bufferSize)), uintptr(unsafe.Pointer(buffer)), 0)
++	if r0 != 0 {
++		ntstatus = NTStatus(r0)
++	}
++	return
++}
++
++func BCryptFreeBuffer(buffer unsafe.Pointer) {
++	syscall.Syscall(procBCryptFreeBuffer.Addr(), 1, uintptr(buffer), 0, 0)
++	return
++}
++
+ func ProcessPrng(buf []byte) (err error) {
+ 	var _p0 *byte
+ 	if len(buf) > 0 {

--- a/patches/0011-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0011-implement-ms_tls_config_schannel-experiment.patch
@@ -1,27 +1,27 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: qmuntal <qmuntaldiaz@microsoft.com>
 Date: Thu, 3 Jul 2025 15:13:26 +0200
-Subject: [PATCH] implement ms_schannelsiphersuites experiment
+Subject: [PATCH] implement ms_tls_config_schannel experiment
 
 ---
  src/crypto/tls/cipher_suites_windows.go       | 74 +++++++++++++++++++
  src/crypto/tls/cipher_suites_windows_test.go  | 67 +++++++++++++++++
- src/crypto/tls/fips140_test.go                |  4 +
+ src/crypto/tls/fips140_test.go                |  7 ++
  src/crypto/tls/tls_test.go                    |  8 ++
- .../exp_ms_schannelciphersuites_off.go        |  8 ++
- .../exp_ms_schannelciphersuites_on.go         |  8 ++
+ .../exp_ms_tls_config_schannel_off.go         |  8 ++
+ .../exp_ms_tls_config_schannel_on.go          |  8 ++
  src/internal/goexperiment/flags.go            |  4 +
  .../syscall/windows/security_windows.go       | 28 +++++++
  .../syscall/windows/zsyscall_windows.go       | 16 ++++
- 9 files changed, 217 insertions(+)
+ 9 files changed, 220 insertions(+)
  create mode 100644 src/crypto/tls/cipher_suites_windows.go
  create mode 100644 src/crypto/tls/cipher_suites_windows_test.go
- create mode 100644 src/internal/goexperiment/exp_ms_schannelciphersuites_off.go
- create mode 100644 src/internal/goexperiment/exp_ms_schannelciphersuites_on.go
+ create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
+ create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_on.go
 
 diff --git a/src/crypto/tls/cipher_suites_windows.go b/src/crypto/tls/cipher_suites_windows.go
 new file mode 100644
-index 00000000000000..d9276b46fbadc9
+index 00000000000000..c1dcd97555fe4d
 --- /dev/null
 +++ b/src/crypto/tls/cipher_suites_windows.go
 @@ -0,0 +1,74 @@
@@ -29,7 +29,7 @@ index 00000000000000..d9276b46fbadc9
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.ms_schannelciphersuites
++//go:build goexperiment.ms_tls_config_schannel
 +
 +package tls
 +
@@ -101,7 +101,7 @@ index 00000000000000..d9276b46fbadc9
 +}
 diff --git a/src/crypto/tls/cipher_suites_windows_test.go b/src/crypto/tls/cipher_suites_windows_test.go
 new file mode 100644
-index 00000000000000..02e28482bb813b
+index 00000000000000..4a1e932e609749
 --- /dev/null
 +++ b/src/crypto/tls/cipher_suites_windows_test.go
 @@ -0,0 +1,67 @@
@@ -109,7 +109,7 @@ index 00000000000000..02e28482bb813b
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.ms_schannelciphersuites
++//go:build goexperiment.ms_tls_config_schannel
 +
 +package tls
 +
@@ -173,7 +173,7 @@ index 00000000000000..02e28482bb813b
 +	}
 +}
 diff --git a/src/crypto/tls/fips140_test.go b/src/crypto/tls/fips140_test.go
-index 711ce750a71a93..c4a1834adf70b7 100644
+index 711ce750a71a93..13ecc49a05e14e 100644
 --- a/src/crypto/tls/fips140_test.go
 +++ b/src/crypto/tls/fips140_test.go
 @@ -14,6 +14,7 @@ import (
@@ -184,18 +184,28 @@ index 711ce750a71a93..c4a1834adf70b7 100644
  	"internal/obscuretestdata"
  	"internal/testenv"
  	"math/big"
-@@ -174,6 +175,9 @@ func isFIPSSignatureScheme(alg SignatureScheme) bool {
+@@ -51,6 +52,9 @@ func generateKeyShare(group CurveID) keyShare {
+ }
+ 
+ func TestFIPSServerProtocolVersion(t *testing.T) {
++	if goexperiment.MS_TLS_Config_Schannel {
++		t.Skip("skipping Schannel cipher suite test")
++	}
+ 	test := func(t *testing.T, name string, v uint16, msg string) {
+ 		t.Run(name, func(t *testing.T) {
+ 			serverConfig := testConfig.Clone()
+@@ -174,6 +178,9 @@ func isFIPSSignatureScheme(alg SignatureScheme) bool {
  }
  
  func TestFIPSServerCipherSuites(t *testing.T) {
-+	if goexperiment.MS_SchannelCipherSuites {
++	if goexperiment.MS_TLS_Config_Schannel {
 +		t.Skip("skipping Schannel cipher suite test")
 +	}
  	serverConfig := testConfig.Clone()
  	serverConfig.Certificates = make([]Certificate, 1)
  
 diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
-index bfcc62ccfb8ba0..3f4da38fcde887 100644
+index bfcc62ccfb8ba0..1bea8f21789d4f 100644
 --- a/src/crypto/tls/tls_test.go
 +++ b/src/crypto/tls/tls_test.go
 @@ -21,6 +21,7 @@ import (
@@ -210,7 +220,7 @@ index bfcc62ccfb8ba0..3f4da38fcde887 100644
  	if fips140tls.Required() {
  		t.Skip("skipping test in FIPS mode")
  	}
-+	if goexperiment.MS_SchannelCipherSuites {
++	if goexperiment.MS_TLS_Config_Schannel {
 +		// Reuse the FIPS skip logic for Schannel.
 +		t.Skip("skipping test in Schannel mode")
 +	}
@@ -221,42 +231,42 @@ index bfcc62ccfb8ba0..3f4da38fcde887 100644
  }
  
  func TestCipherSuites(t *testing.T) {
-+	if goexperiment.MS_SchannelCipherSuites {
-+		t.Skip("Skipping CipherSuites test in MS_SchannelCipherSuites mode")
++	if goexperiment.MS_TLS_Config_Schannel {
++		t.Skip("Skipping CipherSuites test in Schannel mode")
 +	}
  	var lastID uint16
  	for _, c := range CipherSuites() {
  		if lastID > c.ID {
-diff --git a/src/internal/goexperiment/exp_ms_schannelciphersuites_off.go b/src/internal/goexperiment/exp_ms_schannelciphersuites_off.go
+diff --git a/src/internal/goexperiment/exp_ms_tls_config_schannel_off.go b/src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
 new file mode 100644
-index 00000000000000..a3b7d02c464a9c
+index 00000000000000..db7790d1a1f1b9
 --- /dev/null
-+++ b/src/internal/goexperiment/exp_ms_schannelciphersuites_off.go
++++ b/src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
 @@ -0,0 +1,8 @@
 +// Code generated by mkconsts.go. DO NOT EDIT.
 +
-+//go:build !goexperiment.ms_schannelciphersuites
++//go:build !goexperiment.ms_tls_config_schannel
 +
 +package goexperiment
 +
-+const MS_SchannelCipherSuites = false
-+const MS_SchannelCipherSuitesInt = 0
-diff --git a/src/internal/goexperiment/exp_ms_schannelciphersuites_on.go b/src/internal/goexperiment/exp_ms_schannelciphersuites_on.go
++const MS_TLS_Config_Schannel = false
++const MS_TLS_Config_SchannelInt = 0
+diff --git a/src/internal/goexperiment/exp_ms_tls_config_schannel_on.go b/src/internal/goexperiment/exp_ms_tls_config_schannel_on.go
 new file mode 100644
-index 00000000000000..e23dc6f2a6f361
+index 00000000000000..a2dbc6187da2a0
 --- /dev/null
-+++ b/src/internal/goexperiment/exp_ms_schannelciphersuites_on.go
++++ b/src/internal/goexperiment/exp_ms_tls_config_schannel_on.go
 @@ -0,0 +1,8 @@
 +// Code generated by mkconsts.go. DO NOT EDIT.
 +
-+//go:build goexperiment.ms_schannelciphersuites
++//go:build goexperiment.ms_tls_config_schannel
 +
 +package goexperiment
 +
-+const MS_SchannelCipherSuites = true
-+const MS_SchannelCipherSuitesInt = 1
++const MS_TLS_Config_Schannel = true
++const MS_TLS_Config_SchannelInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 6b4289503d57ae..37455eab360f40 100644
+index 6b4289503d57ae..90b046af1965f1 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -147,4 +147,8 @@ type Flags struct {
@@ -264,9 +274,9 @@ index 6b4289503d57ae..37455eab360f40 100644
  	// GreenTeaGC enables the Green Tea GC implementation.
  	GreenTeaGC bool
 +
-+	// MS_SchannelCipherSuites enables the filtering and ordering of cipher suites
++	// MS_TLS_Config_Schannel enables the filtering and ordering of cipher suites
 +	// according to the Windows Schannel settings.
-+	MS_SchannelCipherSuites bool
++	MS_TLS_Config_Schannel bool
  }
 diff --git a/src/internal/syscall/windows/security_windows.go b/src/internal/syscall/windows/security_windows.go
 index f0ab52ac819baf..d6ef32c0e5c089 100644

--- a/patches/0011-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0011-implement-ms_tls_config_schannel-experiment.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
 
 ---
  src/crypto/tls/fips140_test.go                | 10 +++
+ src/crypto/tls/handshake_client_test.go       |  6 ++
  src/crypto/tls/handshake_server_test.go       |  4 +
  src/crypto/tls/schannel_disabled_test.go      | 11 +++
  src/crypto/tls/schannel_windows.go            | 75 +++++++++++++++++
@@ -15,7 +16,7 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
  src/internal/goexperiment/flags.go            |  4 +
  .../syscall/windows/security_windows.go       | 28 +++++++
  .../syscall/windows/zsyscall_windows.go       | 16 ++++
- 11 files changed, 258 insertions(+)
+ 12 files changed, 264 insertions(+)
  create mode 100644 src/crypto/tls/schannel_disabled_test.go
  create mode 100644 src/crypto/tls/schannel_windows.go
  create mode 100644 src/crypto/tls/schannel_windows_test.go
@@ -57,6 +58,30 @@ index 711ce750a71a93..f3b993fc0c669e 100644
  			clientHello := &clientHelloMsg{
  				vers:                         VersionTLS12,
  				random:                       make([]byte, 32),
+diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
+index 6118711a0eb65a..93ce0c90875cd8 100644
+--- a/src/crypto/tls/handshake_client_test.go
++++ b/src/crypto/tls/handshake_client_test.go
+@@ -20,6 +20,7 @@ import (
+ 	"errors"
+ 	"fmt"
+ 	"internal/byteorder"
++	"internal/goexperiment"
+ 	"io"
+ 	"math/big"
+ 	"net"
+@@ -2398,6 +2399,11 @@ func testGetClientCertificate(t *testing.T, version uint16) {
+ 			t.Logf("skipping test %d for FIPS mode", i)
+ 			continue
+ 		}
++		if goexperiment.MS_TLS_Config_Schannel && clientConfig.MaxVersion == VersionTLS11 {
++			// TLS 1.1 isn't available on Schannel
++			t.Logf("skipping test %d on Schannel", i)
++			continue
++		}
+ 
+ 		type serverResult struct {
+ 			cs  ConnectionState
 diff --git a/src/crypto/tls/handshake_server_test.go b/src/crypto/tls/handshake_server_test.go
 index a6d64a506a0542..0c604228f7786f 100644
 --- a/src/crypto/tls/handshake_server_test.go

--- a/patches/0011-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0011-implement-ms_tls_config_schannel-experiment.patch
@@ -4,27 +4,104 @@ Date: Thu, 3 Jul 2025 15:13:26 +0200
 Subject: [PATCH] implement ms_tls_config_schannel experiment
 
 ---
- src/crypto/tls/cipher_suites_windows.go       | 74 +++++++++++++++++++
- src/crypto/tls/cipher_suites_windows_test.go  | 67 +++++++++++++++++
- src/crypto/tls/fips140_test.go                |  7 ++
- src/crypto/tls/tls_test.go                    |  8 ++
+ src/crypto/tls/fips140_test.go                | 10 +++
+ src/crypto/tls/handshake_server_test.go       |  4 +
+ src/crypto/tls/schannel_disabled_test.go      | 11 +++
+ src/crypto/tls/schannel_windows.go            | 75 +++++++++++++++++
+ src/crypto/tls/schannel_windows_test.go       | 81 +++++++++++++++++++
+ src/crypto/tls/tls_test.go                    | 13 +++
  .../exp_ms_tls_config_schannel_off.go         |  8 ++
  .../exp_ms_tls_config_schannel_on.go          |  8 ++
  src/internal/goexperiment/flags.go            |  4 +
  .../syscall/windows/security_windows.go       | 28 +++++++
  .../syscall/windows/zsyscall_windows.go       | 16 ++++
- 9 files changed, 220 insertions(+)
- create mode 100644 src/crypto/tls/cipher_suites_windows.go
- create mode 100644 src/crypto/tls/cipher_suites_windows_test.go
+ 11 files changed, 258 insertions(+)
+ create mode 100644 src/crypto/tls/schannel_disabled_test.go
+ create mode 100644 src/crypto/tls/schannel_windows.go
+ create mode 100644 src/crypto/tls/schannel_windows_test.go
  create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
  create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_on.go
 
-diff --git a/src/crypto/tls/cipher_suites_windows.go b/src/crypto/tls/cipher_suites_windows.go
+diff --git a/src/crypto/tls/fips140_test.go b/src/crypto/tls/fips140_test.go
+index 711ce750a71a93..f3b993fc0c669e 100644
+--- a/src/crypto/tls/fips140_test.go
++++ b/src/crypto/tls/fips140_test.go
+@@ -14,6 +14,7 @@ import (
+ 	"crypto/x509/pkix"
+ 	"encoding/pem"
+ 	"fmt"
++	"internal/goexperiment"
+ 	"internal/obscuretestdata"
+ 	"internal/testenv"
+ 	"math/big"
+@@ -52,6 +53,12 @@ func generateKeyShare(group CurveID) keyShare {
+ 
+ func TestFIPSServerProtocolVersion(t *testing.T) {
+ 	test := func(t *testing.T, name string, v uint16, msg string) {
++		if goexperiment.MS_TLS_Config_Schannel {
++			if v < VersionTLS12 {
++				// Most Windows versions do not support TLS 1.0 or 1.1.
++				t.Skipf("skipping Schannel cipher suite test for version %x", v)
++			}
++		}
+ 		t.Run(name, func(t *testing.T) {
+ 			serverConfig := testConfig.Clone()
+ 			serverConfig.MinVersion = VersionSSL30
+@@ -187,6 +194,9 @@ func TestFIPSServerCipherSuites(t *testing.T) {
+ 		}
+ 		serverConfig.BuildNameToCertificate()
+ 		t.Run(fmt.Sprintf("suite=%s", CipherSuiteName(id)), func(t *testing.T) {
++			if goexperiment.MS_TLS_Config_Schannel && !isSchannelCipherSuite(id) {
++				t.Skip("skipping Schannel unsupported cipher suite")
++			}
+ 			clientHello := &clientHelloMsg{
+ 				vers:                         VersionTLS12,
+ 				random:                       make([]byte, 32),
+diff --git a/src/crypto/tls/handshake_server_test.go b/src/crypto/tls/handshake_server_test.go
+index a6d64a506a0542..0c604228f7786f 100644
+--- a/src/crypto/tls/handshake_server_test.go
++++ b/src/crypto/tls/handshake_server_test.go
+@@ -16,6 +16,7 @@ import (
+ 	"encoding/pem"
+ 	"errors"
+ 	"fmt"
++	"internal/goexperiment"
+ 	"io"
+ 	"net"
+ 	"os"
+@@ -341,6 +342,9 @@ func TestTLSPointFormats(t *testing.T) {
+ 			continue
+ 		}
+ 		t.Run(tt.name, func(t *testing.T) {
++			if goexperiment.MS_TLS_Config_Schannel && !isSchannelCipherSuite(tt.cipherSuites[0]) {
++				t.Skip("skipping Schannel unsupported cipher suite")
++			}
+ 			clientHello := &clientHelloMsg{
+ 				vers:               VersionTLS12,
+ 				random:             make([]byte, 32),
+diff --git a/src/crypto/tls/schannel_disabled_test.go b/src/crypto/tls/schannel_disabled_test.go
 new file mode 100644
-index 00000000000000..c1dcd97555fe4d
+index 00000000000000..d598d48dedf762
 --- /dev/null
-+++ b/src/crypto/tls/cipher_suites_windows.go
-@@ -0,0 +1,74 @@
++++ b/src/crypto/tls/schannel_disabled_test.go
+@@ -0,0 +1,11 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !windows || !goexperiment.ms_tls_config_schannel
++
++package tls
++
++func isSchannelCipherSuite(id uint16) bool {
++	return false
++}
+diff --git a/src/crypto/tls/schannel_windows.go b/src/crypto/tls/schannel_windows.go
+new file mode 100644
+index 00000000000000..cf660080f24c2f
+--- /dev/null
++++ b/src/crypto/tls/schannel_windows.go
+@@ -0,0 +1,75 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -66,7 +143,7 @@ index 00000000000000..c1dcd97555fe4d
 +	return 0, false
 +}
 +
-+// cipherSuitesSchannel returns all the cipher suites that Schannel supports in preference order.
++// cipherSuitesSchannel returns all the cipher suites that Schannel supports in Schannel's preference order.
 +func cipherSuitesSchannel() ([]uint16, error) {
 +	// Get all the cipher suites that Schannel supports in preference order.
 +	var size uint32
@@ -89,7 +166,8 @@ index 00000000000000..c1dcd97555fe4d
 +	return suites, nil
 +}
 +
-+// filterCipherSuites filters the provided cipher suites, removing those that are not in the allowed list.
++// filterCipherSuites filters the provided cipher suites, creating a new slice
++// that only includes those that are in the allowed list.
 +func filterCipherSuites(suites, allowed []uint16) []uint16 {
 +	out := make([]uint16, 0, len(suites))
 +	for _, suite := range suites {
@@ -99,12 +177,12 @@ index 00000000000000..c1dcd97555fe4d
 +	}
 +	return out
 +}
-diff --git a/src/crypto/tls/cipher_suites_windows_test.go b/src/crypto/tls/cipher_suites_windows_test.go
+diff --git a/src/crypto/tls/schannel_windows_test.go b/src/crypto/tls/schannel_windows_test.go
 new file mode 100644
-index 00000000000000..4a1e932e609749
+index 00000000000000..3387e8419b950f
 --- /dev/null
-+++ b/src/crypto/tls/cipher_suites_windows_test.go
-@@ -0,0 +1,67 @@
++++ b/src/crypto/tls/schannel_windows_test.go
+@@ -0,0 +1,81 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -116,8 +194,22 @@ index 00000000000000..4a1e932e609749
 +import (
 +	"bytes"
 +	"os/exec"
++	"slices"
++	"sync"
 +	"testing"
 +)
++
++var schannelSuites = sync.OnceValue(func() []uint16 {
++	cipherSuites, err := cipherSuitesSchannel()
++	if err != nil {
++		panic(err) // This should never happen, as Schannel is always available on Windows.
++	}
++	return cipherSuites
++})
++
++func isSchannelCipherSuite(id uint16) bool {
++	return slices.Contains(schannelSuites(), id)
++}
 +
 +func TestCipherSuitesSchannel(t *testing.T) {
 +	cipherSuites, err := cipherSuitesSchannel()
@@ -172,40 +264,8 @@ index 00000000000000..4a1e932e609749
 +		t.Error("the preference order should not depend on Config.CipherSuites")
 +	}
 +}
-diff --git a/src/crypto/tls/fips140_test.go b/src/crypto/tls/fips140_test.go
-index 711ce750a71a93..13ecc49a05e14e 100644
---- a/src/crypto/tls/fips140_test.go
-+++ b/src/crypto/tls/fips140_test.go
-@@ -14,6 +14,7 @@ import (
- 	"crypto/x509/pkix"
- 	"encoding/pem"
- 	"fmt"
-+	"internal/goexperiment"
- 	"internal/obscuretestdata"
- 	"internal/testenv"
- 	"math/big"
-@@ -51,6 +52,9 @@ func generateKeyShare(group CurveID) keyShare {
- }
- 
- func TestFIPSServerProtocolVersion(t *testing.T) {
-+	if goexperiment.MS_TLS_Config_Schannel {
-+		t.Skip("skipping Schannel cipher suite test")
-+	}
- 	test := func(t *testing.T, name string, v uint16, msg string) {
- 		t.Run(name, func(t *testing.T) {
- 			serverConfig := testConfig.Clone()
-@@ -174,6 +178,9 @@ func isFIPSSignatureScheme(alg SignatureScheme) bool {
- }
- 
- func TestFIPSServerCipherSuites(t *testing.T) {
-+	if goexperiment.MS_TLS_Config_Schannel {
-+		t.Skip("skipping Schannel cipher suite test")
-+	}
- 	serverConfig := testConfig.Clone()
- 	serverConfig.Certificates = make([]Certificate, 1)
- 
 diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
-index bfcc62ccfb8ba0..1bea8f21789d4f 100644
+index bfcc62ccfb8ba0..737157b881881b 100644
 --- a/src/crypto/tls/tls_test.go
 +++ b/src/crypto/tls/tls_test.go
 @@ -21,6 +21,7 @@ import (
@@ -227,12 +287,24 @@ index bfcc62ccfb8ba0..1bea8f21789d4f 100644
  }
  
  func TestDialTimeout(t *testing.T) {
-@@ -1545,6 +1550,9 @@ func TestClientHelloInfo_SupportsCertificate(t *testing.T) {
+@@ -1289,6 +1294,9 @@ func TestConnectionState(t *testing.T) {
+ 		if !isFIPSVersion(v) && fips140tls.Required() {
+ 			t.Skipf("skipping test in FIPS 140-3 mode for non-FIPS version %x", v)
+ 		}
++		if goexperiment.MS_TLS_Config_Schannel && v < VersionTLS12 {
++			t.Skipf("skipping test for Schannel unsupported version %x", v)
++		}
+ 		var name string
+ 		switch v {
+ 		case VersionTLS10:
+@@ -1545,6 +1553,11 @@ func TestClientHelloInfo_SupportsCertificate(t *testing.T) {
  }
  
  func TestCipherSuites(t *testing.T) {
 +	if goexperiment.MS_TLS_Config_Schannel {
-+		t.Skip("Skipping CipherSuites test in Schannel mode")
++		// Schannel modifies the cipher suite list, so this test
++		// is not applicable.
++		t.Skip("skipping CipherSuites test in Schannel mode")
 +	}
  	var lastID uint16
  	for _, c := range CipherSuites() {


### PR DESCRIPTION
This PR does the following:

- Adds `GOEXPERIMENT=ms_tls_config_schannel`
- When the new experiment is enabled, all TLS cipher suites are filtered and reordered based on the Windows' Schannel configuration (as retrieved by [BCryptEnumContextFunctions](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptenumcontextfunctions))
- For TLS 1.2, [tls.Config.CipherSuites](https://pkg.go.dev/crypto/tls#Config) can still be used to further limit the enabled cipher suites.

Note that Schannel might support more cipher suites than Go. These cipher suites won't be used.

This new feature is orthogonal to `GOEXPERIMENT=systemcrypto`, so it can be enabled independenlty.

For https://github.com/microsoft/go-lab/issues/215.