### PR TITLE
linter: extract linter fixes from #1762

### DIFF
--- a/.github/workflows/patch-build.yml
+++ b/.github/workflows/patch-build.yml
@@ -10,9 +10,10 @@ on:
   pull_request:
     branches: [ microsoft/* ]
 
+# Cancel existing runs if user makes another push.
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/microsoft/main' }}
+  group: "${{ github.ref }}-${{ github.workflow}}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_patches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ on:
 
 # Cancel existing runs if user makes another push.
 concurrency:
-  group: "${{ github.ref }}"
+  group: "${{ github.ref }}-${{ github.workflow}}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/eng/_util/.golangci.yml
+++ b/eng/_util/.golangci.yml
@@ -1,0 +1,18 @@
+version: "2"
+linters:
+  enable:
+    - bodyclose
+    - godox
+    - nakedret
+    - predeclared
+    - unconvert
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+formatters:
+  enable:
+    - gofumpt

--- a/eng/_util/buildutil/buildutil.go
+++ b/eng/_util/buildutil/buildutil.go
@@ -15,7 +15,7 @@ import (
 
 // Retry runs f until it succeeds or the attempt limit is reached.
 func Retry(attempts int, f func() error) error {
-	var i = 0
+	i := 0
 	for ; i < attempts; i++ {
 		if attempts > 1 {
 			fmt.Printf("---- Running attempt %v of %v...\n", i+1, attempts)

--- a/eng/_util/cmd/build/build.go
+++ b/eng/_util/cmd/build/build.go
@@ -37,7 +37,7 @@ Example: Build Go, run tests, and produce an archive file:
 `
 
 func main() {
-	var help = flag.Bool("h", false, "Print this help message.")
+	help := flag.Bool("h", false, "Print this help message.")
 	o := &options{}
 
 	flag.BoolVar(&o.SkipBuild, "skipbuild", false, "Disable building Go.")
@@ -92,7 +92,6 @@ type options struct {
 }
 
 func build(o *options) (err error) {
-
 	scriptExtension := ".bash"
 	executableExtension := ""
 	archiveExtension := ".tar.gz"

--- a/eng/_util/cmd/cmdscan/cmdscan.go
+++ b/eng/_util/cmd/cmdscan/cmdscan.go
@@ -186,7 +186,7 @@ func scan(r io.Reader, commands, echo *os.File) error {
 		for _, f := range filters {
 			if f.regexp.MatchString(s.Text()) {
 				fmt.Fprintf(echo, "Found pattern '%v'\n", f.regexp)
-				fmt.Fprintf(commands, warn(&f, s.Text()))
+				fmt.Fprint(commands, warn(&f, s.Text()))
 			}
 		}
 	}

--- a/eng/_util/cmd/run-builder/run-builder.go
+++ b/eng/_util/cmd/run-builder/run-builder.go
@@ -37,15 +37,15 @@ in your repository to read-only.
 var dryRun = flag.Bool("n", false, "Enable dry run: print the commands that would be run, but do not run them.")
 
 func main() {
-	var builder = flag.String("builder", "", "[Required] Specify a builder to run. Note, this may be destructive!")
-	var experiment = flag.String("experiment", "", "Include this string in GOEXPERIMENT.")
-	var fipsMode = flag.Bool("fipsmode", false, "Run the Go tests in FIPS mode.")
-	var build = flag.Bool("build", false, "Run the build.")
-	var test = flag.Bool("test", false, "Run the tests.")
+	builder := flag.String("builder", "", "[Required] Specify a builder to run. Note, this may be destructive!")
+	experiment := flag.String("experiment", "", "Include this string in GOEXPERIMENT.")
+	fipsMode := flag.Bool("fipsmode", false, "Run the Go tests in FIPS mode.")
+	build := flag.Bool("build", false, "Run the build.")
+	test := flag.Bool("test", false, "Run the tests.")
 
-	var testJSONFlags = buildutil.BindTestJSONFlags()
+	testJSONFlags := buildutil.BindTestJSONFlags()
 
-	var help = flag.Bool("h", false, "Print this help message.")
+	help := flag.Bool("h", false, "Print this help message.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of run-builder.go:\n")

--- a/eng/_util/cmd/selftest/selftest.go
+++ b/eng/_util/cmd/selftest/selftest.go
@@ -18,7 +18,7 @@ This command runs the _util self-tests using the stage 0 Go toolchain.
 `
 
 func main() {
-	var help = flag.Bool("h", false, "Print this help message.")
+	help := flag.Bool("h", false, "Print this help message.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of selftest:\n")

--- a/eng/_util/cmd/sign/archive.go
+++ b/eng/_util/cmd/sign/archive.go
@@ -102,10 +102,6 @@ func (a *archive) macIndividualNotarizePackPath() string {
 	return filepath.Join(a.workDir, a.name+".FilesToNotarize.zip")
 }
 
-func (a *archive) macBundleNotarizePackPath() string {
-	return filepath.Join(a.workDir, a.name+".BundlesToNotarize.zip")
-}
-
 // entrySignInfo returns signing details for a given file in the Go archive, or nil if the given
 // file entry doesn't need to be signed.
 func (a *archive) entrySignInfo(name string) *fileToSign {

--- a/eng/_util/cmd/sign/sign.go
+++ b/eng/_util/cmd/sign/sign.go
@@ -109,6 +109,9 @@ func run() error {
 	individualFilesToNotarize, err := flatMapSlice(archives, func(a *archive) ([]*fileToSign, error) {
 		return a.prepareIndividualNotarize(ctx)
 	})
+	if err != nil {
+		return err
+	}
 
 	if err := sign(ctx, "2-Notarize-Individual", individualFilesToNotarize); err != nil {
 		return err

--- a/eng/_util/cmd/submodule-refresh/submodule-refresh.go
+++ b/eng/_util/cmd/submodule-refresh/submodule-refresh.go
@@ -19,11 +19,13 @@ This command refreshes the Go submodule: initializes it, resets the content, and
 applies patches to the stage by default, or optionally as commits.
 `
 
-var commits = flag.Bool("commits", false, "Apply the patches as commits.")
-var skipPatch = flag.Bool("skip-patch", false, "Skip applying patches.")
-var origin = flag.String("origin", "", "Use this origin instead of the default defined in '.gitmodules' to fetch the repository.")
-var shallow = flag.Bool("shallow", false, "Clone the submodule with depth 1.")
-var fetchBearerToken = flag.String("fetch-bearer-token", "", "Use this bearer token to fetch the submodule repository.")
+var (
+	commits          = flag.Bool("commits", false, "Apply the patches as commits.")
+	skipPatch        = flag.Bool("skip-patch", false, "Skip applying patches.")
+	origin           = flag.String("origin", "", "Use this origin instead of the default defined in '.gitmodules' to fetch the repository.")
+	shallow          = flag.Bool("shallow", false, "Clone the submodule with depth 1.")
+	fetchBearerToken = flag.String("fetch-bearer-token", "", "Use this bearer token to fetch the submodule repository.")
+)
 
 func main() {
 	repoRootDir, err := os.Getwd()
@@ -31,7 +33,7 @@ func main() {
 		panic(err)
 	}
 
-	var help = flag.Bool("h", false, "Print this help message.")
+	help := flag.Bool("h", false, "Print this help message.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage:\n")

--- a/eng/_util/cmd/updatelinktable/updatelinktable.go
+++ b/eng/_util/cmd/updatelinktable/updatelinktable.go
@@ -129,21 +129,27 @@ func filename(version, platform, ext string) string {
 	return "go" + version + "." + platform + ext
 }
 
-const checksumSuffix = ".sha256"
-const checksumMsg = "Checksum (SHA256)"
-const signatureSuffix = ".sig"
-const signatureMsg = "Signature<sup>1</sup>"
+const (
+	checksumSuffix  = ".sha256"
+	checksumMsg     = "Checksum (SHA256)"
+	signatureSuffix = ".sig"
+	signatureMsg    = "Signature<sup>1</sup>"
+)
 
 const baseURL = "https://aka.ms/golang/release/latest/"
 
-var docPath = filepath.Join("eng", "doc", "Downloads.md")
-var jsonPath = filepath.Join("eng", "doc", "release-branch-links.json")
+var (
+	docPath  = filepath.Join("eng", "doc", "Downloads.md")
+	jsonPath = filepath.Join("eng", "doc", "release-branch-links.json")
+)
 
-const beginMark = "<!-- BEGIN TABLES -->"
-const endMark = "<!-- END TABLES -->"
+const (
+	beginMark = "<!-- BEGIN TABLES -->"
+	endMark   = "<!-- END TABLES -->"
+)
 
 func main() {
-	var help = flag.Bool("h", false, "Print this help message.")
+	help := flag.Bool("h", false, "Print this help message.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage:\n")


### PR DESCRIPTION
While we continue to work out the best way to enable `golangci-lint` in https://github.com/microsoft/go/pull/1762, it makes sense to extract out the fixes to avoid them going stale.