### PR TITLE
[release-branch.go1.25] Upgrade telemetry module

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -15,22 +15,22 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-infra/telemetry/README.md    |    7 +
  .../go-infra/telemetry/config/LICENSE         |   21 +
  .../go-infra/telemetry/config/config.go       |   11 +
- .../go-infra/telemetry/config/config.json     |   61 +
+ .../go-infra/telemetry/config/config.json     |   64 +
  .../go-infra/telemetry/counter/counter.go     |   63 +
  .../telemetry/internal/appinsights/README.md  |   12 +
- .../telemetry/internal/appinsights/client.go  |  175 ++
- .../internal/appinsights/inmemorychannel.go   |  310 +++
+ .../telemetry/internal/appinsights/client.go  |  169 ++
+ .../internal/appinsights/inmemorychannel.go   |  341 +++
  .../internal/contracts/contexttagkeys.go      |   50 +
  .../internal/contracts/envelope.go            |  123 +
  .../internal/contracts/response.go            |   32 +
  .../internal/appinsights/jsonserializer.go    |   33 +
  .../telemetry/internal/appinsights/package.go |   13 +
  .../internal/appinsights/telemetrycontext.go  |   44 +
- .../internal/appinsights/transmitter.go       |  169 ++
+ .../internal/appinsights/transmitter.go       |  172 ++
  .../telemetry/internal/config/config.go       |   63 +
  .../telemetry/internal/telemetry/proginfo.go  |   32 +
  .../telemetry/internal/telemetry/telemetry.go |   32 +
- .../microsoft/go-infra/telemetry/telemetry.go |  120 +
+ .../microsoft/go-infra/telemetry/telemetry.go |  125 +
  src/cmd/vendor/modules.txt                    |   11 +
  src/crypto/internal/backend/deps_ignore.go    |   22 +
  src/go.mod                                    |    6 +
@@ -137,7 +137,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 129 files changed, 19192 insertions(+), 7 deletions(-)
+ 129 files changed, 19228 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -261,30 +261,30 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 
 diff --git a/src/cmd/go.mod b/src/cmd/go.mod
-index 5624b81cc51bac..caebaf25fad844 100644
+index 5624b81cc51bac..c915383a7bd7d6 100644
 --- a/src/cmd/go.mod
 +++ b/src/cmd/go.mod
 @@ -4,6 +4,8 @@ go 1.25
  
  require (
  	github.com/google/pprof v0.0.0-20250208200701-d0013a598941
-+	github.com/microsoft/go-infra/telemetry v0.0.0-20250716090631-5672f943a6c1
-+	github.com/microsoft/go-infra/telemetry/config v0.0.0-20250716090631-5672f943a6c1
++	github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed
++	github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed
  	golang.org/x/arch v0.18.1-0.20250605182141-b2f4e2807dec
  	golang.org/x/build v0.0.0-20250606033421-8c8ff6f34a83
  	golang.org/x/mod v0.25.0
 diff --git a/src/cmd/go.sum b/src/cmd/go.sum
-index d5d1553e5b7829..be5d9688943e8d 100644
+index d5d1553e5b7829..cb73d0abe4e905 100644
 --- a/src/cmd/go.sum
 +++ b/src/cmd/go.sum
 @@ -4,6 +4,10 @@ github.com/google/pprof v0.0.0-20250208200701-d0013a598941 h1:43XjGa6toxLpeksjcx
  github.com/google/pprof v0.0.0-20250208200701-d0013a598941/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
  github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd h1:EVX1s+XNss9jkRW9K6XGJn2jL2lB1h5H804oKPsxOec=
  github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
-+github.com/microsoft/go-infra/telemetry v0.0.0-20250716090631-5672f943a6c1 h1:GrwQB5oC7TORdL+bRRKP+7ceLwr2iK0+vBpG82zgLyI=
-+github.com/microsoft/go-infra/telemetry v0.0.0-20250716090631-5672f943a6c1/go.mod h1:XQP+NhZgM1i1+asOSnAFPRzv2HhQibhk6k6FIllx8/Y=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20250716090631-5672f943a6c1 h1:2doxdRr67OgtkPNjGuLcdf+i4+HVQgikubr3xv0dXg8=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20250716090631-5672f943a6c1/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
++github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed h1:AZR+rR1NvHCXyilk3BMgq2M9uGPibhTU1O4hxNIwFJo=
++github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed/go.mod h1:XQP+NhZgM1i1+asOSnAFPRzv2HhQibhk6k6FIllx8/Y=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed h1:+WzG8k10xzL+oOrycm6GJTGi/sMZkWtnAhAUZ+Fpvwg=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
  github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
  github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
  golang.org/x/arch v0.18.1-0.20250605182141-b2f4e2807dec h1:fCOjXc18tBlkVy4m+VuL1WU8VTukYOGtAk7nC5QYPRY=
@@ -397,10 +397,10 @@ index 00000000000000..044268a046a54d
 +var Config []byte
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
 new file mode 100644
-index 00000000000000..8c1a4bff90bf9b
+index 00000000000000..7c662b93fcd017
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,64 @@
 +{
 +	"GOOS": [
 +		"aix",
@@ -457,6 +457,9 @@ index 00000000000000..8c1a4bff90bf9b
 +				},
 +				{
 +					"Name": "go/goexperiment:{ms_tls_config_schannel,systemcrypto,nosystemcrypto,opensslcrypto,cngcrypto,darwincrypto}"
++				},
++				{
++					"Name": "go/subcommand:{build,install,run}"
 +				}
 +			]
 +		}
