### PR TITLE
microbuild: switch to prod signing

### DIFF
--- a/eng/pipeline/stages/sign-stage.yml
+++ b/eng/pipeline/stages/sign-stage.yml
@@ -44,6 +44,8 @@ stages:
               signing:
                 enabled: true
                 signType: $(SigningType)
+                ${{ if eq(variables['SigningType'], 'real') }}:
+                  signWithProd: true
                 zipSources: false
                 feedSource: 'https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json'
             outputs:

--- a/eng/pipeline/stages/sign-stage.yml
+++ b/eng/pipeline/stages/sign-stage.yml
@@ -44,8 +44,7 @@ stages:
               signing:
                 enabled: true
                 signType: $(SigningType)
-                ${{ if eq(variables['SigningType'], 'real') }}:
-                  signWithProd: true
+                signWithProd: ${{ eq(variables['SigningType'], 'real') }}
                 zipSources: false
                 feedSource: 'https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json'
             outputs:


### PR DESCRIPTION
As per https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/46279/Real-signing-with-PME-Enforcement?anchor=non-windows

Test run here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2765516

@dagood I wonder if we should set SignType to `test` by default to prevent using PME in test environments? Thoughts?

* For https://github.com/microsoft/go-lab/issues/225