### PR TITLE
Set definitive instrumentation key and endpoint

### DIFF
--- a/patches/0010-add-appinsights-telemetry.patch
+++ b/patches/0010-add-appinsights-telemetry.patch
@@ -8,8 +8,8 @@ Subject: [PATCH] Add appinsights telemetry
  .../internal/telemetrystats/telemetrystats.go | 13 +++++
  src/cmd/go/main.go                            |  1 +
  src/cmd/go/mstelemetry_test.go                | 52 +++++++++++++++++++
- src/cmd/go/script_test.go                     |  7 +++
- src/cmd/internal/telemetry/counter/counter.go | 36 ++++++++++++-
+ src/cmd/go/script_test.go                     |  6 +++
+ src/cmd/internal/telemetry/counter/counter.go | 37 ++++++++++++-
  .../telemetry/counter/counter_bootstrap.go    |  2 +
  7 files changed, 125 insertions(+), 1 deletion(-)
  create mode 100644 src/cmd/go/mstelemetry_test.go
@@ -138,7 +138,7 @@ index 00000000000000..6993137ad56e8c
 +	fmt.Fprint(w, `{"itemsReceived": 1, "itemsAccepted": 1}`)
 +}
 diff --git a/src/cmd/go/script_test.go b/src/cmd/go/script_test.go
