### PR TITLE
Fix Ed25519 tests for supported algorithm check.

### DIFF
--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -67,7 +67,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/sha256/sha256_test.go              |  20 +-
  src/crypto/sha512/sha512.go                   |   2 +-
  src/crypto/sha512/sha512_test.go              |  24 ++-
- src/crypto/tls/auth_test.go                   |   8 +
+ src/crypto/tls/auth_test.go                   |   7 +
  src/crypto/tls/cipher_suites.go               |   2 +-
  src/crypto/tls/defaults_boring.go             |   2 +-
  src/crypto/tls/defaults_fips140.go            |   2 +-
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1161 insertions(+), 96 deletions(-)
+ 86 files changed, 1160 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -2318,18 +2318,10 @@ index 080bf694f03652..8962a54f1bcddd 100644
  	})
  }
 diff --git a/src/crypto/tls/auth_test.go b/src/crypto/tls/auth_test.go
-index 727bdc4df76393..1a95932f002a71 100644
+index 727bdc4df76393..73dee851e1bb4a 100644
 --- a/src/crypto/tls/auth_test.go
 +++ b/src/crypto/tls/auth_test.go
-@@ -12,6 +12,7 @@ import (
- )
- 
- func TestSignatureSelection(t *testing.T) {
-+	t.Skip("Skipping this test until #1715 is resolved.")
- 	rsaCert := &Certificate{
- 		Certificate: [][]byte{testRSACertificate},
- 		PrivateKey:  testRSAPrivateKey,
-@@ -67,6 +68,13 @@ func TestSignatureSelection(t *testing.T) {
+@@ -67,6 +67,13 @@ func TestSignatureSelection(t *testing.T) {
  			t.Logf("skipping test[%d] - not compatible with TLS FIPS mode", testNo)
  			continue
  		}

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -67,7 +67,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/sha256/sha256_test.go              |  20 +-
  src/crypto/sha512/sha512.go                   |   2 +-
  src/crypto/sha512/sha512_test.go              |  24 ++-
- src/crypto/tls/auth_test.go                   |   1 +
+ src/crypto/tls/auth_test.go                   |   8 +
  src/crypto/tls/cipher_suites.go               |   2 +-
  src/crypto/tls/defaults_boring.go             |   2 +-
  src/crypto/tls/defaults_fips140.go            |   2 +-
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1154 insertions(+), 96 deletions(-)
+ 86 files changed, 1161 insertions(+), 96 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -116,7 +116,7 @@ index f0e3575637c62a..9eab3b4e66e60b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index c2adb959460ac2..ee766afaca06e7 100644
+index c3f3a8324c507c..aedd8cd2902f27 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -719,7 +719,7 @@ func (t *tester) registerTests() {
@@ -128,7 +128,7 @@ index c2adb959460ac2..ee766afaca06e7 100644
  		// Test standard crypto packages with fips140=on.
  		t.registerTest("GOFIPS140=latest go test crypto/...", &goTest{
  			variant: "gofips140",
-@@ -1199,6 +1199,11 @@ func (t *tester) internalLink() bool {
+@@ -1211,6 +1211,11 @@ func (t *tester) internalLink() bool {
  	if goos == "windows" && goarch == "arm64" {
  		return false
  	}
@@ -140,7 +140,7 @@ index c2adb959460ac2..ee766afaca06e7 100644
  	// Internally linking cgo is incomplete on some architectures.
  	// https://golang.org/issue/10373
  	// https://golang.org/issue/14449
-@@ -1362,12 +1367,11 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1374,12 +1379,11 @@ func (t *tester) registerCgoTests(heading string) {
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
@@ -2318,7 +2318,7 @@ index 080bf694f03652..8962a54f1bcddd 100644
  	})
  }
 diff --git a/src/crypto/tls/auth_test.go b/src/crypto/tls/auth_test.go
-index 727bdc4df76393..8fd9fc75cf05ef 100644
+index 727bdc4df76393..1a95932f002a71 100644
 --- a/src/crypto/tls/auth_test.go
 +++ b/src/crypto/tls/auth_test.go
 @@ -12,6 +12,7 @@ import (
@@ -2329,6 +2329,20 @@ index 727bdc4df76393..8fd9fc75cf05ef 100644
  	rsaCert := &Certificate{
  		Certificate: [][]byte{testRSACertificate},
  		PrivateKey:  testRSAPrivateKey,
+@@ -67,6 +68,13 @@ func TestSignatureSelection(t *testing.T) {
+ 			t.Logf("skipping test[%d] - not compatible with TLS FIPS mode", testNo)
+ 			continue
+ 		}
++
++		if fips140tls.Required() && test.expectedSigAlg == Ed25519 {
++			// CNG and SymCrypt do not support Ed25519.
++			t.Logf("skipping test[%d] - Ed25519 is not compatible with Microsoft TLS FIPS mode", testNo)
++			continue
++		}
++
+ 		savedGODEBUG := os.Getenv("GODEBUG")
+ 		os.Setenv("GODEBUG", savedGODEBUG+","+test.godebug)
+ 
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
 index 2a96fa69036a07..f3c19c7faf1c21 100644
 --- a/src/crypto/tls/cipher_suites.go
@@ -2831,7 +2845,7 @@ index e7369542a73270..ff52175e4ac636 100644
  	}
  }
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index eddaf170772e19..dbd96efb9a7dce 100644
+index 1997d90f2f20ba..f69862c628eea4 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -517,7 +517,7 @@ var depsRules = `


### PR DESCRIPTION
Unlike default fips140 of mainstream Golang, Microsoft Build of Go does not provide FIPS compliant Ed25519, but tests expects to see Ed25519. Thats why currently we decided to pass Ed25519 until we provide FIPS compliant versions of this algorithm in Microsoft Build of Go. 
Fixes: #1715