### PR TITLE
Use errors.Is instead of string comparison in hash marshal interface

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -53,7 +53,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../golang-fips/openssl/v2/ecdsa.go           |  226 ++
  .../golang-fips/openssl/v2/ed25519.go         |  229 ++
  .../github.com/golang-fips/openssl/v2/evp.go  |  590 +++++
- .../github.com/golang-fips/openssl/v2/hash.go |  455 ++++
+ .../github.com/golang-fips/openssl/v2/hash.go |  463 ++++
  .../golang-fips/openssl/v2/hashclone.go       |   14 +
  .../golang-fips/openssl/v2/hashclone_go125.go |    9 +
  .../github.com/golang-fips/openssl/v2/hkdf.go |  444 ++++
@@ -86,7 +86,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/cryptokit/cryptokit.h            |   67 +
  .../internal/cryptokit/ed25519.go             |   72 +
  .../internal/cryptokit/gcm.go                 |   36 +
- .../internal/cryptokit/hash.go                |  247 ++
+ .../internal/cryptokit/hash.go                |  257 ++
  .../internal/cryptokit/hashclone.go           |   17 +
  .../internal/cryptokit/hashclone_go125.go     |   12 +
  .../internal/cryptokit/hkdf.go                |   77 +
@@ -119,7 +119,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/dsa.go  |  465 ++++
  .../microsoft/go-crypto-winnative/cng/ecdh.go |  255 ++
  .../go-crypto-winnative/cng/ecdsa.go          |  169 ++
- .../microsoft/go-crypto-winnative/cng/hash.go |  315 +++
+ .../microsoft/go-crypto-winnative/cng/hash.go |  325 +++
  .../go-crypto-winnative/cng/hashclone.go      |   18 +
  .../cng/hashclone_go125.go                    |   13 +
  .../microsoft/go-crypto-winnative/cng/hkdf.go |  128 +
@@ -129,7 +129,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/rand.go |   28 +
  .../microsoft/go-crypto-winnative/cng/rc4.go  |   65 +
  .../microsoft/go-crypto-winnative/cng/rsa.go  |  396 ++++
- .../microsoft/go-crypto-winnative/cng/sha3.go |  311 +++
+ .../microsoft/go-crypto-winnative/cng/sha3.go |  310 +++
  .../go-crypto-winnative/cng/tls1prf.go        |   89 +
  .../internal/bcrypt/bcrypt_windows.go         |  368 +++
  .../internal/bcrypt/ntstatus_windows.go       |   45 +
@@ -137,7 +137,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 129 files changed, 19192 insertions(+), 7 deletions(-)
+ 129 files changed, 19219 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -1875,7 +1875,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index b81f19068aef23..da03dfd87e7aec 100644
+index b81f19068aef23..26eb72c358987f 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -1884,26 +1884,26 @@ index b81f19068aef23..da03dfd87e7aec 100644
  )
 +
 +require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7
-+	github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20250725144648-7a97d5786d1f
++	github.com/microsoft/go-crypto-darwin v0.0.2-0.20250725141434-15e65307af05
++	github.com/microsoft/go-crypto-winnative v0.0.0-20250725141601-8349e082e173
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 410eb8648a710a..928d040435b4b7 100644
+index 410eb8648a710a..f4132c078c86a5 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7 h1:ZjpSTr5uh4P3EKwrZQ8Fr/NZJ6NBgf+8UabCp9Kmtoc=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
-+github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7 h1:6a0YcJOAJWLtEqDW55bUhhe4Nx/9Rpmm80KVMUxD6B4=
-+github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7/go.mod h1:LyP4oZ0QcysEJdqUTOk9ngNFArRFK94YRImkoJ8julQ=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b h1:Yf6lm9r6Aid3PG5FoeSX2v4iU+xWnAmCRQNjBxgceWI=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20250725144648-7a97d5786d1f h1:fIaGpyow9azEUBACTdiDwF4oFCxNhtfb3Yy7GstINQI=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20250725144648-7a97d5786d1f/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
++github.com/microsoft/go-crypto-darwin v0.0.2-0.20250725141434-15e65307af05 h1:I6L7NzERXHhyif6YpLgL8GTvSbF8ac3j1bwUBDri9Fo=
++github.com/microsoft/go-crypto-darwin v0.0.2-0.20250725141434-15e65307af05/go.mod h1:LyP4oZ0QcysEJdqUTOk9ngNFArRFK94YRImkoJ8julQ=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250725141601-8349e082e173 h1:Dro+lH95siHfrTlCNZOR2ySBdxHJbmi8awkgi3FGmzY=
++github.com/microsoft/go-crypto-winnative v0.0.0-20250725141601-8349e082e173/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
  golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
  golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
  golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 6d92542e31b652..9b7613a62b5a31 100644
