### PR TITLE
release notes: bump to go1.26

### DIFF
--- a/docs/go1.25.md
+++ b/docs/go1.25.md
@@ -1,3 +1,0 @@
-# Microsoft build of Go 1.25 release notes
-
-After the release of 1.25, 1.23 is no longer supported, per the [Go release policy](https://go.dev/doc/devel/release).

--- a/docs/go1.26.md
+++ b/docs/go1.26.md
@@ -1,0 +1,3 @@
+# Microsoft build of Go 1.26 release notes
+
+After the release of 1.26, 1.24 is no longer supported, per the [Go release policy](https://go.dev/doc/devel/release).


### PR DESCRIPTION
bumping now that we've split out the 1.25 release branch

* For https://github.com/microsoft/go/issues/1796