### PR TITLE
Make ms_tls_config_schannel no-op on Windows Server 2012

### DIFF
--- a/patches/0016-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0016-implement-ms_tls_config_schannel-experiment.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
  src/crypto/tls/bogo_shim_test.go              |   7 +
  src/crypto/tls/handshake_server_test.go       |  20 ++
  src/crypto/tls/handshake_test.go              |   6 +
- src/crypto/tls/schannel_windows.go            | 163 ++++++++++++++
+ src/crypto/tls/schannel_windows.go            | 166 ++++++++++++++
  src/crypto/tls/schannel_windows_test.go       | 211 ++++++++++++++++++
  src/crypto/tls/tls_test.go                    |  11 +
  .../exp_ms_tls_config_schannel_off.go         |   8 +
@@ -16,8 +16,10 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
  src/internal/goexperiment/flags.go            |   4 +
  .../syscall/windows/security_windows.go       |  28 +++
  .../syscall/windows/syscall_windows.go        |  16 ++
+ .../syscall/windows/version_windows.go        |   9 +
+ .../syscall/windows/version_windows_test.go   |   7 +
  .../syscall/windows/zsyscall_windows.go       |  23 ++
- 13 files changed, 506 insertions(+), 1 deletion(-)
+ 15 files changed, 525 insertions(+), 1 deletion(-)
  create mode 100644 src/crypto/tls/schannel_windows.go
  create mode 100644 src/crypto/tls/schannel_windows_test.go
  create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
@@ -143,10 +145,10 @@ index 803aa736578f8c..92b31362f3d65d 100644
  			t.Parallel()
 diff --git a/src/crypto/tls/schannel_windows.go b/src/crypto/tls/schannel_windows.go
 new file mode 100644
-index 00000000000000..e28d33ab093473
+index 00000000000000..ed20b44ef7ee39
 --- /dev/null
 +++ b/src/crypto/tls/schannel_windows.go