@@ -552,10 +555,10 @@ index 00000000000000..2e96890f60b871
 +- Improve testing.
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/client.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/client.go
 new file mode 100644
-index 00000000000000..1a629e35709231
+index 00000000000000..8e280f7c675a46
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/client.go
-@@ -0,0 +1,175 @@
+@@ -0,0 +1,169 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -564,7 +567,7 @@ index 00000000000000..1a629e35709231
 +import (
 +	"cmp"
 +	"context"
-+	"log"
++	"log/slog"
 +	"maps"
 +	"net/http"
 +	"sync"
@@ -603,10 +606,9 @@ index 00000000000000..1a629e35709231
 +	// If nil, no additional tags will be sent.
 +	Tags map[string]string
 +
-+	// ErrorLog specifies an optional logger for errors
-+	// that occur when attempting to upload telemetry.
-+	// If nil, logging is done via the log package's standard logger.
-+	ErrorLog *log.Logger
++	// Logger specifies a structured logger.
++	// If nil nothing is logged.
++	Logger *slog.Logger
 +
 +	// Function to filter out telemetry items by name before they are sent.
 +	// If nil, all telemetry items are sent.
@@ -630,15 +632,10 @@ index 00000000000000..1a629e35709231
 +		batchSize := cmp.Or(c.MaxBatchSize, 1024)
 +		batchInterval := cmp.Or(c.MaxBatchInterval, 10*time.Second)
 +		httpClient := cmp.Or(c.HTTPClient, http.DefaultClient)
-+		errorLog := c.ErrorLog
-+		if errorLog == nil {
-+			std := log.Default()
-+			errorLog = log.New(std.Writer(), std.Prefix()+"appinsights: ", std.Flags())
-+		}
-+		c.channel = newInMemoryChannel(endpoint, batchSize, batchInterval, httpClient, errorLog)
++		c.channel = newInMemoryChannel(endpoint, batchSize, batchInterval, httpClient, c.Logger)
 +		c.context = setupContext(c.InstrumentationKey, c.Tags)
 +		if err := contracts.SanitizeTags(c.context.Tags); err != nil {
-+			c.channel.logf("Warning sanitizing tags: %v", err)
++			c.channel.warn("tags were not sanitary and have been sanitized", "error", err)
 +		}
 +
 +		go c.channel.acceptLoop()
@@ -701,7 +698,7 @@ index 00000000000000..1a629e35709231
 +	c.init()
 +	ev := c.context.envelop(data)
 +	if err := ev.Sanitize(); err != nil {
-+		c.channel.logf("Warning sanitizing telemetry item: %v", err)
++		c.channel.warn("tags were not sanitary and have been sanitized", "error", err)
 +	}
 +	for range n {
 +		c.channel.send(ev)
@@ -733,10 +730,10 @@ index 00000000000000..1a629e35709231
 +}
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/inmemorychannel.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/inmemorychannel.go
 new file mode 100644
-index 00000000000000..05dbdfe0e3efcd
+index 00000000000000..af13a2102d2933
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/inmemorychannel.go
-@@ -0,0 +1,310 @@
+@@ -0,0 +1,341 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -745,7 +742,7 @@ index 00000000000000..05dbdfe0e3efcd
 +import (
 +	"context"
 +	"errors"
-+	"log"
++	"log/slog"
 +	"net/http"
 +	"slices"
 +	"sync"
@@ -767,7 +764,7 @@ index 00000000000000..05dbdfe0e3efcd
 +	endpointAddr  string
 +	batchSize     int
 +	batchInterval time.Duration
-+	errorLog      *log.Logger
++	logger        *slog.Logger
 +
 +	collectChan chan *contracts.Envelope
 +	flushChan   chan struct{}
@@ -786,6 +783,7 @@ index 00000000000000..05dbdfe0e3efcd
 +	sendQueue   []*[]batchItem
 +	sendQueueMu sync.Mutex
 +	sendMu      sync.Mutex
++	inflight    atomic.Int64 // Number of items currently being sent.
 +
 +	itemsBuf sync.Pool
 +}
@@ -797,13 +795,13 @@ index 00000000000000..05dbdfe0e3efcd
 +}
 +
 +// newInMemoryChannel creates an inMemoryChannel instance and starts a background submission goroutine.
