### PR TITLE
Summarize test JSON output to stdout

### DIFF
--- a/eng/_util/buildutil/buildutil.go
+++ b/eng/_util/buildutil/buildutil.go
@@ -125,7 +125,7 @@ func UnassignGOROOT() error {
 
 // RunCmdMultiWriter runs a command and outputs the stdout to multiple [io.Writer].
 // The writers are closed after the command completes.
-func RunCmdMultiWriter(cmdline []string, stdout ...io.Writer) (err error) {
+func RunCmdMultiWriter(cmdline []string, stdout ...io.Writer) error {
 	c := exec.Command(cmdline[0], cmdline[1:]...)
 	c.Stdout = io.MultiWriter(stdout...)
 	c.Stderr = os.Stderr

--- a/eng/_util/buildutil/testjson.go
+++ b/eng/_util/buildutil/testjson.go
@@ -88,11 +88,11 @@ func (f *TestJSONFlags) RunTestCmd(cmdline []string) error {
 		cmdline = append(cmdline, "-json")
 	}
 
-	errs := []error{RunCmdMultiWriter(cmdline, writers...)}
+	err := RunCmdMultiWriter(cmdline, writers...)
 	for _, closer := range extraClosers {
-		errs = append(errs, closer())
+		err = errors.Join(err, closer())
 	}
-	return errors.Join(errs...)
+	return err
 }
 
 // testJSONSummaryConverter reads Go JSON test output and writes a summary that

--- a/eng/_util/buildutil/testjson.go
+++ b/eng/_util/buildutil/testjson.go
@@ -12,25 +12,25 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/microsoft/go-infra/json2junit"
 )
 
 type TestJSONFlags struct {
-	JUnitOutFile           string
-	RawTestOutArtifactName string
+	JUnitOutFile   string
+	RawTestOutFile string
 }
 
 func BindTestJSONFlags() *TestJSONFlags {
 	var f TestJSONFlags
 	flag.StringVar(
 		&f.JUnitOutFile, "junitout", "junit.xml",
-		"Write the test output to this path as a JUnit file if running tests.")
+		"Write the test output to a new file at this path as a JUnit file if running tests.")
 	flag.StringVar(
-		&f.RawTestOutArtifactName, "rawtestoutartifact", "",
-		"Upload raw test output to AzDO as an artifact with this name\n"+
-			"and summarize any test JSON before it reaches stdout.")
+		&f.RawTestOutFile, "rawtestout", "",
+		"Write raw test output to a new file at this path and summarize any test JSON before it reaches stdout.")
 	return &f
 }
 
@@ -39,45 +39,45 @@ func (f *TestJSONFlags) AppendToCmdline(cmdline []string) []string {
 		if f.JUnitOutFile != "" {
 			cmdline = append(cmdline, "-junitout", f.JUnitOutFile)
 		}
-		if f.RawTestOutArtifactName != "" {
-			cmdline = append(cmdline, "-rawtestoutartifact", f.RawTestOutArtifactName)
+		if f.RawTestOutFile != "" {
+			cmdline = append(cmdline, "-rawtestout", f.RawTestOutFile)
 		}
 	}
 	return cmdline
 }
 
