### PR TITLE
[release-branch.go1.23] Attribute patch files to bot: clarify lack of ownership (#1787)

### DIFF
--- a/.git-go-patch
+++ b/.git-go-patch
@@ -1,0 +1,7 @@
+{
+  "MinimumToolVersion": "v1.0.1",
+  "SubmoduleDir": "go",
+  "PatchesDir": "patches",
+  "StatusFileDir": "eng/artifacts/go-patch",
+  "ExtractAsAuthor": "bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>"
+}

--- a/patches/0001-Add-systemcrypto-GOEXPERIMENT.patch
+++ b/patches/0001-Add-systemcrypto-GOEXPERIMENT.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 31 May 2023 16:54:31 -0500
 Subject: [PATCH] Add systemcrypto GOEXPERIMENT
 
@@ -33,10 +33,10 @@ maintain this feature. For more information, see the test files.
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_on.go
 
 diff --git a/src/cmd/go/internal/modindex/build.go b/src/cmd/go/internal/modindex/build.go
-index b57f2f6368f0fe..9ddde1ce9a2286 100644
+index 0b06373984190a..bbf6d48cf97238 100644
 --- a/src/cmd/go/internal/modindex/build.go
 +++ b/src/cmd/go/internal/modindex/build.go
-@@ -880,13 +880,67 @@ func (ctxt *Context) matchTag(name string, allTags map[string]bool) bool {
+@@ -885,13 +885,67 @@ func (ctxt *Context) matchTag(name string, allTags map[string]bool) bool {
  		name = "goexperiment.boringcrypto" // boringcrypto is an old name for goexperiment.boringcrypto
  	}
  
@@ -184,10 +184,10 @@ index 00000000000000..1756c5d027fee0
 +	}
 +}
 diff --git a/src/go/build/build.go b/src/go/build/build.go
-index dd6cdc903a21a8..48adcfed5cf3cb 100644
+index 000db9fb652e95..01cf6afa20012c 100644
 --- a/src/go/build/build.go
 +++ b/src/go/build/build.go
