### PR TITLE
Attribute patch files to bot: clarify lack of ownership

### DIFF
--- a/.git-go-patch
+++ b/.git-go-patch
@@ -1,0 +1,7 @@
+{
+  "MinimumToolVersion": "v1.0.1",
+  "SubmoduleDir": "go",
+  "PatchesDir": "patches",
+  "StatusFileDir": "eng/artifacts/go-patch",
+  "ExtractAsAuthor": "bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>"
+}

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Quim Muntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Mon, 23 May 2022 12:59:36 +0000
 Subject: [PATCH] Vendor external dependencies
 

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 31 May 2023 16:54:31 -0500
 Subject: [PATCH] Add crypto backend GOEXPERIMENTs
 
@@ -566,7 +566,7 @@ index 00000000000000..fcd4cb9da0d162
 +const SystemCrypto = true
 +const SystemCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 63a338883991e0..04f8fce2dfed03 100644
+index d0ae75d4e1a1a3..8eb3f97bdd4dbd 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,24 @@ type Flags struct {

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 15 Jan 2025 16:32:26 +0100
 Subject: [PATCH] Implement crypto/internal/backend
 

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Tue, 14 Jan 2025 11:10:21 +0100
 Subject: [PATCH] Use crypto backends
 

--- a/patches/0005-Disable-GOTOOLCHAIN-support.patch
+++ b/patches/0005-Disable-GOTOOLCHAIN-support.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Thu, 8 Jun 2023 14:17:13 +0200
 Subject: [PATCH] Disable GOTOOLCHAIN support
 
@@ -29,10 +29,10 @@ index 6ff2b921d464bc..36c3bdfc9b6087 100644
 -GOTOOLCHAIN=auto
 +GOTOOLCHAIN=local
 diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
-index 3b9f27e91d517e..3084f681499c2c 100644
+index 10ee92536b96cd..200ba17202276f 100644
 --- a/src/cmd/go/internal/cfg/cfg.go
 +++ b/src/cmd/go/internal/cfg/cfg.go
-@@ -401,6 +401,24 @@ func Getenv(key string) string {
+@@ -452,6 +452,24 @@ func Getenv(key string) string {
  	}
  	val := os.Getenv(key)
  	if val != "" {

--- a/patches/0006-Skip-failing-tests-on-Windows.patch
+++ b/patches/0006-Skip-failing-tests-on-Windows.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 11 Oct 2023 10:44:22 +0200
 Subject: [PATCH] Skip failing tests on Windows
 

--- a/patches/0007-add-support-for-logging-used-Windows-APIs.patch
+++ b/patches/0007-add-support-for-logging-used-Windows-APIs.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Tue, 19 Mar 2024 16:48:18 +0100
 Subject: [PATCH] add support for logging used Windows APIs
 
@@ -17,10 +17,10 @@ Subject: [PATCH] add support for logging used Windows APIs
  create mode 100644 src/runtime/zsyscalltrace_windows.go
 
 diff --git a/src/runtime/os_windows.go b/src/runtime/os_windows.go
-index 7183e79f7df093..2b382202bf7e49 100644
+index 04752f26036d22..cbabc52b639bdd 100644
 --- a/src/runtime/os_windows.go
 +++ b/src/runtime/os_windows.go
-@@ -223,6 +223,7 @@ func windowsFindfunc(lib uintptr, name []byte) stdFunction {
+@@ -222,6 +222,7 @@ func windowsFindfunc(lib uintptr, name []byte) stdFunction {
  	if name[len(name)-1] != 0 {
  		throw("usage")
  	}

--- a/patches/0008-remove-long-path-support-hack.patch
+++ b/patches/0008-remove-long-path-support-hack.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Mon, 25 Mar 2024 12:14:00 +0100
 Subject: [PATCH] remove long path support hack
 
@@ -17,7 +17,7 @@ only affect long relative paths, which can't be used with the `\\?\`.
  1 file changed, 1 insertion(+), 22 deletions(-)
 
 diff --git a/src/runtime/os_windows.go b/src/runtime/os_windows.go
-index fc7296f28ab12f..d3e0149c90febc 100644
+index cbabc52b639bdd..abbe437183ba86 100644
 --- a/src/runtime/os_windows.go
 +++ b/src/runtime/os_windows.go
 @@ -136,7 +136,6 @@ var (

--- a/patches/0009-Omit-internal-go.mod-files-used-for-codegen.patch
+++ b/patches/0009-Omit-internal-go.mod-files-used-for-codegen.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 24 May 2024 15:38:31 -0700
 Subject: [PATCH] Omit internal go.mod files used for codegen
 

--- a/patches/0010-add-appinsights-telemetry.patch
+++ b/patches/0010-add-appinsights-telemetry.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Thu, 29 May 2025 14:53:58 +0200
 Subject: [PATCH] Add appinsights telemetry
 


### PR DESCRIPTION
* https://github.com/microsoft/go/issues/383

We've had this feature in git-go-patch for a while, but haven't actually enabled it here. We should, for the reasons mentioned in the issue.