### PR TITLE
[release-branch.go1.23] Update MS_TLS_Config_Schannel comments

### DIFF
--- a/patches/0016-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0016-implement-ms_tls_config_schannel-experiment.patch
@@ -13,13 +13,13 @@ Subject: [PATCH] implement ms_tls_config_schannel experiment
  src/crypto/tls/tls_test.go                    |  11 +
  .../exp_ms_tls_config_schannel_off.go         |   8 +
  .../exp_ms_tls_config_schannel_on.go          |   8 +
- src/internal/goexperiment/flags.go            |   4 +
+ src/internal/goexperiment/flags.go            |   8 +
  .../syscall/windows/security_windows.go       |  28 +++
  .../syscall/windows/syscall_windows.go        |  16 ++
- .../syscall/windows/version_windows.go        |   9 +
+ .../syscall/windows/version_windows.go        |  11 +
  .../syscall/windows/version_windows_test.go   |   7 +
  .../syscall/windows/zsyscall_windows.go       |  23 ++
- 15 files changed, 525 insertions(+), 1 deletion(-)
+ 15 files changed, 531 insertions(+), 1 deletion(-)
  create mode 100644 src/crypto/tls/schannel_windows.go
  create mode 100644 src/crypto/tls/schannel_windows_test.go
  create mode 100644 src/internal/goexperiment/exp_ms_tls_config_schannel_off.go
@@ -597,16 +597,20 @@ index 00000000000000..a2dbc6187da2a0
 +const MS_TLS_Config_Schannel = true
 +const MS_TLS_Config_SchannelInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 8e4cf87664e28e..206d7b110cbc4e 100644
+index 8e4cf87664e28e..a497d228390d5a 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
-@@ -140,4 +140,8 @@ type Flags struct {
+@@ -140,4 +140,12 @@ type Flags struct {
  	// Requires that gotypesalias=1 is set with GODEBUG.
  	// This flag will be removed with Go 1.24.
  	AliasTypeParams bool
 +
-+	// MS_TLS_Config_Schannel enables the filtering and ordering of cipher suites
-+	// according to the Windows Schannel settings.
++	// MS_TLS_Config_Schannel enables the filtering and ordering of cipher
++	// suites according to the Windows Schannel settings.
++	//
++	// Does nothing on Windows Server 2012 (Windows 8) and earlier. In these
++	// versions, very few cipher suites are implemented by both Windows and Go,
++	// so it's unlikely the resulting TLS configuration will be usable.
 +	MS_TLS_Config_Schannel bool
  }
 diff --git a/src/internal/syscall/windows/security_windows.go b/src/internal/syscall/windows/security_windows.go
@@ -672,10 +676,10 @@ index cc26a50bb0acf2..d5a8b86718e4f4 100644
 +}
 \ No newline at end of file
 diff --git a/src/internal/syscall/windows/version_windows.go b/src/internal/syscall/windows/version_windows.go
-index ff21fc59e5bf53..162a4cc55f8afc 100644
+index ff21fc59e5bf53..e82b54cef476fd 100644
 --- a/src/internal/syscall/windows/version_windows.go
 +++ b/src/internal/syscall/windows/version_windows.go
-@@ -111,3 +111,12 @@ var SupportUnixSocket = sync.OnceValue(func() bool {
+@@ -111,3 +111,14 @@ var SupportUnixSocket = sync.OnceValue(func() bool {
  	}
  	return false
  })
@@ -684,8 +688,10 @@ index ff21fc59e5bf53..162a4cc55f8afc 100644
 +// supports getting the TLS configuration from Schannel.
 +func SupportsTLSConfigSchannel() bool {
 +	major, _, _ := version()
-+	// Prior to Windows 10, Schannel and Go only shared a few cipher suites,
-+	// which increased the risk of not being able to negotiate a secure connection.
++	// Prior to Windows 10, Schannel is implemented, however Windows 10 and Go
++	// only share a few cipher suites. This makes it infeasible to negotiate a
++	// secure connection, so we do not use Schannel even when the GOEXPERIMENT
++	// is active.
 +	return major >= 10
 +}
 diff --git a/src/internal/syscall/windows/version_windows_test.go b/src/internal/syscall/windows/version_windows_test.go


### PR DESCRIPTION
* A few things that I thought about for https://github.com/microsoft/go/pull/1768

Since we don't have docs (yet), I figure the goexperiment's doc comment is a decent place to keep this info.

"Increases risk" doesn't seem like a good enough reason to me. The way I see it, the Schannel feature inherently increases risk of the Go app not working, no matter what Windows version. 😄 Changed to `This makes it infeasible to negotiate a secure connection` for now.

(Also, prefer present tense because Windows Server 2012 and Go are still both being used, and the comment describes what happens to a Go app that runs now.)