### PR TITLE
[release-branch.go1.25] Port fixes to use new Windows builder and test 2019

### DIFF
--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -57,14 +57,15 @@ stages:
                 createSourceArchive: ${{ parameters.createSourceArchive }}
                 releaseVersion: ${{ parameters.releaseVersion }}
                 createSymbols: ${{ parameters.createSymbols }}
-                # Attempt to retry the build on Windows to mitigate flakiness:
-                # "Access Denied" during EXE copying and general flakiness during tests.
-                ${{ if eq(builder.os, 'windows') }}:
-                  retryAttempts: [1, 2, 3, 4, "FINAL"]
-                # Attempt to retry the build on macOS to mitigate flakiness:
-                # "read: connection reset by peer" in cmd/go tests
-                ${{ if eq(builder.os, 'darwin') }}:
-                  retryAttempts: [1, 2, "FINAL"]
+                ${{ if not(builder.broken) }}:
+                  # Attempt to retry the build on Windows to mitigate flakiness:
+                  # "Access Denied" during EXE copying and general flakiness during tests.
+                  ${{ if eq(builder.os, 'windows') }}:
+                    retryAttempts: [1, 2, 3, 4, "FINAL"]
+                  # Attempt to retry the build on macOS to mitigate flakiness:
+                  # "read: connection reset by peer" in cmd/go tests
+                  ${{ if eq(builder.os, 'darwin') }}:
+                    retryAttempts: [1, 2, "FINAL"]
 
     - ${{ if eq(parameters.sign, true) }}:
       - template: pool.yml

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -76,7 +76,7 @@ stages:
             parameters:
               ctx: ${{ parameters.ctx }}
               # This is not a builder, but provide partial builder info for agent selection.
-              builder: { os: windows, arch: amd64 }
+              builder: { os: windows, arch: amd64, distro: '2022' }
               # The list of builders to depend on and grab artifacts from.
               builders:
                 - ${{ each builder in parameters.builders }}:
@@ -101,7 +101,7 @@ stages:
             template: internal-publish-stage.yml
             parameters:
               ctx: ${{ parameters.ctx }}
-              builder: { os: windows, arch: amd64 }
+              builder: { os: windows, arch: amd64, distro: '2022' }
               builders:
                 - ${{ each builder in parameters.builders }}:
                   - ${{ if eq(builder.config, 'buildandpack') }}:

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -97,6 +97,7 @@ stages:
           - { experiment: nosystemcrypto, os: windows, arch: amd64, config: test }
           - { experiment: systemcrypto, os: windows, arch: amd64, config: test }
           - { experiment: systemcrypto, os: windows, arch: amd64, config: test, fips: true }
+          - { experiment: systemcrypto, os: windows, arch: amd64, config: test, distro: '2019', broken: true } # Affected by https://golang.org/issue/10842.
           # Test that buildandpack works on Windows x86-32, but don't release it.
           - { experiment: nosystemcrypto, os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if parameters.outerloop }}:

--- a/eng/pipeline/stages/pool-1.yml
+++ b/eng/pipeline/stages/pool-1.yml
@@ -17,6 +17,8 @@ parameters:
     type: string
   - name: hostArch
     type: string
+  - name: distro
+    type: string
 
 stages:
   - template: pool-2.yml

--- a/eng/pipeline/stages/pool-2.yml
+++ b/eng/pipeline/stages/pool-2.yml
@@ -17,6 +17,8 @@ parameters:
     type: string
   - name: hostArch
     type: string
+  - name: distro
+    type: string
 
   - name: name
     type: string
@@ -31,13 +33,13 @@ stages:
 
         ${{ if eq(parameters.os, 'windows') }}:
           ${{ if parameters.ctx['Go1ESOfficial'] }}:
-            image: 1es-windows-2022
+            image: 1es-windows-${{ parameters.distro }}
             os: windows
           ${{ elseif parameters.public }}:
             # https://helix.dot.net/#1esPools
-            demands: ImageOverride -equals 1es-windows-2022-open
+            demands: ImageOverride -equals 1es-windows-${{ parameters.distro }}-open
           ${{ else }}:
-            demands: ImageOverride -equals 1es-windows-2022
+            demands: ImageOverride -equals 1es-windows-${{ parameters.distro }}
             os: windows
 
         ${{ elseif eq(parameters.os, 'linux') }}:

--- a/eng/pipeline/stages/pool.yml
+++ b/eng/pipeline/stages/pool.yml
@@ -30,4 +30,5 @@ stages:
       servicing: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/microsoft/release-branch') }}
       os: ${{ parameters.inner.parameters.builder.os }}
       hostArch: ${{ parameters.inner.parameters.builder.hostArch }}
+      distro: ${{ parameters.inner.parameters.builder.distro }}
       inner: ${{ parameters.inner }}

--- a/eng/pipeline/stages/shorthand-builders-to-builders.yml
+++ b/eng/pipeline/stages/shorthand-builders-to-builders.yml
@@ -41,6 +41,8 @@ stages:
             id: ${{ builder.os }}_${{ coalesce(builder.distro, 'default') }}_${{ coalesce(builder.hostArch, 'default') }}_${{ builder.arch }}_${{ builder.config }}_${{ coalesce(builder.experiment, 'default') }}_${{ coalesce(builder.fips, false) }}
             ${{ if not(builder.hostArch) }}:
               hostArch: ${{ builder.arch }}
+            ${{ if and(not(builder.distro), eq(builder.os, 'windows')) }}:
+              distro: '2022'
             # Set up some parameters that are for display purposes. AzDO YAML expressions can't
             # branch, so we must to prepare these values here rather than where they're used.
             ${{ if builder.distro }}:


### PR DESCRIPTION
Port fixes related to old Windows builder:

* https://github.com/microsoft/go/pull/1765
* https://github.com/microsoft/go/pull/1791

Fixes https://github.com/microsoft/go-lab/issues/241