### PR TITLE
Document installation of Microsoft build of Go for Ubuntu 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ includes builds of this Go fork.
 
 ### Ubuntu
 
-To install the Microsoft Build of Go using an Ubuntu package, open a terminal and run the following commands:
+To install the Microsoft build of Go using an Ubuntu package, open a terminal and run the following commands:
 
 ```bash
 # Supported Ubuntu versions: 22.04 and 24.04.

--- a/README.md
+++ b/README.md
@@ -90,18 +90,9 @@ includes builds of this Go fork.
 
 ### Ubuntu
 
-To install the Microsoft build of Go using an Ubuntu package, open a terminal and run the following commands:
-
-```bash
-# Supported Ubuntu versions: 22.04 and 24.04.
-# For other versions, please use the tar.gz package.
-# See Microsoft's official instructions for up-to-date steps:
-# https://learn.microsoft.com/linux/packages
-ubuntu_release=`lsb_release -rs`
-wget https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-sudo dpkg -i packages-microsoft-prod.deb
-```
-After the repository is added, install the Microsoft Build of Go by running the following commands:
+To install the Microsoft build of Go using an Ubuntu package, first set up the [Linux package repository for Microsoft Products](https://learn.microsoft.com/en-us/linux/packages).
+Packages are available in the Ubuntu 22.04 and 24.04 repositories.
+After the repository is added, install the Microsoft build of Go by running the following commands:
 
 ```bash
 sudo apt-get update && sudo apt-get install msft-golang

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ includes builds of this Go fork.
 
 To install the Microsoft build of Go using an Ubuntu package, first set up the [Linux package repository for Microsoft Products](https://learn.microsoft.com/en-us/linux/packages).
 Packages are available in the Ubuntu 22.04 and 24.04 repositories.
+
 After the repository is added, install the Microsoft build of Go by running the following commands:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ includes builds of this Go fork.
 To install the Microsoft Build of Go using an Ubuntu package, open a terminal and run the following commands:
 
 ```bash
-# Valid values are only '22.04' and '24.04'
-# For other versions of Ubuntu, please use the tar.gz package
+# Supported Ubuntu versions: 22.04 and 24.04.
+# For other versions, please use the tar.gz package.
+# See Microsoft's official instructions for up-to-date steps:
+# https://learn.microsoft.com/linux/packages
 ubuntu_release=`lsb_release -rs`
 wget https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ includes builds of this Go fork.
 
 ### Ubuntu
 
-To install the Microsoft Build of Go on Ubuntu 22.04 or 24.04 LTS, open a terminal and run the following commands:
+To install the Microsoft Build of Go on Ubuntu, open a terminal and run the following commands:
 ```bash
 # Valid values are only '22.04' and '24.04'
 # For other versions of Ubuntu, please use the tar.gz package

--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ After the repository is added, install the Microsoft Build of Go by running the 
 sudo apt-get update
 sudo apt-get install msft-golang
 ```
+Installing a Specific Version
+To install a specific version of the Microsoft Build of Go:
+
+List available versions:
+
+```bash
+apt-cache madison msft-golang
+```
+Install a specific version by specifying it explicitly:
+```bash
+sudo apt-get install msft-golang=<version>
+```
+For example:
+```bash
+sudo apt-get install msft-golang=1.22.3-1
+```
+Replace 1.22.3-1 with the version string listed in the apt-cache madison output.
+
 To verify the installation:
 ```bash
 go version

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ includes builds of this Go fork.
 * In Azure Linux 2.0, the package `msft-golang` installs this fork.
 * In Azure Linux 3.0, the `golang` package installs this fork.
 
+### Ubuntu
+
+To install the Microsoft Build of Go on Ubuntu 22.04 or 24.04 LTS, open a terminal and run the following commands:
+```bash
+# Valid values are only '22.04' and '24.04'
+# For other versions of Ubuntu, please use the tar.gz package
+ubuntu_release=`lsb_release -rs`
+wget https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+```
+After the repository is added, install the Microsoft Build of Go by running the following commands:
+```bash
+sudo apt-get update
+sudo apt-get install msft-golang
+```
+To verify the installation:
+```bash
+go version
+```
+
 ### Binary archive
 
 [Signed builds of Go](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/Downloads.md)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ includes builds of this Go fork.
 
 ### Ubuntu
 
-To install the Microsoft Build of Go on Ubuntu, open a terminal and run the following commands:
+To install the Microsoft Build of Go using an Ubuntu package, open a terminal and run the following commands:
 
 ```bash
 # Valid values are only '22.04' and '24.04'
@@ -102,33 +102,7 @@ sudo dpkg -i packages-microsoft-prod.deb
 After the repository is added, install the Microsoft Build of Go by running the following commands:
 
 ```bash
-sudo apt-get update
-sudo apt-get install msft-golang
-```
-Installing a Specific Version
-To install a specific version of the Microsoft Build of Go:
-
-List available versions:
-
-```bash
-apt-cache madison msft-golang
-```
-Install a specific version by specifying it explicitly:
-
-```bash
-sudo apt-get install msft-golang=<version>
-```
-For example:
-
-```bash
-sudo apt-get install msft-golang=1.22.3-1
-```
-Replace 1.22.3-1 with the version string listed in the apt-cache madison output.
-
-To verify the installation:
-
-```bash
-go version
+sudo apt-get update && sudo apt-get install msft-golang
 ```
 
 ### Binary archive

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ includes builds of this Go fork.
 ### Ubuntu
 
 To install the Microsoft Build of Go on Ubuntu, open a terminal and run the following commands:
+
 ```bash
 # Valid values are only '22.04' and '24.04'
 # For other versions of Ubuntu, please use the tar.gz package
@@ -99,6 +100,7 @@ wget https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-mic
 sudo dpkg -i packages-microsoft-prod.deb
 ```
 After the repository is added, install the Microsoft Build of Go by running the following commands:
+
 ```bash
 sudo apt-get update
 sudo apt-get install msft-golang
@@ -112,16 +114,19 @@ List available versions:
 apt-cache madison msft-golang
 ```
 Install a specific version by specifying it explicitly:
+
 ```bash
 sudo apt-get install msft-golang=<version>
 ```
 For example:
+
 ```bash
 sudo apt-get install msft-golang=1.22.3-1
 ```
 Replace 1.22.3-1 with the version string listed in the apt-cache madison output.
 
 To verify the installation:
+
 ```bash
 go version
 ```


### PR DESCRIPTION
This PR documents installing Microsoft build of Go on Ubuntu via apt package manager.
Fixes: #1430