### PR TITLE
Set supported TLS version based on Schannel cipher suites

### DIFF
--- a/patches/0016-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0016-implement-ms_tls_config_schannel-experiment.patch
@@ -8,16 +8,16 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
  src/crypto/tls/bogo_shim_test.go              |   7 +
  src/crypto/tls/handshake_server_test.go       |  20 ++
  src/crypto/tls/handshake_test.go              |   6 +
- src/crypto/tls/schannel_windows.go            | 142 ++++++++++++++
- src/crypto/tls/schannel_windows_test.go       | 178 ++++++++++++++++++
- src/crypto/tls/tls_test.go                    |  11 ++
+ src/crypto/tls/schannel_windows.go            | 142 +++++++++++++
+ src/crypto/tls/schannel_windows_test.go       | 192 ++++++++++++++++++
+ src/crypto/tls/tls_test.go                    |  11 +
  .../exp_ms_tls_config_schannel_off.go         |   8 +
  .../exp_ms_tls_config_schannel_on.go          |   8 +
  src/internal/goexperiment/flags.go            |   4 +
  .../syscall/windows/security_windows.go       |  28 +++
  .../syscall/windows/syscall_windows.go        |  16 ++
  .../syscall/windows/zsyscall_windows.go       |  23 +++
- 13 files changed, 452 insertions(+), 1 deletion(-)
+ 13 files changed, 466 insertions(+), 1 deletion(-)
  create mode 100644 src/crypto/tls/schannel_windows.go
  create mode 100644 src/crypto/tls/schannel_windows_test.go
  create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
@@ -240,7 +240,7 @@ index 00000000000000..4e338175f48651
 +
 +// filterCipherSuites filters the provided cipher suites, creating a new slice
 +// that only includes those that are in the allowed list.
