### PR TITLE
codeql: set GOEXPERIMENT=nosystemcrypto

### DIFF
--- a/eng/pipeline/stages/run-codeql.yml
+++ b/eng/pipeline/stages/run-codeql.yml
@@ -118,6 +118,11 @@ stages:
                 chmod 755 "${WORKAROUND_DIR}/go"
                 export PATH="${WORKAROUND_DIR}:${PATH}"
 
+                # Set GOEXPERIMENT for linux arm32/arm64 to avoid crypto backend issues
+                if [ "${{ c.os }}" = "linux" ] && ([ "${{ c.arch }}" = "arm" ] || [ "${{ c.arch }}" = "arm64" ]); then
+                  export GOEXPERIMENT=nosystemcrypto
+                fi
+
                 # Build Go itself.
                 go build std
                 go build cmd/...

--- a/eng/pipeline/stages/run-codeql.yml
+++ b/eng/pipeline/stages/run-codeql.yml
@@ -118,14 +118,11 @@ stages:
                 chmod 755 "${WORKAROUND_DIR}/go"
                 export PATH="${WORKAROUND_DIR}:${PATH}"
 
-                # Set GOEXPERIMENT for linux arm32/arm64 to avoid crypto backend issues
-                if [ "${{ c.os }}" = "linux" ] && ([ "${{ c.arch }}" = "arm" ] || [ "${{ c.arch }}" = "arm64" ]); then
-                  export GOEXPERIMENT=nosystemcrypto
-                fi
-
                 # Build Go itself.
                 go build std
                 go build cmd/...
                 # Build our infra tools.
                 ( cd eng/_util/ && go build ./... )
+              env:
+                GOEXPERIMENT: nosystemcrypto
               displayName: Build ${{ c.os }}-${{ c.arch }}


### PR DESCRIPTION
Without this the codeql run for linux arm32/aarch64 fails with:

```output
# crypto
../Binaries Signed/go/src/crypto/systemcrypto_nocgo.go:10:2: `
	Using a crypto backend requires CGO_ENABLED=1.
	
	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
	` (untyped string constant "\n\tUsing a crypto backend requires CGO_ENABLED=1.\n\t\n\tFor more i...) is not used
```

Test run here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2755002&view=results