### PR TITLE
[go1.25] telemetry: add target goos and goarch to the upload config

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -15,7 +15,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-infra/telemetry/README.md    |    7 +
  .../go-infra/telemetry/config/LICENSE         |   21 +
  .../go-infra/telemetry/config/config.go       |   11 +
- .../go-infra/telemetry/config/config.json     |   64 +
+ .../go-infra/telemetry/config/config.json     |   70 +
  .../go-infra/telemetry/counter/counter.go     |   63 +
  .../telemetry/internal/appinsights/README.md  |   12 +
  .../telemetry/internal/appinsights/client.go  |  169 ++
@@ -137,7 +137,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 129 files changed, 19228 insertions(+), 7 deletions(-)
+ 129 files changed, 19234 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -261,7 +261,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 
 diff --git a/src/cmd/go.mod b/src/cmd/go.mod
-index 5624b81cc51bac..c915383a7bd7d6 100644
+index 5624b81cc51bac..3de22708c0e7fd 100644
 --- a/src/cmd/go.mod
 +++ b/src/cmd/go.mod
 @@ -4,6 +4,8 @@ go 1.25
@@ -269,12 +269,12 @@ index 5624b81cc51bac..c915383a7bd7d6 100644
  require (
  	github.com/google/pprof v0.0.0-20250208200701-d0013a598941
 +	github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed
-+	github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed
++	github.com/microsoft/go-infra/telemetry/config v0.0.0-20250917073240-06691d690b57
  	golang.org/x/arch v0.18.1-0.20250605182141-b2f4e2807dec
  	golang.org/x/build v0.0.0-20250606033421-8c8ff6f34a83
  	golang.org/x/mod v0.25.0
 diff --git a/src/cmd/go.sum b/src/cmd/go.sum
-index d5d1553e5b7829..cb73d0abe4e905 100644
+index d5d1553e5b7829..5a65a13dd5c718 100644
 --- a/src/cmd/go.sum
 +++ b/src/cmd/go.sum
 @@ -4,6 +4,10 @@ github.com/google/pprof v0.0.0-20250208200701-d0013a598941 h1:43XjGa6toxLpeksjcx
@@ -283,8 +283,8 @@ index d5d1553e5b7829..cb73d0abe4e905 100644
  github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 +github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed h1:AZR+rR1NvHCXyilk3BMgq2M9uGPibhTU1O4hxNIwFJo=
 +github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed/go.mod h1:XQP+NhZgM1i1+asOSnAFPRzv2HhQibhk6k6FIllx8/Y=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed h1:+WzG8k10xzL+oOrycm6GJTGi/sMZkWtnAhAUZ+Fpvwg=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20250917073240-06691d690b57 h1:+EIywWbZ+Onkl/aUE0vf5nSFy5NV0OPcd/4dJQKLaMg=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20250917073240-06691d690b57/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
  github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
  github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
  golang.org/x/arch v0.18.1-0.20250605182141-b2f4e2807dec h1:fCOjXc18tBlkVy4m+VuL1WU8VTukYOGtAk7nC5QYPRY=
@@ -397,10 +397,10 @@ index 00000000000000..044268a046a54d
 +var Config []byte
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
 new file mode 100644
-index 00000000000000..7c662b93fcd017
+index 00000000000000..b4d1b3712f0f10
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,70 @@
 +{
 +	"GOOS": [
 +		"aix",
@@ -460,6 +460,12 @@ index 00000000000000..7c662b93fcd017
 +				},
 +				{
 +					"Name": "go/subcommand:{build,install,run}"
++				},
++				{
++					"Name": "go/platform/target/goos:{aix,android,darwin,dragonfly,freebsd,hurd,illumos,ios,js,linux,nacl,netbsd,openbsd,plan9,solaris,wasip1,windows,zos}"
++				},
++				{
++					"Name": "go/platform/target/goarch:{386,amd64,amd64p32,arm,arm64,arm64be,armbe,loong64,mips,mips64,mips64le,mips64p32,mips64p32le,mipsle,ppc,ppc64,ppc64le,riscv,riscv64,s390,s390x,sparc,sparc64,wasm}"
 +				}
 +			]
 +		}
@@ -1861,7 +1867,7 @@ index 00000000000000..d592037b570130
 +	return ok
 +}
 diff --git a/src/cmd/vendor/modules.txt b/src/cmd/vendor/modules.txt
-index 6e5783fdd4767a..81dd9beff245d6 100644
+index 6e5783fdd4767a..d622f199fdf56b 100644
 --- a/src/cmd/vendor/modules.txt
 +++ b/src/cmd/vendor/modules.txt
 @@ -16,6 +16,17 @@ github.com/google/pprof/third_party/svgpan
@@ -1876,7 +1882,7 @@ index 6e5783fdd4767a..81dd9beff245d6 100644
 +github.com/microsoft/go-infra/telemetry/internal/appinsights/internal/contracts
 +github.com/microsoft/go-infra/telemetry/internal/config
 +github.com/microsoft/go-infra/telemetry/internal/telemetry
-+# github.com/microsoft/go-infra/telemetry/config v0.0.0-20250728075224-e97e760169ed
++# github.com/microsoft/go-infra/telemetry/config v0.0.0-20250917073240-06691d690b57
 +## explicit; go 1.24
 +github.com/microsoft/go-infra/telemetry/config
  # golang.org/x/arch v0.18.1-0.20250605182141-b2f4e2807dec
@@ -1939,7 +1945,7 @@ index 410eb8648a710a..928d040435b4b7 100644
  golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
  golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index b3d8f66bc761ee..09e91285502bcf 100644
+index 6d92542e31b652..9b7613a62b5a31 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -519,6 +519,24 @@ var depsRules = `


### PR DESCRIPTION
Backport of #1875.