### PR TITLE
[release-branch.go1.24] Attribute patch files to bot: clarify lack of ownership (#1787)

### DIFF
--- a/.git-go-patch
+++ b/.git-go-patch
@@ -1,0 +1,7 @@
+{
+  "MinimumToolVersion": "v1.0.1",
+  "SubmoduleDir": "go",
+  "PatchesDir": "patches",
+  "StatusFileDir": "eng/artifacts/go-patch",
+  "ExtractAsAuthor": "bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>"
+}

--- a/patches/0001-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0001-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 31 May 2023 16:54:31 -0500
 Subject: [PATCH] Add crypto backend GOEXPERIMENTs
 
@@ -512,7 +512,7 @@ index 00000000000000..fcd4cb9da0d162
 +const SystemCrypto = true
 +const SystemCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 31b3d0315b64f8..e6c9b7d5e62dc0 100644
+index 948ed5c802801c..bcdba27b0f836d 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -59,6 +59,24 @@ type Flags struct {

--- a/patches/0002-Vendor-crypto-backends.patch
+++ b/patches/0002-Vendor-crypto-backends.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Quim Muntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Mon, 23 May 2022 12:59:36 +0000
 Subject: [PATCH] Vendor crypto backends
 

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 15 Jan 2025 16:32:26 +0100
 Subject: [PATCH] Implement crypto/internal/backend
 

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Tue, 14 Jan 2025 11:10:21 +0100
 Subject: [PATCH] Use crypto backends
 

--- a/patches/0005-Update-default-go.env.patch
+++ b/patches/0005-Update-default-go.env.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Thu, 8 Jun 2023 14:17:13 +0200
 Subject: [PATCH] Update default go.env
 

--- a/patches/0006-Skip-failing-tests-on-Windows.patch
+++ b/patches/0006-Skip-failing-tests-on-Windows.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 11 Oct 2023 10:44:22 +0200
 Subject: [PATCH] Skip failing tests on Windows
 
@@ -8,10 +8,10 @@ Subject: [PATCH] Skip failing tests on Windows
  1 file changed, 3 insertions(+)
 
 diff --git a/src/cmd/cgo/internal/test/test.go b/src/cmd/cgo/internal/test/test.go
-index 9a6c6d82cefa1a..b0b6795f6920f6 100644
+index fcac0762253247..131206f2058090 100644
 --- a/src/cmd/cgo/internal/test/test.go
 +++ b/src/cmd/cgo/internal/test/test.go
-@@ -1074,6 +1074,9 @@ func testErrno(t *testing.T) {
+@@ -1096,6 +1096,9 @@ func testErrno(t *testing.T) {
  }
  
  func testMultipleAssign(t *testing.T) {

--- a/patches/0007-add-support-for-logging-used-Windows-APIs.patch
+++ b/patches/0007-add-support-for-logging-used-Windows-APIs.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Tue, 19 Mar 2024 16:48:18 +0100
 Subject: [PATCH] add support for logging used Windows APIs
 
@@ -17,7 +17,7 @@ Subject: [PATCH] add support for logging used Windows APIs
  create mode 100644 src/runtime/zsyscalltrace_windows.go
 
 diff --git a/src/runtime/os_windows.go b/src/runtime/os_windows.go
-index 7183e79f7df093..2b382202bf7e49 100644
+index 54407a320c054d..9073fd4f008dcd 100644
 --- a/src/runtime/os_windows.go
 +++ b/src/runtime/os_windows.go
 @@ -223,6 +223,7 @@ func windowsFindfunc(lib uintptr, name []byte) stdFunction {

--- a/patches/0008-remove-long-path-support-hack.patch
+++ b/patches/0008-remove-long-path-support-hack.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Mon, 25 Mar 2024 12:14:00 +0100
 Subject: [PATCH] remove long path support hack
 
@@ -17,10 +17,10 @@ only affect long relative paths, which can't be used with the `\\?\`.
  1 file changed, 1 insertion(+), 22 deletions(-)
 
 diff --git a/src/runtime/os_windows.go b/src/runtime/os_windows.go
-index fc7296f28ab12f..d3e0149c90febc 100644
+index 9073fd4f008dcd..fdf14e5852f32a 100644
 --- a/src/runtime/os_windows.go
 +++ b/src/runtime/os_windows.go
-@@ -136,7 +136,6 @@ var (
+@@ -137,7 +137,6 @@ var (
  	_NtCreateWaitCompletionPacket    stdFunction
  	_NtAssociateWaitCompletionPacket stdFunction
  	_NtCancelWaitCompletionPacket    stdFunction
@@ -28,7 +28,7 @@ index fc7296f28ab12f..d3e0149c90febc 100644
  	_RtlGetVersion                   stdFunction
  
  	// These are from non-kernel32.dll, so we prefer to LoadLibraryEx them.
-@@ -286,7 +285,6 @@ func loadOptionalSyscalls() {
+@@ -287,7 +286,6 @@ func loadOptionalSyscalls() {
  			throw("NtCreateWaitCompletionPacket exists but NtCancelWaitCompletionPacket does not")
  		}
  	}
@@ -36,7 +36,7 @@ index fc7296f28ab12f..d3e0149c90febc 100644
  	_RtlGetVersion = windowsFindfunc(n32, []byte("RtlGetVersion\000"))
  }
  
-@@ -450,26 +448,7 @@ var canUseLongPaths bool
+@@ -451,26 +449,7 @@ var canUseLongPaths bool
  
  // initLongPathSupport enables long path support.
  func initLongPathSupport() {

--- a/patches/0009-Omit-internal-go.mod-files-used-for-codegen.patch
+++ b/patches/0009-Omit-internal-go.mod-files-used-for-codegen.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 24 May 2024 15:38:31 -0700
 Subject: [PATCH] Omit internal go.mod files used for codegen
 


### PR DESCRIPTION
Backports https://github.com/microsoft/go/pull/1787 to go1.24