### PR TITLE
[release-branch.go1.25] More specific GoPublishReleaseStudio to avoid dev branches (#1830)

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -64,11 +64,12 @@ variables:
 
   - name: GoPublishReleaseStudio
     ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/') }}:
-      value: '' # Never publish internal branches using release studio.
+      value: '' # Never publish internal branches using release studio, even if checkbox ticked.
     ${{ elseif parameters.publishReleaseStudio }}:
       value: 'true'
-    ${{ elseif and(variables['Go1ESOfficial'], ne(variables['Build.SourceBranch'], 'refs/heads/microsoft/main')) }}:
-      value: 'true'
+    # We've dealt with manual opt-in. Next, determine the default behavior:
+    ${{ elseif and(variables['Go1ESOfficial'], startsWith(variables['Build.SourceBranch'], 'refs/heads/microsoft/release-branch.go')) }}:
+      value: 'true' # Publish a release branch built in the official pipeline by default.
     ${{ else }}:
       value: ''
 


### PR DESCRIPTION
(cherry picked from https://github.com/microsoft/go/pull/1830)

* For https://github.com/microsoft/go-lab/issues/225