### PR TITLE
[release-branch.go1.25] Add branch to .gitmodules file

### DIFF
--- a/.github/workflows/patch-build.yml
+++ b/.github/workflows/patch-build.yml
@@ -10,9 +10,10 @@ on:
   pull_request:
     branches: [ microsoft/* ]
 
+# Cancel existing runs if user makes another push.
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/microsoft/main' }}
+  group: "${{ github.ref }}-${{ github.workflow}}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_patches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ on:
 
 # Cancel existing runs if user makes another push.
 concurrency:
-  group: "${{ github.ref }}"
+  group: "${{ github.ref }}-${{ github.workflow}}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "go"]
 	path = go
 	url = https://github.com/golang/go
+	branch = release-branch.go1.25


### PR DESCRIPTION
Currently when running `git submodule update --remote`, the `go` submodule is updated to the latest `master` commit. By explictly setting the branch to be `release-branch.go1.25` this ensures we never pull in the wrong submodule commit.