-+func newInMemoryChannel(endpointUrl string, batchSize int, batchInterval time.Duration, httpClient *http.Client, errorLog *log.Logger) *inMemoryChannel {
++func newInMemoryChannel(endpointUrl string, batchSize int, batchInterval time.Duration, httpClient *http.Client, logger *slog.Logger) *inMemoryChannel {
 +	// Set up the channel
 +	channel := &inMemoryChannel{
 +		endpointAddr:  endpointUrl,
 +		batchSize:     batchSize,
 +		batchInterval: batchInterval,
-+		errorLog:      errorLog,
++		logger:        logger,
 +		collectChan:   make(chan *contracts.Envelope),
 +		flushChan:     make(chan struct{}),
 +		retryChan:     make(chan retryMessage),
@@ -819,8 +817,25 @@ index 00000000000000..05dbdfe0e3efcd
 +	return channel
 +}
 +
-+func (channel *inMemoryChannel) logf(format string, args ...any) {
-+	channel.errorLog.Printf(format, args...)
++func (channel *inMemoryChannel) info(msg string, args ...any) {
++	if channel.logger == nil {
++		return
++	}
++	channel.logger.Info("telemetry: "+msg, args...)
++}
++
++func (channel *inMemoryChannel) warn(msg string, args ...any) {
++	if channel.logger == nil {
++		return
++	}
++	channel.logger.Warn("telemetry: "+msg, args...)
++}
++
++func (channel *inMemoryChannel) error(msg string, args ...any) {
++	if channel.logger == nil {
++		return
++	}
++	channel.logger.Error("telemetry: "+msg, args...)
 +}
 +
 +// Queues a single telemetry item
@@ -854,6 +869,7 @@ index 00000000000000..05dbdfe0e3efcd
 +
 +	channel.closed.Store(true)
 +	channel.cancelCauseFunc(errStopped)
++	channel.checkInflight()
 +}
 +
 +// close flushes and tears down the submission goroutine and closes internal
@@ -872,6 +888,13 @@ index 00000000000000..05dbdfe0e3efcd
 +		channel.cancelCauseFunc(context.Cause(ctx))
 +	case <-channel.cancelCtx.Done():
 +		// Successfully flushed
++	}
++	channel.checkInflight()
++}
++
++func (channel *inMemoryChannel) checkInflight() {
++	if inflight := channel.inflight.Load(); inflight > 0 {
++		channel.error("client closed with pending items", "itemsLost", inflight)
 +	}
 +}
 +
@@ -895,12 +918,14 @@ index 00000000000000..05dbdfe0e3efcd
 +				// Check if there is space to add the item to the batch.
 +				// If not, then drop the event.
 +				if len(items) < channel.batchSize {
++					channel.inflight.Add(1)
 +					items = append(items, batchItem{item, 0})
 +				} else {
 +					dropped++
 +				}
 +				continue
 +			}
