### PR TITLE
More specific GoPublishReleaseStudio to avoid dev branches

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -64,11 +64,12 @@ variables:
 
   - name: GoPublishReleaseStudio
     ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/') }}:
-      value: '' # Never publish internal branches using release studio.
+      value: '' # Never publish internal branches using release studio, even if checkbox ticked.
     ${{ elseif parameters.publishReleaseStudio }}:
       value: 'true'
-    ${{ elseif and(variables['Go1ESOfficial'], ne(variables['Build.SourceBranch'], 'refs/heads/microsoft/main')) }}:
-      value: 'true'
+    # We've dealt with manual opt-in. Next, determine the default behavior:
+    ${{ elseif and(variables['Go1ESOfficial'], startsWith(variables['Build.SourceBranch'], 'refs/heads/microsoft/release-branch.go')) }}:
+      value: 'true' # Publish a release branch built in the official pipeline by default.
     ${{ else }}:
       value: ''
 


### PR DESCRIPTION
* A bit of cleanup for https://github.com/microsoft/go-lab/issues/225

Currently, dev branches have publish enabled by default because they're not `microsoft/main`. Fix the condition to be positive about release branches.

Needs backport for a proper test of the branch name match.