### PR TITLE
Migration guide fix; point to guide from root docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ cross-compilation may be necessary.
 * `linux_arm64`
 * `windows_amd64`
 
-The following sections list the ways to get a build of the Microsoft fork of Go.
+For guidance about how we recommend migrating existing Go projects to use the
+Microsoft build of Go, visit the [Migration Guide](eng/doc/MigrationGuide.md).
+This guide also helps resolve commonly encountered issues.
+
+The following sections list the ways to get the Microsoft build of Go.
 
 > [!NOTE]
 > Don't see an option that works for you? Let us know!  

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,6 +2,8 @@
 
 For help and questions about the Go programming language and tools, visit the official website: <https://go.dev/>.
 
+Take a look at the [Migration Guide](eng/doc/MigrationGuide.md) for more information about migrating from the official build of Go to the Microsoft build of Go, specifically.
+
 ## How to file issues and get help
 
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -147,19 +147,17 @@ If this isn't feasible, see [migration to `systemcrypto`](#migration-to-systemcr
 > The macOS `systemcrytpo` implementation also requires cgo.
 > macOS support is in preview, and the dependency on cgo may be removed before we fully support this build configuration.
 
-#### No C compiler is installed
+#### Missing C toolchain and dependencies
+
+A C toolchain is required to build programs that use `systemcrypto` on Linux.
+The errors shown with a partially missing C toolchain can be unintuitive, so some errors and corresponding missing packages with the names they have on Azure Linux 3 are listed below.
 
 ```
 # runtime/cgo
 cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in $PATH
 ```
 
-If this isn't feasible, see [migration to `systemcrypto`](#migration-to-systemcrypto).
-
-#### Missing C toolchain and dependencies
-
-A C toolchain is required to build programs that use `systemcrypto` on Linux.
-The errors shown with a partially missing C toolchain can be unintuitive, so some errors and corresponding missing packages with the names they have on Azure Linux 3 are listed below.
+`gcc`
 
 ```
 _cgo_export.c:3:10: fatal error: stdlib.h: No such file or directory


### PR DESCRIPTION
* For #1377 

Fix the part where I accidentally the `gcc` instructions by moving it to the next section, where it fits nicely.

Refer to the guide from a few docs in the root to make it discoverable.