### PR TITLE
[release-branch.go1.25] Fix pipeline variables location

### DIFF
--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -13,15 +13,15 @@ trigger:
       - dev/official/*
 pr: none
 
-variables:
-  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
-
 parameters:
   # By default, don't use the shared, potentially constrained linux-arm64 pool.
   - name: includeArm64Host
     displayName: 'Include Linux arm64 host builders'
     type: boolean
     default: false
+
+variables:
+  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
 
 resources:
   repositories:

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -13,9 +13,6 @@ trigger:
       - dev/official/*
 pr: none
 
-variables:
-  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
-
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
   - name: releaseVersion
@@ -46,6 +43,8 @@ variables:
   # MicroBuild configuration.
   - name: TeamName
     value: golang
+  - name: MS_GOTOOLCHAIN_TELEMETRY_ENABLED
+    value: '0'
 
 resources:
   repositories:

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -7,9 +7,6 @@
 trigger: none
 pr: none
 
-variables:
-  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
-
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
   - name: enableCodeQL
@@ -35,6 +32,8 @@ variables:
     # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-general-faq#how-do-i-check-if-my-project-is-onboarded
     - name: Codeql.Cadence
       value: 0
+  - name: MS_GOTOOLCHAIN_TELEMETRY_ENABLED
+    value: '0'
 
 resources:
   pipelines:


### PR DESCRIPTION
When I added the `MS_GOTOOLCHAIN_TELEMETRY_ENABLED` variable to our pipeline yaml's I missed to see that we already had a top-level variables object in some of the pipelines. Instead of creating a new one, move that variable to the existing one.