-@@ -1947,13 +1947,67 @@ func (ctxt *Context) matchTag(name string, allTags map[string]bool) bool {
+@@ -1983,13 +1983,67 @@ func (ctxt *Context) matchTag(name string, allTags map[string]bool) bool {
  		name = "goexperiment.boringcrypto" // boringcrypto is an old name for goexperiment.boringcrypto
  	}
  
@@ -394,7 +394,7 @@ index 00000000000000..9c5b0bbc7b99dc
 +const SystemCrypto = true
 +const SystemCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index ae3cbaf89fa5dd..de79140b2d4780 100644
+index 3f9c5af68e36eb..777337d92d3c72 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,21 @@ type Flags struct {

--- a/patches/0002-Add-crypto-backend-foundation.patch
+++ b/patches/0002-Add-crypto-backend-foundation.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Thu, 30 Jun 2022 10:03:03 +0200
 Subject: [PATCH] Add crypto backend foundation
 

--- a/patches/0003-Add-BoringSSL-crypto-backend.patch
+++ b/patches/0003-Add-BoringSSL-crypto-backend.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Quim Muntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 22 Jun 2022 12:16:05 +0000
 Subject: [PATCH] Add BoringSSL crypto backend
 
@@ -30,7 +30,7 @@ index 00000000000000..0b62cef68546d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/boring_linux.go b/src/crypto/internal/backend/boring_linux.go
 new file mode 100644
-index 00000000000000..7c5fbeea717618
+index 00000000000000..549b50d7cffe3e
 --- /dev/null
 +++ b/src/crypto/internal/backend/boring_linux.go
 @@ -0,0 +1,225 @@

--- a/patches/0004-Add-OpenSSL-crypto-backend.patch
+++ b/patches/0004-Add-OpenSSL-crypto-backend.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Thu, 30 Jun 2022 10:06:19 +0200
 Subject: [PATCH] Add OpenSSL crypto backend
 

--- a/patches/0005-Add-CNG-crypto-backend.patch
+++ b/patches/0005-Add-CNG-crypto-backend.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Tue, 19 Jul 2022 15:58:02 +0200
 Subject: [PATCH] Add CNG crypto backend
 

--- a/patches/0006-Vendor-crypto-backends.patch
+++ b/patches/0006-Vendor-crypto-backends.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Quim Muntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Mon, 23 May 2022 12:59:36 +0000
 Subject: [PATCH] Vendor crypto backends
 
@@ -9662,7 +9662,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b8a0b84a282a32..676e784fcf04e2 100644
+index 1c88c1299f14cf..296702e10ed1c6 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,14 @@

--- a/patches/0007-Add-backend-code-gen.patch
+++ b/patches/0007-Add-backend-code-gen.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 23 Jun 2023 11:58:31 -0500
 Subject: [PATCH] Add backend code gen
 
@@ -370,7 +370,7 @@ index 00000000000000..1ba948c8f207e5
 +	return bs
 +}
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-index ad6081552af15d..d5948dbc5f8a2a 100644
+index 08600a2c833ac7..eddfb35aca54e9 100644
 --- a/src/crypto/internal/backend/nobackend.go
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -4,7 +4,7 @@
@@ -413,7 +413,7 @@ index 00000000000000..8d0c3fde9ab5e8
 +const AllowCryptoFallback = true
 +const AllowCryptoFallbackInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index c2f69930e2240e..c8e10ebc1696c4 100644
+index c0f1a8a0322dbf..8e4cf87664e28e 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -77,6 +77,14 @@ type Flags struct {
@@ -562,7 +562,7 @@ index 00000000000000..ae7f798ea41225
 +}
 diff --git a/src/runtime/backenderr_gen_nofallback_openssl.go b/src/runtime/backenderr_gen_nofallback_openssl.go
 new file mode 100644
-index 00000000000000..351be70262084b
+index 00000000000000..7e1679dfc37a23
 --- /dev/null
 +++ b/src/runtime/backenderr_gen_nofallback_openssl.go
 @@ -0,0 +1,24 @@

--- a/patches/0008-Update-default-go.env.patch
+++ b/patches/0008-Update-default-go.env.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Thu, 8 Jun 2023 14:17:13 +0200
 Subject: [PATCH] Update default go.env
 

--- a/patches/0009-Skip-failing-tests-on-Windows.patch
+++ b/patches/0009-Skip-failing-tests-on-Windows.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 11 Oct 2023 10:44:22 +0200
 Subject: [PATCH] Skip failing tests on Windows
 
@@ -8,10 +8,10 @@ Subject: [PATCH] Skip failing tests on Windows
  1 file changed, 3 insertions(+)
 
 diff --git a/src/cmd/cgo/internal/test/test.go b/src/cmd/cgo/internal/test/test.go
-index 9a6c6d82cefa1a..b0b6795f6920f6 100644
+index 362be79a737bee..b1a74464866357 100644
 --- a/src/cmd/cgo/internal/test/test.go
 +++ b/src/cmd/cgo/internal/test/test.go
-@@ -1074,6 +1074,9 @@ func testErrno(t *testing.T) {
+@@ -1095,6 +1095,9 @@ func testErrno(t *testing.T) {
  }
  
  func testMultipleAssign(t *testing.T) {

--- a/patches/0010-Support-TLS-1.3-in-fipstls-mode.patch
+++ b/patches/0010-Support-TLS-1.3-in-fipstls-mode.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Tue, 30 Jan 2024 11:40:31 +0100
 Subject: [PATCH] Support TLS 1.3 in fipstls mode
 
@@ -187,7 +187,7 @@ index 9b28acdc2d866a..3e780f447b522b 100644
  
  // defaultCipherSuitesTLS13FIPS are the FIPS-allowed cipher suites for TLS 1.3.
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
-index 6873e8daf631a7..585640d4b1a4d5 100644
+index bdbdee94af1bab..e4452283e59869 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
 @@ -141,13 +141,22 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCon
@@ -216,7 +216,7 @@ index 6873e8daf631a7..585640d4b1a4d5 100644
  		if curveID == x25519Kyber768Draft00 {
  			keyShareKeys.ecdhe, err = generateECDHEKey(config.rand(), X25519)
 diff --git a/src/crypto/tls/handshake_client_tls13.go b/src/crypto/tls/handshake_client_tls13.go
-index 6744e713c9ffa8..5b4c4568555d3d 100644
+index db5e35d9a46c2e..21a501fbfd592b 100644
 --- a/src/crypto/tls/handshake_client_tls13.go
 +++ b/src/crypto/tls/handshake_client_tls13.go
 @@ -45,10 +45,6 @@ type clientHandshakeStateTLS13 struct {
@@ -231,10 +231,10 @@ index 6744e713c9ffa8..5b4c4568555d3d 100644
  	// sections 4.1.2 and 4.1.3.
  	if c.handshakes > 0 {
 diff --git a/src/crypto/tls/handshake_server_test.go b/src/crypto/tls/handshake_server_test.go
-index bc45a289c1ed70..47e2ce17bb9e8e 100644
+index bbfe44bd97daa2..1d6419376f3871 100644
 --- a/src/crypto/tls/handshake_server_test.go
 +++ b/src/crypto/tls/handshake_server_test.go
-@@ -27,6 +27,7 @@ import (
+@@ -28,6 +28,7 @@ import (
  )
  
  func testClientHello(t *testing.T, serverConfig *Config, m handshakeMessage) {
@@ -242,7 +242,7 @@ index bc45a289c1ed70..47e2ce17bb9e8e 100644
  	testClientHelloFailure(t, serverConfig, m, "")
  }
  
-@@ -84,9 +85,11 @@ func testClientHelloFailure(t *testing.T, serverConfig *Config, m handshakeMessa
+@@ -85,9 +86,11 @@ func testClientHelloFailure(t *testing.T, serverConfig *Config, m handshakeMessa
  	t.Helper()
  	if len(expectedSubStr) == 0 {
  		if err != nil && err != io.EOF {
@@ -255,7 +255,7 @@ index bc45a289c1ed70..47e2ce17bb9e8e 100644
  	}
  }
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index f88fcad4e78f0d..b95299a44c8fc1 100644
+index 53dfce967b3c2a..eb289a3f7467fb 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
 @@ -48,10 +48,6 @@ type serverHandshakeStateTLS13 struct {

--- a/patches/0011-unset-GOFIPS-when-running-the-Go-toolchain.patch
+++ b/patches/0011-unset-GOFIPS-when-running-the-Go-toolchain.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 14 Feb 2024 11:03:01 +0100
 Subject: [PATCH] unset GOFIPS when running the Go toolchain
 
@@ -48,10 +48,10 @@ index 00000000000000..009eece5b6c080
 +	return gofips, gofipsSet
 +}
 diff --git a/src/cmd/go/main.go b/src/cmd/go/main.go
-index d380aae489436f..fe619a8aadd2ae 100644
+index 1c58232a6621b9..59961da22e5653 100644
 --- a/src/cmd/go/main.go
 +++ b/src/cmd/go/main.go
-@@ -29,6 +29,7 @@ import (
+@@ -27,6 +27,7 @@ import (
  	"cmd/go/internal/fix"
  	"cmd/go/internal/fmtcmd"
  	"cmd/go/internal/generate"
@@ -59,7 +59,7 @@ index d380aae489436f..fe619a8aadd2ae 100644
  	"cmd/go/internal/help"
  	"cmd/go/internal/list"
  	"cmd/go/internal/modcmd"
-@@ -223,6 +224,10 @@ func invoke(cmd *base.Command, args []string) {
+@@ -261,6 +262,10 @@ func invoke(cmd *base.Command, args []string) {
  	// but in practice there might be skew
  	// This makes sure we all agree.
  	cfg.OrigEnv = toolchain.FilterEnv(os.Environ())

--- a/patches/0012-add-support-for-logging-used-Windows-APIs.patch
+++ b/patches/0012-add-support-for-logging-used-Windows-APIs.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Tue, 19 Mar 2024 16:48:18 +0100
 Subject: [PATCH] add support for logging used Windows APIs
 
@@ -29,7 +29,7 @@ index 4aabc29644e6f9..fc7296f28ab12f 100644
  	return stdFunction(unsafe.Pointer(f))
  }
 diff --git a/src/runtime/syscall_windows.go b/src/runtime/syscall_windows.go
-index 69d720a395c48d..2772c019a15af2 100644
+index 85b1b8c9024a73..384be25350726e 100644
 --- a/src/runtime/syscall_windows.go
 +++ b/src/runtime/syscall_windows.go
 @@ -443,6 +443,7 @@ func syscall_loadlibrary(filename *uint16) (handle, err uintptr) {

--- a/patches/0013-remove-long-path-support-hack.patch
+++ b/patches/0013-remove-long-path-support-hack.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Mon, 25 Mar 2024 12:14:00 +0100
 Subject: [PATCH] remove long path support hack
 

--- a/patches/0014-Omit-internal-go.mod-files-used-for-codegen.patch
+++ b/patches/0014-Omit-internal-go.mod-files-used-for-codegen.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 24 May 2024 15:38:31 -0700
 Subject: [PATCH] Omit internal go.mod files used for codegen
 

--- a/patches/0015-Ignore-missing-telemetry-counters-with-cngcrypto-exp.patch
+++ b/patches/0015-Ignore-missing-telemetry-counters-with-cngcrypto-exp.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 24 Jul 2024 17:52:52 -0700
 Subject: [PATCH] Ignore missing telemetry counters with cngcrypto experiment
 

--- a/patches/0016-implement-ms_tls_config_schannel-experiment.patch
+++ b/patches/0016-implement-ms_tls_config_schannel-experiment.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <qmuntaldiaz@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Tue, 8 Jul 2025 16:04:25 +0200
 Subject: [PATCH] implement ms_tls_config_schannel experiment
 

--- a/patches/0017-cmd-cgo-internal-testsanitizers-fix-TSAN-tests-using.patch
+++ b/patches/0017-cmd-cgo-internal-testsanitizers-fix-TSAN-tests-using.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: qmuntal <quimmuntal@gmail.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 20 Nov 2024 16:02:03 +0100
 Subject: [PATCH] cmd/cgo/internal/testsanitizers: fix TSAN tests using setarch
 


### PR DESCRIPTION
Backports https://github.com/microsoft/go/pull/1787 to go1.23