### PR TITLE
Include build number in go version output

### DIFF
--- a/patches/0012-Include-build-number-in-go-version-output.patch
+++ b/patches/0012-Include-build-number-in-go-version-output.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
+Date: Thu, 4 Sep 2025 14:15:05 +0100
+Subject: [PATCH] Include build number in go version output
+
+---
+ src/cmd/go/internal/version/version.go | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/cmd/go/internal/version/version.go b/src/cmd/go/internal/version/version.go
+index c26dd42b4e1a08..0ed01f8685cc1c 100644
+--- a/src/cmd/go/internal/version/version.go
++++ b/src/cmd/go/internal/version/version.go
+@@ -88,7 +88,13 @@ func runVersion(ctx context.Context, cmd *base.Command, args []string) {
+ 		if gover.TestVersion != "" {
+ 			v = gover.TestVersion + " (TESTGO_VERSION)"
+ 		}
+-		fmt.Printf("go version %s %s/%s\n", v, runtime.GOOS, runtime.GOARCH)
++		// Indicate this is a Microsoft build of the Go toolchain.
++		// If Azure DevOps build number is available, include it.
++		if buildNum := os.Getenv("BUILD_BUILDNUMBER"); buildNum != "" {
++			fmt.Printf("go version %s (msft: %s) %s/%s\n", v, buildNum, runtime.GOOS, runtime.GOARCH)
++		} else {
++			fmt.Printf("go version %s (msft) %s/%s\n", v, runtime.GOOS, runtime.GOARCH)
++		}
+ 		return
+ 	}
+ 


### PR DESCRIPTION
for: #262

Sample output:

```output
go version             
go version go1.26-devel_c1b4d756f4 Thu Sep 4 14:06:31 2025 +0100 (msft: 12345678) darwin/arm64
```