### PR TITLE
Do not skip allocation tests and remove extra allocations from hash structs

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -86,7 +86,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/cryptokit/cryptokit.h            |   67 +
  .../internal/cryptokit/ed25519.go             |   72 +
  .../internal/cryptokit/gcm.go                 |   36 +
- .../internal/cryptokit/hash.go                |  245 ++
+ .../internal/cryptokit/hash.go                |  247 ++
  .../internal/cryptokit/hashclone.go           |   17 +
  .../internal/cryptokit/hashclone_go125.go     |   12 +
  .../internal/cryptokit/hkdf.go                |   77 +
@@ -137,7 +137,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 129 files changed, 19190 insertions(+), 7 deletions(-)
+ 129 files changed, 19192 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -1875,7 +1875,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index b81f19068aef23..74c129d7995deb 100644
+index b81f19068aef23..da03dfd87e7aec 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -1885,18 +1885,18 @@ index b81f19068aef23..74c129d7995deb 100644
 +
 +require (
 +	github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7
-+	github.com/microsoft/go-crypto-darwin v0.0.2-0.20250703113729-2543273fb498
++	github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 410eb8648a710a..31a26b0d5104e1 100644
+index 410eb8648a710a..928d040435b4b7 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7 h1:ZjpSTr5uh4P3EKwrZQ8Fr/NZJ6NBgf+8UabCp9Kmtoc=
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
-+github.com/microsoft/go-crypto-darwin v0.0.2-0.20250703113729-2543273fb498 h1:UbccQbkPCI4kCh2s4gnJevJEaNyb/R19lXsII1RC8Nw=
-+github.com/microsoft/go-crypto-darwin v0.0.2-0.20250703113729-2543273fb498/go.mod h1:LyP4oZ0QcysEJdqUTOk9ngNFArRFK94YRImkoJ8julQ=
++github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7 h1:6a0YcJOAJWLtEqDW55bUhhe4Nx/9Rpmm80KVMUxD6B4=
++github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7/go.mod h1:LyP4oZ0QcysEJdqUTOk9ngNFArRFK94YRImkoJ8julQ=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b h1:Yf6lm9r6Aid3PG5FoeSX2v4iU+xWnAmCRQNjBxgceWI=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
  golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
@@ -14238,10 +14238,10 @@ index 00000000000000..458e9eb57416b1
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/hash.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/hash.go
 new file mode 100644
-index 00000000000000..469bcb16f4c7e5
+index 00000000000000..977ee3152ada71
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/hash.go
-@@ -0,0 +1,245 @@
+@@ -0,0 +1,247 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -14314,9 +14314,9 @@ index 00000000000000..469bcb16f4c7e5
 +	size          int
 +}
 +