+index b3d8f66bc761ee..09e91285502bcf 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -519,6 +519,24 @@ var depsRules = `
@@ -4970,10 +4970,10 @@ index 00000000000000..a6ad55906ecd8a
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hash.go b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
 new file mode 100644
-index 00000000000000..621822102024f8
+index 00000000000000..3c4db5fe3f851d
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
-@@ -0,0 +1,455 @@
+@@ -0,0 +1,463 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -5348,11 +5348,19 @@ index 00000000000000..621822102024f8
 +	return h2, nil
 +}
 +
-+var errHashNotMarshallable = errors.New("openssl: hash state is not marshallable")
++type errMarshallUnsupported struct{}
++
++func (e errMarshallUnsupported) Error() string {
++	return "cryptokit: hash state is not marshallable"
++}
++
++func (e errMarshallUnsupported) Unwrap() error {
++	return errors.ErrUnsupported
++}
 +
 +func (d *evpHash) MarshalBinary() ([]byte, error) {
 +	if !d.alg.marshallable {
-+		return nil, errHashNotMarshallable
++		return nil, errMarshallUnsupported{}
 +	}
 +	buf := make([]byte, 0, d.alg.marshalledSize)
 +	return d.AppendBinary(buf)
@@ -5361,7 +5369,7 @@ index 00000000000000..621822102024f8
 +func (d *evpHash) AppendBinary(buf []byte) ([]byte, error) {
 +	defer runtime.KeepAlive(d)
 +	if !d.alg.marshallable {
-+		return nil, errHashNotMarshallable
++		return nil, errMarshallUnsupported{}
 +	}
 +	d.init()
 +	switch d.alg.provider {
@@ -5378,7 +5386,7 @@ index 00000000000000..621822102024f8
 +	defer runtime.KeepAlive(d)
 +	d.init()
 +	if !d.alg.marshallable {
-+		return errHashNotMarshallable
++		return errMarshallUnsupported{}
 +	}
 +	if len(b) < len(d.alg.magic) || string(b[:len(d.alg.magic)]) != d.alg.magic {
 +		return errors.New("openssl: invalid hash state identifier")
@@ -14238,10 +14246,10 @@ index 00000000000000..458e9eb57416b1
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/hash.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/hash.go
 new file mode 100644
-index 00000000000000..977ee3152ada71
+index 00000000000000..14b5e1b1c0d8ae
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/hash.go
-@@ -0,0 +1,247 @@
+@@ -0,0 +1,257 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -14392,16 +14400,26 @@ index 00000000000000..977ee3152ada71
 +	return b
 +}
 +
++type errMarshallUnsupported struct{}
++
++func (e errMarshallUnsupported) Error() string {
++	return "cryptokit: hash state is not marshallable"
++}
++
++func (e errMarshallUnsupported) Unwrap() error {
++	return errors.ErrUnsupported
++}
++
 +func (h *evpHash) MarshalBinary() ([]byte, error) {
-+	return nil, errors.New("cryptokit: hash state is not marshallable")
++	return nil, errMarshallUnsupported{}
 +}
 +
 +func (h *evpHash) AppendBinary(b []byte) ([]byte, error) {
-+	return nil, errors.New("cryptokit: hash state is not marshallable")
++	return nil, errMarshallUnsupported{}
 +}
 +
 +func (h *evpHash) UnmarshalBinary(data []byte) error {
-+	return errors.New("cryptokit: hash state is not marshallable")
++	return errMarshallUnsupported{}
 +}
 +
 +func (h *evpHash) Reset() {
@@ -18601,10 +18619,10 @@ index 00000000000000..586e9ae2ebb0c9
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
 new file mode 100644
-index 00000000000000..2c871ee31a327d
+index 00000000000000..d22f6231cbf33a
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
-@@ -0,0 +1,315 @@
+@@ -0,0 +1,325 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -18848,16 +18866,26 @@ index 00000000000000..2c871ee31a327d
 +	return int(h.alg.blockSize)
 +}
 +
++type errMarshallUnsupported struct{}
++
++func (e errMarshallUnsupported) Error() string {
++	return "cryptokit: hash state is not marshallable"
++}
++
++func (e errMarshallUnsupported) Unwrap() error {
++	return errors.ErrUnsupported
++}
++
 +func (hx *hashX) MarshalBinary() ([]byte, error) {
-+	return nil, errors.New("cng: hash state is not marshallable")
++	return nil, errMarshallUnsupported{}
 +}
 +
 +func (hx *hashX) AppendBinary(b []byte) ([]byte, error) {
-+	return nil, errors.New("cng: hash state is not marshallable")
++	return nil, errMarshallUnsupported{}
 +}
 +
 +func (hx *hashX) UnmarshalBinary(data []byte) error {
-+	return errors.New("cng: hash state is not marshallable")
++	return errMarshallUnsupported{}
 +}
 +
 +// hashData writes p to ctx. It panics on error.
@@ -19982,10 +20010,10 @@ index 00000000000000..0269f9cf86539e
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha3.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha3.go
 new file mode 100644
-index 00000000000000..bd366bfd130ba7
+index 00000000000000..36a7c6125fe7a1
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha3.go
-@@ -0,0 +1,311 @@
+@@ -0,0 +1,310 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -19995,7 +20023,6 @@ index 00000000000000..bd366bfd130ba7
 +package cng
 +
 +import (
-+	"errors"
 +	"hash"
 +	"runtime"
 +	"unsafe"
@@ -20154,15 +20181,15 @@ index 00000000000000..bd366bfd130ba7
 +}
 +
 +func (ds *DigestSHA3) MarshalBinary() ([]byte, error) {
-+	return nil, errors.New("cng: hash state is not marshallable")
++	return nil, errMarshallUnsupported{}
 +}
 +
 +func (ds *DigestSHA3) AppendBinary(b []byte) ([]byte, error) {
-+	return nil, errors.New("cng: hash state is not marshallable")
++	return nil, errMarshallUnsupported{}
 +}
 +
 +func (ds *DigestSHA3) UnmarshalBinary(data []byte) error {
-+	return errors.New("cng: hash state is not marshallable")
++	return errMarshallUnsupported{}
 +}
 +
 +// NewSHA3_256 returns a new SHA256 hash.
@@ -20287,15 +20314,15 @@ index 00000000000000..bd366bfd130ba7
 +}
 +
 +func (s *SHAKE) MarshalBinary() ([]byte, error) {
-+	return nil, errors.New("cng: hash state is not marshallable")
++	return nil, errMarshallUnsupported{}
 +}
 +
 +func (s *SHAKE) AppendBinary(b []byte) ([]byte, error) {
-+	return nil, errors.New("cng: hash state is not marshallable")
++	return nil, errMarshallUnsupported{}
 +}
 +
 +func (s *SHAKE) UnmarshalBinary(data []byte) error {
-+	return errors.New("cng: hash state is not marshallable")
++	return errMarshallUnsupported{}
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
 new file mode 100644
@@ -21335,21 +21362,21 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 8507f01b12f518..918aaab0a32fef 100644
+index 8507f01b12f518..c1b4f54a6195dd 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,20 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20250725144648-7a97d5786d1f
 +## explicit; go 1.22
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
 +github.com/golang-fips/openssl/v2/internal/ossl
-+# github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7
++# github.com/microsoft/go-crypto-darwin v0.0.2-0.20250725141434-15e65307af05
 +## explicit; go 1.22
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/cryptokit
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b
++# github.com/microsoft/go-crypto-winnative v0.0.0-20250725141601-8349e082e173
 +## explicit; go 1.22
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -1496,10 +1496,10 @@ index 9274f89d3e2c15..605c37c15f1012 100644
  	d.Reset()
  	d.Write(data)
 diff --git a/src/crypto/md5/md5_test.go b/src/crypto/md5/md5_test.go
-index 403ff2881f4b68..5c689e332d847c 100644
+index 403ff2881f4b68..5417556a86700e 100644
 --- a/src/crypto/md5/md5_test.go
 +++ b/src/crypto/md5/md5_test.go
-@@ -6,12 +6,14 @@ package md5
+@@ -6,9 +6,11 @@ package md5
  
  import (
  	"bytes"
@@ -1507,18 +1507,15 @@ index 403ff2881f4b68..5c689e332d847c 100644
  	"crypto/internal/cryptotest"
  	"crypto/rand"
  	"encoding"
++	"errors"
  	"fmt"
  	"hash"
  	"io"
-+	"strings"
- 	"testing"
- 	"unsafe"
- )
 @@ -96,6 +98,9 @@ func TestGoldenMarshal(t *testing.T) {
  
  		state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
  		if err != nil {
-+			if strings.Contains(err.Error(), "hash state is not marshallable") {
++			if errors.Is(err, errors.ErrUnsupported) {
 +				t.Skip("BinaryMarshaler not supported")
 +			}
  			t.Errorf("could not marshal: %v", err)
@@ -1547,7 +1544,7 @@ index 403ff2881f4b68..5c689e332d847c 100644
  
  		h := New()
  		if err := h.(encoding.BinaryUnmarshaler).UnmarshalBinary([]byte(test.state)); err != nil {
-+			if strings.Contains(err.Error(), "hash state is not marshallable") {
++			if errors.Is(err, errors.ErrUnsupported) {
 +				t.Skip("BinaryMarshaler not supported")
 +			}
  			t.Errorf("test %d could not unmarshal: %v", i, err)
@@ -2137,10 +2134,10 @@ index 3acc5b11fb789e..36187a8d5bc4ac 100644
  	d.Reset()
  	d.Write(data)
 diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
-index ef6e5ddcbb2d97..3ef46e3be515df 100644
+index ef6e5ddcbb2d97..cc88965f966aae 100644
 --- a/src/crypto/sha1/sha1_test.go
 +++ b/src/crypto/sha1/sha1_test.go
-@@ -8,12 +8,13 @@ package sha1
+@@ -8,9 +8,10 @@ package sha1
  
  import (
  	"bytes"
@@ -2148,18 +2145,15 @@ index ef6e5ddcbb2d97..3ef46e3be515df 100644
 +	boring "crypto/internal/backend"
  	"crypto/internal/cryptotest"
  	"encoding"
++	"errors"
  	"fmt"
  	"hash"
  	"io"
-+	"strings"
- 	"testing"
- )
- 
 @@ -112,6 +113,9 @@ func testGoldenMarshal(t *testing.T) {
  
  		state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
  		if err != nil {
-+			if strings.Contains(err.Error(), "hash state is not marshallable") {
++			if errors.Is(err, errors.ErrUnsupported) {
 +				t.Skip("BinaryMarshaler not supported")
 +			}
  			t.Errorf("could not marshal: %v", err)
@@ -2169,7 +2163,7 @@ index ef6e5ddcbb2d97..3ef46e3be515df 100644
  	for i, test := range largeUnmarshalTests {
  		h := New()
  		if err := h.(encoding.BinaryUnmarshaler).UnmarshalBinary([]byte(test.state)); err != nil {
-+			if strings.Contains(err.Error(), "hash state is not marshallable") {
++			if errors.Is(err, errors.ErrUnsupported) {
 +				t.Skip("BinaryMarshaler not supported")
 +			}
  			t.Errorf("test %d could not unmarshal: %v", i, err)
@@ -2216,28 +2210,25 @@ index 069938a22dbc5a..8d0e06b86f4359 100644
  	}
  	h := New224()
 diff --git a/src/crypto/sha256/sha256_test.go b/src/crypto/sha256/sha256_test.go
-index 11b24db7d6b0a0..9aa28dd024385f 100644
+index 11b24db7d6b0a0..837ace4f7200fb 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
-@@ -8,11 +8,13 @@ package sha256
+@@ -8,8 +8,10 @@ package sha256
  
  import (
  	"bytes"
 +	boring "crypto/internal/backend"
  	"crypto/internal/cryptotest"
  	"encoding"
++	"errors"
  	"fmt"
  	"hash"
  	"io"
-+	"strings"
- 	"testing"
- )
- 
 @@ -163,6 +165,9 @@ func testGoldenMarshal(t *testing.T) {
  
  				state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
  				if err != nil {
-+					if strings.Contains(err.Error(), "hash state is not marshallable") {
++					if errors.Is(err, errors.ErrUnsupported) {
 +						t.Skip("BinaryMarshaler not supported")
 +					}
  					t.Errorf("could not marshal: %v", err)
@@ -2247,7 +2238,7 @@ index 11b24db7d6b0a0..9aa28dd024385f 100644
  
  	state1, err := h1.(encoding.BinaryMarshaler).MarshalBinary()
  	if err != nil {
-+		if strings.Contains(err.Error(), "hash state is not marshallable") {
++		if errors.Is(err, errors.ErrUnsupported) {
 +			t.Skip("BinaryMarshaler not supported")
 +		}
  		t.Errorf("could not marshal: %v", err)
@@ -2266,7 +2257,7 @@ index 11b24db7d6b0a0..9aa28dd024385f 100644
  
  		h := New()
  		if err := h.(encoding.BinaryUnmarshaler).UnmarshalBinary([]byte(test.state)); err != nil {
-+			if strings.Contains(err.Error(), "hash state is not marshallable") {
++			if errors.Is(err, errors.ErrUnsupported) {
 +				t.Skip("BinaryMarshaler not supported")
 +			}
  			t.Errorf("test %d could not unmarshal: %v", i, err)
@@ -2333,10 +2324,10 @@ index 1435eac1f5b5dc..17e8501154762a 100644
  	"hash"
  )
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index 080bf694f03652..d6058d541e9e61 100644
+index 080bf694f03652..0c899f5c407ffa 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
-@@ -8,12 +8,14 @@ package sha512
+@@ -8,9 +8,11 @@ package sha512
  
  import (
  	"bytes"
@@ -2344,18 +2335,15 @@ index 080bf694f03652..d6058d541e9e61 100644
  	"crypto/internal/cryptotest"
  	"encoding"
  	"encoding/hex"
++	"errors"
  	"fmt"
  	"hash"
  	"io"
-+	"strings"
- 	"testing"
- )
- 
 @@ -751,6 +753,9 @@ func testGoldenMarshal(t *testing.T) {
  
  				state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
  				if err != nil {
-+					if strings.Contains(err.Error(), "hash state is not marshallable") {
++					if errors.Is(err, errors.ErrUnsupported) {
 +						t.Skip("BinaryMarshaler not supported")
 +					}
  					t.Errorf("could not marshal: %v", err)
@@ -2365,7 +2353,7 @@ index 080bf694f03652..d6058d541e9e61 100644
  
  			state, err := h1.(encoding.BinaryMarshaler).MarshalBinary()
  			if err != nil {
-+				if strings.Contains(err.Error(), "hash state is not marshallable") {
++				if errors.Is(err, errors.ErrUnsupported) {
 +					t.Skip("BinaryMarshaler not supported")
 +				}
  				t.Errorf("i=%d: could not marshal: %v", i, err)
@@ -2384,7 +2372,7 @@ index 080bf694f03652..d6058d541e9e61 100644
  
  		h := New()
  		if err := h.(encoding.BinaryUnmarshaler).UnmarshalBinary([]byte(test.state)); err != nil {
-+			if strings.Contains(err.Error(), "hash state is not marshallable") {
++			if errors.Is(err, errors.ErrUnsupported) {
 +				t.Skip("BinaryMarshaler not supported")
 +			}
  			t.Errorf("test %d could not unmarshal: %v", i, err)
@@ -2962,7 +2950,7 @@ index e7369542a73270..ff52175e4ac636 100644
  	}
  }
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 1997d90f2f20ba..f69862c628eea4 100644
+index b2c6db15a23e98..55e34940125e86 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -517,7 +517,7 @@ var depsRules = `
@@ -3020,22 +3008,22 @@ index f07b9aaa2c4898..b380537215634d 100644
  
  import (
 diff --git a/src/hash/marshal_test.go b/src/hash/marshal_test.go
-index 3091f7a67acede..d952cf45797ac6 100644
+index 3091f7a67acede..fa3f0fd82cfd30 100644
 --- a/src/hash/marshal_test.go
 +++ b/src/hash/marshal_test.go
-@@ -21,6 +21,7 @@ import (
+@@ -16,6 +16,7 @@ import (
+ 	"crypto/sha512"
+ 	"encoding"
+ 	"encoding/hex"
++	"errors"
+ 	"hash"
+ 	"hash/adler32"
  	"hash/crc32"
- 	"hash/crc64"
- 	"hash/fnv"
-+	"strings"
- 	"testing"
- )
- 
 @@ -80,6 +81,9 @@ func TestMarshalHash(t *testing.T) {
  			}
  			enc, err := h2m.MarshalBinary()
  			if err != nil {
-+				if strings.Contains(err.Error(), "hash state is not marshallable") {
++				if errors.Is(err, errors.ErrUnsupported) {
 +					t.Skip("BinaryMarshaler not supported")
 +				}
  				t.Fatalf("MarshalBinary: %v", err)


### PR DESCRIPTION
Fixes: #1683
Currently we are making string comparison for checking returned error types from our backends for hash marshalling interface. Previously we weren't returning proper error type, instead we were just checking the error message with raw string comparison. This PR fixes this issue with returning proper error and using correct `errors.Is` comparison API