-index 1345ea8bb8e530..f915bd26994ffe 100644
+index 1345ea8bb8e530..1a7a62fdc7c19d 100644
 --- a/src/cmd/go/script_test.go
 +++ b/src/cmd/go/script_test.go
 @@ -60,6 +60,7 @@ func TestScript(t *testing.T) {
@@ -149,17 +149,16 @@ index 1345ea8bb8e530..f915bd26994ffe 100644
  
  	var (
  		ctx         = context.Background()
-@@ -254,6 +255,9 @@ func scriptEnv(srv *vcstest.Server, srvCertFile string) ([]string, error) {
+@@ -254,6 +255,8 @@ func scriptEnv(srv *vcstest.Server, srvCertFile string) ([]string, error) {
  		"HGRCPATH=",
  		"GOTOOLCHAIN=auto",
  		"MS_GOTOOLCHAIN_ALLOW_NON_LOCAL=1", // allow non-local toolchains, some tests expect GOTOOLCHAIN to be honored
 +		"MS_GOTOOLCHAIN_TELEMETRY_ENDPOINT=" + appInsightsURL,
 +		"MS_GOTOOLCHAIN_TELEMETRY_ALLOW_GO_DEVEL=1", // allow telemetry for Go development versions
-+		"MS_GOTOOLCHAIN_TELEMETRY_INSTRUMENTATION_KEY=fake_key",
  		"newline=\n",
  	}
  
-@@ -404,6 +408,9 @@ func readCounters(t *testing.T, telemetryDir string) map[string]uint64 {
+@@ -404,6 +407,9 @@ func readCounters(t *testing.T, telemetryDir string) map[string]uint64 {
  func checkCounters(t *testing.T, telemetryDir string) {
  	counters := readCounters(t, telemetryDir)
  	if _, ok := scriptGoInvoked.Load(testing.TB(t)); ok {
@@ -170,13 +169,14 @@ index 1345ea8bb8e530..f915bd26994ffe 100644
  			t.Fatal("go was invoked but no counters were incremented")
  		}
 diff --git a/src/cmd/internal/telemetry/counter/counter.go b/src/cmd/internal/telemetry/counter/counter.go
-index 5cef0b0041551a..229758ef8e61b4 100644
+index 5cef0b0041551a..a099b4698a21c4 100644
 --- a/src/cmd/internal/telemetry/counter/counter.go
 +++ b/src/cmd/internal/telemetry/counter/counter.go
-@@ -7,10 +7,22 @@
+@@ -7,10 +7,23 @@
  package counter
  
  import (
++	"cmp"
 +	"context"
  	"flag"
 +	"log"
@@ -196,14 +196,14 @@ index 5cef0b0041551a..229758ef8e61b4 100644
  )
  
  var openCalled bool
-@@ -22,11 +34,30 @@ func OpenCalled() bool { return openCalled }
+@@ -22,11 +35,30 @@ func OpenCalled() bool { return openCalled }
  func Open() {
  	openCalled = true
  	counter.OpenDir(os.Getenv("TEST_TELEMETRY_DIR"))
 +	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENABLED") != "0" {
 +		mstelemetry.Start(mstelemetry.Config{
 +			InstrumentationKey: appInsightsInstrumentationKey,
-+			Endpoint:           appInsightsEndpoint,
++			Endpoint:           cmp.Or(os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENDPOINT"), appInsightsEndpoint), // configurable for testing purposes
 +			AllowGoDevel:       os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ALLOW_GO_DEVEL") == "1",
 +			UploadConfig:       msconfig.Config,
 +		})
@@ -227,7 +227,7 @@ index 5cef0b0041551a..229758ef8e61b4 100644
  }
  
  // New returns a counter with the given name.
-@@ -44,6 +75,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
+@@ -44,6 +76,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
  // the concatenation of prefix and the flag name.
  func CountFlags(prefix string, flagSet flag.FlagSet) {
  	counter.CountFlags(prefix, flagSet)
@@ -235,7 +235,7 @@ index 5cef0b0041551a..229758ef8e61b4 100644
  }
  
  // CountFlagValue creates a counter for the flag value
-@@ -56,7 +88,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
+@@ -56,7 +89,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
  	// TODO(matloob): Add this to x/telemetry?
  	flagSet.Visit(func(f *flag.Flag) {
  		if f.Name == flagName {

--- a/patches/0010-add-appinsights-telemetry.patch
+++ b/patches/0010-add-appinsights-telemetry.patch
@@ -9,9 +9,9 @@ Subject: [PATCH] Add appinsights telemetry
  src/cmd/go/main.go                            |  1 +
  src/cmd/go/mstelemetry_test.go                | 52 +++++++++++++++++++
  src/cmd/go/script_test.go                     |  7 +++
- src/cmd/internal/telemetry/counter/counter.go | 33 +++++++++++-
+ src/cmd/internal/telemetry/counter/counter.go | 36 ++++++++++++-
  .../telemetry/counter/counter_bootstrap.go    |  2 +
- 7 files changed, 122 insertions(+), 1 deletion(-)
+ 7 files changed, 125 insertions(+), 1 deletion(-)
  create mode 100644 src/cmd/go/mstelemetry_test.go
 
 diff --git a/README.md b/README.md
@@ -170,10 +170,10 @@ index 1345ea8bb8e530..f915bd26994ffe 100644
  			t.Fatal("go was invoked but no counters were incremented")
  		}
 diff --git a/src/cmd/internal/telemetry/counter/counter.go b/src/cmd/internal/telemetry/counter/counter.go
-index 5cef0b0041551a..ec2a0b962bf29c 100644
+index 5cef0b0041551a..229758ef8e61b4 100644
 --- a/src/cmd/internal/telemetry/counter/counter.go
 +++ b/src/cmd/internal/telemetry/counter/counter.go
-@@ -7,12 +7,21 @@
+@@ -7,10 +7,22 @@
  package counter
  
  import (
@@ -188,21 +188,22 @@ index 5cef0b0041551a..ec2a0b962bf29c 100644
 +	mstelemetry "github.com/microsoft/go-infra/telemetry"
 +	msconfig "github.com/microsoft/go-infra/telemetry/config"
 +	mscounter "github.com/microsoft/go-infra/telemetry/counter"
++)
++
++const (
++	appInsightsInstrumentationKey = "128126c8-4e88-44c2-a70a-dfb7fbe94fb7"
++	appInsightsEndpoint           = "https://centralus-2.in.applicationinsights.azure.com/v2/track"
  )
  
-+var appInsightsInstrumentationKey = os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_INSTRUMENTATION_KEY") // TODO: hardcode to the correct value once we have a real key
-+
  var openCalled bool
- 
- func OpenCalled() bool { return openCalled }
-@@ -22,11 +31,30 @@ func OpenCalled() bool { return openCalled }
+@@ -22,11 +34,30 @@ func OpenCalled() bool { return openCalled }
  func Open() {
  	openCalled = true
  	counter.OpenDir(os.Getenv("TEST_TELEMETRY_DIR"))
-+	if appInsightsInstrumentationKey != "" && os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENABLED") != "0" {
++	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENABLED") != "0" {
 +		mstelemetry.Start(mstelemetry.Config{
 +			InstrumentationKey: appInsightsInstrumentationKey,
-+			Endpoint:           os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENDPOINT"),
++			Endpoint:           appInsightsEndpoint,
 +			AllowGoDevel:       os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ALLOW_GO_DEVEL") == "1",
 +			UploadConfig:       msconfig.Config,
 +		})
@@ -214,7 +215,7 @@ index 5cef0b0041551a..ec2a0b962bf29c 100644
 +	defer cancel()
 +	start := time.Now()
 +	mstelemetry.Close(ctx)
-+	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_STATS") == "on" {
++	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_STATS") == "1" {
 +		log.Printf("telemetry: closed in %s\n", time.Since(start))
 +	}
  }
@@ -226,7 +227,7 @@ index 5cef0b0041551a..ec2a0b962bf29c 100644
  }
  
  // New returns a counter with the given name.
-@@ -44,6 +72,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
+@@ -44,6 +75,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
  // the concatenation of prefix and the flag name.
  func CountFlags(prefix string, flagSet flag.FlagSet) {
  	counter.CountFlags(prefix, flagSet)
@@ -234,7 +235,7 @@ index 5cef0b0041551a..ec2a0b962bf29c 100644
  }
  
  // CountFlagValue creates a counter for the flag value
-@@ -56,7 +85,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
+@@ -56,7 +88,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
  	// TODO(matloob): Add this to x/telemetry?
  	flagSet.Visit(func(f *flag.Flag) {
  		if f.Name == flagName {


### PR DESCRIPTION
We already have the definitive App Insights instrumentation key and endpoint. Let's use it.

This means that when we release Go 1.25, the toolchain will upload data by default. For development versions of the toolchain, `MS_GOTOOLCHAIN_TELEMETRY_ALLOW_GO_DEVEL=1` is still required.

While here, change `MS_GOTOOLCHAIN_TELEMETRY_STATS` to be enabled if it is set to `1` instead of `on` for consitency.

For #1672.