-+func filterCipherSuites(suites, allowed []uint16) []uint16 {
++func filterCipherSuites(suites []uint16, allowed []uint16) []uint16 {
 +	out := make([]uint16, 0, len(allowed))
 +	for _, id := range suites {
 +		if slices.Contains(allowed, id) {
@@ -291,10 +291,10 @@ index 00000000000000..4e338175f48651
 +}
 diff --git a/src/crypto/tls/schannel_windows_test.go b/src/crypto/tls/schannel_windows_test.go
 new file mode 100644
-index 00000000000000..01fb8852f38c6f
+index 00000000000000..06bf2f80bc20bc
 --- /dev/null
 +++ b/src/crypto/tls/schannel_windows_test.go
-@@ -0,0 +1,178 @@
+@@ -0,0 +1,192 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -305,11 +305,25 @@ index 00000000000000..01fb8852f38c6f
 +
 +import (
 +	"bytes"
++	"fmt"
 +	"internal/testenv"
 +	"os"
 +	"os/exec"
 +	"testing"
 +)
++
++func init() {
++	cipherSuites, versions, err := getCipherSuitesSchannel()
++	if err != nil {
++		panic(err)
++	}
++	fmt.Println("Schannel cipher suites:")
++	for _, id := range cipherSuites {
++		name, _ := cipherSuiteFromID(id)
++		fmt.Println(id, name)
++	}
++	fmt.Println("Schannel versions:", versions)
++}
 +
 +// testSchannel runs the provided function in a child process with Schannel cipher suites set.
 +func testSchannel(t *testing.T, ids, versions []uint16, fn func()) {

--- a/patches/0016-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0016-implement-ms_tls_config_schannel-experiment.patch
@@ -5,19 +5,19 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
 
 ---
  src/cmd/go/script_test.go                     |   2 +-
- src/crypto/tls/bogo_shim_test.go              |   7 ++
- src/crypto/tls/handshake_server_test.go       |  20 +++
+ src/crypto/tls/bogo_shim_test.go              |   7 +
+ src/crypto/tls/handshake_server_test.go       |  20 ++
  src/crypto/tls/handshake_test.go              |   6 +
- src/crypto/tls/schannel_windows.go            | 118 ++++++++++++++++++
- src/crypto/tls/schannel_windows_test.go       |  94 ++++++++++++++
+ src/crypto/tls/schannel_windows.go            | 142 ++++++++++++++
+ src/crypto/tls/schannel_windows_test.go       | 178 ++++++++++++++++++
  src/crypto/tls/tls_test.go                    |  11 ++
- .../exp_ms_tls_config_schannel_off.go         |   8 ++
- .../exp_ms_tls_config_schannel_on.go          |   8 ++
+ .../exp_ms_tls_config_schannel_off.go         |   8 +
+ .../exp_ms_tls_config_schannel_on.go          |   8 +
  src/internal/goexperiment/flags.go            |   4 +
- .../syscall/windows/security_windows.go       |  28 +++++
- .../syscall/windows/syscall_windows.go        |  16 +++
- .../syscall/windows/zsyscall_windows.go       |  23 ++++
- 13 files changed, 344 insertions(+), 1 deletion(-)
+ .../syscall/windows/security_windows.go       |  28 +++
+ .../syscall/windows/syscall_windows.go        |  16 ++
+ .../syscall/windows/zsyscall_windows.go       |  23 +++
+ 13 files changed, 452 insertions(+), 1 deletion(-)
  create mode 100644 src/crypto/tls/schannel_windows.go
  create mode 100644 src/crypto/tls/schannel_windows_test.go
  create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
@@ -143,10 +143,10 @@ index 803aa736578f8c..92b31362f3d65d 100644
  			t.Parallel()
 diff --git a/src/crypto/tls/schannel_windows.go b/src/crypto/tls/schannel_windows.go
 new file mode 100644
-index 00000000000000..93b7e8c912b3c1
+index 00000000000000..4e338175f48651
 --- /dev/null
 +++ b/src/crypto/tls/schannel_windows.go
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,142 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -161,78 +161,90 @@ index 00000000000000..93b7e8c912b3c1
 +	"unsafe"
 +)
 +
-+// init modifies the default cipher suites, the preference order, and the disabled cipher suites
-+// based on the cipher suites that Schannel supports.
++func init() {
++	cipherSuitesSchannel, versionsSchannel, err := getCipherSuitesSchannel()
++	if err != nil {
++		panic(err) // This should never happen, as Schannel is always available on Windows.
++	}
++	setSchannelCipherSuites(cipherSuitesSchannel, versionsSchannel)
++}
++
++// loadSchannelCipherSuites modifies the default cipher suites, the preference order, and the disabled cipher suites
++// based on provided suites.
 +//
 +// The user-visible behavior changes are:
 +// - The cipher suites used when [Config.CipherSuites] is nil, or when using TLS 1.3, only include those that Schannel supports.
 +// - The order in which cipher suites are tried, regardless of whether the user sets [Config.CipherSuites] or not, is the order that Schannel prefers.
-+func init() {
-+	cipherSuitesSchannel, err := cipherSuitesSchannel()
-+	if err != nil {
-+		panic(err) // This should never happen, as Schannel is always available on Windows.
-+	}
++// - The TLS supported versions are filtered to only include those that Schannel supports.
++func setSchannelCipherSuites(suites, versions []uint16) {
++	disableCipherSuites(CipherSuites(), suites, disabledCipherSuites)
++	disableCipherSuites(InsecureCipherSuites(), suites, disabledCipherSuites)
 +
-+	// cipherSuitesSchannel contains the cipher suites that Schannel supports in its preference order.
-+	// We use this to filter the default cipher suites and to order the preference order.
++	cipherSuitesPreferenceOrder = orderCipherSuites(cipherSuitesPreferenceOrder, suites)
 +
-+	disableCipherSuites(CipherSuites(), cipherSuitesSchannel, disabledCipherSuites)
-+	disableCipherSuites(InsecureCipherSuites(), cipherSuitesSchannel, disabledCipherSuites)
++	defaultCipherSuitesFIPS = filterCipherSuites(suites, defaultCipherSuitesFIPS)
++	defaultCipherSuitesTLS13 = filterCipherSuites(suites, defaultCipherSuitesTLS13)
++	defaultCipherSuitesTLS13FIPS = filterCipherSuites(suites, defaultCipherSuitesTLS13FIPS)
 +
-+	cipherSuitesPreferenceOrder = orderCipherSuites(cipherSuitesPreferenceOrder, cipherSuitesSchannel)
-+	cipherSuitesPreferenceOrderNoAES = orderCipherSuites(cipherSuitesPreferenceOrderNoAES, cipherSuitesSchannel)
++	// Schannel doesn't have a separate preference order without AES.
++	cipherSuitesPreferenceOrderNoAES = cipherSuitesPreferenceOrder
++	defaultCipherSuitesTLS13NoAES = defaultCipherSuitesTLS13
 +
-+	defaultCipherSuitesFIPS = filterCipherSuites(cipherSuitesSchannel, defaultCipherSuitesFIPS)
-+	defaultCipherSuitesTLS13 = filterCipherSuites(cipherSuitesSchannel, defaultCipherSuitesTLS13)
-+	defaultCipherSuitesTLS13NoAES = filterCipherSuites(cipherSuitesSchannel, defaultCipherSuitesTLS13NoAES)
-+	defaultCipherSuitesTLS13FIPS = filterCipherSuites(cipherSuitesSchannel, defaultCipherSuitesTLS13FIPS)
++	// Now filter the supported versions to only include those that Schannel supports.
++	supportedVersions = filterSupportedVersions(supportedVersions, versions)
++	defaultSupportedVersionsFIPS = filterSupportedVersions(defaultSupportedVersionsFIPS, versions)
 +}
 +
-+// cipherSuiteID returns the ID of the cipher suite with the given name.
-+func cipherSuiteID(name string) (uint16, bool) {
++// cipherSuitedByName returns the [CipherSuite] with the given name.
++func cipherSuitedByName(name string) (*CipherSuite, bool) {
 +	for _, c := range CipherSuites() {
 +		if c.Name == name {
-+			return c.ID, true
++			return c, true
 +		}
 +	}
 +	for _, c := range InsecureCipherSuites() {
 +		if c.Name == name {
-+			return c.ID, true
++			return c, true
 +		}
 +	}
-+	return 0, false
++	return nil, false
 +}
 +
-+// cipherSuitesSchannel returns all the cipher suites that Schannel supports in Schannel's preference order.
-+func cipherSuitesSchannel() ([]uint16, error) {
++// getCipherSuitesSchannel returns all the cipher suites that Schannel supports in Schannel's preference order.
++func getCipherSuitesSchannel() (suites []uint16, versions []uint16, err error) {
 +	// Get all the cipher suites that Schannel supports in preference order.
 +	var size uint32
 +	var funcs *windows.CRYPT_CONTEXT_FUNCTIONS
-+	err := windows.BCryptEnumContextFunctions(windows.CRYPT_LOCAL, unsafe.SliceData(windows.SSL_CONTEXT[:]), windows.NCRYPT_SCHANNEL_INTERFACE, &size, &funcs)
++	err = windows.BCryptEnumContextFunctions(windows.CRYPT_LOCAL, unsafe.SliceData(windows.SSL_CONTEXT[:]), windows.NCRYPT_SCHANNEL_INTERFACE, &size, &funcs)
 +	if err != nil {
-+		return nil, err
++		return nil, nil, err
 +	}
 +	defer windows.BCryptFreeBuffer(unsafe.Pointer(funcs))
 +
-+	suites := make([]uint16, 0, funcs.Count) // order[i] will be the index of suites[i] in the Schannel list
++	suites = make([]uint16, 0, funcs.Count)
 +	for i := range funcs.Count {
 +		name := windows.UTF16PtrToString(funcs.At(int(i)))
-+		id, ok := cipherSuiteID(name)
++		suite, ok := cipherSuitedByName(name)
 +		if !ok {
 +			continue // cipher suite not found in the provided list
 +		}
-+		suites = append(suites, id)
++		for _, v := range suite.SupportedVersions {
++			if !slices.Contains(versions, v) {
++				versions = append(versions, v)
++			}
++		}
++		suites = append(suites, suite.ID)
 +	}
-+	return suites, nil
++	return suites, versions, nil
 +}
 +
 +// filterCipherSuites filters the provided cipher suites, creating a new slice
 +// that only includes those that are in the allowed list.
 +func filterCipherSuites(suites, allowed []uint16) []uint16 {
-+	out := make([]uint16, 0, len(suites))
-+	for _, suite := range suites {
-+		if slices.Contains(allowed, suite) {
-+			out = append(out, suite)
++	out := make([]uint16, 0, len(allowed))
++	for _, id := range suites {
++		if slices.Contains(allowed, id) {
++			out = append(out, id)
 +		}
 +	}
 +	return out
@@ -241,7 +253,7 @@ index 00000000000000..93b7e8c912b3c1
 +// orderCipherSuites returns a new slice of cipher suites ordered according to the provided order.
 +// If suites contains a cipher suite that is not in the order, it will be placed
 +// at the end of the returned slice in the order they appear in suites.
-+func orderCipherSuites(suites []uint16, order []uint16) []uint16 {
++func orderCipherSuites(suites, order []uint16) []uint16 {
 +	out := make([]uint16, 0, len(suites))
 +	for _, id := range order {
 +		if slices.Contains(suites, id) {
@@ -265,12 +277,24 @@ index 00000000000000..93b7e8c912b3c1
 +		}
 +	}
 +}
++
++// filterSupportedVersions filters the provided supported versions, creating a new slice
++// that only includes those that are in the allowed list.
++func filterSupportedVersions(supported, allowed []uint16) []uint16 {
++	out := make([]uint16, 0, len(allowed))
++	for _, v := range supported {
++		if slices.Contains(allowed, v) {
++			out = append(out, v)
++		}
++	}
++	return out
++}
 diff --git a/src/crypto/tls/schannel_windows_test.go b/src/crypto/tls/schannel_windows_test.go
 new file mode 100644
-index 00000000000000..88f693ddce77a6
+index 00000000000000..01fb8852f38c6f
 --- /dev/null
 +++ b/src/crypto/tls/schannel_windows_test.go
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,178 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -281,32 +305,58 @@ index 00000000000000..88f693ddce77a6
 +
 +import (
 +	"bytes"
++	"internal/testenv"
++	"os"
 +	"os/exec"
-+	"sync"
 +	"testing"
 +)
 +
-+var schannelSuites = sync.OnceValue(func() []uint16 {
-+	cipherSuites, err := cipherSuitesSchannel()
-+	if err != nil {
-+		panic(err) // This should never happen, as Schannel is always available on Windows.
++// testSchannel runs the provided function in a child process with Schannel cipher suites set.
++func testSchannel(t *testing.T, ids, versions []uint16, fn func()) {
++	// We need to run this in a child process because the cipher suites are set in init(),
++	// and it is difficult to restore the original state in the same process without
++	// incurring a performance penalty for non-testing code.
++	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" {
++		setSchannelCipherSuites(ids, versions)
++		fn()
++		os.Exit(0)
 +	}
-+	return cipherSuites
-+})
++	exe, err := os.Executable()
++	if err != nil {
++		t.Fatalf("failed to get executable path: %v", err)
++	}
++	cmd := testenv.Command(t, exe, "-test.v", "-test.run=^"+t.Name()+"$")
++	cmd.Env = append(cmd.Environ(), "GO_WANT_HELPER_PROCESS=1")
++	output, err := cmd.CombinedOutput()
++	if err != nil {
++		t.Fatalf("failed to spawn child process: %v\n%s", err, output)
++	}
++}
++
++func cipherSuiteFromID(id uint16) (*CipherSuite, bool) {
++	for _, c := range CipherSuites() {
++		if c.ID == id {
++			return c, true
++		}
++	}
++	for _, c := range InsecureCipherSuites() {
++		if c.ID == id {
++			return c, true
++		}
++	}
++	return nil, false
++}
 +
 +func TestCipherSuitesSchannel(t *testing.T) {
-+	cipherSuites, err := cipherSuitesSchannel()
++	cipherSuites, versions, err := getCipherSuitesSchannel()
 +	if err != nil {
 +		t.Fatal(err)
 +	}
 +	if len(cipherSuites) == 0 {
 +		t.Fatal("cipherSuitesSchannel returned no cipher suites")
 +	}
-+
-+	for _, suite := range cipherSuites {
-+		if suite == 0 {
-+			t.Fatal("cipherSuitesSchannel returned a 0 cipher suite")
-+		}
++	if len(versions) == 0 {
++		t.Fatal("cipherSuitesSchannel returned no versions")
 +	}
 +
 +	// Check that all the cipher suites are present in the Get-TlsCipherSuite output.
@@ -315,55 +365,113 @@ index 00000000000000..88f693ddce77a6
 +		t.Fatalf("failed to get TLS cipher suites: %v\n%s", err, output)
 +	}
 +	for _, id := range cipherSuites {
-+		name := CipherSuiteName(id)
-+		if !bytes.Contains(output, []byte(name)) {
-+			t.Errorf("cipher suite %s not found in PowerShell output", name)
++		suite, ok := cipherSuiteFromID(id)
++		if !ok {
++			t.Fatalf("cipher suite with ID %d not found", id)
++		}
++		if !bytes.Contains(output, []byte(suite.Name)) {
++			t.Errorf("cipher suite %s not found in PowerShell output", suite.Name)
 +		}
 +	}
 +}
 +
 +func TestCipherSuitePreferenceSchannelTLS12(t *testing.T) {
-+	// Schannel should prefer AES-256 over AES-128.
-+	serverConfig := &Config{
-+		CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
-+		Certificates: testConfig.Certificates,
-+		MaxVersion:   VersionTLS12,
-+		GetConfigForClient: func(chi *ClientHelloInfo) (*Config, error) {
-+			if chi.CipherSuites[0] != TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
-+				t.Error("the advertised order should not depend on Config.CipherSuites")
-+			}
-+			return nil, nil
-+		},
-+	}
-+	clientConfig := &Config{
-+		CipherSuites:       []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
-+		InsecureSkipVerify: true,
-+	}
-+	state, _, err := testHandshake(t, clientConfig, serverConfig)
-+	if err != nil {
-+		t.Fatalf("handshake failed: %s", err)
-+	}
-+	if state.CipherSuite != TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
-+		t.Error("the preference order should not depend on Config.CipherSuites")
-+	}
++	testSchannel(t, []uint16{
++		TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
++		TLS_RSA_WITH_RC4_128_SHA,
++	}, []uint16{VersionTLS12}, func() {
++		serverConfig := &Config{
++			CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
++			Certificates: testConfig.Certificates,
++			MaxVersion:   VersionTLS12,
++			GetConfigForClient: func(chi *ClientHelloInfo) (*Config, error) {
++				if chi.CipherSuites[0] != TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
++					t.Error("the advertised order should not depend on Config.CipherSuites")
++				}
++				return nil, nil
++			},
++		}
++		clientConfig := &Config{
++			CipherSuites:       []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
++			InsecureSkipVerify: true,
++		}
++		state, _, err := testHandshake(t, clientConfig, serverConfig)
++		if err != nil {
++			t.Fatalf("handshake failed: %s", err)
++		}
++		if state.CipherSuite != TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
++			t.Error("the preference order should not depend on Config.CipherSuites")
++		}
++	})
++
 +}
 +
-+func TestCipherSuitePreferenceSchannelTLS13(t *testing.T) {
-+	// Schannel should prefer AES-256 over AES-128.
-+	serverConfig := &Config{
-+		Certificates: testConfig.Certificates,
-+		MaxVersion:   VersionTLS13,
-+	}
-+	clientConfig := &Config{
-+		InsecureSkipVerify: true,
-+	}
-+	state, _, err := testHandshake(t, clientConfig, serverConfig)
-+	if err != nil {
-+		t.Fatalf("handshake failed: %s", err)
-+	}
-+	if state.CipherSuite != TLS_AES_256_GCM_SHA384 {
-+		t.Error("the preference order should not depend on Config.CipherSuites")
-+	}
++func TestCipherSuitePreferenceSchannelNoTLS12(t *testing.T) {
++	testSchannel(t, []uint16{
++		TLS_AES_256_GCM_SHA384,
++	}, []uint16{VersionTLS13}, func() {
++		serverConfig := &Config{
++			Certificates: testConfig.Certificates,
++		}
++		clientConfig := &Config{
++			InsecureSkipVerify: true,
++		}
++		state, _, err := testHandshake(t, clientConfig, serverConfig)
++		if err != nil {
++			t.Fatalf("handshake failed: %s", err)
++		}
++		if state.CipherSuite != TLS_AES_256_GCM_SHA384 {
++			t.Error("the preference order should not depend on Config.CipherSuites")
++		}
++		if state.Version != VersionTLS13 {
++			t.Error("the version should be TLS 1.3 when available")
++		}
++	})
++}
++
++func TestCipherSuitePreferenceSchannel(t *testing.T) {
++	testSchannel(t, []uint16{
++		TLS_AES_256_GCM_SHA384,
++		TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
++	}, []uint16{VersionTLS13, VersionTLS12}, func() {
++		serverConfig := &Config{
++			Certificates: testConfig.Certificates,
++			MaxVersion:   VersionTLS13,
++		}
++		clientConfig := &Config{
++			InsecureSkipVerify: true,
++		}
++		state, _, err := testHandshake(t, clientConfig, serverConfig)
++		if err != nil {
++			t.Fatalf("handshake failed: %s", err)
++		}
++		if state.CipherSuite != TLS_AES_256_GCM_SHA384 {
++			t.Error("the preference order should not depend on Config.CipherSuites")
++		}
++	})
++}
++
++func TestCipherSuitePreferenceSchannelNoTLS13(t *testing.T) {
++	testSchannel(t, []uint16{
++		TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
++	}, []uint16{VersionTLS12}, func() {
++		serverConfig := &Config{
++			Certificates: testConfig.Certificates,
++		}
++		clientConfig := &Config{
++			InsecureSkipVerify: true,
++		}
++		state, _, err := testHandshake(t, clientConfig, serverConfig)
++		if err != nil {
++			t.Fatalf("handshake failed: %s", err)
++		}
++		if state.CipherSuite != TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
++			t.Error("the preference order should not depend on Config.CipherSuites")
++		}
++		if state.Version != VersionTLS12 {
++			t.Error("the version should be TLS 1.2 when TLS 1.3 is not available")
++		}
++	})
 +}
 diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
 index 13c5ddced2cddb..423796e36cd155 100644

--- a/patches/0016-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0016-implement-ms_tls_config_schannel-experiment.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
  src/crypto/tls/handshake_server_test.go       |  20 ++
  src/crypto/tls/handshake_test.go              |   6 +
  src/crypto/tls/schannel_windows.go            | 142 +++++++++++++
- src/crypto/tls/schannel_windows_test.go       | 192 ++++++++++++++++++
+ src/crypto/tls/schannel_windows_test.go       | 190 ++++++++++++++++++
  src/crypto/tls/tls_test.go                    |  11 +
  .../exp_ms_tls_config_schannel_off.go         |   8 +
  .../exp_ms_tls_config_schannel_on.go          |   8 +
@@ -17,7 +17,7 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
  .../syscall/windows/security_windows.go       |  28 +++
  .../syscall/windows/syscall_windows.go        |  16 ++
  .../syscall/windows/zsyscall_windows.go       |  23 +++
- 13 files changed, 466 insertions(+), 1 deletion(-)
+ 13 files changed, 464 insertions(+), 1 deletion(-)
  create mode 100644 src/crypto/tls/schannel_windows.go
  create mode 100644 src/crypto/tls/schannel_windows_test.go
  create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
@@ -143,7 +143,7 @@ index 803aa736578f8c..92b31362f3d65d 100644
  			t.Parallel()
 diff --git a/src/crypto/tls/schannel_windows.go b/src/crypto/tls/schannel_windows.go
 new file mode 100644
-index 00000000000000..4e338175f48651
+index 00000000000000..a77186c66d3095
 --- /dev/null
 +++ b/src/crypto/tls/schannel_windows.go
 @@ -0,0 +1,142 @@
@@ -211,7 +211,7 @@ index 00000000000000..4e338175f48651
 +}
 +
 +// getCipherSuitesSchannel returns all the cipher suites that Schannel supports in Schannel's preference order.
-+func getCipherSuitesSchannel() (suites []uint16, versions []uint16, err error) {
++func getCipherSuitesSchannel() (suites, versions []uint16, err error) {
 +	// Get all the cipher suites that Schannel supports in preference order.
 +	var size uint32
 +	var funcs *windows.CRYPT_CONTEXT_FUNCTIONS
@@ -240,7 +240,7 @@ index 00000000000000..4e338175f48651
 +
 +// filterCipherSuites filters the provided cipher suites, creating a new slice
 +// that only includes those that are in the allowed list.
-+func filterCipherSuites(suites []uint16, allowed []uint16) []uint16 {
++func filterCipherSuites(suites, allowed []uint16) []uint16 {
 +	out := make([]uint16, 0, len(allowed))
 +	for _, id := range suites {
 +		if slices.Contains(allowed, id) {
@@ -291,10 +291,10 @@ index 00000000000000..4e338175f48651
 +}
 diff --git a/src/crypto/tls/schannel_windows_test.go b/src/crypto/tls/schannel_windows_test.go
 new file mode 100644
-index 00000000000000..06bf2f80bc20bc
+index 00000000000000..426eb120adf559
 --- /dev/null
 +++ b/src/crypto/tls/schannel_windows_test.go
-@@ -0,0 +1,192 @@
+@@ -0,0 +1,190 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -305,7 +305,6 @@ index 00000000000000..06bf2f80bc20bc
 +
 +import (
 +	"bytes"
-+	"fmt"
 +	"internal/testenv"
 +	"os"
 +	"os/exec"
@@ -313,16 +312,15 @@ index 00000000000000..06bf2f80bc20bc
 +)
 +
 +func init() {
-+	cipherSuites, versions, err := getCipherSuitesSchannel()
-+	if err != nil {
-+		panic(err)
++	// Many tests require TLS 1.1 and TLS 1.0 to be available, so we override the
++	// supported versions previously set in Schannel init() to include them.
++	// This increases the coverage for Schannel cipher suites.
++	supportedVersions = []uint16{
++		VersionTLS13,
++		VersionTLS12,
++		VersionTLS11,
++		VersionTLS10,
 +	}
-+	fmt.Println("Schannel cipher suites:")
-+	for _, id := range cipherSuites {
-+		name, _ := cipherSuiteFromID(id)
-+		fmt.Println(id, name)
-+	}
-+	fmt.Println("Schannel versions:", versions)
 +}
 +
 +// testSchannel runs the provided function in a child process with Schannel cipher suites set.


### PR DESCRIPTION
the `tls.Config.MaxVersion` default value is `tls.VersionTLS13`, but on Windows Server 2016 TLS 1.3 is not supported. This means that when using the `ms_tls_config_schannel` experiment the TLS handshake will say that TLS 1.3 is supported but it won't provide any cipher suite for that version.

This discordance can produce issues down the line, so we better avoid it by filtering the TLS supported versions based on the cipher suites supported by Schannel.

This PR also improves the Schannel tests so that we can easily override the configuration retrieved from Windows.