### PR TITLE
Split validation pipeline for resource trigger

### DIFF
--- a/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This pipeline runs rolling validation, like CodeQL.
+
+# unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1486
+
+trigger: none
+pr: none
+
+variables:
+  - template: variables/pipeline.yml
+  - template: variables/codeql.yml
+  - template: variables/pool-providers.yml
+
+  # The default cadence is ok for official branches. The cadence is per-branch.
+  # For a dev build, the cadence would prevent dev iteration.
+  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-general-faq#how-do-i-check-if-my-project-is-onboarded
+  - name: Codeql.Cadence
+    value: 0
+
+resources:
+  pipelines:
+    - pipeline: build
+      source: microsoft-go
+
+extends:
+  template: rolling-internal-validation.yml
+  parameters:
+    ctx:
+      ${{ each variable in variables }}:
+        ${{ if startsWith(variable.key, 'Go') }}:
+          ${{ variable.key }}: ${{ variable.value }}

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -5,37 +5,14 @@
 # This pipeline runs rolling validation, like CodeQL.
 
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1354
-# unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1486
 
 trigger: none
 pr: none
 
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
-parameters:
-  - name: enableCodeQL
-    displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications in dev branches.'
-    type: boolean
-    default: false
-  - name: disableTSA
-    displayName: '[Debug input] Disable TSA reporting. Use to try modifications in dev branches.'
-    type: boolean
-    default: false
-
 variables:
   - template: variables/pipeline.yml
+  - template: variables/codeql.yml
   - template: variables/pool-providers.yml
-  - name: Codeql.PublishDatabase
-    value: true
-  - name: Codeql.PublishDatabaseLog
-    value: true
-  - name: Codeql.PublishDatabaseLog
-    value: true
-  - ${{ if parameters.enableCodeQL }}:
-    # The default cadence is ok for official branches. The cadence is per-branch.
-    # For a dev build, the cadence would prevent dev iteration.
-    # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-general-faq#how-do-i-check-if-my-project-is-onboarded
-    - name: Codeql.Cadence
-      value: 0
 
 resources:
   pipelines:
@@ -48,45 +25,18 @@ resources:
       # This means we can have SDL scan the currently-checked-out source code as the way to scan the
       # source code of the internal rolling build.
       source: microsoft-go
+      # Trigger can't be conditioned, so this resource can't be declared inside
+      # the template. "A template expression is not allowed in this context".
       trigger:
         branches:
           include:
             - microsoft/main
             - microsoft/release-branch.*
-  repositories:
-    - repository: 1ESPipelineTemplates
-      type: git
-      name: 1ESPipelineTemplates/1ESPipelineTemplates
-      ref: refs/tags/release
 
 extends:
-  ${{ if variables['Go1ESOfficial'] }}:
-    template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
-  ${{ else }}:
-    template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  template: rolling-internal-validation.yml
   parameters:
-    pool:
-      name: $(DncEngInternalBuildPool)
-      image: 1es-windows-2022
-      os: windows
-    sdl:
-      codeql:
-        enabledOnNonDefaultBranches: ${{ parameters.enableCodeQL }}
-        language: go,cpp,powershell,javascript
-      suppression:
-        suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
-      tsa:
-        enabled: ${{ not(parameters.disableTSA) }}
-        configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
-
-    stages:
-      - template: /eng/pipeline/stages/shorthand-builders-to-builders.yml@self
-        parameters:
-          ctx: {}
-          jobsTemplate: builders-to-stages.yml
-          shorthandBuilders:
-            # CodeQL doesn't submit the scan to both the outer repo
-            # (microsoft-go) and inner repo (microsoft-go-mirror).
-            # Use two jobs to submit two scans.
-            - { os: linux, arch: amd64, config: codeql_outer }
-            - { os: linux, arch: amd64, config: codeql_inner }
+    ctx:
+      ${{ each variable in variables }}:
+        ${{ if startsWith(variable.key, 'Go') }}:
+          ${{ variable.key }}: ${{ variable.value }}

--- a/eng/pipeline/rolling-internal-validation.yml
+++ b/eng/pipeline/rolling-internal-validation.yml
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This pipeline runs rolling validation, like CodeQL.
+
+parameters:
+  - name: ctx
+    type: object
+
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  ${{ if variables['Go1ESOfficial'] }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: 1es-windows-2022
+      os: windows
+    sdl:
+      codeql:
+        enabledOnNonDefaultBranches: ${{ not(variables['Go1ESOfficial']) }}
+        language: go,cpp,powershell,javascript
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
+      tsa:
+        enabled: ${{ variables['Go1ESOfficial'] }}
+        configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
+
+    stages:
+      - template: /eng/pipeline/stages/shorthand-builders-to-builders.yml@self
+        parameters:
+          ctx: ${{ parameters.ctx }}
+          jobsTemplate: builders-to-stages.yml
+          shorthandBuilders:
+            # CodeQL doesn't submit the scan to both the outer repo
+            # (microsoft-go) and inner repo (microsoft-go-mirror).
+            # Use two jobs to submit two scans.
+            - { os: linux, arch: amd64, config: codeql_outer }
+            - { os: linux, arch: amd64, config: codeql_inner }

--- a/eng/pipeline/variables/codeql.yml
+++ b/eng/pipeline/variables/codeql.yml
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+variables:
+  - name: Codeql.PublishDatabase
+    value: true
+  - name: Codeql.PublishDatabaseLog
+    value: true
+  - name: Codeql.PublishDatabaseLog
+    value: true


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/225

I noticed the unofficial pipeline was triggering for every build along with the official pipeline. Only the official one should trigger. The unofficial one is for dev work.

See https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#pipeline-templates-to-reduce-duplication-with-officialunofficial-split

The split removes the need for `parameters` because we can treat unofficial as for-developers, which is lucky because we can't share parameters through pipeline yml templates.

Test official pipeline: https://dev.azure.com/dnceng/internal/_build/results?buildId=2769728&view=results
Test unofficial pipeline: https://dev.azure.com/dnceng/internal/_build/results?buildId=2769727&view=results