-func (f *TestJSONFlags) RunTestCmd(cmdline []string) error {
+func (f *TestJSONFlags) RunTestCmd(cmdline []string) (err error) {
 	var writers []io.Writer
-	var extraClosers []func() error
-
 	var needJSON bool
 
 	if f != nil {
 		if f.JUnitOutFile != "" {
-			jf, err := os.Create(f.JUnitOutFile)
-			if err != nil {
+			var jf *os.File
+			if jf, err = os.Create(f.JUnitOutFile); err != nil {
 				return err
 			}
+			defer func() {
+				err = errors.Join(err, jf.Close())
+			}()
 			writers = append(writers, json2junit.NewConverter(jf))
-			extraClosers = append(extraClosers, jf.Close)
 			needJSON = true
 		}
-		if f.RawTestOutArtifactName != "" {
-			tmpFile, err := os.CreateTemp("", "ms-go-raw-test-out-*.txt")
-			if err != nil {
+		if f.RawTestOutFile != "" {
+			var rf *os.File
+			if err := os.MkdirAll(filepath.Dir(f.RawTestOutFile), 0o755); err != nil {
+				return fmt.Errorf("failed to create directory for raw test output: %w", err)
+			}
+			if rf, err = os.Create(f.RawTestOutFile); err != nil {
 				return err
 			}
-			fmt.Printf("---- Created temp file for raw JSON test output: %v\n", tmpFile.Name())
+			defer func() {
+				err = errors.Join(err, rf.Close())
+			}()
 			writers = append(
 				writers,
 				&testJSONSummaryConverter{w: os.Stdout},
-				tmpFile,
+				rf,
 			)
-			extraClosers = append(extraClosers, func() error {
-				err := tmpFile.Close()
-				fmt.Fprintf(os.Stdout, "##vso[artifact.upload artifactname=%s]%s\n", f.RawTestOutArtifactName, tmpFile.Name())
-				return err
-			})
 			needJSON = true
 		} else {
 			// If we don't summarize, we need to write directly to stdout.
@@ -88,11 +88,7 @@ func (f *TestJSONFlags) RunTestCmd(cmdline []string) error {
 		cmdline = append(cmdline, "-json")
 	}
 
-	err := RunCmdMultiWriter(cmdline, writers...)
-	for _, closer := range extraClosers {
-		err = errors.Join(err, closer())
-	}
-	return err
+	return RunCmdMultiWriter(cmdline, writers...)
 }
 
 // testJSONSummaryConverter reads Go JSON test output and writes a summary that

--- a/eng/_util/buildutil/testjson.go
+++ b/eng/_util/buildutil/testjson.go
@@ -1,3 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package buildutil
 
 import (

--- a/eng/_util/buildutil/testjson.go
+++ b/eng/_util/buildutil/testjson.go
@@ -1,0 +1,145 @@
+package buildutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/microsoft/go-infra/json2junit"
+)
+
+type TestJSONFlags struct {
+	JUnitOutFile           string
+	RawTestOutArtifactName string
+}
+
+func BindTestJSONFlags() *TestJSONFlags {
+	var f TestJSONFlags
+	flag.StringVar(
+		&f.JUnitOutFile, "junitout", "junit.xml",
+		"Write the test output to this path as a JUnit file if running tests.")
+	flag.StringVar(
+		&f.RawTestOutArtifactName, "rawtestoutartifact", "",
+		"Upload raw test output to AzDO as an artifact with this name\n"+
+			"and summarize any test JSON before it reaches stdout.")
+	return &f
+}
+
+func (f *TestJSONFlags) AppendToCmdline(cmdline []string) []string {
+	if f != nil {
+		if f.JUnitOutFile != "" {
+			cmdline = append(cmdline, "-junitout", f.JUnitOutFile)
+		}
+		if f.RawTestOutArtifactName != "" {
+			cmdline = append(cmdline, "-rawtestoutartifact", f.RawTestOutArtifactName)
+		}
+	}
+	return cmdline
+}
+
+func (f *TestJSONFlags) RunTestCmd(cmdline []string) error {
+	var writers []io.Writer
+	var extraClosers []func() error
+
+	var needJSON bool
+
+	if f != nil {
+		if f.JUnitOutFile != "" {
+			jf, err := os.Create(f.JUnitOutFile)
+			if err != nil {
+				return err
+			}
+			writers = append(writers, json2junit.NewConverter(jf))
+			extraClosers = append(extraClosers, jf.Close)
+			needJSON = true
+		}
+		if f.RawTestOutArtifactName != "" {
+			tmpFile, err := os.CreateTemp("", "ms-go-raw-test-out-*.txt")
+			if err != nil {
+				return err
+			}
+			fmt.Printf("---- Created temp file for raw JSON test output: %v\n", tmpFile.Name())
+			writers = append(
+				writers,
+				&testJSONSummaryConverter{w: os.Stdout},
+				tmpFile,
+			)
+			extraClosers = append(extraClosers, func() error {
+				err := tmpFile.Close()
+				fmt.Fprintf(os.Stdout, "##vso[artifact.upload artifactname=%s]%s\n", f.RawTestOutArtifactName, tmpFile.Name())
+				return err
+			})
+			needJSON = true
+		} else {
+			// If we don't summarize, we need to write directly to stdout.
+			writers = append(writers, os.Stdout)
+		}
+	}
+	if needJSON {
+		cmdline = append(cmdline, "-json")
+	}
+
+	errs := []error{RunCmdMultiWriter(cmdline, writers...)}
+	for _, closer := range extraClosers {
+		errs = append(errs, closer())
+	}
+	return errors.Join(errs...)
+}
+
+// testJSONSummaryConverter reads Go JSON test output and writes a summary that
+// is sufficient for human readability in CI while filtering out excessive
+// details that would otherwise result in hard-to-load CI logs.
+//
+// It is very similar to default "go test" output, but only good enough. It
+// doesn't have the same behavior in some situations.
+type testJSONSummaryConverter struct {
+	b bytes.Buffer
+	w io.Writer
+}
+
+func (c *testJSONSummaryConverter) Write(b []byte) (int, error) {
+	c.b.Write(b)
+	lines := bytes.Split(c.b.Bytes(), []byte("\n"))
+	if len(lines) < 2 {
+		// We don't have a complete line yet.
+		return len(b), nil
+	}
+	completeLines := lines[:len(lines)-1]
+	for _, line := range completeLines {
+		var entry jsonEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			// An error means it either isn't a JSON line, or it's an invalid one.
+			// In both cases, simply write it for the summary.
+			fmt.Fprintf(c.w, "%q %v\n", line, err)
+			continue
+		}
+		if entry.Action != "output" || entry.Test != "" {
+			// Too much info for a summary.
+			continue
+		}
+		if entry.Output == "PASS\n" ||
+			entry.Output == "FAIL\n" {
+			continue
+		}
+		_, _ = c.w.Write([]byte(entry.Output))
+	}
+	// Keep the last, incomplete line in the buffer for the next call, if any.
+	c.b.Reset()
+	_, _ = c.b.Write(lines[len(lines)-1])
+	return len(b), nil
+}
+
+// jsonEntry is the parts of a single entry in the JSON file relevant to testJSONHumanConverter.
+type jsonEntry struct {
+	Time    time.Time
+	Action  string
+	Package string
+	Test    string
+	Output  string
+	Elapsed float64
+}

--- a/eng/_util/buildutil/testjson.go
+++ b/eng/_util/buildutil/testjson.go
@@ -134,7 +134,7 @@ func (c *testJSONSummaryConverter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-// jsonEntry is the parts of a single entry in the JSON file relevant to testJSONHumanConverter.
+// jsonEntry is the parts of a single entry in the JSON file relevant to testJSONSummaryConverter.
 type jsonEntry struct {
 	Time    time.Time
 	Action  string

--- a/eng/_util/cmd/build/build.go
+++ b/eng/_util/cmd/build/build.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/microsoft/go-infra/json2junit"
 	"github.com/microsoft/go-infra/patch"
 	"github.com/microsoft/go-infra/submodule"
 	"github.com/microsoft/go/_util/buildutil"
@@ -53,7 +52,8 @@ func main() {
 			"For more refresh options, use the top level 'submodule-refresh' command instead of 'build'.")
 
 	flag.StringVar(&o.Experiment, "experiment", "", "Include this string in GOEXPERIMENT.")
-	flag.StringVar(&o.JUnitOutFile, "junitout", "", "Write the test output to this path as a JUnit file if this builder runs tests.")
+
+	o.TestJSONFlags = buildutil.BindTestJSONFlags()
 
 	o.MaxMakeAttempts = buildutil.MaxMakeRetryAttemptsOrExit()
 
@@ -78,14 +78,15 @@ func main() {
 }
 
 type options struct {
-	SkipBuild    bool
-	Test         bool
-	PackBuild    bool
-	PackSource   bool
-	CreatePDB    bool
-	Refresh      bool
-	Experiment   string
-	JUnitOutFile string
+	SkipBuild  bool
+	Test       bool
+	PackBuild  bool
+	PackSource bool
+	CreatePDB  bool
+	Refresh    bool
+	Experiment string
+
+	TestJSONFlags *buildutil.TestJSONFlags
 
 	MaxMakeAttempts int
 }
@@ -208,27 +209,8 @@ func build(o *options) (err error) {
 			}...,
 		)
 
-		if o.JUnitOutFile != "" {
-			testCommandLine = append(testCommandLine, "-json")
-			f, err := os.Create(o.JUnitOutFile)
-			if err != nil {
-				return err
-			}
-			conv := json2junit.NewConverter(f)
-			err = buildutil.RunCmdMultiWriter(testCommandLine, conv, os.Stdout)
-			if closeErr := conv.Close(); err == nil {
-				err = closeErr
-			}
-			if closeErr := f.Close(); err == nil {
-				err = closeErr
-			}
-			if err != nil {
-				return err
-			}
-		} else {
-			if err := buildutil.RunCmdMultiWriter(testCommandLine, os.Stdout); err != nil {
-				return err
-			}
+		if err := o.TestJSONFlags.RunTestCmd(testCommandLine); err != nil {
+			return err
 		}
 	}
 

--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -13,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/microsoft/go-infra/json2junit"
 	"github.com/microsoft/go/_util/buildutil"
 )
 
@@ -40,9 +40,10 @@ func main() {
 	var builder = flag.String("builder", "", "[Required] Specify a builder to run. Note, this may be destructive!")
 	var experiment = flag.String("experiment", "", "Include this string in GOEXPERIMENT.")
 	var fipsMode = flag.Bool("fipsmode", false, "Run the Go tests in FIPS mode.")
-	var junitOutFile = flag.String("junitout", "", "Write the test output to this path as a JUnit file if this builder runs tests.")
 	var build = flag.Bool("build", false, "Run the build.")
 	var test = flag.Bool("test", false, "Run the tests.")
+
+	var testJSONFlags = buildutil.BindTestJSONFlags()
 
 	var help = flag.Bool("h", false, "Print this help message.")
 
@@ -134,9 +135,7 @@ func main() {
 		// validate the run.ps1 script with "build" tool works to build and test Go. It runs a
 		// subset of the "test" builder's tests, but it uses the dev workflow.
 		testCmdline := append(buildCmdline, "-skipbuild", "-test")
-		if *junitOutFile != "" {
-			testCmdline = append(testCmdline, "-junitout", *junitOutFile)
-		}
+		testCmdline = testJSONFlags.AppendToCmdline(testCmdline)
 		if err := run(testCmdline...); err != nil {
 			log.Fatal(err)
 		}
@@ -197,32 +196,16 @@ func main() {
 			)
 		}
 
-		cmdline = append(cmdline, "-json")
-
 		if *dryRun {
 			fmt.Printf("---- Dry run. Would have run test command: %v\n", cmdline)
 		} else {
-			f, err := os.Create(*junitOutFile)
-			if err != nil {
-				log.Fatal(err)
-			}
-			conv := json2junit.NewConverter(f)
-			err = buildutil.RunCmdMultiWriter(cmdline, conv, os.Stdout)
-			if errClose := conv.Close(); err == nil {
-				err = errClose
-			}
-			if errClose := f.Close(); err == nil {
-				err = errClose
-			}
-			if err != nil {
-				log.Fatal(err)
-			}
-			// If we got an ExitError, the error message was already printed by the command. We just
-			// need to exit with the same exit code.
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				os.Exit(exitErr.ExitCode())
-			}
-			if err != nil {
+			if err := testJSONFlags.RunTestCmd(cmdline); err != nil {
+				// If we got an ExitError, the error message was already printed by the command. We just
+				// need to exit with the same exit code.
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					os.Exit(exitErr.ExitCode())
+				}
 				// Something else happened: alert the user.
 				log.Fatal(err)
 			}

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -270,7 +270,8 @@ stages:
                       -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
                       $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
                       $(if ('${{ parameters.builder.fips }}') { '-fipsmode' }) `
-                      -junitout '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml'
+                      -junitout '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml' `
+                      -rawtestoutartifact '${{ parameters.builder.id }}-raw-test-output-${{ attempt }}'
                 ${{ if eq(length(parameters.retryAttempts), 1) }}:
                   displayName: Test
                 ${{ else }}:

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -297,7 +297,7 @@ stages:
                 buildConfiguration: ${{ parameters.builder.config }}
                 publishRunAttachments: true
 
-            - task: 1ES.PublishPipelineArtifact@1
+            - task: ${{ iif(eq(variables['System.TeamProject'], 'public'), '', '1ES.') }}PublishPipelineArtifact@1
               displayName: Publish raw test results
               condition: succeededOrFailed()
               inputs:

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -271,7 +271,7 @@ stages:
                       $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
                       $(if ('${{ parameters.builder.fips }}') { '-fipsmode' }) `
                       -junitout '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml' `
-                      -rawtestoutartifact '${{ parameters.builder.id }}-raw-test-output-${{ attempt }}'
+                      -rawtestout '$(Build.SourcesDirectory)/eng/artifacts/RawTestOutput/RawTestOutput-attempt-${{ attempt }}.txt'
                 ${{ if eq(length(parameters.retryAttempts), 1) }}:
                   displayName: Test
                 ${{ else }}:
@@ -296,6 +296,13 @@ stages:
                 buildPlatform: ${{ parameters.builder.arch }}
                 buildConfiguration: ${{ parameters.builder.config }}
                 publishRunAttachments: true
+
+            - task: 1ES.PublishPipelineArtifact@1
+              displayName: Publish raw test results
+              condition: succeededOrFailed()
+              inputs:
+                targetPath: $(Build.SourcesDirectory)/eng/artifacts/RawTestOutput
+                artifactName: raw-test-output-${{ parameters.builder.id }}-retry-$(System.JobAttempt)
 
           # - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
           #   - ${{ if ne(parameters.releaseVersion, 'nil') }}:


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/1598

Initial probably-good-enough attempt at summarizing the test JSON. What's important to me is that it shows progress, is relevant, and is significantly less than the ~100MB of text that was previously being uploaded as logs.

Unfortunately, it seems that the artifact upload logging command doesn't work from inside a containerized build, so went with an artifact publish task.

Example internal builds:
https://dev.azure.com/dnceng/internal/_build/results?buildId=2756913&view=results (slightly old)
https://dev.azure.com/dnceng/internal/_build/results?buildId=2756922&view=results