### PR TITLE
Fix GoPublishReleaseStudio microsoft/main exclusion

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -61,7 +61,7 @@ variables:
       value: '' # Never publish internal branches using release studio.
     ${{ elseif parameters.publishReleaseStudio }}:
       value: 'true'
-    ${{ elseif and(variables['Go1ESOfficial'], ne(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+    ${{ elseif and(variables['Go1ESOfficial'], ne(variables['Build.SourceBranch'], 'refs/heads/microsoft/main')) }}:
       value: 'true'
     ${{ else }}:
       value: ''


### PR DESCRIPTION
* Fix branch check introduced by https://github.com/microsoft/go/pull/1795 intended to reduce publish resource usage in the main branch, where publish is never needed by automation.
* For https://github.com/microsoft/go-lab/issues/225

