### PR TITLE
Introduce ctx and use it to convey official and sign type data

### DIFF
--- a/eng/_util/cmd/sign/sign.go
+++ b/eng/_util/cmd/sign/sign.go
@@ -39,7 +39,10 @@ var (
 	tempDir          = flag.String("temp-dir", "eng/signing/signing-temp", "Directory to store temporary files.")
 	signingCsprojDir = flag.String("signing-csproj-dir", "eng/signing", "Directory containing Sign.csproj and related files.")
 
-	signType = flag.String("sign-type", "test", "Type of signing to perform. Options: test, real.")
+	signType = flag.String("sign-type", "test",
+		"Type of signing to perform. Options: test, real. "+
+			// https://github.com/microsoft/go-lab/issues/231
+			"Test signing skips using MicroBuild tooling because it throws exception 'The test signing method for cert (8020) has NOT been implemented.'")
 
 	timeout = flag.Duration("timeout", 0,
 		"Timeout for signing operations. Zero means no timeout. "+
@@ -230,6 +233,18 @@ func sign(ctx context.Context, step string, files []*fileToSign) error {
 	log.Printf("Signing with props file content:\n%s\n", sb.String())
 	if *dryRun {
 		log.Printf("Dry run: skipping signing.")
+		return nil
+	}
+	if *signType == "test" {
+		log.Printf("Testing signing: skipping MicroBuild tooling.")
+		for _, f := range files {
+			if strings.HasSuffix(f.fullPath, ".sig") {
+				log.Printf("Replacing file with placeholder content to reduce size and simulate signature: %q", f.fullPath)
+				if err := os.WriteFile(f.fullPath, []byte("This is a placeholder test signature file."), 0o666); err != nil {
+					return fmt.Errorf("failed to write test signature file %q: %v", f.fullPath, err)
+				}
+			}
+		}
 		return nil
 	}
 

--- a/eng/pipeline/pr-outerloop-pipeline.yml
+++ b/eng/pipeline/pr-outerloop-pipeline.yml
@@ -17,7 +17,7 @@ pr:
   - dev/*
 
 variables:
-  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
+  - template: variables/pipeline.yml
 
 resources:
   containers:
@@ -33,4 +33,5 @@ resources:
 stages:
   - template: stages/go-builder-matrix-stages.yml
     parameters:
+      ctx: {}
       outerloop: true

--- a/eng/pipeline/pr-pipeline.yml
+++ b/eng/pipeline/pr-pipeline.yml
@@ -10,7 +10,7 @@ pr:
   - dev/*
 
 variables:
-  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
+  - template: variables/pipeline.yml
 
 resources:
   containers:
@@ -30,5 +30,6 @@ resources:
 stages:
   - template: stages/go-builder-matrix-stages.yml
     parameters:
+      ctx: {}
       innerloop: true
       buildandpack: true

--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -21,7 +21,7 @@ parameters:
     default: false
 
 variables:
-  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
+  - template: variables/pipeline.yml
 
 resources:
   repositories:
@@ -53,6 +53,7 @@ extends:
     stages:
       - template: stages/go-builder-matrix-stages.yml
         parameters:
+          ctx: {}
           innerloop: true
           # Include buildandpack builders. The official internal build uses slightly different build
           # machines than this pipeline. This one tests against our minimum requirements.

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -22,9 +22,9 @@ parameters:
 
   - name: publishReleaseStudio
     displayName: >
-      [Release automation input]
-      Publish artifacts to the public using Release Studio integration.
-      To save resources, leave false for builds that definitely won't be released, like microsoft/main rolling builds.
+      For debugging publish steps: force publishing artifacts to the public
+      using Release Studio integration, even if this isn't the official pipeline
+      or this isn't a release branch.
     type: boolean
     default: false
 
@@ -39,12 +39,28 @@ parameters:
     default: 'nil'
 
 variables:
+  - template: variables/pipeline.yml
   - template: variables/pool-providers.yml
+
   # MicroBuild configuration.
   - name: TeamName
     value: golang
-  - name: MS_GOTOOLCHAIN_TELEMETRY_ENABLED
-    value: '0'
+
+  - name: GoSigningType # Note: not quite SignType. MicroBuild generates SignType.
+    ${{ if variables['Go1ESOfficial'] }}:
+      value: 'real'
+    ${{ else }}:
+      value: 'test'
+
+  - name: GoPublishReleaseStudio
+    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/') }}:
+      value: '' # Never publish internal branches using release studio.
+    ${{ elseif parameters.publishReleaseStudio }}:
+      value: 'true'
+    ${{ elseif and(variables['Go1ESOfficial'], ne(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+      value: 'true'
+    ${{ else }}:
+      value: ''
 
 resources:
   repositories:
@@ -54,7 +70,10 @@ resources:
       ref: refs/tags/release
 
 extends:
-  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  ${{ if variables['Go1ESOfficial'] }}:
+    template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  ${{ else }}:
+    template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
     pool:
       # Default, used for SDL analysis.
@@ -62,6 +81,7 @@ extends:
       image: 1es-windows-2022
       os: windows
     sdl:
+      enableProductionSDL: true
       codeql:
         compiled:
           enabled: false
@@ -75,13 +95,25 @@ extends:
     stages:
       - template: stages/go-builder-matrix-stages.yml
         parameters:
+          # There is a limitation with compile-time references to user-defined
+          # variables: each stages template actually has its own "variables" map
+          # and doesn't inherit global variables other than default ones. Values
+          # that can be used in this file like "variables['Go1ESOfficial']" must
+          # be passed along manually for compile-time use like
+          # "parameters.ctx['Go1ESOfficial']" by templates. This limitation is not
+          # documented as of writing.
+          #
+          # Only pass "Go*" variables to avoid built-in variables. There are a
+          # lot, and they clutter attempts to debug pipeline behavior.
+          ctx:
+            ${{ each variable in variables }}:
+              ${{ if startsWith(variable.key, 'Go') }}:
+                ${{ variable.key }}: ${{ variable.value }}
           buildandpack: true
-          official: true
           sign: true
           signExistingRunID: ${{ parameters.signExistingRunID }}
           createSourceArchive: true
           createSymbols: true
           publish: true
-          publishReleaseStudio: ${{ parameters.publishReleaseStudio }}
           publishExistingRunID: ${{ parameters.publishExistingRunID }}
           releaseVersion: ${{ parameters.releaseVersion }}

--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -52,6 +52,10 @@ variables:
     ${{ else }}:
       value: 'test'
 
+  # Publish buildandpack artifacts to pipeline using 1ES PT.
+  - name: GoPublishArtifacts
+    value: 'true'
+
   - name: GoPublishReleaseStudio
     ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/') }}:
       value: '' # Never publish internal branches using release studio.

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -19,6 +19,7 @@ parameters:
     default: false
 
 variables:
+  - template: variables/pipeline.yml
   - template: variables/pool-providers.yml
   - name: Codeql.PublishDatabase
     value: true
@@ -32,8 +33,6 @@ variables:
     # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-general-faq#how-do-i-check-if-my-project-is-onboarded
     - name: Codeql.Cadence
       value: 0
-  - name: MS_GOTOOLCHAIN_TELEMETRY_ENABLED
-    value: '0'
 
 resources:
   pipelines:
@@ -77,9 +76,8 @@ extends:
     stages:
       - template: /eng/pipeline/stages/shorthand-builders-to-builders.yml@self
         parameters:
+          ctx: {}
           jobsTemplate: builders-to-stages.yml
-          jobsParameters:
-            official: true
           shorthandBuilders:
             # CodeQL doesn't submit the scan to both the outer repo
             # (microsoft-go) and inner repo (microsoft-go-mirror).

--- a/eng/pipeline/rolling-pipeline.yml
+++ b/eng/pipeline/rolling-pipeline.yml
@@ -14,7 +14,7 @@ trigger:
 pr: none
 
 variables:
-  MS_GOTOOLCHAIN_TELEMETRY_ENABLED: '0'
+  - template: variables/pipeline.yml
 
 resources:
   repositories:
@@ -46,4 +46,5 @@ extends:
     stages:
       - template: stages/go-builder-matrix-stages.yml
         parameters:
+          ctx: {}
           outerloop: true

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -5,25 +5,39 @@
 # This template expands a list of builders into a list of jobs.
 
 parameters:
+  - name: ctx
+    type: object
+
   # [] of { id, os, arch, hostarch, config, distro?, experiment?, broken? }
-  builders: []
+  - name: builders
+    type: object
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.
-  sign: false
+  - name: sign
+    type: boolean
+    default: false
   # If changed to specify an existing pipeline run, skip build and sign the existing run.
-  signExistingRunID: 'nil'
-  # If true, publish build artifacts to blob storage.
-  publish: false
-  # If true, publish artifacts to the public using Release Studio integration.
-  publishReleaseStudio: false
+  - name: signExistingRunID
+    type: string
+    default: 'nil'
+  # If true, publish build artifacts.
+  - name: publish
+    type: boolean
+    default: false
   # If changed to specify an existing pipeline run, skip build/sign and publish the existing run.
-  publishExistingRunID: 'nil'
-  # If true, the stage will run in 1ES PT Official template compatibility mode.
-  official: false
+  - name: publishExistingRunID
+    type: string
+    default: 'nil'
   # If true, generate source archive tarballs.
-  createSourceArchive: false
+  - name: createSourceArchive
+    type: boolean
+    default: false
   # If true, generate and publish symbols (aka PDBs).
-  createSymbols: false
-  releaseVersion: 'nil'
+  - name: createSymbols
+    type: boolean
+    default: false
+  - name: releaseVersion
+    type: string
+    default: 'nil'
 
 stages:
   - ${{ if eq(parameters.publishExistingRunID, 'nil') }}:
@@ -31,16 +45,17 @@ stages:
       - ${{ each builder in parameters.builders }}:
         - template: pool.yml
           parameters:
+            ctx: ${{ parameters.ctx }}
             inner:
               ${{ if startsWith(builder.config, 'codeql') }}:
                 template: run-codeql.yml
               ${{ else }}:
                 template: run-stage.yml
               parameters:
+                ctx: ${{ parameters.ctx }}
                 builder: ${{ builder }}
                 createSourceArchive: ${{ parameters.createSourceArchive }}
                 releaseVersion: ${{ parameters.releaseVersion }}
-                official: ${{ parameters.official }}
                 createSymbols: ${{ parameters.createSymbols }}
                 ${{ if not(builder.broken) }}:
                   # Attempt to retry the build on Windows to mitigate flakiness:
@@ -55,12 +70,13 @@ stages:
     - ${{ if eq(parameters.sign, true) }}:
       - template: pool.yml
         parameters:
+          ctx: ${{ parameters.ctx }}
           inner:
             template: sign-stage.yml
             parameters:
+              ctx: ${{ parameters.ctx }}
               # This is not a builder, but provide partial builder info for agent selection.
               builder: { os: windows, arch: amd64, distro: '2022' }
-              official: ${{ parameters.official }}
               # The list of builders to depend on and grab artifacts from.
               builders:
                 - ${{ each builder in parameters.builders }}:
@@ -69,22 +85,26 @@ stages:
               signExistingRunID: ${{ parameters.signExistingRunID }}
 
   - ${{ if eq(parameters.publish, true) }}:
-    - ${{ if and(not(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/')), eq(parameters.publishReleaseStudio, true)) }}:
+    - ${{ if parameters.ctx['GoPublishReleaseStudio'] }}:
       - template: public-publish-stages.yml
         parameters:
+          ctx: ${{ parameters.ctx }}
           publishExistingRunID: ${{ parameters.publishExistingRunID }}
 
-    # Always publish the results to a private storage account and publish symbols to AzDO.
-    - template: pool.yml
-      parameters:
-        inner:
-          template: internal-publish-stage.yml
-          parameters:
-            builder: { os: windows, arch: amd64, distro: '2022' }
-            official: true
-            builders:
-              - ${{ each builder in parameters.builders }}:
-                - ${{ if eq(builder.config, 'buildandpack') }}:
-                  - ${{ builder }}
-            publishSymbols: ${{ parameters.createSymbols }}
-            publishExistingRunID: ${{ parameters.publishExistingRunID }}
+    # If publishing, always publish the results to a private storage account and
+    # publish symbols to AzDO.
+    - ${{ if parameters.ctx['Go1ESOfficial'] }}:
+      - template: pool.yml
+        parameters:
+          ctx: ${{ parameters.ctx }}
+          inner:
+            template: internal-publish-stage.yml
+            parameters:
+              ctx: ${{ parameters.ctx }}
+              builder: { os: windows, arch: amd64, distro: '2022' }
+              builders:
+                - ${{ each builder in parameters.builders }}:
+                  - ${{ if eq(builder.config, 'buildandpack') }}:
+                    - ${{ builder }}
+              publishSymbols: ${{ parameters.createSymbols }}
+              publishExistingRunID: ${{ parameters.publishExistingRunID }}

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -5,6 +5,9 @@
 # This template defines the build/test matrix of jobs/stages based on the given flags.
 
 parameters:
+  - name: ctx
+    type: object
+
   # buildandpack builders build the tar.gz/zips of our distribution.
   # Minimal dependencies, and runnable in the official pipeline.
   - name: buildandpack
@@ -25,9 +28,6 @@ parameters:
     default: false
 
   # Passthrough to the build job.
-  - name: official
-    type: boolean
-    default: false
   - name: sign
     type: boolean
     default: false
@@ -46,9 +46,6 @@ parameters:
   - name: releaseVersion
     type: string
     default: 'nil'
-  - name: publishReleaseStudio
-    type: boolean
-    default: false
   - name: publishExistingRunID
     type: string
     default: 'nil'
@@ -56,13 +53,12 @@ parameters:
 stages:
   - template: shorthand-builders-to-builders.yml
     parameters:
+      ctx: ${{ parameters.ctx }}
       jobsTemplate: builders-to-stages.yml
       jobsParameters:
-        official: ${{ parameters.official }}
         sign: ${{ parameters.sign }}
         signExistingRunID: ${{ parameters.signExistingRunID }}
         publish: ${{ parameters.publish }}
-        publishReleaseStudio: ${{ parameters.publishReleaseStudio }}
         publishExistingRunID: ${{ parameters.publishExistingRunID }}
         createSourceArchive: ${{ parameters.createSourceArchive }}
         createSymbols: ${{ parameters.createSymbols }}

--- a/eng/pipeline/stages/internal-publish-stage.yml
+++ b/eng/pipeline/stages/internal-publish-stage.yml
@@ -5,6 +5,9 @@
 # Create a build asset JSON file as a pipeline artifact and publish build artifacts to blob storage.
 
 parameters:
+  - name: ctx
+    type: object
+
   - name: pool
     type: object
 
@@ -15,8 +18,6 @@ parameters:
   # Unused. Declared so pool selection doesn't fail when trying to pass them.
   - name: builder
     type: object
-  - name: official
-    type: boolean
   - name: builders
     type: object
     default: []

--- a/eng/pipeline/stages/pool-1.yml
+++ b/eng/pipeline/stages/pool-1.yml
@@ -3,14 +3,15 @@
 # license that can be found in the LICENSE file.
 
 parameters:
+  - name: ctx
+    type: object
+
   - name: inner
     type: object
 
   - name: public
     type: boolean
   - name: servicing
-    type: boolean
-  - name: official
     type: boolean
   - name: os
     type: string

--- a/eng/pipeline/stages/pool-2.yml
+++ b/eng/pipeline/stages/pool-2.yml
@@ -3,14 +3,15 @@
 # license that can be found in the LICENSE file.
 
 parameters:
+  - name: ctx
+    type: object
+
   - name: inner
     type: object
 
   - name: public
     type: boolean
   - name: servicing
-    type: boolean
-  - name: official
     type: boolean
   - name: os
     type: string
@@ -31,7 +32,7 @@ stages:
         name: ${{ parameters.name }}
 
         ${{ if eq(parameters.os, 'windows') }}:
-          ${{ if parameters.official }}:
+          ${{ if parameters.ctx['Go1ESOfficial'] }}:
             image: 1es-windows-${{ parameters.distro }}
             os: windows
           ${{ elseif parameters.public }}:
@@ -44,7 +45,7 @@ stages:
         ${{ elseif eq(parameters.os, 'linux') }}:
           # The arm64 pool doesn't need demands: it runs on a uniform pool.
           ${{ if ne(parameters.name, 'Docker-Linux-Arm-Internal') }}:
-            ${{ if parameters.official }}:
+            ${{ if parameters.ctx['Go1ESOfficial'] }}:
               image: 1es-ubuntu-2004
               os: linux
             ${{ elseif parameters.public }}:

--- a/eng/pipeline/stages/pool.yml
+++ b/eng/pipeline/stages/pool.yml
@@ -14,6 +14,9 @@
 # choices. Each pool*.yml feeds more information into the next one.
 
 parameters:
+  - name: ctx
+    type: object
+
   # The inner template: { template string, parameters object }
   # Note: the template path is relative to this file (inside "stages/"), not the caller's file path.
   - name: inner
@@ -22,9 +25,9 @@ parameters:
 stages:
   - template: pool-1.yml
     parameters:
+      ctx: ${{ parameters.ctx }}
       public: ${{ eq(variables['System.TeamProject'], 'public') }}
       servicing: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/microsoft/release-branch') }}
-      official: ${{ parameters.inner.parameters.official }}
       os: ${{ parameters.inner.parameters.builder.os }}
       hostArch: ${{ parameters.inner.parameters.builder.hostArch }}
       distro: ${{ parameters.inner.parameters.builder.distro }}

--- a/eng/pipeline/stages/public-publish-stage.yml
+++ b/eng/pipeline/stages/public-publish-stage.yml
@@ -8,6 +8,9 @@
 # stage involved, and then executes some provided steps.
 
 parameters:
+  - name: ctx
+    type: object
+
   - name: id 
     type: string
 

--- a/eng/pipeline/stages/public-publish-stages.yml
+++ b/eng/pipeline/stages/public-publish-stages.yml
@@ -6,6 +6,9 @@
 # Studio integration.
 
 parameters:
+  - name: ctx
+    type: object
+
   - name: publishExistingRunID
     type: string
     default: 'nil'
@@ -13,6 +16,8 @@ parameters:
 stages:
   - template: public-publish-stage.yml
     parameters:
+      ctx: ${{ parameters.ctx }}
+
       id: PublishPublicBinaries
 
       ${{ if eq(parameters.publishExistingRunID, 'nil') }}:
@@ -45,6 +50,7 @@ stages:
 
   - template: public-publish-stage.yml
     parameters:
+      ctx: ${{ parameters.ctx }}
       id: WaitPublicBinaries
       dependsOn: PublishPublicBinaries
       variables:
@@ -82,6 +88,7 @@ stages:
 
   - template: public-publish-stage.yml
     parameters:
+      ctx: ${{ parameters.ctx }}
       id: PublishAssetManifest
       dependsOn: WaitPublicBinaries
       variables:
@@ -134,6 +141,7 @@ stages:
 
   - template: public-publish-stage.yml
     parameters:
+      ctx: ${{ parameters.ctx }}
       id: WaitAssetManifest
       dependsOn: PublishAssetManifest
       variables:

--- a/eng/pipeline/stages/run-codeql.yml
+++ b/eng/pipeline/stages/run-codeql.yml
@@ -5,6 +5,9 @@
 # This job runs a builder for any OS.
 
 parameters:
+  - name: ctx
+    type: object
+
   # { id, os, arch, hostArch, config, distro?, experiment?, fips?, broken? }
   - name: builder
     type: object
@@ -23,9 +26,6 @@ parameters:
 
   - name: pool
     type: object
-
-  - name: official # Ignored
-    type: boolean
 
   - name: retryAttempts # Ignored
     type: object

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -96,7 +96,7 @@ stages:
             - name: Codeql.ADO.Build.Repository.Uri
               value: https://dev.azure.com/dnceng/internal/_git/microsoft-go-mirror
 
-        ${{ if and(parameters.ctx['Go1ESOfficial'], eq(parameters.builder.config, 'buildandpack')) }}:
+        ${{ if and(parameters.ctx['GoPublishArtifacts'], eq(parameters.builder.config, 'buildandpack')) }}:
           templateContext:
             outputs:
               # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -5,6 +5,9 @@
 # This job runs a builder for any OS.
 
 parameters:
+  - name: ctx
+    type: object
+
   # { id, os, arch, hostArch, config, distro?, experiment?, fips?, broken? }
   - name: builder
     type: object
@@ -23,11 +26,6 @@ parameters:
 
   - name: pool
     type: object
-
-  # Indicates that this is in the official pipeline: image usage is restricted, and the artifacts
-  # will be signed by a followup step.
-  - name: official
-    type: boolean
 
   # List of retry attempt numbers. Pass a list of each index (values are only for display purposes),
   # where the final element is "FINAL" instead. AzDO has limited looping capabilities, and this is a
@@ -66,7 +64,7 @@ stages:
 
         pool: ${{ parameters.pool }}
 
-        ${{ if not(parameters.official) }}:
+        ${{ if not(parameters.ctx['Go1ESOfficial']) }}:
           ${{ if eq(parameters.builder.os, 'linux') }}:
             ${{ if eq(parameters.builder.hostArch, 'amd64') }}:
               ${{ if eq(parameters.builder.distro, 'ubuntu') }}:
@@ -98,7 +96,7 @@ stages:
             - name: Codeql.ADO.Build.Repository.Uri
               value: https://dev.azure.com/dnceng/internal/_git/microsoft-go-mirror
 
-        ${{ if and(parameters.official, eq(parameters.builder.config, 'buildandpack')) }}:
+        ${{ if and(parameters.ctx['Go1ESOfficial'], eq(parameters.builder.config, 'buildandpack')) }}:
           templateContext:
             outputs:
               # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs

--- a/eng/pipeline/stages/shorthand-builders-to-builders.yml
+++ b/eng/pipeline/stages/shorthand-builders-to-builders.yml
@@ -11,19 +11,27 @@
 # to be used by template expressions, as of writing.
 
 parameters:
+  - name: ctx
+    type: object
+
   # [] of { os, arch, hostArch, config, distro?, experiment?, broken? }
   # If hostArch is not defined, defaults to the arch value.
   # The job ID is generated based on these values.
-  shorthandBuilders: []
+  - name: shorthandBuilders
+    type: object
   # The inner jobs template to pass the filed-out builders into.
   #
   # It should accept parameter "builders", [] of { id, os, arch, hostArch, config, distro?, fips?, broken? }
-  jobsTemplate: ""
-  jobsParameters: {}
+  - name: jobsTemplate
+    type: string
+  - name: jobsParameters
+    type: object
+    default: {}
 
 stages:
   - template: ${{ parameters.jobsTemplate }}
     parameters:
+      ctx: ${{ parameters.ctx }}
       ${{ insert }}: ${{ parameters.jobsParameters }}
       builders:
         - ${{ each builder in parameters.shorthandBuilders }}:

--- a/eng/pipeline/stages/sign-stage.yml
+++ b/eng/pipeline/stages/sign-stage.yml
@@ -6,10 +6,11 @@
 # publishes the signed files and signatures into a consolidated pipeline artifact.
 
 parameters:
+  - name: ctx
+    type: object
+
   - name: builder
     type: object
-  - name: official
-    type: boolean
   - name: pool
     type: object
 
@@ -22,6 +23,7 @@ parameters:
 
 stages:
   - stage: Sign
+    displayName: Sign (${{ parameters.ctx['GoSigningType'] }})
     ${{ if eq(parameters.signExistingRunID, 'nil') }}:
       dependsOn:
         # Depend on all build stages that produced artifacts that need signing.
@@ -32,6 +34,7 @@ stages:
     jobs:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
         - job: Sign
+          displayName: Sign (${{ parameters.ctx['GoSigningType'] }})
           pool: ${{ parameters.pool }}
           workspace:
             clean: all
@@ -43,7 +46,7 @@ stages:
             mb:
               signing:
                 enabled: true
-                signType: $(SigningType)
+                signType: ${{ parameters.ctx['GoSigningType'] }}
                 zipSources: false
                 feedSource: 'https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json'
             outputs:

--- a/eng/pipeline/variables/pipeline.yml
+++ b/eng/pipeline/variables/pipeline.yml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Variables that are evaluated the same way by all pipelines.
+
+variables:
+  # Go1ESOfficial compile-time variable. Indicates that this is in the official
+  # pipeline. For example, image usage may be restricted, and the artifacts may
+  # be signed by a followup step, if this is the rolling build.
+  #
+  # Check for not ending in (unofficial), rather than ending in (official).
+  # Existing official pipeline names doing signing are "stuck" with their old
+  # names due to how signing authorization is checked, so not all pipelines that
+  # are official have an "(official)" suffix.
+  #
+  # Note that the value is coerced when used as a bool because variables are
+  # always strings. Not-defined evaluates as false and works fine in conditions.
+  - ${{ if not(endsWith(variables['Build.DefinitionName'], '(unofficial)')) }}:
+    - name: Go1ESOfficial
+      value: 'true'
+
+  # Don't include our own CI in telemetry data.
+  - name: MS_GOTOOLCHAIN_TELEMETRY_ENABLED
+    value: '0'
+


### PR DESCRIPTION
Pass along a `ctx` bag to store more global variable information. Now that official/unofficial production/non-production splits are becoming more of a focus, this will help deliver context to deep templates without an overwhelming amount of parameter declarations.

After merging this PR, we can move some other parameters to `ctx` to clean up the pipelines.

I tried to use compile-time variables directly, but still hit the same issue we [work around in go-images](https://github.com/microsoft/go-images/blob/b3565c200ac922e6a3e84226e4fd781ddc47e244/eng/pipeline/go-docker-rolling-internal-pipeline.yml#L60-L64).

Convert all templates to typed parameters to clarify and to get clearer errors out of AzDO in some cases.

* For https://github.com/microsoft/go-lab/issues/225

---

Test builds on c82bc47911075e10601b2094d2963d8f965df0ef in order of https://dev.azure.com/dnceng/internal/_build?definitionScope=%5CMicrosoft%5Cgo:

- https://dev.azure.com/dnceng/internal/_build/results?buildId=2764830&view=results ❌ (test signing fail: no pipeline artifacts)
- https://dev.azure.com/dnceng/internal/_build/results?buildId=2764831&view=results ✅
- https://dev.azure.com/dnceng/internal/_build/results?buildId=2764832&view=results ✅
- https://dev.azure.com/dnceng/internal/_build/results?buildId=2764833&view=results ✅
- https://dev.azure.com/dnceng/internal/_build/results?buildId=2764834&view=results ✅
- https://dev.azure.com/dnceng/internal/_build/results?buildId=2764835&view=results ❌ (publish)

Retrying publish on 40610e23 got past the failure, but commit change was unrelated. Was apparently just flakiness.

- https://dev.azure.com/dnceng/internal/_build/results?buildId=2765402&view=results ✅

Running signing fixes 1942ca51:

- https://dev.azure.com/dnceng/internal/_build/results?buildId=2765438&view=results ✅