++			channel.inflight.Add(1)
 +			items = append(items, batchItem{item, 0})
 +			if len(items) >= channel.batchSize {
 +				timer.Stop()
@@ -926,7 +951,7 @@ index 00000000000000..05dbdfe0e3efcd
 +				// so if we get here, then we're no longer throttled.
 +				channel.throttled.Store(false)
 +				if dropped > 0 {
-+					channel.logf("Dropped %d telemetry items due to throttling", dropped)
++					channel.error("items dropped due to throttling", "itemsLost", dropped)
 +					dropped = 0
 +				}
 +			}
@@ -934,6 +959,7 @@ index 00000000000000..05dbdfe0e3efcd
 +			items = items[:0]
 +
 +		case msg := <-channel.retryChan:
++			channel.info("items enqueued for retry", "count", len(msg.items), "throttled", msg.throttled, "retryAfter", msg.retryAfter)
 +			// If there is not enough space in the batch, drop the items.
 +			space := channel.batchSize - len(items)
 +			if space < len(msg.items) {
@@ -1008,43 +1034,45 @@ index 00000000000000..05dbdfe0e3efcd
 +	itemsPtr := channel.sendQueue[0]
 +	channel.sendQueue = channel.sendQueue[1:]
 +	channel.sendQueueMu.Unlock()
-+	defer channel.itemsBuf.Put(itemsPtr)
 +
-+	result, err := channel.transmitter.transmit(channel.cancelCtx, *itemsPtr)
++	defer channel.itemsBuf.Put(itemsPtr)
++	resp, err := channel.transmitter.transmit(channel.cancelCtx, *itemsPtr)
 +	if err != nil {
-+		channel.logf("Error transmitting payload: %v", err)
-+		if result == nil {
++		if resp == nil {
++			channel.inflight.Add(-int64(len(*itemsPtr)))
++			channel.error("upload request failed", "itemsLost", len(*itemsPtr), "error", err)
 +			return false
 +		}
 +	}
-+	if result.isSuccess() {
-+		return false
-+	}
-+	canRetry := result.canRetry()
-+	throttled := result.isThrottled()
-+	channel.logf("Failed to transmit payload: code=%v, received=%d, accepted=%d, canRetry=%t, throttled=%t",
-+		result.statusCode, result.response.ItemsReceived, result.response.ItemsAccepted, canRetry, throttled)
-+
-+	if !canRetry {
++	if resp.isSuccess() {
++		channel.inflight.Add(-int64(len(*itemsPtr)))
 +		return false
 +	}
 +
-+	// Filter down to failed items.
-+	retryItems := result.getRetryItems(*itemsPtr)
++	// If the response is not successful, check if we can retry.
++	succCount, failCount, retryItems := resp.result(*itemsPtr)
 +
-+	// Delete items that have been retried more than 2 times.
++	// Remove items that have been retried too many times.
++	retries := len(retryItems)
 +	retryItems = slices.DeleteFunc(retryItems, func(item batchItem) bool {
 +		return item.retries > 2
 +	})
++	for i := range retryItems {
++		retryItems[i].retries++
++	}
++
++	dropped := retries - len(retryItems)
++	channel.inflight.Add(-int64(succCount + failCount + dropped))
++	if failCount > 0 {
++		channel.error("server rejected items", "itemsLost", failCount, "statusCode", resp.statusCode)
++	}
++	if dropped > 0 {
++		channel.error("items dropped due to retry limit", "itemsLost", dropped)
++	}
 +	if len(retryItems) == 0 {
 +		return false
 +	}
-+	for i := range retryItems {
-+		item := &retryItems[i]
-+		item.retries++
-+	}
-+
-+	channel.retry(throttled, result.retryAfter, retryItems)
++	channel.retry(resp.isThrottled(), resp.retryAfter, retryItems)
 +	return true
 +}
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/internal/contracts/contexttagkeys.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/internal/contracts/contexttagkeys.go
@@ -1380,10 +1408,10 @@ index 00000000000000..a2e954ae84aa6e
 +}
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/transmitter.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/transmitter.go
 new file mode 100644
-index 00000000000000..3cca77e3070fd2
+index 00000000000000..0299c87c81cb41
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/transmitter.go
-@@ -0,0 +1,169 @@
+@@ -0,0 +1,172 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -1469,7 +1497,7 @@ index 00000000000000..3cca77e3070fd2
 +
 +	resp, err := transmitter.client.Do(req)
 +	if err != nil {
-+		return nil, fmt.Errorf("failed to transmit telemetry: %v", err)
++		return nil, fmt.Errorf("failed to send request: %v", err)
 +	}
 +	defer resp.Body.Close()
 +
@@ -1489,35 +1517,31 @@ index 00000000000000..3cca77e3070fd2
 +	return result, jsonErr
 +}
 +
