### PR TITLE
Fix missing JUnit converter Close and other test JSON summarization issues

### DIFF
--- a/eng/_util/buildutil/testjson.go
+++ b/eng/_util/buildutil/testjson.go
@@ -26,7 +26,7 @@ type TestJSONFlags struct {
 func BindTestJSONFlags() *TestJSONFlags {
 	var f TestJSONFlags
 	flag.StringVar(
-		&f.JUnitOutFile, "junitout", "junit.xml",
+		&f.JUnitOutFile, "junitout", "",
 		"Write the test output to a new file at this path as a JUnit file if running tests.")
 	flag.StringVar(
 		&f.RawTestOutFile, "rawtestout", "",

--- a/eng/_util/buildutil/testjson.go
+++ b/eng/_util/buildutil/testjson.go
@@ -53,19 +53,26 @@ func (f *TestJSONFlags) RunTestCmd(cmdline []string) (err error) {
 	if f != nil {
 		if f.JUnitOutFile != "" {
 			var jf *os.File
+			if err := os.MkdirAll(filepath.Dir(f.JUnitOutFile), 0o755); err != nil {
+				return fmt.Errorf("failed to create directory for JUnit output: %v", err)
+			}
 			if jf, err = os.Create(f.JUnitOutFile); err != nil {
 				return err
 			}
 			defer func() {
 				err = errors.Join(err, jf.Close())
 			}()
-			writers = append(writers, json2junit.NewConverter(jf))
+			c := json2junit.NewConverter(jf)
+			defer func() {
+				err = errors.Join(err, c.Close())
+			}()
+			writers = append(writers, c)
 			needJSON = true
 		}
 		if f.RawTestOutFile != "" {
 			var rf *os.File
 			if err := os.MkdirAll(filepath.Dir(f.RawTestOutFile), 0o755); err != nil {
-				return fmt.Errorf("failed to create directory for raw test output: %w", err)
+				return fmt.Errorf("failed to create directory for raw test output: %v", err)
 			}
 			if rf, err = os.Create(f.RawTestOutFile); err != nil {
 				return err

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -270,8 +270,8 @@ stages:
                       -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
                       $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
                       $(if ('${{ parameters.builder.fips }}') { '-fipsmode' }) `
-                      -junitout '$(Build.SourcesDirectory)/eng/artifacts/TestResults.xml' `
-                      -rawtestout '$(Build.SourcesDirectory)/eng/artifacts/RawTestOutput/RawTestOutput-attempt-${{ attempt }}.txt'
+                      -junitout '$(Build.SourcesDirectory)/eng/artifacts/RawTestOutput/TestResults.xml' `
+                      -rawtestout '$(Build.SourcesDirectory)/eng/artifacts/RawTestOutput/raw-json-attempt-${{ attempt }}.txt'
                 ${{ if eq(length(parameters.retryAttempts), 1) }}:
                   displayName: Test
                 ${{ else }}:
@@ -286,17 +286,19 @@ stages:
                   # Don't fail the job if we are at the last retry and the builder is marked as broken.
                   continueOnError: true
 
+            # Publish test results. Use the last-overwritten result, if multiple attempts were made.
             - task: PublishTestResults@2
               displayName: Publish test results
               condition: succeededOrFailed()
               inputs:
                 testResultsFormat: JUnit
-                testResultsFiles: $(Build.SourcesDirectory)/eng/artifacts/TestResults.xml
+                testResultsFiles: $(Build.SourcesDirectory)/eng/artifacts/RawTestOutput/TestResults.xml
                 testRunTitle: $(System.JobDisplayName)
                 buildPlatform: ${{ parameters.builder.arch }}
                 buildConfiguration: ${{ parameters.builder.config }}
                 publishRunAttachments: true
 
+            # Publish raw test JSON output and the published (or attempted to publish) JUnit XML.
             - task: ${{ iif(eq(variables['System.TeamProject'], 'public'), '', '1ES.') }}PublishPipelineArtifact@1
               displayName: Publish raw test results
               condition: succeededOrFailed()


### PR DESCRIPTION
* Fixes missing JUnit XML end tag due to missing Close() call in https://github.com/microsoft/go/pull/1771
  * Spotted in https://github.com/microsoft/go/pull/1773
* Improve diagnosability of failed-to-publish JUnit XML by publishing it along with other raw data.
* Fixes new default value of junitout introduced by https://github.com/microsoft/go/pull/1771 that would cause unwanted JUnit conversion by default.
* For https://github.com/microsoft/go/issues/1598