### PR TITLE
Only upload MS telemetry when building code

### DIFF
--- a/patches/0010-add-appinsights-telemetry.patch
+++ b/patches/0010-add-appinsights-telemetry.patch
@@ -6,12 +6,13 @@ Subject: [PATCH] Add appinsights telemetry
 ---
  README.md                                     | 15 ++++++
  .../internal/telemetrystats/telemetrystats.go | 13 +++++
- src/cmd/go/main.go                            |  1 +
+ src/cmd/go/main.go                            |  8 +++
  src/cmd/go/mstelemetry_test.go                | 52 +++++++++++++++++++
- src/cmd/go/script_test.go                     |  6 +++
- src/cmd/internal/telemetry/counter/counter.go | 37 ++++++++++++-
- .../telemetry/counter/counter_bootstrap.go    |  2 +
- 7 files changed, 125 insertions(+), 1 deletion(-)
+ src/cmd/go/script_test.go                     |  8 +++
+ src/cmd/go/scriptcmds_test.go                 | 11 ++++
+ src/cmd/internal/telemetry/counter/counter.go | 50 +++++++++++++++++-
+ .../telemetry/counter/counter_bootstrap.go    |  3 ++
+ 8 files changed, 159 insertions(+), 1 deletion(-)
  create mode 100644 src/cmd/go/mstelemetry_test.go
 
 diff --git a/README.md b/README.md
@@ -68,17 +69,24 @@ index 950453fa951374..d5b642240f16b7 100644
 +	}
  }
 diff --git a/src/cmd/go/main.go b/src/cmd/go/main.go
-index e81969ca4a3144..61b9219df8f389 100644
+index e81969ca4a3144..67dbcb2e7a3cb9 100644
 --- a/src/cmd/go/main.go
 +++ b/src/cmd/go/main.go
-@@ -102,6 +102,7 @@ func main() {
- 	cmdIsGoTelemetryOff := cmdIsGoTelemetryOff()
- 	if !cmdIsGoTelemetryOff {
- 		counter.Open() // Open the telemetry counter file so counters can be written to it.
-+		base.AtExit(counter.Close)
+@@ -111,6 +111,14 @@ func main() {
  	}
- 	handleChdirFlag()
- 	toolchain.Select()
+ 	flag.Usage = base.Usage
+ 	flag.Parse()
++	if args := flag.Args(); len(args) > 0 {
++		switch args[0] {
++		case "build", "install", "run":
++			// Don't start Microsoft telemetry for commands that don't build anything.
++			counter.OpenMicrosoft()
++			base.AtExit(counter.CloseMicrosoft)
++		}
++	}
+ 	counter.Inc("go/invocations")
+ 	counter.CountFlags("go/flag:", *flag.CommandLine)
+ 
 diff --git a/src/cmd/go/mstelemetry_test.go b/src/cmd/go/mstelemetry_test.go
 new file mode 100644
 index 00000000000000..6993137ad56e8c
@@ -138,7 +146,7 @@ index 00000000000000..6993137ad56e8c
 +	fmt.Fprint(w, `{"itemsReceived": 1, "itemsAccepted": 1}`)
 +}
 diff --git a/src/cmd/go/script_test.go b/src/cmd/go/script_test.go
-index 1345ea8bb8e530..1a7a62fdc7c19d 100644
+index 1345ea8bb8e530..e2b75957e21d3a 100644
 --- a/src/cmd/go/script_test.go
 +++ b/src/cmd/go/script_test.go
 @@ -60,6 +60,7 @@ func TestScript(t *testing.T) {
@@ -158,18 +166,49 @@ index 1345ea8bb8e530..1a7a62fdc7c19d 100644
  		"newline=\n",
  	}
  
-@@ -404,6 +407,9 @@ func readCounters(t *testing.T, telemetryDir string) map[string]uint64 {
- func checkCounters(t *testing.T, telemetryDir string) {
- 	counters := readCounters(t, telemetryDir)
- 	if _, ok := scriptGoInvoked.Load(testing.TB(t)); ok {
+@@ -408,6 +411,11 @@ func checkCounters(t *testing.T, telemetryDir string) {
+ 			t.Fatal("go was invoked but no counters were incremented")
+ 		}
+ 	}
++	if _, ok := scriptGoBuildInvoked.Load(testing.TB(t)); ok {
 +		if appInsightsRequests.Load() == 0 {
 +			t.Fatal("go was invoked but no App Insights request were recorded")
 +		}
- 		if !disabledOnPlatform && len(counters) == 0 {
- 			t.Fatal("go was invoked but no counters were incremented")
++	}
+ }
+ 
+ // Copied from https://go.googlesource.com/telemetry/+/5f08a0cbff3f/internal/telemetry/mode.go#122
+diff --git a/src/cmd/go/scriptcmds_test.go b/src/cmd/go/scriptcmds_test.go
+index ced8d880e9ae3a..b3ad521ff94873 100644
+--- a/src/cmd/go/scriptcmds_test.go
++++ b/src/cmd/go/scriptcmds_test.go
+@@ -71,6 +71,7 @@ func scriptCC(cmdExec script.Cmd) script.Cmd {
+ }
+ 
+ var scriptGoInvoked sync.Map // testing.TB → go command was invoked
++var scriptGoBuildInvoked sync.Map
+ 
+ // scriptGo runs the go command.
+ func scriptGo(cancel func(*exec.Cmd) error, waitDelay time.Duration) script.Cmd {
+@@ -85,6 +86,16 @@ func scriptGo(cancel func(*exec.Cmd) error, waitDelay time.Duration) script.Cmd
+ 		if !dup {
+ 			t.Cleanup(func() { scriptGoInvoked.Delete(t) })
  		}
++		if len(s) > 0 {
++			// If the first argument is a subcommand, record it.
++			switch s[0] {
++			case "build", "install", "run":
++				_, dup = scriptGoBuildInvoked.LoadOrStore(t, true)
++				if !dup {
++					t.Cleanup(func() { scriptGoBuildInvoked.Delete(t) })
++				}
++			}
++		}
+ 		return cmd.Run(state, s...)
+ 	})
+ }
 diff --git a/src/cmd/internal/telemetry/counter/counter.go b/src/cmd/internal/telemetry/counter/counter.go
-index 5cef0b0041551a..a099b4698a21c4 100644
+index 5cef0b0041551a..6c180bf9e60482 100644
 --- a/src/cmd/internal/telemetry/counter/counter.go
 +++ b/src/cmd/internal/telemetry/counter/counter.go
 @@ -7,10 +7,23 @@
@@ -196,7 +235,7 @@ index 5cef0b0041551a..a099b4698a21c4 100644
  )
  
  var openCalled bool
