### PR TITLE
move vendor checks to patch-build.yml

### DIFF
--- a/.github/workflows/patch-build.yml
+++ b/.github/workflows/patch-build.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [ microsoft/* ]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/microsoft/main' }}
+
 jobs:
   build_patches:
     name: Patches Build in Order

--- a/.github/workflows/patch-build.yml
+++ b/.github/workflows/patch-build.yml
@@ -29,10 +29,15 @@ jobs:
         run: |
           for file in $(ls -v patches/*.patch); do
             echo "::group::Building $file"
-            cd go
-            git am --whitespace=nowarn ../$file
-            cd src
+            cd ${{ github.workspace }}/go
+            git am --whitespace=nowarn ${{ github.workspace }}/$file
+            cd ${{ github.workspace }}/go/src
             bash make.bash
-            cd ../../
+            ${{ github.workspace }}/go/bin/go mod vendor
+            cd ${{ github.workspace }}/go/src/cmd
+            ${{ github.workspace }}/go/bin/go mod vendor
+            cd ${{ github.workspace }}/go/src
+            # Check if the vendor directory is clean
+            git diff --exit-code vendor cmd/vendor || (echo "Vendor directories are not clean. Please run 'go mod vendor' in the appropriate directories and commit the changes." && exit 1)
             echo "::endgroup::"
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,22 +31,3 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - run: pwsh eng/run.ps1 submodule-refresh -shallow
-
-      - name: Build Go toolchain
-        working-directory: go/src
-        run: ./make.bash
-
-      - name: Run go mod vendor (go/src)
-        working-directory: go/src
-        run: |
-          ../bin/go mod vendor
-
-      - name: Run go mod vendor (go/src/cmd)
-        working-directory: go/src/cmd
-        run: |
-          ../../bin/go mod vendor
-
-      - name: Check if vendor directory is clean
-        working-directory: go/src
-        run: |
-          git diff --exit-code vendor cmd/vendor || (echo "Vendor directories are not clean. Please run 'go mod vendor' in the appropriate directories and commit the changes." && exit 1)

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -1954,7 +1954,7 @@ index 00000000000000..b6c942fc91eec7
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/.gitignore
 @@ -0,0 +1,2 @@
 +**/.DS_Store
-+.vscode/
++.vscode/fooBar
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml b/src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
 new file mode 100644
 index 00000000000000..aed2e22df2d555

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -1954,7 +1954,7 @@ index 00000000000000..b6c942fc91eec7
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/.gitignore
 @@ -0,0 +1,2 @@
 +**/.DS_Store
-+.vscode/fooBar
++.vscode/
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml b/src/vendor/github.com/golang-fips/openssl/v2/.gitleaks.toml
 new file mode 100644
 index 00000000000000..aed2e22df2d555


### PR DESCRIPTION
This way we can check that the vendoring is correct in each patch

fixes: #1474