### PR TITLE
ed25519: check for boring enabled, and rand at the same time

### DIFF
--- a/patches/0099-ed25519-check-for-boring-enabled-and-rand-at-the-sam.patch
+++ b/patches/0099-ed25519-check-for-boring-enabled-and-rand-at-the-sam.patch
@@ -1,0 +1,59 @@
+From 3accfa5a92997343c59ccbd52cee112fa30d971f Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Tue, 29 Jul 2025 21:50:56 +0100
+Subject: [PATCH] ed25519: check for boring enabled, and rand at the same time
+
+When compiling upstream projects (in particular
+https://github.com/nats-io/nkeys) it is possible to reach Unreachable
+code path.
+
+It seems much safer to check for rand reader at the same time as
+boring.Enabled and boring.SupportsEd25519 as otherwise automatic
+fallback to the other implementation does not happen.
+
+If the intention is to automatically allow using fallback, as the code
+suggests to be the case.
+---
+ src/crypto/ed25519/ed25519.go | 25 +++++++++++--------------
+ 1 file changed, 11 insertions(+), 14 deletions(-)
+
+diff --git a/src/crypto/ed25519/ed25519.go b/src/crypto/ed25519/ed25519.go
+index b770c8c498..4ac5e90bb7 100644
+--- a/src/crypto/ed25519/ed25519.go
++++ b/src/crypto/ed25519/ed25519.go
+@@ -146,21 +146,18 @@ func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
+ 	if rand == nil {
+ 		rand = cryptorand.Reader
+ 	}
+-	if boring.Enabled && boring.SupportsEd25519() {
+-		if rand == boring.RandReader {
+-			priv, err := boring.GenerateKeyEd25519()
+-			if err != nil {
+-				return nil, nil, err
+-			}
+-			privData, err := priv.Bytes()
+-			if err != nil {
+-				return nil, nil, err
+-			}
+-			privKey := PrivateKey(privData)
+-			pubKey := privKey.Public().(PublicKey)
+-			return pubKey, privKey, err
++	if boring.Enabled && rand == boring.RandReader && boring.SupportsEd25519() {
++		priv, err := boring.GenerateKeyEd25519()
++		if err != nil {
++			return nil, nil, err
++		}
++		privData, err := priv.Bytes()
++		if err != nil {
++			return nil, nil, err
+ 		}
+-		boring.UnreachableExceptTests()
++		privKey := PrivateKey(privData)
++		pubKey := privKey.Public().(PublicKey)
++		return pubKey, privKey, err
+ 	}
+ 
+ 	seed := make([]byte, SeedSize)
+-- 
+2.48.1
+


### PR DESCRIPTION
When compiling upstream projects (in particular
https://github.com/nats-io/nkeys) it is possible to reach Unreachable
code path.

It seems much safer to check for rand reader at the same time as
boring.Enabled and boring.SupportsEd25519 as otherwise automatic
fallback to the other implementation does not happen.

If the intention is to automatically allow using fallback, as the code
suggests to be the case.

Reported-by: @javacruft