-@@ -0,0 +1,163 @@
+@@ -0,0 +1,166 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -162,6 +164,9 @@ index 00000000000000..e28d33ab093473
 +)
 +
 +func init() {
++	if !windows.SupportsTLSConfigSchannel() {
++		return
++	}
 +	cipherSuitesSchannel, versionsSchannel, err := getCipherSuitesSchannel()
 +	if err != nil {
 +		panic(err) // This should never happen, as Schannel is always available on Windows.
@@ -224,7 +229,7 @@ index 00000000000000..e28d33ab093473
 +	suites = make([]uint16, 0, funcs.Count)
 +	for i := range funcs.Count {
 +		name := windows.UTF16PtrToString(funcs.At(int(i)))
-+		name = removeCipherSuiteCurvePrefix(name)
++		name = removeCipherSuiteCurveSuffix(name)
 +		suite, ok := cipherSuitedByName(name)
 +		if !ok {
 +			continue // cipher suite not found in the provided list
@@ -242,19 +247,19 @@ index 00000000000000..e28d33ab093473
 +	return suites, versions, nil
 +}
 +
-+// removeCipherSuiteCurvePrefix removes the curve prefix from the cipher suite name.
-+// Windows Schannel supports cipher suites with curve prefixes, in the form of
++// removeCipherSuiteCurveSuffix removes the curve suffix from the cipher suite name.
++// Windows Schannel supports cipher suites with curve suffixes, in the form of
 +// _P256, _P384, or _P521, which are not present in the Go cipher suite names.
-+// This is not common, as since Windows 2016 the curve prefix is discarded by Schannel,
++// This is not common, as since Windows 2016 the curve suffix is discarded by Schannel,
 +// but it can still be present in case Windows was upgraded from an earlier version.
-+func removeCipherSuiteCurvePrefix(name string) string {
-+	const prefixLength = 5 // Length of "_P256", "_P384", or "_P521"
-+	if len(name) < prefixLength {
-+		return name // No curve prefix to remove
++func removeCipherSuiteCurveSuffix(name string) string {
++	const suffixLength = 5 // Length of "_P256", "_P384", or "_P521"
++	if len(name) < suffixLength {
++		return name // No curve suffix to remove
 +	}
-+	switch name[len(name)-prefixLength:] {
++	switch name[len(name)-suffixLength:] {
 +	case "_P256", "_P384", "_P521":
-+		name = name[:len(name)-prefixLength] // Remove the curve prefix
++		name = name[:len(name)-suffixLength] // Remove the curve suffix
 +	}
 +	return name
 +}
@@ -312,7 +317,7 @@ index 00000000000000..e28d33ab093473
 +}
 diff --git a/src/crypto/tls/schannel_windows_test.go b/src/crypto/tls/schannel_windows_test.go
 new file mode 100644
-index 00000000000000..9124f7b325db5b
+index 00000000000000..b6ce7ffcc3356d
 --- /dev/null
 +++ b/src/crypto/tls/schannel_windows_test.go
 @@ -0,0 +1,211 @@
@@ -521,7 +526,7 @@ index 00000000000000..9124f7b325db5b
 +		{"", ""},
 +	}
 +	for _, tt := range tests {
-+		got := removeCipherSuiteCurvePrefix(tt.in)
++		got := removeCipherSuiteCurveSuffix(tt.in)
 +		if got != tt.want {
 +			t.Errorf("removeCipherSuiteCurvePrefix(%q) = %q, want %q", tt.in, got, tt.want)
 +		}
@@ -666,6 +671,38 @@ index cc26a50bb0acf2..d5a8b86718e4f4 100644
 +	return s.Errno().Error()
 +}
 \ No newline at end of file
+diff --git a/src/internal/syscall/windows/version_windows.go b/src/internal/syscall/windows/version_windows.go
+index ff21fc59e5bf53..162a4cc55f8afc 100644
+--- a/src/internal/syscall/windows/version_windows.go
++++ b/src/internal/syscall/windows/version_windows.go
+@@ -111,3 +111,12 @@ var SupportUnixSocket = sync.OnceValue(func() bool {
+ 	}
+ 	return false
+ })
++
++// SupportsTLSConfigSchannel returns true if the current Windows version
++// supports getting the TLS configuration from Schannel.
++func SupportsTLSConfigSchannel() bool {
++	major, _, _ := version()
++	// Prior to Windows 10, Schannel and Go only shared a few cipher suites,
++	// which increased the risk of not being able to negotiate a secure connection.
++	return major >= 10
++}
+diff --git a/src/internal/syscall/windows/version_windows_test.go b/src/internal/syscall/windows/version_windows_test.go
+index 09be2eb0807932..b74b311279e81f 100644
+--- a/src/internal/syscall/windows/version_windows_test.go
++++ b/src/internal/syscall/windows/version_windows_test.go
+@@ -29,3 +29,10 @@ func TestSupportUnixSocket(t *testing.T) {
+ 		t.Errorf("SupportUnixSocket = %v; want %v", got, want)
+ 	}
+ }
++
++func TestSupportsTLSConfigSchannel(t *testing.T) {
++	if !windows.SupportsTLSConfigSchannel() {
++		// Sanity check. CI only runs on Windows 10 and later, so this should never happen.
++		t.Fatal("SupportsTLSConfigSchannel should return true on Windows 10 and later")
++	}
++}
 diff --git a/src/internal/syscall/windows/zsyscall_windows.go b/src/internal/syscall/windows/zsyscall_windows.go
 index 414ad2647d1abd..35ee24f125928d 100644
 --- a/src/internal/syscall/windows/zsyscall_windows.go


### PR DESCRIPTION
On Windows Server 2012, Schannel and Go don't share that many secure TLS cipher suites, which increases the likelihood of not being able to negotiate a TLS handshake.

Windows Server 2012 is not supported by Go, but some 1P customers are still using it.