### PR TITLE
Support disabling systemcrypto using the MS_GO_NOSYSTEMCRYPTO env

### DIFF
--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -153,7 +153,7 @@ In this case, you should first try to install a C compiler, like `gcc`.
 
 You may also need to set the `CGO_ENABLED` environment variable to `1` or [otherwise enable cgo](https://pkg.go.dev/cmd/cgo).
 
-If this isn't feasible, see [migration to `systemcrypto`](#migration-to-systemcrypto).
+If this isn't feasible, see [disabling systemcrypto](#disabling-systemcrypto).
 
 > [!NOTE]
 > The macOS `systemcrytpo` implementation also requires cgo.
@@ -203,7 +203,7 @@ sudo tdnf install gcc glibc-devel binutils kernel-headers
 
 Alternatively, the `build-essential` package contains all of these packages and more.
 
-If this isn't feasible, see [migration to `systemcrypto`](#migration-to-systemcrypto).
+If this isn't feasible, see [disabling systemcrypto](#disabling-systemcrypto).
 
 #### Unknown GOEXPERIMENT systemcrypto
 
@@ -267,7 +267,7 @@ Otherwise, identify why these packages are not present.
 
 If your system has a `libcrypto.so[...]` file that doesn't follow [the expected naming conventions, you can set the `GO_OPENSSL_VERSION_OVERRIDE` environment variable](fips/README.md#runtime-openssl-version-override) to make your Go program look for a specific suffix.
 
-If this isn't feasible, see [migration to `systemcrypto`](#migration-to-systemcrypto).
+If this isn't feasible, see [disabling systemcrypto](#disabling-systemcrypto).
 
 #### FIPS mode requested but not available
 
@@ -327,7 +327,7 @@ It uses `musl` instead of `glibc`.
 Try installing the `gcompat` or `libc6-compat` Alpine packages to use a `glibc` compatibility layer.
 Gathering more information about behavior on Alpine is tracked by [microsoft/go#1867](https://github.com/microsoft/go/issues/1867).
 
-If this isn't feasible, see [migration to `systemcrypto`](#migration-to-systemcrypto).
+If this isn't feasible, see [disabling systemcrypto](#disabling-systemcrypto).
 
 #### Cryptography package failures while in FIPS mode
 
@@ -359,8 +359,12 @@ For specific guidance within Microsoft:
 The difficulty of migrating to using `systemcrypto` can vary significantly depending on the Go project.
 If the change requires further planning and if it's acceptable for your project to be temporarily out of compliance with Microsoft cryptography policy, you can disable `systemcrypto`.
 
-To do so, set the `MS_GO_NOSYSTEMCRYPTO` environment variable to `1` if using Go 1.25.2 or later, else set the `GOEXPERIMENT` environment variable to `nosystemcrypto`.
-In the latter case, if you have already set `GOEXPERIMENT`, append `,nosystemcrypto` to the existing value.
+If the change requires further planning and if it's acceptable for your project to be temporarily out of compliance with Microsoft cryptography policy, you can disable `systemcrypto` by following these instructions:
+
+- If you're using Go 1.25.2 or later, set the `MS_GO_NOSYSTEMCRYPTO` environment variable to 1.
+- Otherwise, set the `GOEXPERIMENT` environment variable to `nosystemcrypto`.
+  - If you have already set `GOEXPERIMENT`, append `,nosystemcrypto` to the existing value.
+
 After that, build commands won't encounter errors related to `systemcrypto`, and the resulting program won't attempt to use system-provided cryptography at runtime.
 
 Alternatively, if you experienced an unexpected auto-update to 1.25 that broke your project, you should downgrade to the latest version of 1.24.

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -243,14 +243,9 @@ This makes all subsequent `go` commands automatically use that build tag.
 See [`cmd/go` documentation](https://pkg.go.dev/cmd/go#hdr-Environment_variables) and [the FIPS readme](fips/README.md#assign-goflags-environment-variable-to-automatically-pass--tags-to-go-build) for more information about using GOFLAGS.
 
 > [!WARNING]
-> Unfortunately, `nosystemcrypto` can't be specified as a build tag.
-> If you need to disable `systemcrypto` and maintain build command compatibility with the official Go distribution, you must use `GOEXPERIMENT=nosystemcrypto` selectively, or use 1.24.
->
-> For example, we would recommend setting `GOEXPERIMENT=nosystemcrypto` in specific CI pipelines and only using the Microsoft build of Go in those pipelines.
+> `nosystemcrypto` can't be specified as a build tag.
 
-> [!NOTE]
-> We plan to implement a compatibility improvement that allows using `nosystemcrypto` without reducing build command compatibility with the official Go distribution.
-> See [microsoft/go#1880](https://github.com/microsoft/go/issues/1880).
+See [Disabling `systemcrypto`](#disabling-systemcrypto) for information about how to disable `systemcrypto` if you need to temporarily avoid migrating to it.
 
 ### Common test or runtime issues
 
@@ -359,13 +354,13 @@ For specific guidance within Microsoft:
 - Read [Microsoft.Security.Cryptography.10010 on the Liquid Microsoft-internal site.][msc10010]
 - Contact the crypto board
 
-## Migration to `systemcrypto`
+## Disabling `systemcrypto`
 
 The difficulty of migrating to using `systemcrypto` can vary significantly depending on the Go project.
 If the change requires further planning and if it's acceptable for your project to be temporarily out of compliance with Microsoft cryptography policy, you can disable `systemcrypto`.
 
-To do so, set the `GOEXPERIMENT` environment variable to `nosystemcrypto`.
-If you have already set `GOEXPERIMENT`, append `,nosystemcrypto` to the existing value.
+To do so, set the `MS_GO_NOSYSTEMCRYPTO` environment variable to `1` if using Go 1.25.2 or later, else set the `GOEXPERIMENT` environment variable to `nosystemcrypto`.
+In the latter case, if you have already set `GOEXPERIMENT`, append `,nosystemcrypto` to the existing value.
 After that, build commands won't encounter errors related to `systemcrypto`, and the resulting program won't attempt to use system-provided cryptography at runtime.
 
 Alternatively, if you experienced an unexpected auto-update to 1.25 that broke your project, you should downgrade to the latest version of 1.24.
@@ -391,7 +386,7 @@ For most installation methods, specify 1.24, and you will get the latest, most s
 > `dnf` has `versionlock` capabilities, but it doesn't enable upgrades to newer patches within the major version.
 > It will only lock to a specific version.
 
-If you're unable to complete migration to `systemcrypto` right away, we recommend using `nosystemcrypto` with 1.25 rather than using 1.24, if possible.
+If you're unable to complete migration to `systemcrypto` right away, we recommend disabling systemcrypto with 1.25 rather than using 1.24, if possible.
 This approach lets you benefit from other changes in 1.25.
 It also avoids setting the migration deadline of 1.24 EOL.
 

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -357,8 +357,6 @@ For specific guidance within Microsoft:
 ## Disabling `systemcrypto`
 
 The difficulty of migrating to using `systemcrypto` can vary significantly depending on the Go project.
-If the change requires further planning and if it's acceptable for your project to be temporarily out of compliance with Microsoft cryptography policy, you can disable `systemcrypto`.
-
 If the change requires further planning and if it's acceptable for your project to be temporarily out of compliance with Microsoft cryptography policy, you can disable `systemcrypto` by following these instructions:
 
 - If you're using Go 1.25.2 or later, set the `MS_GO_NOSYSTEMCRYPTO` environment variable to 1.

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -77,7 +77,7 @@ There are typically two goals that lead to this document. Creating a FIPS compli
 | `GOEXPERIMENT=systemcrypto` | `GODEBUG=fips140=on` or `GOFIPS=1` | Compliant | Can be used to create a compliant app. Depending on platform, the app enables FIPS mode, ensures it is already enabled, or doesn't do any additional checks. The app panics if there is a problem. See [Usage: Runtime](#usage-runtime). |
 | `GOEXPERIMENT=systemcrypto` | `GO_OPENSSL_VERSION_OVERRIDE=1.1.1k-fips` | Compliant | Can be used to create a compliant app. If the app is built for Linux, `systemcrypto` chooses `opensslcrypto`, and the environment variable causes it to load `libcrypto.so.1.1.1k-fips` instead of using the automatic search behavior. This environment variable has no effect with `cngcrypto`. |
 | `GOEXPERIMENT=systemcrypto` and `-tags=requirefips` | Default | Compliant | Can be used to create a compliant app. The behavior is the same as `GODEBUG=fips140=on` and `GOFIPS=1`, but no runtime configuration is necessary. See [the `requirefips` section](#build-option-to-require-fips-mode) for more information on when this "locked-in" approach may be useful rather than the flexible approach. |
-| `GOEXPERIMENT=nosystemcrypto` | Default | Not compliant | Crypto usage is not FIPS compliant. |
+| `MS_GO_DISABLE_SYSTEMCRYPTO=1` (since Go 1.25.2) or `GOEXPERIMENT=nosystemcrypto` | Default | Not compliant | Crypto usage is not FIPS compliant. |
 
 A [Docker base image](#dockerfile-base-image) is available that includes suitable build-time config in the environment.
 
@@ -95,7 +95,7 @@ The `GOEXPERIMENT` environment variable is used at build time to select a crypto
 
 - `systemcrypto` automatically selects the suggested crypto backend for the target platform
    - Prior to Go 1.21, this experiment is not available and the backend must be selected manually
-   - Since Go 1.25, this experiment is enabled automatically on Windows and Linux. It can be disabled like any other `GOEXPERIMENT`: setting `GOEXPERIMENT=nosystemcrypto`
+   - Since Go 1.25, this experiment is enabled automatically on Windows and Linux. To disable it, see [Disabling `systemcrypto`](../MigrationGuide.md#disabling-systemcrypto).
 - `opensslcrypto` selects OpenSSL, for Linux
 - `cngcrypto` selects CNG, for Windows
 - Since 1.24, `darwincrypto` selects CommonCrypto & CryptoKit for macOS
@@ -368,11 +368,8 @@ Selecting most `GOEXPERIMENT`s can also be done by setting the corresponding `go
 For example, `go build -tags=goexperiment.systemcrypto` command will enable the same backend as setting `GOEXPERIMENT=systemcrypto` then running the build command.
 
 > [!NOTE]
-> Experiments can't be disabled by a build tag.
+> Experiments can't be disabled by a build tag, see [Disabling `systemcrypto`](../MigrationGuide.md#disabling-systemcrypto) for how to disable `systemcrypto`.
 > For example, `go build -tags=goexperiment.nosystemcrypto` has no effect.
->
-> We plan to implement a compatibility improvement that allows using `nosystemcrypto` without reducing build command compatibility with the official Go distribution.
-> See [microsoft/go#1880](https://github.com/microsoft/go/issues/1880).
 
 ### Conditional behavior if a crypto backend is enabled
 
@@ -453,6 +450,14 @@ A program running in FIPS mode can claim it is using a FIPS-certified cryptograp
 ## Changelog
 
 This list of major changes is intended for quick reference and for access to historical information about versions that are no longer supported. The behavior of all in-support versions are documented in the sections above with notes for version-specific differences where necessary.
+
+### Go 1.26 (Feb 2026)
+
+- `systemcrypto` can be disabled using `MS_GO_DISABLE_SYSTEMCRYPTO=1`. This is now the preferred way to disable `systemcrypto` when necessary.
+
+### Go 1.25.2 (Oct 2025)
+
+- `systemcrypto` can be disabled using `MS_GO_DISABLE_SYSTEMCRYPTO=1`. This is now the preferred way to disable `systemcrypto` when necessary.
 
 ### Go 1.25 (Aug 2025)
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -453,11 +453,11 @@ This list of major changes is intended for quick reference and for access to his
 
 ### Go 1.26 (Feb 2026)
 
-- `systemcrypto` can be disabled using `MS_GO_DISABLE_SYSTEMCRYPTO=1`. This is now the preferred way to disable `systemcrypto` when necessary.
+- `systemcrypto` can be disabled at build time using `MS_GO_DISABLE_SYSTEMCRYPTO=1`. This is now the preferred way to disable `systemcrypto` when necessary.
 
 ### Go 1.25.2 (Oct 2025)
 
-- `systemcrypto` can be disabled using `MS_GO_DISABLE_SYSTEMCRYPTO=1`. This is now the preferred way to disable `systemcrypto` when necessary.
+- `systemcrypto` can be disabled at build time using `MS_GO_DISABLE_SYSTEMCRYPTO=1`. This is now the preferred way to disable `systemcrypto` when necessary.
 
 ### Go 1.25 (Aug 2025)
 

--- a/eng/pipeline/stages/run-codeql.yml
+++ b/eng/pipeline/stages/run-codeql.yml
@@ -124,5 +124,5 @@ stages:
                 # Build our infra tools.
                 ( cd eng/_util/ && go build ./... )
               env:
-                GOEXPERIMENT: nosystemcrypto
+                MS_GO_NOSYSTEMCRYPTO: 1
               displayName: Build ${{ c.os }}-${{ c.arch }}

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -19,7 +19,7 @@ maintain this feature. For more information, see the test files.
  .../testdata/backendtags_openssl/openssl.go   |  3 +
  .../build/testdata/backendtags_system/main.go |  3 +
  .../backendtags_system/systemcrypto.go        |  3 +
- src/internal/buildcfg/exp.go                  | 28 +++++++
+ src/internal/buildcfg/exp.go                  | 42 ++++++++++
  .../goexperiment/exp_cngcrypto_off.go         |  8 ++
  src/internal/goexperiment/exp_cngcrypto_on.go |  8 ++
  .../goexperiment/exp_darwincrypto_off.go      |  8 ++
@@ -29,7 +29,7 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 ++++
- 18 files changed, 387 insertions(+), 4 deletions(-)
+ 18 files changed, 401 insertions(+), 4 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/main.go
@@ -387,10 +387,38 @@ index 00000000000000..eb8a026982259c
 +
 +package main
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index 707776b374b0d4..91b4a71e1ee836 100644
+index 707776b374b0d4..6eab28497a3f2e 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
-@@ -67,6 +67,18 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -6,6 +6,7 @@ package buildcfg
+ 
+ import (
+ 	"fmt"
++	"os"
+ 	"reflect"
+ 	"strings"
+ 
+@@ -29,6 +30,19 @@ type ExperimentFlags struct {
+ // default in the current toolchain. This is, in effect, the "control"
+ // configuration and any variation from this is an experiment.
+ var Experiment ExperimentFlags = func() ExperimentFlags {
++	if os.Getenv("MS_GO_NOSYSTEMCRYPTO") == "1" {
++		// If MS_GO_NOSYSTEMCRYPTO is set, ensure that nosystemcrypto is in GOEXPERIMENT.
++		// We do it here because it is the earliest point where the toolchain tries to retrive
++		// the GOEXPERIMENT value.
++		// The environment variable is updated rather than appending "nosystemcrypto" to the
++		// result of ParseGOEXPERIMENT because the latter will be moved at some point to
++		// internal/goexperiment, which can't import the os package.
++		v := os.Getenv("GOEXPERIMENT")
++		if v != "" {
++			v += ","
++		}
++		os.Setenv("GOEXPERIMENT", v+"nosystemcrypto")
++	}
+ 	flags, err := ParseGOEXPERIMENT(GOOS, GOARCH, envOr("GOEXPERIMENT", defaultGOEXPERIMENT))
+ 	if err != nil {
+ 		Error = err
+@@ -67,6 +81,18 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  		regabiSupported = true
  	}
  
@@ -409,7 +437,7 @@ index 707776b374b0d4..91b4a71e1ee836 100644
  	// Older versions (anything before V16) of dsymutil don't handle
  	// the .debug_rnglists section in DWARF5. See
  	// https://github.com/golang/go/issues/26379#issuecomment-2677068742
-@@ -83,6 +95,7 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -83,6 +109,7 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  		RegabiArgs:           regabiSupported,
  		Dwarf5:               dwarf5Supported,
  		RandomizedHeapBase64: true,
@@ -417,7 +445,7 @@ index 707776b374b0d4..91b4a71e1ee836 100644
  	}
  
  	// Start with the statically enabled set of experiments.
-@@ -124,6 +137,14 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -124,6 +151,14 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  				// to build with any experiment flags.
  				flags.Flags = goexperiment.Flags{}
  				continue
@@ -432,7 +460,7 @@ index 707776b374b0d4..91b4a71e1ee836 100644
  			}
  			val := true
  			if strings.HasPrefix(f, "no") {
-@@ -137,6 +158,10 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -137,6 +172,10 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  		}
  	}
  
@@ -443,7 +471,7 @@ index 707776b374b0d4..91b4a71e1ee836 100644
  	if regabiAlwaysOn {
  		flags.RegabiWrappers = true
  		flags.RegabiArgs = true
-@@ -150,6 +175,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -150,6 +189,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.RegabiArgs && !flags.RegabiWrappers {
  		return nil, fmt.Errorf("GOEXPERIMENT regabiargs requires regabiwrappers")
  	}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -19,7 +19,7 @@ desired goexperiments and build tags.
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/internal/tool/tool.go              |   9 +-
- src/cmd/go/systemcrypto_test.go               | 144 +++++++
+ src/cmd/go/systemcrypto_test.go               | 154 ++++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
  src/cmd/internal/testdir/testdir_test.go      |   7 +
@@ -55,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2308 insertions(+), 22 deletions(-)
+ 46 files changed, 2318 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -160,7 +160,7 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index fb70047dd0e81c..bb7ff4a68764da 100644
+index 9a7951726f6f04..a09cdd9550cbab 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
 @@ -1387,6 +1387,80 @@ func toolenv() []string {
@@ -261,7 +261,7 @@ index fb70047dd0e81c..bb7ff4a68764da 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index ec4ff649b3815d..6ec763259efee6 100644
+index 1e74438f48db39..6c31b623897048 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -291,7 +291,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  		}
  	}
  
-@@ -749,11 +751,18 @@ func (t *tester) registerTests() {
+@@ -750,11 +752,18 @@ func (t *tester) registerTests() {
  			variant: "jsonv2",
  			env:     []string{"GOEXPERIMENT=jsonv2"},
  			pkg:     "encoding/json/...",
@@ -311,7 +311,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  		t.registerTest("GOOS=ios on darwin/amd64",
  			&goTest{
  				variant:  "amd64ios",
-@@ -863,14 +872,21 @@ func (t *tester) registerTests() {
+@@ -864,14 +873,21 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
@@ -319,7 +319,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
 +		if goos != "windows" {
 +			// Linux and macOS don't support systemcrypto with CGO_ENABLED=0.
 +			tags = append(tags, "ms_skipfipscheck")
-+			env = append(env, "GOEXPERIMENT=nosystemcrypto")
++			env = append(env, "MS_GO_NOSYSTEMCRYPTO=1")
 +		}
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
@@ -334,7 +334,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  			})
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
-@@ -878,9 +894,10 @@ func (t *tester) registerTests() {
+@@ -879,9 +895,10 @@ func (t *tester) registerTests() {
  				timeout:   60 * time.Second,
  				buildmode: "pie",
  				ldflags:   "-linkmode=internal",
@@ -346,7 +346,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-@@ -897,15 +914,22 @@ func (t *tester) registerTests() {
+@@ -898,15 +915,22 @@ func (t *tester) registerTests() {
  
  	if t.extLink() && !t.compileOnly {
  		if goos != "android" { // Android does not support non-PIE linking
@@ -354,7 +354,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
 +			if goos == "darwin" {
 +				// Darwincrypto doesn't support external linking.
 +				tags = append(tags, "ms_skipfipscheck")
-+				env = append(env, "GOEXPERIMENT=nosystemcrypto")
++				env = append(env, "MS_GO_NOSYSTEMCRYPTO=1")
 +			}
  			t.registerTest("external linking, -buildmode=exe",
  				&goTest{
@@ -370,7 +370,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  				})
  		}
  		if t.externalLinkPIE() && !disablePIE {
-@@ -984,7 +1008,9 @@ func (t *tester) registerTests() {
+@@ -985,7 +1009,9 @@ func (t *tester) registerTests() {
  		t.registerRaceTests()
  	}
  
@@ -382,10 +382,10 @@ index ec4ff649b3815d..6ec763259efee6 100644
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
-index 3e691abe41f702..b799031d598892 100644
+index e4ee9bd1e8d2ec..3bdb6b4d31fe46 100644
 --- a/src/cmd/go/go_test.go
 +++ b/src/cmd/go/go_test.go
-@@ -14,6 +14,7 @@ import (
+@@ -13,6 +13,7 @@ import (
  	"fmt"
  	"go/format"
  	"internal/godebug"
@@ -393,7 +393,7 @@ index 3e691abe41f702..b799031d598892 100644
  	"internal/platform"
  	"internal/testenv"
  	"io"
-@@ -111,6 +112,13 @@ func TestMain(m *testing.M) {
+@@ -110,6 +111,13 @@ func TestMain(m *testing.M) {
  		if v := os.Getenv("TESTGO_TOOLCHAIN_VERSION"); v != "" {
  			work.ToolchainVersion = v
  		}
@@ -407,7 +407,7 @@ index 3e691abe41f702..b799031d598892 100644
  
  		if testGOROOT := os.Getenv("TESTGO_GOROOT"); testGOROOT != "" {
  			// Disallow installs to the GOROOT from which testgo was built.
-@@ -1861,6 +1869,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
+@@ -1860,6 +1868,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
  }
  
  func TestGoEnv(t *testing.T) {
@@ -418,7 +418,7 @@ index 3e691abe41f702..b799031d598892 100644
  	tg.parallel()
  	defer tg.cleanup()
 diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
-index 97e4eeeff3c8cf..eb23d4e66a750c 100644
+index a4edd854f1d35a..10ee92536b96cd 100644
 --- a/src/cmd/go/internal/cfg/cfg.go
 +++ b/src/cmd/go/internal/cfg/cfg.go
 @@ -19,6 +19,7 @@ import (
@@ -429,7 +429,7 @@ index 97e4eeeff3c8cf..eb23d4e66a750c 100644
  	"strings"
  	"sync"
  	"time"
-@@ -230,6 +231,21 @@ func ForceHost() {
+@@ -229,6 +230,21 @@ func ForceHost() {
  	BuildContext = defaultContext()
  	// Call SetGOROOT to properly set the GOROOT on the new context.
  	SetGOROOT(Getenv("GOROOT"), false)
@@ -495,10 +495,10 @@ index 120ef5339bede0..b7b145fdfc9972 100644
  	buildAndRunTool(ctx, tool, args, runFunc)
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
-index 00000000000000..5ee9c2e050cf24
+index 00000000000000..d12c79c4713e51
 --- /dev/null
 +++ b/src/cmd/go/systemcrypto_test.go
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,154 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -604,30 +604,40 @@ index 00000000000000..5ee9c2e050cf24
 +
 +	type testCase struct {
 +		enabled bool
-+		exp     string
++		env     []string
 +	}
 +	tests := []testCase{
-+		{false, "nosystemcrypto"},
-+		{true, "systemcrypto"},
++		{false, []string{"GOEXPERIMENT=nosystemcrypto"}},
++		{false, []string{"GOEXPERIMENT=systemcrypto,nosystemcrypto"}},
++		{false, []string{"MS_GO_NOSYSTEMCRYPTO=1"}},
++		{true, []string{"GOEXPERIMENT=systemcrypto"}},
++		{true, []string{"GOEXPERIMENT=nosystemcrypto,systemcrypto"}},
 +	}
 +	switch runtime.GOOS {
 +	case "linux":
-+		tests = append(tests, testCase{true, "opensslcrypto"})
++		tests = append(tests, testCase{true, []string{"GOEXPERIMENT=opensslcrypto"}})
 +	case "windows":
 +		switch runtime.GOARCH {
 +		case "amd64", "arm64":
-+			tests = append(tests, testCase{true, "cngcrypto"})
++			tests = append(tests, testCase{true, []string{"GOEXPERIMENT=cngcrypto"}})
 +		}
 +	case "darwin":
-+		tests = append(tests, testCase{true, "darwincrypto"})
++		tests = append(tests, testCase{true, []string{"GOEXPERIMENT=darwincrypto"}})
++	}
++	// Duplicate each test with MS_GO_NOSYSTEMCRYPTO=1, which should always result
++	// in systemcrypto being disabled.
++	n := len(tests)
++	for i := range n {
++		tt := tests[i]
++		tests = append(tests, testCase{false, append(tt.env, "MS_GO_NOSYSTEMCRYPTO=1")})
 +	}
 +	for _, tt := range tests {
-+		t.Run(tt.exp, func(t *testing.T) {
++		t.Run(strings.Join(tt.env, ","), func(t *testing.T) {
 +			t.Parallel()
 +			out := outPath(t)
 +
 +			// Build the binary with the specified GOEXPERIMENT.
-+			_, ok := execGoTool(t, true, []string{"GOEXPERIMENT=" + tt.exp}, "build", "-o", out, file)
++			_, ok := execGoTool(t, true, tt.env, "build", "-o", out, file)
 +			if !ok {
 +				t.Skip("skipping test because GOEXPERIMENT not supported by the current toolchain")
 +			}
@@ -667,7 +677,7 @@ index 2f46a6b44bffe1..69071289e2de81 100644
  
  ! go build -o $devnull cmd/buildid
 diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index 5781276afadba7..f684b73098954c 100644
+index c5aa91ba4732e7..9e838fa785af46 100644
 --- a/src/cmd/internal/testdir/testdir_test.go
 +++ b/src/cmd/internal/testdir/testdir_test.go
 @@ -118,6 +118,13 @@ func Test(t *testing.T) {
@@ -717,7 +727,7 @@ index d913953944bc43..daa8aa3d964ed0 100644
  	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
  
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
-index a87d452ed39446..c03aba6e415873 100644
+index 0125ba8e0f56be..2bc0b65f1035ed 100644
 --- a/src/cmd/link/link_test.go
 +++ b/src/cmd/link/link_test.go
 @@ -9,6 +9,7 @@ import (
@@ -2860,15 +2870,16 @@ index bc85bf170eb2eb..51ea2b8f994d4a 100644
  	< crypto/rand
  	< crypto/ed25519 # depends on crypto/rand.Reader
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index 16a25b602b6966..57067754466b0a 100644
+index 6eab28497a3f2e..81296762c7e231 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
-@@ -5,11 +5,14 @@
+@@ -5,12 +5,15 @@
  package buildcfg
  
  import (
 +	"errors"
  	"fmt"
+ 	"os"
  	"reflect"
 +	"slices"
  	"strings"
@@ -2878,7 +2889,7 @@ index 16a25b602b6966..57067754466b0a 100644
  )
  
  // ExperimentFlags represents a set of GOEXPERIMENT flags relative to a baseline
-@@ -177,6 +180,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -192,6 +195,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.BoringCrypto {
  		return nil, fmt.Errorf("GOEXPERIMENT boringcrypto is not supported in the Microsoft build of Go")
  	}
@@ -2950,7 +2961,7 @@ index 831ee67afc952d..d2f00d57c10286 100644
 +	return boring_runtime_arg0()
 +}
 diff --git a/src/syscall/exec_linux_test.go b/src/syscall/exec_linux_test.go
-index 69d49169446d1c..e6d344ff67a8aa 100644
+index 69d49169446d1c..0e6360a353f07f 100644
 --- a/src/syscall/exec_linux_test.go
 +++ b/src/syscall/exec_linux_test.go
 @@ -300,7 +300,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
@@ -2958,7 +2969,7 @@ index 69d49169446d1c..e6d344ff67a8aa 100644
  
  	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
 -	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
-+	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0", "GOEXPERIMENT=nosystemcrypto")
++	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0", "MS_GO_NOSYSTEMCRYPTO=1")
  	if o, err := cmd.CombinedOutput(); err != nil {
  		t.Fatalf("%v: %v\n%s", cmd, err, o)
  	}


### PR DESCRIPTION
Disabling `systemcrypto` via `GOEXPERIMENT=nosystemcrypto` has some tricky corner cases (see #1880). We better provide a dedicated environment variable for it. The side benefit is that this goes in the direction of decoupling systemcrypto from the GOEXPERIMENT machinery.

Closes #1880