### PR TITLE
telemetry: add target goos and goarch to the upload config

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -15,7 +15,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-infra/telemetry/README.md    |    7 +
  .../go-infra/telemetry/config/LICENSE         |   21 +
  .../go-infra/telemetry/config/config.go       |   11 +
- .../go-infra/telemetry/config/config.json     |   64 +
+ .../go-infra/telemetry/config/config.json     |   70 +
  .../go-infra/telemetry/counter/counter.go     |   63 +
  .../telemetry/internal/appinsights/README.md  |   12 +
  .../telemetry/internal/appinsights/client.go  |  169 ++
@@ -137,7 +137,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 129 files changed, 19255 insertions(+), 7 deletions(-)
+ 129 files changed, 19261 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -261,7 +261,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 
 diff --git a/src/cmd/go.mod b/src/cmd/go.mod
-index e6431c0f20adf8..1052bcd1419c9f 100644
+index e6431c0f20adf8..287fa9c6ceea6b 100644
 --- a/src/cmd/go.mod
 +++ b/src/cmd/go.mod
 @@ -4,6 +4,8 @@ go 1.26
@@ -269,12 +269,12 @@ index e6431c0f20adf8..1052bcd1419c9f 100644
  require (
  	github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5
 +	github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed
-+	github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed
++	github.com/microsoft/go-infra/telemetry/config v0.0.0-20250917073240-06691d690b57
  	golang.org/x/arch v0.20.1-0.20250808194827-46ba08e3ae58
  	golang.org/x/build v0.0.0-20250806225920-b7c66c047964
  	golang.org/x/mod v0.28.0
 diff --git a/src/cmd/go.sum b/src/cmd/go.sum
-index 5a70558fe9cef0..9b87e101a9db5f 100644
+index 5a70558fe9cef0..4e06980a282694 100644
 --- a/src/cmd/go.sum
 +++ b/src/cmd/go.sum
 @@ -4,6 +4,10 @@ github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5 h1:xhMrHhTJ6zxu3gA4en
@@ -283,8 +283,8 @@ index 5a70558fe9cef0..9b87e101a9db5f 100644
  github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 +github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed h1:AZR+rR1NvHCXyilk3BMgq2M9uGPibhTU1O4hxNIwFJo=
 +github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed/go.mod h1:XQP+NhZgM1i1+asOSnAFPRzv2HhQibhk6k6FIllx8/Y=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed h1:+WzG8k10xzL+oOrycm6GJTGi/sMZkWtnAhAUZ+Fpvwg=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20250917073240-06691d690b57 h1:+EIywWbZ+Onkl/aUE0vf5nSFy5NV0OPcd/4dJQKLaMg=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20250917073240-06691d690b57/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
  github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
  github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
  golang.org/x/arch v0.20.1-0.20250808194827-46ba08e3ae58 h1:uxPa6+/WsUfzikIAPMqpTho10y4qtYpINBurU+6NrHE=
@@ -397,10 +397,10 @@ index 00000000000000..044268a046a54d
 +var Config []byte
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
 new file mode 100644
-index 00000000000000..7c662b93fcd017
+index 00000000000000..b4d1b3712f0f10
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,70 @@
 +{
 +	"GOOS": [
 +		"aix",
@@ -460,6 +460,12 @@ index 00000000000000..7c662b93fcd017
 +				},
 +				{
 +					"Name": "go/subcommand:{build,install,run}"
++				},
++				{
++					"Name": "go/platform/target/goos:{aix,android,darwin,dragonfly,freebsd,hurd,illumos,ios,js,linux,nacl,netbsd,openbsd,plan9,solaris,wasip1,windows,zos}"
++				},
++				{
++					"Name": "go/platform/target/goarch:{386,amd64,amd64p32,arm,arm64,arm64be,armbe,loong64,mips,mips64,mips64le,mips64p32,mips64p32le,mipsle,ppc,ppc64,ppc64le,riscv,riscv64,s390,s390x,sparc,sparc64,wasm}"
 +				}
 +			]
 +		}
@@ -1861,7 +1867,7 @@ index 00000000000000..d592037b570130
 +	return ok
 +}
 diff --git a/src/cmd/vendor/modules.txt b/src/cmd/vendor/modules.txt
-index 37cd448bc9e8c0..24a25977511c2b 100644
+index 37cd448bc9e8c0..c48c2757435845 100644
 --- a/src/cmd/vendor/modules.txt
 +++ b/src/cmd/vendor/modules.txt
 @@ -16,6 +16,17 @@ github.com/google/pprof/third_party/svgpan
@@ -1876,7 +1882,7 @@ index 37cd448bc9e8c0..24a25977511c2b 100644
 +github.com/microsoft/go-infra/telemetry/internal/appinsights/internal/contracts
 +github.com/microsoft/go-infra/telemetry/internal/config
 +github.com/microsoft/go-infra/telemetry/internal/telemetry
-+# github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed
++# github.com/microsoft/go-infra/telemetry/config v0.0.0-20250917073240-06691d690b57
 +## explicit; go 1.24
 +github.com/microsoft/go-infra/telemetry/config
  # golang.org/x/arch v0.20.1-0.20250808194827-46ba08e3ae58


### PR DESCRIPTION
Updating the telemetry/config module to include the following change: https://github.com/microsoft/go-infra/pull/339