-+func (result *transmissionResponse) isSuccess() bool {
-+	return result.statusCode == successResponse ||
++func (resp *transmissionResponse) isSuccess() bool {
++	return resp.statusCode == successResponse ||
 +		// Partial response but all items accepted
-+		(result.statusCode == partialSuccessResponse &&
-+			result.response.ItemsReceived == result.response.ItemsAccepted)
++		(resp.statusCode == partialSuccessResponse &&
++			resp.response.ItemsReceived == resp.response.ItemsAccepted)
 +}
 +
-+func (result *transmissionResponse) isFailure() bool {
-+	return result.statusCode != successResponse && result.statusCode != partialSuccessResponse
-+}
-+
-+func (result *transmissionResponse) canRetry() bool {
-+	if result.isSuccess() {
++func (resp *transmissionResponse) canRetry() bool {
++	if resp.isSuccess() {
 +		return false
 +	}
 +
-+	return result.statusCode == partialSuccessResponse ||
-+		!result.retryAfter.IsZero() ||
-+		(result.statusCode == requestTimeoutResponse ||
-+			result.statusCode == serviceUnavailableResponse ||
-+			result.statusCode == errorResponse ||
-+			result.statusCode == tooManyRequestsResponse ||
-+			result.statusCode == tooManyRequestsOverExtendedTimeResponse)
++	return resp.statusCode == partialSuccessResponse ||
++		!resp.retryAfter.IsZero() ||
++		(resp.statusCode == requestTimeoutResponse ||
++			resp.statusCode == serviceUnavailableResponse ||
++			resp.statusCode == errorResponse ||
++			resp.statusCode == tooManyRequestsResponse ||
++			resp.statusCode == tooManyRequestsOverExtendedTimeResponse)
 +}
 +
-+func (result *transmissionResponse) isThrottled() bool {
-+	return result.statusCode == tooManyRequestsResponse ||
-+		result.statusCode == tooManyRequestsOverExtendedTimeResponse ||
-+		!result.retryAfter.IsZero()
++func (resp *transmissionResponse) isThrottled() bool {
++	return resp.statusCode == tooManyRequestsResponse ||
++		resp.statusCode == tooManyRequestsOverExtendedTimeResponse ||
++		!resp.retryAfter.IsZero()
 +}
 +
 +func canRetryBackendError(berror contracts.BackendResponseError) bool {
@@ -1528,30 +1552,37 @@ index 00000000000000..3cca77e3070fd2
 +		berror.StatusCode == tooManyRequestsOverExtendedTimeResponse
 +}
 +
-+func (result *transmissionResponse) getRetryItems(items []batchItem) []batchItem {
-+	if result.statusCode == partialSuccessResponse {
++// result returns the number of succeeded and failed items, and a list of items that can be retried.
++// Items is the complete list of result that was sent.
++func (resp *transmissionResponse) result(items []batchItem) (succeed, failed int, retries []batchItem) {
++	if resp.statusCode == partialSuccessResponse {
 +		// Make sure errors are ordered by index
-+		slices.SortFunc(result.response.Errors, func(a, b contracts.BackendResponseError) int {
++		slices.SortFunc(resp.response.Errors, func(a, b contracts.BackendResponseError) int {
 +			return cmp.Compare(a.Index, b.Index)
 +		})
 +
-+		resultItems := make([]batchItem, 0, len(result.response.Errors))
++		retries = make([]batchItem, 0, len(resp.response.Errors))
 +		// Find each retryable error
-+		for _, responseResult := range result.response.Errors {
++		for _, responseResult := range resp.response.Errors {
++			if responseResult.StatusCode == successResponse {
++				succeed++
++				continue
++			}
 +			if !canRetryBackendError(responseResult) {
++				failed++
 +				continue
 +			}
 +			if responseResult.Index >= len(items) {
 +				continue
 +			}
-+			resultItems = append(resultItems, items[responseResult.Index])
++			retries = append(retries, items[responseResult.Index])
 +		}
 +
-+		return resultItems
-+	} else if result.canRetry() {
-+		return items
++		return succeed, failed, retries
++	} else if resp.canRetry() {
++		return 0, 0, items
 +	}
-+	return nil
++	return 0, len(items), nil
 +}
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/config/config.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/config/config.go
 new file mode 100644
@@ -1700,10 +1731,10 @@ index 00000000000000..02d112edb8ad3e
 +}
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/telemetry.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/telemetry.go
 new file mode 100644
-index 00000000000000..338e225866a5b0
+index 00000000000000..d592037b570130
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/telemetry.go
-@@ -0,0 +1,120 @@
+@@ -0,0 +1,125 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -1711,8 +1742,8 @@ index 00000000000000..338e225866a5b0
 +
 +import (
 +	"context"
-+	_ "embed"
 +	"fmt"
++	"log/slog"
 +	"runtime"
 +	"runtime/debug"
 +	"slices"
@@ -1750,6 +1781,10 @@ index 00000000000000..338e225866a5b0
 +	// Allow uploading telemetry for Go development versions even if the
 +	// upload configuration does not explicitly include them.
 +	AllowGoDevel bool
++
++	// Logger specifies a structured logger.
++	// If nil nothing is logged.
++	Logger *slog.Logger
 +}
 +
 +var countersToUpload map[string]struct{}
@@ -1808,6 +1843,7 @@ index 00000000000000..338e225866a5b0
 +			"ai.cloud.role":      prog,
 +		},
 +		UploadFilter: uploadFilter,
++		Logger:       cfg.Logger,
 +	})
 +}
 +
@@ -1825,14 +1861,14 @@ index 00000000000000..338e225866a5b0
 +	return ok
 +}
 diff --git a/src/cmd/vendor/modules.txt b/src/cmd/vendor/modules.txt
-index 6e5783fdd4767a..7ab070975606f8 100644
+index 6e5783fdd4767a..81dd9beff245d6 100644
 --- a/src/cmd/vendor/modules.txt
 +++ b/src/cmd/vendor/modules.txt
 @@ -16,6 +16,17 @@ github.com/google/pprof/third_party/svgpan
  # github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd
  ## explicit; go 1.13
  github.com/ianlancetaylor/demangle
-+# github.com/microsoft/go-infra/telemetry v0.0.0-20250716090631-5672f943a6c1
++# github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed
 +## explicit; go 1.24
 +github.com/microsoft/go-infra/telemetry
 +github.com/microsoft/go-infra/telemetry/counter
@@ -1840,7 +1876,7 @@ index 6e5783fdd4767a..7ab070975606f8 100644
 +github.com/microsoft/go-infra/telemetry/internal/appinsights/internal/contracts
 +github.com/microsoft/go-infra/telemetry/internal/config
 +github.com/microsoft/go-infra/telemetry/internal/telemetry
-+# github.com/microsoft/go-infra/telemetry/config v0.0.0-20250716090631-5672f943a6c1
++# github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed
 +## explicit; go 1.24
 +github.com/microsoft/go-infra/telemetry/config
  # golang.org/x/arch v0.18.1-0.20250605182141-b2f4e2807dec
@@ -1903,7 +1939,7 @@ index 410eb8648a710a..928d040435b4b7 100644
  golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
  golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 6d92542e31b652..9b7613a62b5a31 100644
+index b3d8f66bc761ee..09e91285502bcf 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -519,6 +519,24 @@ var depsRules = `

--- a/patches/0010-add-appinsights-telemetry.patch
+++ b/patches/0010-add-appinsights-telemetry.patch
@@ -10,9 +10,9 @@ Subject: [PATCH] Add appinsights telemetry
  src/cmd/go/mstelemetry_test.go                | 52 +++++++++++++++++++
  src/cmd/go/script_test.go                     |  8 +++
  src/cmd/go/scriptcmds_test.go                 | 11 ++++
- src/cmd/internal/telemetry/counter/counter.go | 50 +++++++++++++++++-
+ src/cmd/internal/telemetry/counter/counter.go | 48 ++++++++++++++++-
  .../telemetry/counter/counter_bootstrap.go    |  3 ++
- 8 files changed, 159 insertions(+), 1 deletion(-)
+ 8 files changed, 157 insertions(+), 1 deletion(-)
  create mode 100644 src/cmd/go/mstelemetry_test.go
 
 diff --git a/README.md b/README.md
@@ -208,10 +208,10 @@ index ced8d880e9ae3a..b3ad521ff94873 100644
  	})
  }
 diff --git a/src/cmd/internal/telemetry/counter/counter.go b/src/cmd/internal/telemetry/counter/counter.go
-index 5cef0b0041551a..6c180bf9e60482 100644
+index 5cef0b0041551a..2c1b8143d60764 100644
 --- a/src/cmd/internal/telemetry/counter/counter.go
 +++ b/src/cmd/internal/telemetry/counter/counter.go
-@@ -7,10 +7,23 @@
+@@ -7,10 +7,24 @@
  package counter
  
  import (
@@ -219,6 +219,7 @@ index 5cef0b0041551a..6c180bf9e60482 100644
 +	"context"
  	"flag"
 +	"log"
++	"log/slog"
  	"os"
 +	"time"
  
@@ -235,30 +236,25 @@ index 5cef0b0041551a..6c180bf9e60482 100644
  )
  
  var openCalled bool
-@@ -22,11 +35,43 @@ func OpenCalled() bool { return openCalled }
- func Open() {
- 	openCalled = true
+@@ -24,9 +38,38 @@ func Open() {
  	counter.OpenDir(os.Getenv("TEST_TELEMETRY_DIR"))
-+	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENABLED") != "0" {
-+		mstelemetry.Start(mstelemetry.Config{
-+			InstrumentationKey: appInsightsInstrumentationKey,
-+			Endpoint:           cmp.Or(os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENDPOINT"), appInsightsEndpoint), // configurable for testing purposes
-+			AllowGoDevel:       os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ALLOW_GO_DEVEL") == "1",
-+			UploadConfig:       msconfig.Config,
-+		})
-+	}
-+}
-+
+ }
+ 
 +func OpenMicrosoft() {
 +	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENABLED") == "0" {
 +		// Telemetry disabled.
 +		return
++	}
++	var logger *slog.Logger
++	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_VERBOSE") == "1" {
++		logger = slog.Default()
 +	}
 +	mstelemetry.Start(mstelemetry.Config{
 +		InstrumentationKey: appInsightsInstrumentationKey,
 +		Endpoint:           cmp.Or(os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ENDPOINT"), appInsightsEndpoint), // configurable for testing purposes
 +		AllowGoDevel:       os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_ALLOW_GO_DEVEL") == "1",
 +		UploadConfig:       msconfig.Config,
++		Logger:             logger,
 +	})
 +}
 +
@@ -267,11 +263,11 @@ index 5cef0b0041551a..6c180bf9e60482 100644
 +	defer cancel()
 +	start := time.Now()
 +	mstelemetry.Close(ctx)
-+	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_STATS") == "1" {
++	if os.Getenv("MS_GOTOOLCHAIN_TELEMETRY_VERBOSE") == "1" {
 +		log.Printf("telemetry: closed in %s\n", time.Since(start))
 +	}
- }
- 
++}
++
  // Inc increments the counter with the given name.
  func Inc(name string) {
  	counter.Inc(name)
@@ -279,7 +275,7 @@ index 5cef0b0041551a..6c180bf9e60482 100644
  }
  
  // New returns a counter with the given name.
-@@ -44,6 +89,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
+@@ -44,6 +87,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
  // the concatenation of prefix and the flag name.
  func CountFlags(prefix string, flagSet flag.FlagSet) {
  	counter.CountFlags(prefix, flagSet)
@@ -287,7 +283,7 @@ index 5cef0b0041551a..6c180bf9e60482 100644
  }
  
  // CountFlagValue creates a counter for the flag value
-@@ -56,7 +102,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
+@@ -56,7 +100,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
  	// TODO(matloob): Add this to x/telemetry?
  	flagSet.Visit(func(f *flag.Flag) {
  		if f.Name == flagName {


### PR DESCRIPTION
(cherry picked from commit 705bbcf6ffe8bccff8efbf19883b7d45460f7034)

Clean https://github.com/microsoft/go/pull/1782. back port.