### PR TITLE
Stop trying to load OpenSSL 1.0, update docs

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -344,7 +344,9 @@ The `opensslcrypto` Go runtime automatically loads the OpenSSL shared library `l
 The `libcrypto` shared library file name varies among different platforms, so a best effort is done to find and load the right file:
 
 - The base name is always `libcrypto.so.`
-- Well-known version strings are appended to the base name in this order: `3` -> `1.1` -> `11` -> `111` -> `1.0.2` -> `1.0.0`.
+- Well-known version strings are appended to the base name in this order:
+  - Since Go 1.25: `3` -> `1.1` -> `11` -> `111`.
+  - Prior to Go 1.25: `3` -> `1.1` -> `11` -> `111` -> `1.0.2` -> `1.0.0`.
 - This may find multiple libraries installed on the machine, so to pick one:
   - A matching library with FIPS mode on by default (e.g. set by system configuration) is chosen immediately.
   - If none have FIPS mode on by default, the first match is used.
@@ -399,7 +401,8 @@ The `opensslcrypto` Go runtime supports multiple OpenSSL versions. It discovers 
 Not all OpenSSL versions are supported. OpenSSL does not maintain ABI compatibility between different releases, even if only the patch version is increased, it needs specific attention to implement support. The relative importance of each version also results in a different amount of automated testing that has been implemented for various supported version. These are supported versions and the amount of automated validation for each one:
 
 - OpenSSL 1.1.1: the Microsoft CI builds official releases and runs the Go toolset test suite with this version.
-- OpenSSL 1.0.2, 1.1.0, 1.1.1, and 3.0.2: the [golang-fips/openssl] and [go-crypto-openssl] repository CI tests basic operation, but not the integration with the Go runtime.
+- OpenSSL 1.1.0, 1.1.1, and 3.0.2: the [golang-fips/openssl] and [go-crypto-openssl] repository CI tests basic operation, but not the integration with the Go runtime.
+  - Prior to Go 1.25, this list includes 1.0.2.
 
 Versions not listed above are not supported at all.
 
@@ -466,6 +469,8 @@ This list of major changes is intended for quick reference and for access to his
 - `GOEXPERIMENT=boringcrypto` has been removed.
 
 - `GOEXPERIMENT=allowcryptofallback` has been removed. Instead, if it's necessary to opt out from using a system crypto backend, use `GOEXPERIMENT=nosystemcrypto`. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
+
+- The OpenSSL backend [no longer supports OpenSSL 1.0](https://github.com/golang-fips/openssl/issues/244). The supported versions are now OpenSSL 1.1.0, 1.1.1, and 3.x.
 
 ### Go 1.24 (Feb 2025)
 

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -44,7 +44,7 @@ desired goexperiments and build tags.
  .../fips140/requirefips_nosystemcrypto.go     |  15 +
  .../backend/fips140/skipfipscheck_off.go      |   9 +
  .../backend/fips140/skipfipscheck_on.go       |   9 +
- .../internal/opensslsetup/opensslsetup.go     |  70 ++++
+ .../internal/opensslsetup/opensslsetup.go     |  68 ++++
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 251 ++++++++++++
@@ -55,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2310 insertions(+), 22 deletions(-)
+ 46 files changed, 2308 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -160,7 +160,7 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 024050c2dd70c4..f91bf0a7c4ad1c 100644
+index fb70047dd0e81c..bb7ff4a68764da 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
 @@ -1387,6 +1387,80 @@ func toolenv() []string {
@@ -261,7 +261,7 @@ index 024050c2dd70c4..f91bf0a7c4ad1c 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aa09d1eba34be8..c3f3a8324c507c 100644
+index ec4ff649b3815d..6ec763259efee6 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -667,7 +667,7 @@ index 2f46a6b44bffe1..69071289e2de81 100644
  
  ! go build -o $devnull cmd/buildid
 diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index 483a9ec33c6798..fad922e3f844ab 100644
+index 5781276afadba7..f684b73098954c 100644
 --- a/src/cmd/internal/testdir/testdir_test.go
 +++ b/src/cmd/internal/testdir/testdir_test.go
 @@ -118,6 +118,13 @@ func Test(t *testing.T) {
@@ -685,7 +685,7 @@ index 483a9ec33c6798..fad922e3f844ab 100644
  		gorootTestDir: filepath.Join(testenv.GOROOT(t), "test"),
  		runoutputGate: make(chan bool, *runoutputLimit),
 diff --git a/src/cmd/link/internal/ld/main.go b/src/cmd/link/internal/ld/main.go
-index 6a684890be0a03..09554a60b23471 100644
+index d913953944bc43..daa8aa3d964ed0 100644
 --- a/src/cmd/link/internal/ld/main.go
 +++ b/src/cmd/link/internal/ld/main.go
 @@ -44,6 +44,7 @@ import (
@@ -696,7 +696,7 @@ index 6a684890be0a03..09554a60b23471 100644
  	"strconv"
  	"strings"
  )
-@@ -187,7 +188,18 @@ func Main(arch *sys.Arch, theArch Arch) {
+@@ -188,7 +189,18 @@ func Main(arch *sys.Arch, theArch Arch) {
  
  	buildVersion := buildcfg.Version
  	if goexperiment := buildcfg.Experiment.String(); goexperiment != "" {
@@ -717,7 +717,7 @@ index 6a684890be0a03..09554a60b23471 100644
  	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
  
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
-index 2fe32600f1d6c7..f84cbdc5ee25f0 100644
+index a87d452ed39446..c03aba6e415873 100644
 --- a/src/cmd/link/link_test.go
 +++ b/src/cmd/link/link_test.go
 @@ -9,6 +9,7 @@ import (
@@ -1971,10 +1971,10 @@ index 00000000000000..d3d39fd77f98db
 +const isSkipFIPSCheck = true
 diff --git a/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go
 new file mode 100644
-index 00000000000000..c6c1f53e7452ab
+index 00000000000000..d816f1be17b6a1
 --- /dev/null
 +++ b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,68 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1995,9 +1995,7 @@ index 00000000000000..c6c1f53e7452ab
 +// knownVersions is a list of supported and well-known libcrypto.so suffixes in decreasing version order.
 +// FreeBSD library version numbering does not directly align to the version of OpenSSL.
 +// Its preferred search order is 11 -> 111.
-+// Some distributions use 1.0.0 and others (such as Debian) 1.0.2 to refer to the same OpenSSL 1.0.2 version.
-+// Fedora derived distros use different naming for the version 1.0.x.
-+var knownVersions = [...]string{"3", "1.1", "11", "111", "1.0.2", "1.0.0", "10"}
++var knownVersions = [...]string{"3", "1.1", "11", "111"}
 +
 +const lcryptoPrefix = "libcrypto.so."
 +
@@ -2790,10 +2788,10 @@ index 00000000000000..13782a8241b99a
 +	`
 +}
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 09e91285502bcf..b2c6db15a23e98 100644
+index bc85bf170eb2eb..51ea2b8f994d4a 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -348,7 +348,7 @@ var depsRules = `
+@@ -350,7 +350,7 @@ var depsRules = `
  	math/big, go/token
  	< go/constant;
  
