### PR TITLE
Fix missing distro parameter causing Windows agent failures

### DIFF
--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -59,7 +59,7 @@ stages:
             template: sign-stage.yml
             parameters:
               # This is not a builder, but provide partial builder info for agent selection.
-              builder: { os: windows, arch: amd64 }
+              builder: { os: windows, arch: amd64, distro: '2022' }
               official: ${{ parameters.official }}
               # The list of builders to depend on and grab artifacts from.
               builders:
@@ -80,7 +80,7 @@ stages:
         inner:
           template: internal-publish-stage.yml
           parameters:
-            builder: { os: windows, arch: amd64 }
+            builder: { os: windows, arch: amd64, distro: '2022' }
             official: true
             builders:
               - ${{ each builder in parameters.builders }}:


### PR DESCRIPTION
fixes: https://github.com/microsoft/go-lab/issues/227

Added missing distro: '2022' to signing and publishing stage builder objects to fix "Image 1es-windows- doesn't exist" error.