### PR TITLE
Disable telemetry while running CI

### DIFF
--- a/eng/pipeline/pr-outerloop-pipeline.yml
+++ b/eng/pipeline/pr-outerloop-pipeline.yml
@@ -16,6 +16,9 @@ pr:
   - microsoft/*
   - dev/*
 
+variables:
+  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
+
 resources:
   containers:
     - container: ubuntu2204

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -9,6 +9,9 @@ pr:
   - microsoft/*
   - dev/*
 
+variables:
+  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
+
 resources:
   containers:
     # Predefine named containers. Using "container:" inside the job would work, because this is not

--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -20,6 +20,9 @@ parameters:
     type: boolean
     default: false
 
+variables:
+  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
+
 resources:
   repositories:
     - repository: 1ESPipelineTemplates

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -43,6 +43,8 @@ variables:
   # MicroBuild configuration.
   - name: TeamName
     value: golang
+  - name: MS_GOTOOLCHAIN_TELEMETRY_ENABLED
+    value: '0'
 
 resources:
   repositories:

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -32,6 +32,8 @@ variables:
     # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-general-faq#how-do-i-check-if-my-project-is-onboarded
     - name: Codeql.Cadence
       value: 0
+  - name: MS_GOTOOLCHAIN_TELEMETRY_ENABLED
+    value: '0'
 
 resources:
   pipelines:

--- a/eng/pipeline/rolling-pipeline.yml
+++ b/eng/pipeline/rolling-pipeline.yml
@@ -13,6 +13,9 @@ trigger:
       - dev/official/*
 pr: none
 
+variables:
+  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
+
 resources:
   repositories:
     - repository: 1ESPipelineTemplates


### PR DESCRIPTION
We don't want to upload telemetry from our CI pipelines, as that would pollute our database with test data. We might enable it again once we come up with a way to better identify the source of each telemetry item.