-@@ -22,11 +35,30 @@ func OpenCalled() bool { return openCalled }
+@@ -22,11 +35,43 @@ func OpenCalled() bool { return openCalled }
  func Open() {
  	openCalled = true
  	counter.OpenDir(os.Getenv("TEST_TELEMETRY_DIR"))
@@ -210,8 +249,21 @@ index 5cef0b0041551a..a099b4698a21c4 100644
 +	}
 +}
 +
-+func Close() {
-+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
++func OpenMicrosoft() {
++	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENABLED") == "0" {
++		// Telemetry disabled.
++		return
++	}
++	mstelemetry.Start(mstelemetry.Config{
++		InstrumentationKey: appInsightsInstrumentationKey,
++		Endpoint:           cmp.Or(os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENDPOINT"), appInsightsEndpoint), // configurable for testing purposes
++		AllowGoDevel:       os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ALLOW_GO_DEVEL") == "1",
++		UploadConfig:       msconfig.Config,
++	})
++}
++
++func CloseMicrosoft() {
++	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 +	defer cancel()
 +	start := time.Now()
 +	mstelemetry.Close(ctx)
@@ -227,7 +279,7 @@ index 5cef0b0041551a..a099b4698a21c4 100644
  }
  
  // New returns a counter with the given name.
-@@ -44,6 +76,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
+@@ -44,6 +89,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
  // the concatenation of prefix and the flag name.
  func CountFlags(prefix string, flagSet flag.FlagSet) {
  	counter.CountFlags(prefix, flagSet)
@@ -235,7 +287,7 @@ index 5cef0b0041551a..a099b4698a21c4 100644
  }
  
  // CountFlagValue creates a counter for the flag value
-@@ -56,7 +89,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
+@@ -56,7 +102,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
  	// TODO(matloob): Add this to x/telemetry?
  	flagSet.Visit(func(f *flag.Flag) {
  		if f.Name == flagName {
@@ -247,12 +299,13 @@ index 5cef0b0041551a..a099b4698a21c4 100644
  	})
  }
 diff --git a/src/cmd/internal/telemetry/counter/counter_bootstrap.go b/src/cmd/internal/telemetry/counter/counter_bootstrap.go
-index 00808294053c23..1adda045749c29 100644
+index 00808294053c23..e19970cf926e16 100644
 --- a/src/cmd/internal/telemetry/counter/counter_bootstrap.go
 +++ b/src/cmd/internal/telemetry/counter/counter_bootstrap.go
-@@ -18,3 +18,5 @@ func New(name string) dummyCounter                                        { retu
+@@ -18,3 +18,6 @@ func New(name string) dummyCounter                                        { retu
  func NewStack(name string, depth int) dummyCounter                        { return dummyCounter{} }
  func CountFlags(name string, flagSet flag.FlagSet)                        {}
  func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {}
 +
-+func Close() {}
++func OpenMicrosoft()  {}
++func CloseMicrosoft() {}


### PR DESCRIPTION
Microsoft telemetry can slow down Go command, as telemetry is uploaded just before the command exits.

For now, better be conservative and only upload telemetry when executing `go build`, `go install`, or `go run`. As these commands are expected to take some good amount of time (unless rebuilding 100% cached code), we can increase the telemetry timeout from 1s to 3s.