### PR TITLE
Consolidate signing diag files, use outputParentDirectory

### DIFF
--- a/eng/_util/cmd/sign/archive.go
+++ b/eng/_util/cmd/sign/archive.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -44,6 +45,8 @@ type archive struct {
 	notarizedPath string
 }
 
+const signingWorkingDirPrefix = "sign-work-"
+
 func newArchive(p string) (*archive, error) {
 	name := filepath.Base(p)
 	a := archive{
@@ -65,7 +68,7 @@ func newArchive(p string) (*archive, error) {
 	if err := os.MkdirAll(*tempDir, 0o777); err != nil {
 		return nil, err
 	}
-	workDir, err := os.MkdirTemp(*tempDir, "sign-work-"+name)
+	workDir, err := os.MkdirTemp(*tempDir, signingWorkingDirPrefix+name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create work directory: %v", err)
 	}
@@ -457,5 +460,80 @@ func (a *archive) copyToDestination(ctx context.Context) error {
 	if err := copyFile(filepath.Join(*destinationDir, a.name+".sig"), a.sigPath()); err != nil {
 		return err
 	}
+	return nil
+}
+
+func consolidateDiagnosticFiles() error {
+	// Signing process logs.
+	if err := copyGlobFilesToDir(
+		*consolidateDiagDir,
+		filepath.Join(*signingCsprojDir, "*.log"),
+		filepath.Join(*tempDir, "*.binlog"),
+		filepath.Join(*tempDir, "*.props"),
+	); err != nil {
+		return err
+	}
+	// .NET diag data, for package versions etc.
+	if err := copyGlobFilesToDir(
+		filepath.Join(*consolidateDiagDir, "obj"),
+		filepath.Join(*signingCsprojDir, "obj", "*"),
+	); err != nil {
+		return err
+	}
+
+	// Signing working dirs. These contain the files actually sent to sign. Make
+	// it clear that they're not production-ready files through the filename.
+	cleanTempDir := filepath.Clean(*tempDir)
+	if err := withTarGzCreate(
+		filepath.Join(*consolidateDiagDir, "sign-work-archives.nonproduction.tar.gz"),
+		func(tw *tar.Writer) error {
+			if err := filepath.WalkDir(cleanTempDir, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				// At the top level, only walk into working dirs.
+				if d.IsDir() &&
+					filepath.Dir(path) == cleanTempDir &&
+					!strings.HasPrefix(d.Name(), signingWorkingDirPrefix) {
+
+					return filepath.SkipDir
+				}
+				// Inside a given working dir, we are free to walk recursively.
+				if d.IsDir() {
+					return nil
+				}
+				// This is a file: archive it.
+				df, err := d.Info()
+				if err != nil {
+					return err
+				}
+				// Basic sanity checks.
+				if !filepath.IsLocal(path) {
+					return fmt.Errorf("path %q is not a local path", path)
+				}
+				tarPath, ok := strings.CutPrefix(path, cleanTempDir+string(filepath.Separator))
+				if !ok {
+					return fmt.Errorf("path %q is not under temp dir %q", path, *tempDir)
+				}
+				tarPath = filepath.ToSlash(tarPath)
+
+				err = tw.WriteHeader(&tar.Header{
+					Name: tarPath,
+					Size: df.Size(),
+					Mode: 0o644,
+				})
+				if err != nil {
+					return err
+				}
+				return copyFromFile(tw, path)
+			}); err != nil {
+				return err
+			}
+			return nil
+		},
+	); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/eng/_util/cmd/sign/archiveutil.go
+++ b/eng/_util/cmd/sign/archiveutil.go
@@ -124,6 +124,30 @@ func copyToFile(path string, r io.Reader) error {
 	return cmp.Or(err, f.Close())
 }
 
+func copyFromFile(w io.Writer, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, f)
+	return cmp.Or(err, f.Close())
+}
+
+func copyGlobFilesToDir(dir string, globs ...string) error {
+	for _, glob := range globs {
+		files, err := filepath.Glob(glob)
+		if err != nil {
+			return err
+		}
+		for _, f := range files {
+			if err := copyFile(filepath.Join(dir, filepath.Base(f)), f); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // matchOrPanic returns whether name matches the pattern glob, or panics if pattern is invalid.
 func matchOrPanic(pattern, name string) bool {
 	ok, err := filepath.Match(pattern, name)

--- a/eng/_util/cmd/sign/sign.go
+++ b/eng/_util/cmd/sign/sign.go
@@ -35,10 +35,11 @@ See /eng/_util/cmd/sign/README.md for more information.
 `
 
 var (
-	filesGlob        = flag.String("files", "eng/signing/tosign/*", "Glob of Go archives to sign.")
-	destinationDir   = flag.String("o", "eng/signing/signed", "Directory to store signed files.")
-	tempDir          = flag.String("temp-dir", "eng/signing/signing-temp", "Directory to store temporary files.")
-	signingCsprojDir = flag.String("signing-csproj-dir", "eng/signing", "Directory containing Sign.csproj and related files.")
+	filesGlob          = flag.String("files", "eng/signing/tosign/*", "Glob of Go archives to sign.")
+	destinationDir     = flag.String("o", "eng/signing/signed", "Directory to store signed files.")
+	consolidateDiagDir = flag.String("consolidate-diag-dir", "eng/signing/diag", "Directory to store consolidated diagnostic files.")
+	tempDir            = flag.String("temp-dir", "eng/signing/signing-temp", "Directory to store temporary files.")
+	signingCsprojDir   = flag.String("signing-csproj-dir", "eng/signing", "Directory containing Sign.csproj and related files.")
 
 	signType = flag.String("sign-type", "test",
 		"Type of signing to perform. Options: test, real. "+
@@ -157,6 +158,7 @@ func run() error {
 	}
 
 	log.Println("Copying finished files to destination")
+	log.Printf("Destination directory: %q", *destinationDir)
 
 	for _, a := range archives {
 		if err := a.copyToDestination(ctx); err != nil {
@@ -170,6 +172,13 @@ func run() error {
 		if err := checksum.WriteSHA256ChecksumFile(filepath.Join(*destinationDir, a.name)); err != nil {
 			return err
 		}
+	}
+
+	log.Println("Consolidating diagnostic files")
+	log.Printf("Consolidated diagnostic directory: %q", *consolidateDiagDir)
+
+	if err := consolidateDiagnosticFiles(); err != nil {
+		return err
 	}
 
 	return nil

--- a/eng/pipeline/stages/sign-stage.yml
+++ b/eng/pipeline/stages/sign-stage.yml
@@ -42,6 +42,14 @@ stages:
           # Give the sign task leeway to finish up after hitting its own timeout.
           timeoutInMinutes: 80
 
+          variables:
+            - name: ArtifactsDir
+              value: $(Build.ArtifactStagingDirectory)\SigningArtifacts
+            - name: SignedDir
+              value: $(ArtifactsDir)\signed
+            - name: DiagnosticsDir
+              value: $(ArtifactsDir)\diag
+
           templateContext:
             mb:
               signing:
@@ -51,20 +59,17 @@ stages:
                 signType: ${{ parameters.ctx['GoSigningType'] }}
                 zipSources: false
                 feedSource: 'https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json'
+            # If we consolidate outputs, 1ES PT can avoid some scan overhead.
+            outputParentDirectory: $(ArtifactsDir)
             outputs:
               # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs
               - output: pipelineArtifact
-                path: 'eng\signing\signed'
+                path: '$(SignedDir)'
                 artifact: Binaries Signed
 
               - output: pipelineArtifact
-                path: 'eng\signing\signing-temp'
-                artifact: Signing temp directory $(System.JobAttempt)
-                condition: always()
-
-              - output: pipelineArtifact
-                path: 'eng\signing'
-                artifact: Signing diagnosis directory $(System.JobAttempt)
+                path: '$(DiagnosticsDir)'
+                artifact: Signing diagnosis files $(System.JobAttempt)
                 condition: always()
 
           steps:
@@ -95,5 +100,7 @@ stages:
                 eng/run.ps1 sign `
                   -files '$(Pipeline.Workspace)/Binaries */*' `
                   -sign-type '$(SignType)' `
+                  -o '$(SignedDir)' `
+                  -consolidate-diag-dir '$(DiagnosticsDir)' `
                   -timeout 60m
               displayName: Sign Files

--- a/eng/signing/.gitignore
+++ b/eng/signing/.gitignore
@@ -6,6 +6,7 @@
 *.binlog
 bin/
 obj/
+diag/
 signing-log/
 signing-temp/
 tosign/


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/170

Consolidate files into a single diag artifact, and copy over specific files. The existing artifacts had a lot of duplicated files.

Put the main diagnostic logs into the artifact directly. Archive the data-to-sign in a tar.gz file.

The data in the tar.gz archive is data that we will eventually be able to upload with a feature that formally treats it as non-production. For now, it seems that putting it in a tar.gz is good enough for https://github.com/microsoft/go-lab/issues/170.

Latest test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2770645&view=results