-+func newEVPHash(ptr unsafe.Pointer, hashAlgorithm C.int, blockSize, size int) *evpHash {
++func newEVPHash(hashAlgorithm C.int, blockSize, size int) *evpHash {
 +	h := &evpHash{
-+		ptr:           ptr,
++		ptr:           C.hashNew(hashAlgorithm),
 +		hashAlgorithm: hashAlgorithm,
 +		blockSize:     blockSize,
 +		size:          size,
@@ -14339,7 +14339,14 @@ index 00000000000000..469bcb16f4c7e5
 +		panic("cryptokit: hash already finalized")
 +	}
 +
-+	newHash := newEVPHash(C.hashCopy(h.hashAlgorithm, h.ptr), h.hashAlgorithm, h.blockSize, h.size)
++	newHash := &evpHash{
++		ptr:           C.hashCopy(h.hashAlgorithm, h.ptr),
++		hashAlgorithm: h.hashAlgorithm,
++		blockSize:     h.blockSize,
++		size:          h.size,
++	}
++
++	runtime.SetFinalizer(newHash, (*evpHash).finalize)
 +
 +	runtime.KeepAlive(h)
 +
@@ -14414,9 +14421,8 @@ index 00000000000000..469bcb16f4c7e5
 +}
 +
 +func NewMD5() hash.Hash {
-+	return &MD5Hash{
++	return MD5Hash{
 +		evpHash: newEVPHash(
-+			C.hashNew(md5),
 +			C.int(md5),
 +			MD5BlockSize,
 +			MD5Size,
@@ -14430,9 +14436,8 @@ index 00000000000000..469bcb16f4c7e5
 +
 +// NewSHA1 initializes a new SHA1 hasher.
 +func NewSHA1() hash.Hash {
-+	return &SHA1Hash{
++	return SHA1Hash{
 +		evpHash: newEVPHash(
-+			C.hashNew(sha1),
 +			sha1,
 +			SHA1BlockSize,
 +			SHA1Size,
@@ -14446,9 +14451,8 @@ index 00000000000000..469bcb16f4c7e5
 +
 +// NewSHA256 initializes a new SHA256 hasher.
 +func NewSHA256() hash.Hash {
-+	return &SHA256Hash{
++	return SHA256Hash{
 +		evpHash: newEVPHash(
-+			C.hashNew(sha256),
 +			sha256,
 +			SHA256BlockSize,
 +			SHA256Size,
@@ -14462,9 +14466,8 @@ index 00000000000000..469bcb16f4c7e5
 +
 +// NewSHA384 initializes a new SHA384 hasher.
 +func NewSHA384() hash.Hash {
-+	return &SHA384Hash{
++	return SHA384Hash{
 +		evpHash: newEVPHash(
-+			C.hashNew(sha384),
 +			sha384,
 +			SHA384BlockSize,
 +			SHA384Size,
@@ -14478,9 +14481,8 @@ index 00000000000000..469bcb16f4c7e5
 +
 +// NewSHA512 initializes a new SHA512 hasher.
 +func NewSHA512() hash.Hash {
-+	return &SHA512Hash{
++	return SHA512Hash{
 +		evpHash: newEVPHash(
-+			C.hashNew(sha512),
 +			sha512,
 +			SHA512BlockSize,
 +			SHA512Size,
@@ -14613,7 +14615,7 @@ index 00000000000000..da161adcd88ea6
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/hmac.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/hmac.go
 new file mode 100644
-index 00000000000000..53790ffa74310e
+index 00000000000000..f06abe11e3854d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/hmac.go
 @@ -0,0 +1,146 @@
@@ -14749,15 +14751,15 @@ index 00000000000000..53790ffa74310e
 +
 +func hashToHMACEnum(h hash.Hash) int {
 +	switch h.(type) {
-+	case *MD5Hash:
++	case MD5Hash:
 +		return 1
-+	case *SHA1Hash:
++	case SHA1Hash:
 +		return 2
-+	case *SHA256Hash:
++	case SHA256Hash:
 +		return 3
-+	case *SHA384Hash:
++	case SHA384Hash:
 +		return 4
-+	case *SHA512Hash:
++	case SHA512Hash:
 +		return 5
 +	default:
 +		return 0
@@ -15881,7 +15883,7 @@ index 00000000000000..f59e6f9af58cd4
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/evp.go b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/evp.go
 new file mode 100644
-index 00000000000000..f01b519ee2c4e7
+index 00000000000000..6928418b4d26b9
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/evp.go
 @@ -0,0 +1,345 @@
@@ -16057,13 +16059,13 @@ index 00000000000000..f01b519ee2c4e7
 +// hashToCryptoHash converts a hash.Hash to a crypto.Hash.
 +func hashToCryptoHash(hash hash.Hash) (crypto.Hash, error) {
 +	switch hash.(type) {
-+	case *cryptokit.SHA1Hash:
++	case cryptokit.SHA1Hash:
 +		return crypto.SHA1, nil
-+	case *cryptokit.SHA256Hash:
++	case cryptokit.SHA256Hash:
 +		return crypto.SHA256, nil
-+	case *cryptokit.SHA384Hash:
++	case cryptokit.SHA384Hash:
 +		return crypto.SHA384, nil
-+	case *cryptokit.SHA512Hash:
++	case cryptokit.SHA512Hash:
 +		return crypto.SHA512, nil
 +	default:
 +		return 0, errors.New("unsupported hash function")
@@ -16405,7 +16407,7 @@ index 00000000000000..ceb33c5cf99ca2
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/pbkdf2.go b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/pbkdf2.go
 new file mode 100644
-index 00000000000000..f29d30e599117c
+index 00000000000000..1f1b25d36981c3
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/pbkdf2.go
 @@ -0,0 +1,65 @@
@@ -16462,13 +16464,13 @@ index 00000000000000..f29d30e599117c
 +// Mapping Go hash functions to CommonCrypto hash constants
 +func hashToCCDigestPBKDF2(hash hash.Hash) (C.CCAlgorithm, error) {
 +	switch hash.(type) {
-+	case *cryptokit.SHA1Hash:
++	case cryptokit.SHA1Hash:
 +		return C.kCCPRFHmacAlgSHA1, nil
-+	case *cryptokit.SHA256Hash:
++	case cryptokit.SHA256Hash:
 +		return C.kCCPRFHmacAlgSHA256, nil
-+	case *cryptokit.SHA384Hash:
++	case cryptokit.SHA384Hash:
 +		return C.kCCPRFHmacAlgSHA384, nil
-+	case *cryptokit.SHA512Hash:
++	case cryptokit.SHA512Hash:
 +		return C.kCCPRFHmacAlgSHA512, nil
 +	default:
 +		return 0, errors.New("unsupported hash function")
@@ -21333,7 +21335,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 8507f01b12f518..13b7bb0fa3777e 100644
+index 8507f01b12f518..918aaab0a32fef 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,20 @@
@@ -21342,7 +21344,7 @@ index 8507f01b12f518..13b7bb0fa3777e 100644
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
 +github.com/golang-fips/openssl/v2/internal/ossl
-+# github.com/microsoft/go-crypto-darwin v0.0.2-0.20250703113729-2543273fb498
++# github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7
 +## explicit; go 1.22
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/cryptokit

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -31,14 +31,14 @@ Subject: [PATCH] Use crypto backends
  src/crypto/ecdsa/notboring.go                 |   4 +-
  src/crypto/ed25519/boring.go                  |  71 +++++++
  src/crypto/ed25519/ed25519.go                 |  73 +++++++
- src/crypto/ed25519/ed25519_test.go            |   3 +-
+ src/crypto/ed25519/ed25519_test.go            |  13 +-
  src/crypto/ed25519/notboring.go               |  16 ++
  src/crypto/fips140/fips140.go                 |   3 +-
  src/crypto/hkdf/hkdf.go                       |  14 ++
  src/crypto/hkdf/hkdf_test.go                  |   2 +-
  src/crypto/hmac/hmac.go                       |   2 +-
  src/crypto/hmac/hmac_test.go                  |   2 +-
- src/crypto/internal/cryptotest/allocations.go |   2 +-
+ src/crypto/internal/cryptotest/allocations.go |   6 -
  src/crypto/internal/cryptotest/hash.go        |   3 +-
  .../internal/cryptotest/implementations.go    |   2 +-
  src/crypto/internal/fips140test/acvp_test.go  |   6 +
@@ -64,9 +64,9 @@ Subject: [PATCH] Use crypto backends
  src/crypto/sha1/sha1.go                       |   8 +-
  src/crypto/sha1/sha1_test.go                  |  11 +-
  src/crypto/sha256/sha256.go                   |   6 +-
- src/crypto/sha256/sha256_test.go              |  20 +-
+ src/crypto/sha256/sha256_test.go              |  35 +++-
  src/crypto/sha512/sha512.go                   |   2 +-
- src/crypto/sha512/sha512_test.go              |  24 ++-
+ src/crypto/sha512/sha512_test.go              |  32 ++-
  src/crypto/tls/auth_test.go                   |   7 +
  src/crypto/tls/cipher_suites.go               |   2 +-
  src/crypto/tls/defaults_boring.go             |   2 +-
@@ -90,7 +90,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1160 insertions(+), 96 deletions(-)
+ 86 files changed, 1179 insertions(+), 114 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -1138,10 +1138,15 @@ index 0e268139587075..b770c8c4987ca6 100644
  	default:
  		return errors.New("ed25519: expected opts.Hash zero (unhashed message, for standard Ed25519) or SHA-512 (for Ed25519ph)")
 diff --git a/src/crypto/ed25519/ed25519_test.go b/src/crypto/ed25519/ed25519_test.go
-index c8a23e3246a949..7f3d012f1a0707 100644
+index c8a23e3246a949..393a1e40ce704e 100644
 --- a/src/crypto/ed25519/ed25519_test.go
 +++ b/src/crypto/ed25519/ed25519_test.go
-@@ -13,6 +13,7 @@ import (
+@@ -9,10 +9,12 @@ import (
+ 	"bytes"
+ 	"compress/gzip"
+ 	"crypto"
++	boring "crypto/internal/backend"
+ 	"crypto/internal/cryptotest"
  	"crypto/rand"
  	"crypto/sha512"
  	"encoding/hex"
@@ -1149,7 +1154,7 @@ index c8a23e3246a949..7f3d012f1a0707 100644
  	"log"
  	"os"
  	"strings"
-@@ -316,7 +317,7 @@ func TestGolden(t *testing.T) {
+@@ -316,7 +318,7 @@ func TestGolden(t *testing.T) {
  		copy(priv[32:], pubKey)
  
  		sig2 := Sign(priv[:], msg)
@@ -1157,6 +1162,29 @@ index c8a23e3246a949..7f3d012f1a0707 100644
 +		if !bytes.Equal(sig, sig2[:]) && !goexperiment.DarwinCrypto {
  			t.Errorf("different signature result on line %d: %x vs %x", lineNo, sig, sig2)
  		}
+ 
+@@ -371,6 +373,11 @@ func TestAllocations(t *testing.T) {
+ 	cryptotest.SkipTestAllocations(t)
+ 	seed := make([]byte, SeedSize)
+ 	priv := NewKeyFromSeed(seed)
++	expectedAllocations := 0.0
++	if boring.Enabled {
++		expectedAllocations = 6
++	}
++
+ 	if allocs := testing.AllocsPerRun(100, func() {
+ 		message := []byte("Hello, world!")
+ 		pub := priv.Public().(PublicKey)
+@@ -378,8 +385,8 @@ func TestAllocations(t *testing.T) {
+ 		if !Verify(pub, message, signature) {
+ 			t.Fatal("signature didn't verify")
+ 		}
+-	}); allocs > 0 {
+-		t.Errorf("expected zero allocations, got %0.1f", allocs)
++	}); allocs > expectedAllocations {
++		t.Errorf("expected %v allocations, got %0.1f", expectedAllocations, allocs)
+ 	}
+ }
  
 diff --git a/src/crypto/ed25519/notboring.go b/src/crypto/ed25519/notboring.go
 new file mode 100644
@@ -1285,18 +1313,29 @@ index 4046a9555a8e35..4721a2a7ac04f7 100644
  	"crypto/md5"
  	"crypto/sha1"
 diff --git a/src/crypto/internal/cryptotest/allocations.go b/src/crypto/internal/cryptotest/allocations.go
-index 70055af70b42ec..3c4b4fbaa98ded 100644
+index 70055af70b42ec..21528faa0d6145 100644
 --- a/src/crypto/internal/cryptotest/allocations.go
 +++ b/src/crypto/internal/cryptotest/allocations.go
-@@ -5,7 +5,7 @@
+@@ -5,7 +5,6 @@
  package cryptotest
  
  import (
 -	"crypto/internal/boring"
-+	boring "crypto/internal/backend"
  	"internal/asan"
  	"internal/msan"
  	"internal/race"
+@@ -17,11 +16,6 @@ import (
+ // SkipTestAllocations skips the test if there are any factors that interfere
+ // with allocation optimizations.
+ func SkipTestAllocations(t *testing.T) {
+-	// Go+BoringCrypto uses cgo.
+-	if boring.Enabled {
+-		t.Skip("skipping allocations test with BoringCrypto")
+-	}
+-
+ 	// The sanitizers sometimes cause allocations.
+ 	if race.Enabled || msan.Enabled || asan.Enabled {
+ 		t.Skip("skipping allocations test with sanitizers")
 diff --git a/src/crypto/internal/cryptotest/hash.go b/src/crypto/internal/cryptotest/hash.go
 index f00e9c80d3c86a..e24b6cbbd00f68 100644
 --- a/src/crypto/internal/cryptotest/hash.go
@@ -1974,10 +2013,10 @@ index e03f4ab06603c6..cd44f3af23b0d4 100644
  		t.Fatal(err)
  	}
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index 95bb4becd2ff8c..73991434dabaf1 100644
+index c557c3710af710..42832da8349355 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
-@@ -42,8 +42,8 @@ package rsa
+@@ -43,8 +43,8 @@ package rsa
  
  import (
  	"crypto"
@@ -2144,7 +2183,7 @@ index 069938a22dbc5a..8d0e06b86f4359 100644
  	}
  	h := New224()
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index 11b24db7d6b0a0..cacfad5c30e4c8 100644
+index 11b24db7d6b0a0..9aa28dd024385f 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -8,11 +8,13 @@ package sha256
@@ -2200,7 +2239,38 @@ index 11b24db7d6b0a0..cacfad5c30e4c8 100644
  			t.Errorf("test %d could not unmarshal: %v", i, err)
  			continue
  		}
-@@ -404,13 +420,13 @@ func TestExtraMethods(t *testing.T) {
+@@ -347,6 +363,10 @@ func TestLargeHashes(t *testing.T) {
+ 
+ func TestAllocations(t *testing.T) {
+ 	cryptotest.SkipTestAllocations(t)
++	expectedAllocations := 0.0
++	if boring.Enabled {
++		expectedAllocations = 1
++	}
+ 	if n := testing.AllocsPerRun(10, func() {
+ 		in := []byte("hello, world!")
+ 		out := make([]byte, 0, Size)
+@@ -357,17 +377,10 @@ func TestAllocations(t *testing.T) {
+ 			h.Write(in)
+ 			out = h.Sum(out[:0])
+ 		}
+-		{
+-			h := New224()
+-			h.Reset()
+-			h.Write(in)
+-			out = h.Sum(out[:0])
+-		}
+ 
+ 		Sum256(in)
+-		Sum224(in)
+-	}); n > 0 {
+-		t.Errorf("allocs = %v, want 0", n)
++	}); n > expectedAllocations {
++		t.Errorf("allocs = %v, want %v", n, expectedAllocations)
+ 	}
+ }
+ 
+@@ -404,13 +417,13 @@ func TestExtraMethods(t *testing.T) {
  	t.Run("SHA-224", func(t *testing.T) {
  		cryptotest.TestAllImplementations(t, "sha256", func(t *testing.T) {
  			h := maybeCloner(New224())
@@ -2230,7 +2300,7 @@ index 1435eac1f5b5dc..17e8501154762a 100644
  	"hash"
  )
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index 080bf694f03652..8962a54f1bcddd 100644
+index 080bf694f03652..d6058d541e9e61 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -8,12 +8,14 @@ package sha512
@@ -2287,7 +2357,29 @@ index 080bf694f03652..8962a54f1bcddd 100644
  			t.Errorf("test %d could not unmarshal: %v", i, err)
  			continue
  		}
-@@ -967,25 +983,25 @@ func TestExtraMethods(t *testing.T) {
+@@ -902,6 +918,10 @@ func TestLargeHashes(t *testing.T) {
+ 
+ func TestAllocations(t *testing.T) {
+ 	cryptotest.SkipTestAllocations(t)
++	expectedAllocations := 0.0
++	if boring.Enabled {
++		expectedAllocations = 2
++	}
+ 	if n := testing.AllocsPerRun(10, func() {
+ 		in := []byte("hello, world!")
+ 		out := make([]byte, 0, Size)
+@@ -935,8 +955,8 @@ func TestAllocations(t *testing.T) {
+ 		Sum384(in)
+ 		Sum512_224(in)
+ 		Sum512_256(in)
+-	}); n > 0 {
+-		t.Errorf("allocs = %v, want 0", n)
++	}); n > expectedAllocations {
++		t.Errorf("allocs = %v, want %v", n, expectedAllocations)
+ 	}
+ }
+ 
+@@ -967,25 +987,25 @@ func TestExtraMethods(t *testing.T) {
  	t.Run("SHA-384", func(t *testing.T) {
  		cryptotest.TestAllImplementations(t, "sha512", func(t *testing.T) {
  			h := maybeCloner(New384())
@@ -2463,7 +2555,7 @@ index 7018bb2336b8f3..d5e02272d7afe1 100644
  	"hash"
  	"slices"
 diff --git a/src/crypto/tls/handshake_server.go b/src/crypto/tls/handshake_server.go
-index 8240e6afae3c6b..5dd00e27037a0f 100644
+index 1e0b5f06672d15..9f72e2376e42ce 100644
 --- a/src/crypto/tls/handshake_server.go
 +++ b/src/crypto/tls/handshake_server.go
 @@ -63,7 +63,15 @@ func (c *Conn) serverHandshake(ctx context.Context) error {
@@ -2484,7 +2576,7 @@ index 8240e6afae3c6b..5dd00e27037a0f 100644
  
  	if err := hs.processClientHello(); err != nil {
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index a52bc76a0d1a9f..6c32550b0129b8 100644
+index 501bdeb66b05a8..571369cdbfcd34 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
 @@ -10,11 +10,12 @@ import (

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -50,6 +50,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/pbkdf2/pbkdf2_test.go              |   6 +-
  src/crypto/purego_test.go                     |   2 +-
  src/crypto/rand/rand.go                       |   2 +-
+ src/crypto/rand/rand_test.go                  |   9 +-
  src/crypto/rc4/rc4.go                         |  18 ++
  src/crypto/rsa/boring.go                      |  12 +-
  src/crypto/rsa/boring_test.go                 |   2 +-
@@ -90,7 +91,7 @@ Subject: [PATCH] Use crypto backends
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 86 files changed, 1179 insertions(+), 114 deletions(-)
+ 87 files changed, 1186 insertions(+), 116 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -1640,6 +1641,38 @@ index 1ca16caa9563e6..3ef22b5ff8222b 100644
  	"crypto/internal/fips140"
  	"crypto/internal/fips140/drbg"
  	"crypto/internal/sysrand"
+diff --git a/src/crypto/rand/rand_test.go b/src/crypto/rand/rand_test.go
+index 22ccb8a35334c9..832910da482f44 100644
+--- a/src/crypto/rand/rand_test.go
++++ b/src/crypto/rand/rand_test.go
+@@ -7,6 +7,7 @@ package rand
+ import (
+ 	"bytes"
+ 	"compress/flate"
++	boring "crypto/internal/backend"
+ 	"crypto/internal/cryptotest"
+ 	"errors"
+ 	"internal/testenv"
+@@ -154,13 +155,17 @@ var sink byte
+ 
+ func TestAllocations(t *testing.T) {
+ 	cryptotest.SkipTestAllocations(t)
++	expectedAllocations := 0
++	if boring.Enabled {
++		expectedAllocations = 1
++	}
+ 	n := int(testing.AllocsPerRun(10, func() {
+ 		buf := make([]byte, 32)
+ 		Read(buf)
+ 		sink ^= buf[0]
+ 	}))
+-	if n > 0 {
+-		t.Errorf("allocs = %d, want 0", n)
++	if n > expectedAllocations {
++		t.Errorf("allocs = %d, want %d", n, expectedAllocations)
+ 	}
+ }
+ 
 diff --git a/src/crypto/rc4/rc4.go b/src/crypto/rc4/rc4.go
 index 90943a0935befb..09ebdfd733e5d6 100644
 --- a/src/crypto/rc4/rc4.go


### PR DESCRIPTION
Previously we were skipping allocation tests, but now with fixed amount of allocations on expected results, rather than passing we running them with correct numbers. Also removed extra allocations from Darwin backend due to returning pointer of hash structs..