### PR TITLE
[release-branch.go1.23] Remove curve prefix from Schannel cipher suite names

### DIFF
--- a/patches/0016-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0016-implement-ms_tls_config_schannel-experiment.patch
@@ -8,16 +8,16 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
  src/crypto/tls/bogo_shim_test.go              |   7 +
  src/crypto/tls/handshake_server_test.go       |  20 ++
  src/crypto/tls/handshake_test.go              |   6 +
- src/crypto/tls/schannel_windows.go            | 142 +++++++++++++
- src/crypto/tls/schannel_windows_test.go       | 190 ++++++++++++++++++
+ src/crypto/tls/schannel_windows.go            | 163 ++++++++++++++
+ src/crypto/tls/schannel_windows_test.go       | 211 ++++++++++++++++++
  src/crypto/tls/tls_test.go                    |  11 +
  .../exp_ms_tls_config_schannel_off.go         |   8 +
  .../exp_ms_tls_config_schannel_on.go          |   8 +
  src/internal/goexperiment/flags.go            |   4 +
  .../syscall/windows/security_windows.go       |  28 +++
  .../syscall/windows/syscall_windows.go        |  16 ++
- .../syscall/windows/zsyscall_windows.go       |  23 +++
- 13 files changed, 464 insertions(+), 1 deletion(-)
+ .../syscall/windows/zsyscall_windows.go       |  23 ++
+ 13 files changed, 506 insertions(+), 1 deletion(-)
  create mode 100644 src/crypto/tls/schannel_windows.go
  create mode 100644 src/crypto/tls/schannel_windows_test.go
  create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
@@ -143,10 +143,10 @@ index 803aa736578f8c..92b31362f3d65d 100644
  			t.Parallel()
 diff --git a/src/crypto/tls/schannel_windows.go b/src/crypto/tls/schannel_windows.go
 new file mode 100644
-index 00000000000000..a77186c66d3095
+index 00000000000000..e28d33ab093473
 --- /dev/null
 +++ b/src/crypto/tls/schannel_windows.go
-@@ -0,0 +1,142 @@
+@@ -0,0 +1,163 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -224,9 +224,13 @@ index 00000000000000..a77186c66d3095
 +	suites = make([]uint16, 0, funcs.Count)
 +	for i := range funcs.Count {
 +		name := windows.UTF16PtrToString(funcs.At(int(i)))
++		name = removeCipherSuiteCurvePrefix(name)
 +		suite, ok := cipherSuitedByName(name)
 +		if !ok {
 +			continue // cipher suite not found in the provided list
++		}
++		if slices.Contains(suites, suite.ID) {
++			continue // already added
 +		}
 +		for _, v := range suite.SupportedVersions {
 +			if !slices.Contains(versions, v) {
@@ -236,6 +240,23 @@ index 00000000000000..a77186c66d3095
 +		suites = append(suites, suite.ID)
 +	}
 +	return suites, versions, nil
++}
++
++// removeCipherSuiteCurvePrefix removes the curve prefix from the cipher suite name.
++// Windows Schannel supports cipher suites with curve prefixes, in the form of
++// _P256, _P384, or _P521, which are not present in the Go cipher suite names.
++// This is not common, as since Windows 2016 the curve prefix is discarded by Schannel,
++// but it can still be present in case Windows was upgraded from an earlier version.
++func removeCipherSuiteCurvePrefix(name string) string {
++	const prefixLength = 5 // Length of "_P256", "_P384", or "_P521"
++	if len(name) < prefixLength {
++		return name // No curve prefix to remove
++	}
++	switch name[len(name)-prefixLength:] {
++	case "_P256", "_P384", "_P521":
++		name = name[:len(name)-prefixLength] // Remove the curve prefix
++	}
++	return name
 +}
 +
 +// filterCipherSuites filters the provided cipher suites, creating a new slice
@@ -291,10 +312,10 @@ index 00000000000000..a77186c66d3095
 +}
 diff --git a/src/crypto/tls/schannel_windows_test.go b/src/crypto/tls/schannel_windows_test.go
 new file mode 100644
-index 00000000000000..426eb120adf559
+index 00000000000000..9124f7b325db5b
 --- /dev/null
 +++ b/src/crypto/tls/schannel_windows_test.go
-@@ -0,0 +1,190 @@
+@@ -0,0 +1,211 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -484,6 +505,27 @@ index 00000000000000..426eb120adf559
 +			t.Error("the version should be TLS 1.2 when TLS 1.3 is not available")
 +		}
 +	})
++}
++func TestRemoveCipherSuiteCurvePrefix(t *testing.T) {
++	tests := []struct {
++		in, want string
++	}{
++		{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_P256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
++		{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_P384", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
++		{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_P521", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
++		{"TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA"},
++		{"_P256", ""},
++		{"_P384", ""},
++		{"_P521", ""},
++		{"TLS_AES_128_GCM_SHA256", "TLS_AES_128_GCM_SHA256"},
++		{"", ""},
++	}
++	for _, tt := range tests {
++		got := removeCipherSuiteCurvePrefix(tt.in)
++		if got != tt.want {
++			t.Errorf("removeCipherSuiteCurvePrefix(%q) = %q, want %q", tt.in, got, tt.want)
++		}
++	}
 +}
 diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
 index 13c5ddced2cddb..423796e36cd155 100644


### PR DESCRIPTION
The ARC team reported that GOEXPERIMENT=ms_tls_config_schannel is not working on Windows Server 2012. The issue is that cipher suite names are not using the standard form (which is also the one understood by Go), but they have the ECC curve name added as a prefix.

Windows Server 2012 is not supported by Go, although ARC still supports it. Anyway, newer Windows do still support these prefixes for the case a newer Windows version got upgraded from Windows Server 2012.