@@ -2802,7 +2800,7 @@ index 09e91285502bcf..b2c6db15a23e98 100644
  	< internal/buildcfg;
  
  	container/heap, go/constant, go/parser, internal/buildcfg, internal/goversion, internal/types/errors
-@@ -537,6 +537,11 @@ var depsRules = `
+@@ -539,6 +539,11 @@ var depsRules = `
  	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
  	< github.com/microsoft/go-crypto-winnative/cng;
  
@@ -2814,7 +2812,7 @@ index 09e91285502bcf..b2c6db15a23e98 100644
  	crypto !< FIPS;
  
  	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
-@@ -545,16 +550,27 @@ var depsRules = `
+@@ -547,16 +552,27 @@ var depsRules = `
  	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
  	sync/atomic < crypto/internal/boring/bcache;
  
@@ -2844,7 +2842,7 @@ index 09e91285502bcf..b2c6db15a23e98 100644
  	< crypto/boring
  	< crypto/aes,
  	  crypto/des,
-@@ -578,8 +594,14 @@ var depsRules = `
+@@ -580,8 +596,14 @@ var depsRules = `
  	math/big, github.com/microsoft/go-crypto-darwin/xcrypto < github.com/microsoft/go-crypto-darwin/bbig;
  	math/big, github.com/microsoft/go-crypto-winnative/cng < github.com/microsoft/go-crypto-winnative/cng/bbig;
  
@@ -2862,7 +2860,7 @@ index 09e91285502bcf..b2c6db15a23e98 100644
  	< crypto/rand
  	< crypto/ed25519 # depends on crypto/rand.Reader
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index 9b3bafd0fc6cd9..b7cc2bdfa6ffd9 100644
+index 16a25b602b6966..57067754466b0a 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
 @@ -5,11 +5,14 @@
@@ -2880,7 +2878,7 @@ index 9b3bafd0fc6cd9..b7cc2bdfa6ffd9 100644
  )
  
  // ExperimentFlags represents a set of GOEXPERIMENT flags relative to a baseline
-@@ -180,6 +183,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -177,6 +180,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.BoringCrypto {
  		return nil, fmt.Errorf("GOEXPERIMENT boringcrypto is not supported in the Microsoft build of Go")
  	}


### PR DESCRIPTION
Addresses most changes I mentioned in:

* https://github.com/microsoft/go/issues/1871

Should probably be backported to 1.25 to avoid odd loading/usage errors with OpenSSL versions we don't really support.