### PR TITLE
[go1.25] backport MS_GO_NOSYSTEMCRYPTO and OpenSSL backend improvements

### DIFF
--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -344,7 +344,9 @@ The `opensslcrypto` Go runtime automatically loads the OpenSSL shared library `l
 The `libcrypto` shared library file name varies among different platforms, so a best effort is done to find and load the right file:
 
 - The base name is always `libcrypto.so.`
-- Well-known version strings are appended to the base name in this order: `3` -> `1.1` -> `11` -> `111` -> `1.0.2` -> `1.0.0`.
+- Well-known version strings are appended to the base name in this order:
+  - Since Go 1.25: `3` -> `1.1` -> `11` -> `111`.
+  - Prior to Go 1.25: `3` -> `1.1` -> `11` -> `111` -> `1.0.2` -> `1.0.0`.
 - This may find multiple libraries installed on the machine, so to pick one:
   - A matching library with FIPS mode on by default (e.g. set by system configuration) is chosen immediately.
   - If none have FIPS mode on by default, the first match is used.
@@ -392,7 +394,8 @@ The `opensslcrypto` Go runtime supports multiple OpenSSL versions. It discovers 
 Not all OpenSSL versions are supported. OpenSSL does not maintain ABI compatibility between different releases, even if only the patch version is increased, it needs specific attention to implement support. The relative importance of each version also results in a different amount of automated testing that has been implemented for various supported version. These are supported versions and the amount of automated validation for each one:
 
 - OpenSSL 1.1.1: the Microsoft CI builds official releases and runs the Go toolset test suite with this version.
-- OpenSSL 1.0.2, 1.1.0, 1.1.1, and 3.0.2: the [golang-fips/openssl] and [go-crypto-openssl] repository CI tests basic operation, but not the integration with the Go runtime.
+- OpenSSL 1.1.0, 1.1.1, and 3.0.2: the [golang-fips/openssl] and [go-crypto-openssl] repository CI tests basic operation, but not the integration with the Go runtime.
+  - Prior to Go 1.25, this list includes 1.0.2.
 
 Versions not listed above are not supported at all.
 
@@ -459,6 +462,8 @@ This list of major changes is intended for quick reference and for access to his
 - `GOEXPERIMENT=boringcrypto` has been removed.
 
 - `GOEXPERIMENT=allowcryptofallback` has been removed. Instead, if it's necessary to opt out from using a system crypto backend, use `GOEXPERIMENT=nosystemcrypto`. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
+
+- The OpenSSL backend [no longer supports OpenSSL 1.0](https://github.com/golang-fips/openssl/issues/244). The supported versions are now OpenSSL 1.1.0, 1.1.1, and 3.x.
 
 ### Go 1.24 (Feb 2025)
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -95,7 +95,7 @@ The `GOEXPERIMENT` environment variable is used at build time to select a crypto
 
 - `systemcrypto` automatically selects the suggested crypto backend for the target platform
    - Prior to Go 1.21, this experiment is not available and the backend must be selected manually
-   - Since Go 1.25, this experiment is enabled automatically on Windows and Linux. To disable it, see [Disabling `systemcrypto`](../MigrationGuide.md#disabling-systemcrypto).
+   - Since Go 1.25, this experiment is enabled automatically on Windows and Linux. It can be disabled like any other `GOEXPERIMENT`: setting `GOEXPERIMENT=nosystemcrypto`
 - `opensslcrypto` selects OpenSSL, for Linux
 - `cngcrypto` selects CNG, for Windows
 - Since 1.24, `darwincrypto` selects CommonCrypto & CryptoKit for macOS

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -77,7 +77,7 @@ There are typically two goals that lead to this document. Creating a FIPS compli
 | `GOEXPERIMENT=systemcrypto` | `GODEBUG=fips140=on` or `GOFIPS=1` | Compliant | Can be used to create a compliant app. Depending on platform, the app enables FIPS mode, ensures it is already enabled, or doesn't do any additional checks. The app panics if there is a problem. See [Usage: Runtime](#usage-runtime). |
 | `GOEXPERIMENT=systemcrypto` | `GO_OPENSSL_VERSION_OVERRIDE=1.1.1k-fips` | Compliant | Can be used to create a compliant app. If the app is built for Linux, `systemcrypto` chooses `opensslcrypto`, and the environment variable causes it to load `libcrypto.so.1.1.1k-fips` instead of using the automatic search behavior. This environment variable has no effect with `cngcrypto`. |
 | `GOEXPERIMENT=systemcrypto` and `-tags=requirefips` | Default | Compliant | Can be used to create a compliant app. The behavior is the same as `GODEBUG=fips140=on` and `GOFIPS=1`, but no runtime configuration is necessary. See [the `requirefips` section](#build-option-to-require-fips-mode) for more information on when this "locked-in" approach may be useful rather than the flexible approach. |
-| `GOEXPERIMENT=nosystemcrypto` | Default | Not compliant | Crypto usage is not FIPS compliant. |
+| `MS_GO_DISABLE_SYSTEMCRYPTO=1` (since Go 1.25.2) or `GOEXPERIMENT=nosystemcrypto` | Default | Not compliant | Crypto usage is not FIPS compliant. |
 
 A [Docker base image](#dockerfile-base-image) is available that includes suitable build-time config in the environment.
 
@@ -95,7 +95,7 @@ The `GOEXPERIMENT` environment variable is used at build time to select a crypto
 
 - `systemcrypto` automatically selects the suggested crypto backend for the target platform
    - Prior to Go 1.21, this experiment is not available and the backend must be selected manually
-   - Since Go 1.25, this experiment is enabled automatically on Windows and Linux. It can be disabled like any other `GOEXPERIMENT`: setting `GOEXPERIMENT=nosystemcrypto`
+   - Since Go 1.25, this experiment is enabled automatically on Windows and Linux. To disable it, see [Disabling `systemcrypto`](../MigrationGuide.md#disabling-systemcrypto).
 - `opensslcrypto` selects OpenSSL, for Linux
 - `cngcrypto` selects CNG, for Windows
 - Since 1.24, `darwincrypto` selects CommonCrypto & CryptoKit for macOS
@@ -446,6 +446,14 @@ A program running in FIPS mode can claim it is using a FIPS-certified cryptograp
 ## Changelog
 
 This list of major changes is intended for quick reference and for access to historical information about versions that are no longer supported. The behavior of all in-support versions are documented in the sections above with notes for version-specific differences where necessary.
+
+### Go 1.26 (Feb 2026)
+
+- `systemcrypto` can be disabled at build time using `MS_GO_DISABLE_SYSTEMCRYPTO=1`. This is now the preferred way to disable `systemcrypto` when necessary.
+
+### Go 1.25.2 (Oct 2025)
+
+- `systemcrypto` can be disabled at build time using `MS_GO_DISABLE_SYSTEMCRYPTO=1`. This is now the preferred way to disable `systemcrypto` when necessary.
 
 ### Go 1.25 (Aug 2025)
 

--- a/eng/pipeline/stages/run-codeql.yml
+++ b/eng/pipeline/stages/run-codeql.yml
@@ -124,5 +124,5 @@ stages:
                 # Build our infra tools.
                 ( cd eng/_util/ && go build ./... )
               env:
-                GOEXPERIMENT: nosystemcrypto
+                MS_GO_NOSYSTEMCRYPTO: 1
               displayName: Build ${{ c.os }}-${{ c.arch }}

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -21,7 +21,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../telemetry/internal/appinsights/client.go  |  169 ++
  .../internal/appinsights/inmemorychannel.go   |  341 +++
  .../internal/contracts/contexttagkeys.go      |   50 +
- .../internal/contracts/envelope.go            |  123 +
+ .../internal/contracts/envelope.go            |  123 ++
  .../internal/contracts/response.go            |   32 +
  .../internal/appinsights/jsonserializer.go    |   33 +
  .../telemetry/internal/appinsights/package.go |   13 +
@@ -30,7 +30,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../telemetry/internal/config/config.go       |   63 +
  .../telemetry/internal/telemetry/proginfo.go  |   32 +
  .../telemetry/internal/telemetry/telemetry.go |   32 +
- .../microsoft/go-infra/telemetry/telemetry.go |  125 +
+ .../microsoft/go-infra/telemetry/telemetry.go |  125 ++
  src/cmd/vendor/modules.txt                    |   11 +
  src/crypto/internal/backend/deps_ignore.go    |   22 +
  src/go.mod                                    |    6 +
@@ -61,21 +61,21 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../github.com/golang-fips/openssl/v2/init.go |  157 ++
  .../golang-fips/openssl/v2/init_unix.go       |   31 +
  .../golang-fips/openssl/v2/init_windows.go    |   36 +
- .../openssl/v2/internal/ossl/errors.go        |  125 +
+ .../openssl/v2/internal/ossl/errors.go        |  119 +
  .../openssl/v2/internal/ossl/ossl.go          |   81 +
  .../openssl/v2/internal/ossl/shims.h          |  399 ++++
- .../openssl/v2/internal/ossl/zossl.c          | 2061 +++++++++++++++++
- .../openssl/v2/internal/ossl/zossl.go         | 1329 +++++++++++
- .../openssl/v2/internal/ossl/zossl.h          |  337 +++
+ .../openssl/v2/internal/ossl/zossl.c          | 1924 +++++++++++++++++
+ .../openssl/v2/internal/ossl/zossl.go         | 1329 ++++++++++++
+ .../openssl/v2/internal/ossl/zossl.h          |  335 +++
  .../openssl/v2/internal/ossl/zossl_go124.go   |   37 +
- .../golang-fips/openssl/v2/openssl.go         |  384 +++
+ .../golang-fips/openssl/v2/openssl.go         |  384 ++++
  .../golang-fips/openssl/v2/params.go          |  185 ++
  .../golang-fips/openssl/v2/pbkdf2.go          |   55 +
  .../golang-fips/openssl/v2/provideropenssl.go |  239 ++
  .../openssl/v2/providersymcrypt.go            |  338 +++
  .../github.com/golang-fips/openssl/v2/rand.go |   22 +
  .../github.com/golang-fips/openssl/v2/rc4.go  |   69 +
- .../github.com/golang-fips/openssl/v2/rsa.go  |  366 +++
+ .../github.com/golang-fips/openssl/v2/rsa.go  |  366 ++++
  .../golang-fips/openssl/v2/tls1prf.go         |  159 ++
  .../github.com/golang-fips/openssl/v2/zaes.go |   86 +
  .../microsoft/go-crypto-darwin/LICENSE        |   21 +
@@ -86,7 +86,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/cryptokit/cryptokit.h            |   67 +
  .../internal/cryptokit/ed25519.go             |   72 +
  .../internal/cryptokit/gcm.go                 |   36 +
- .../internal/cryptokit/hash.go                |  247 ++
+ .../internal/cryptokit/hash.go                |  247 +++
  .../internal/cryptokit/hashclone.go           |   17 +
  .../internal/cryptokit/hashclone_go125.go     |   12 +
  .../internal/cryptokit/hkdf.go                |   77 +
@@ -94,7 +94,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-darwin/xcrypto/aes.go |  336 +++
  .../microsoft/go-crypto-darwin/xcrypto/big.go |   16 +
  .../go-crypto-darwin/xcrypto/cgo_go124.go     |   23 +
- .../go-crypto-darwin/xcrypto/cipher.go        |  122 +
+ .../go-crypto-darwin/xcrypto/cipher.go        |  122 ++
  .../microsoft/go-crypto-darwin/xcrypto/des.go |  117 +
  .../microsoft/go-crypto-darwin/xcrypto/ec.go  |   32 +
  .../go-crypto-darwin/xcrypto/ecdh.go          |  135 ++
@@ -117,12 +117,12 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/cng.go  |  131 ++
  .../microsoft/go-crypto-winnative/cng/des.go  |  106 +
  .../microsoft/go-crypto-winnative/cng/dsa.go  |  465 ++++
- .../microsoft/go-crypto-winnative/cng/ecdh.go |  255 ++
+ .../microsoft/go-crypto-winnative/cng/ecdh.go |  255 +++
  .../go-crypto-winnative/cng/ecdsa.go          |  169 ++
  .../microsoft/go-crypto-winnative/cng/hash.go |  315 +++
  .../go-crypto-winnative/cng/hashclone.go      |   18 +
  .../cng/hashclone_go125.go                    |   13 +
- .../microsoft/go-crypto-winnative/cng/hkdf.go |  128 +
+ .../microsoft/go-crypto-winnative/cng/hkdf.go |  128 ++
  .../microsoft/go-crypto-winnative/cng/hmac.go |   68 +
  .../microsoft/go-crypto-winnative/cng/keys.go |  220 ++
  .../go-crypto-winnative/cng/pbkdf2.go         |   70 +
@@ -131,13 +131,13 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/rsa.go  |  396 ++++
  .../microsoft/go-crypto-winnative/cng/sha3.go |  311 +++
  .../go-crypto-winnative/cng/tls1prf.go        |   89 +
- .../internal/bcrypt/bcrypt_windows.go         |  368 +++
+ .../internal/bcrypt/bcrypt_windows.go         |  368 ++++
  .../internal/bcrypt/ntstatus_windows.go       |   45 +
  .../internal/bcrypt/zsyscall_windows.go       |  412 ++++
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 129 files changed, 19234 insertions(+), 7 deletions(-)
+ 129 files changed, 19089 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -1917,7 +1917,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index b81f19068aef23..da03dfd87e7aec 100644
+index b81f19068aef23..8c6a04e8e8ae4f 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -1926,17 +1926,17 @@ index b81f19068aef23..da03dfd87e7aec 100644
  )
 +
 +require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20251001121009-b4683d758995
 +	github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 410eb8648a710a..928d040435b4b7 100644
+index 410eb8648a710a..3ffe43e5bf0008 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7 h1:ZjpSTr5uh4P3EKwrZQ8Fr/NZJ6NBgf+8UabCp9Kmtoc=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20251001121009-b4683d758995 h1:goQ45x1DM/vXMK8XeeRsRFDZFiI082k8TzvIADlkAOs=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20251001121009-b4683d758995/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7 h1:6a0YcJOAJWLtEqDW55bUhhe4Nx/9Rpmm80KVMUxD6B4=
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7/go.mod h1:LyP4oZ0QcysEJdqUTOk9ngNFArRFK94YRImkoJ8julQ=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b h1:Yf6lm9r6Aid3PG5FoeSX2v4iU+xWnAmCRQNjBxgceWI=
@@ -6489,10 +6489,10 @@ index 00000000000000..3778e21227abb9
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors.go
 new file mode 100644
-index 00000000000000..284952ca345475
+index 00000000000000..68711f8e43d70f
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors.go
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,119 @@
 +package ossl
 +
 +/*
@@ -6510,12 +6510,6 @@ index 00000000000000..284952ca345475
 +	int line[ERR_NUM_MAX];
 +	char *file[ERR_NUM_MAX];
 +} ossl_err_state;
-+
-+// mkcgo_err_clear clears the error queue in OpenSSL.
-+void mkcgo_err_clear() {
-+	// Clear the error queue.
-+	_mkcgo_ERR_clear_error();
-+}
 +
 +// mkcgo_err_retrieve retrieves the error state from OpenSSL.
 +// It returns a pointer to a mkcgo_err_state structure
@@ -7112,10 +7106,10 @@ index 00000000000000..5790defeb6eb55
 +#endif // _GO_OSSL_SHIMS_H
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.c b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.c
 new file mode 100644
-index 00000000000000..1444f551331fb6
+index 00000000000000..8124dfd70a22e3
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.c
-@@ -0,0 +1,2061 @@
+@@ -0,0 +1,1924 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +#include <stddef.h>
@@ -7867,21 +7861,18 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_BIGNUM_PTR _mkcgo_BN_bin2bn(const unsigned char* _arg0, int _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_BIGNUM_PTR _ret = _g_BN_bin2bn(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_BN_bn2binpad(const _BIGNUM_PTR _arg0, unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_BN_bn2binpad(_arg0, _arg1, _arg2);
 +	if (_ret == -1) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_BN_bn2lebinpad(const _BIGNUM_PTR _arg0, unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_BN_bn2lebinpad(_arg0, _arg1, _arg2);
 +	if (_ret == -1) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -7900,14 +7891,12 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_BIGNUM_PTR _mkcgo_BN_lebin2bn(const unsigned char* _arg0, int _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_BIGNUM_PTR _ret = _g_BN_lebin2bn(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_BIGNUM_PTR _mkcgo_BN_new(mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_BIGNUM_PTR _ret = _g_BN_new();
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -7922,7 +7911,6 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +void* _mkcgo_CRYPTO_malloc(size_t _arg0, const char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	void* _ret = _g_CRYPTO_malloc(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -7933,7 +7921,6 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_DSA_generate_key(_DSA_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_DSA_generate_key(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -7948,21 +7935,18 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_DSA_PTR _mkcgo_DSA_new(mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_DSA_PTR _ret = _g_DSA_new();
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_DSA_set0_key(_DSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_DSA_set0_key(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_DSA_set0_pqg(_DSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, _BIGNUM_PTR _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_DSA_set0_pqg(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -7973,14 +7957,12 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_EC_GROUP_PTR _mkcgo_EC_GROUP_new_by_curve_name(int _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EC_GROUP_PTR _ret = _g_EC_GROUP_new_by_curve_name(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EC_KEY_check_key(const _EC_KEY_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EC_KEY_check_key(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8003,28 +7985,24 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_EC_KEY_PTR _mkcgo_EC_KEY_new_by_curve_name(int _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EC_KEY_PTR _ret = _g_EC_KEY_new_by_curve_name(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EC_KEY_set_private_key(_EC_KEY_PTR _arg0, const _BIGNUM_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EC_KEY_set_private_key(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EC_KEY_set_public_key(_EC_KEY_PTR _arg0, const _EC_POINT_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EC_KEY_set_public_key(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EC_KEY_set_public_key_affine_coordinates(_EC_KEY_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EC_KEY_set_public_key_affine_coordinates(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8035,42 +8013,36 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_EC_POINT_get_affine_coordinates_GFp(const _EC_GROUP_PTR _arg0, const _EC_POINT_PTR _arg1, _BIGNUM_PTR _arg2, _BIGNUM_PTR _arg3, _BN_CTX_PTR _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EC_POINT_get_affine_coordinates_GFp(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EC_POINT_mul(const _EC_GROUP_PTR _arg0, _EC_POINT_PTR _arg1, const _BIGNUM_PTR _arg2, const _EC_POINT_PTR _arg3, const _BIGNUM_PTR _arg4, _BN_CTX_PTR _arg5, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EC_POINT_mul(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EC_POINT_PTR _mkcgo_EC_POINT_new(const _EC_GROUP_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EC_POINT_PTR _ret = _g_EC_POINT_new(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EC_POINT_oct2point(const _EC_GROUP_PTR _arg0, _EC_POINT_PTR _arg1, const unsigned char* _arg2, size_t _arg3, _BN_CTX_PTR _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EC_POINT_oct2point(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +size_t _mkcgo_EC_POINT_point2oct(const _EC_GROUP_PTR _arg0, const _EC_POINT_PTR _arg1, point_conversion_form_t _arg2, unsigned char* _arg3, size_t _arg4, _BN_CTX_PTR _arg5, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	size_t _ret = _g_EC_POINT_point2oct(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EC_POINT_set_affine_coordinates(const _EC_GROUP_PTR _arg0, _EC_POINT_PTR _arg1, const _BIGNUM_PTR _arg2, const _BIGNUM_PTR _arg3, _BN_CTX_PTR _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EC_POINT_set_affine_coordinates(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8093,7 +8065,6 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_EVP_CIPHER_CTX_ctrl(_EVP_CIPHER_CTX_PTR _arg0, int _arg1, int _arg2, void* _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_CIPHER_CTX_ctrl(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8104,28 +8075,24 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_EVP_CIPHER_CTX_PTR _mkcgo_EVP_CIPHER_CTX_new(mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_CIPHER_CTX_PTR _ret = _g_EVP_CIPHER_CTX_new();
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_CIPHER_CTX_set_key_length(_EVP_CIPHER_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_CIPHER_CTX_set_key_length(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_CIPHER_CTX_set_padding(_EVP_CIPHER_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_CIPHER_CTX_set_padding(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_CIPHER_PTR _mkcgo_EVP_CIPHER_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_CIPHER_PTR _ret = _g_EVP_CIPHER_fetch(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8140,133 +8107,114 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, _ENGINE_PTR _arg2, const unsigned char* _arg3, const unsigned char* _arg4, int _arg5, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_CipherInit_ex(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, const unsigned char* _arg3, int _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_CipherUpdate(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DecryptFinal_ex(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DecryptInit_ex(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, _ENGINE_PTR _arg2, const unsigned char* _arg3, const unsigned char* _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DecryptInit_ex(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DecryptUpdate(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, const unsigned char* _arg3, int _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DecryptUpdate(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_Digest(const void* _arg0, size_t _arg1, unsigned char* _arg2, unsigned int* _arg3, const _EVP_MD_PTR _arg4, _ENGINE_PTR _arg5, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_Digest(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestFinal_ex(_EVP_MD_CTX_PTR _arg0, unsigned char* _arg1, unsigned int* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestFinal_ex(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestInit(_EVP_MD_CTX_PTR _arg0, const _EVP_MD_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestInit(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestInit_ex(_EVP_MD_CTX_PTR _arg0, const _EVP_MD_PTR _arg1, _ENGINE_PTR _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestInit_ex(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestSign(_EVP_MD_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestSign(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestSignFinal(_EVP_MD_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestSignFinal(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestSignInit(_EVP_MD_CTX_PTR _arg0, _EVP_PKEY_CTX_PTR* _arg1, const _EVP_MD_PTR _arg2, _ENGINE_PTR _arg3, _EVP_PKEY_PTR _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestSignInit(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestUpdate(_EVP_MD_CTX_PTR _arg0, const void* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestUpdate(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestVerify(_EVP_MD_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestVerify(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestVerifyFinal(_EVP_MD_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestVerifyFinal(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_DigestVerifyInit(_EVP_MD_CTX_PTR _arg0, _EVP_PKEY_CTX_PTR* _arg1, const _EVP_MD_PTR _arg2, _ENGINE_PTR _arg3, _EVP_PKEY_PTR _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_DigestVerifyInit(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_EncryptFinal_ex(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_EncryptFinal_ex(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_EncryptInit_ex(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, _ENGINE_PTR _arg2, const unsigned char* _arg3, const unsigned char* _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_EncryptInit_ex(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_EncryptUpdate(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, const unsigned char* _arg3, int _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_EncryptUpdate(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8277,35 +8225,30 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +size_t _mkcgo_EVP_KDF_CTX_get_kdf_size(_EVP_KDF_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	size_t _ret = _g_EVP_KDF_CTX_get_kdf_size(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_KDF_CTX_PTR _mkcgo_EVP_KDF_CTX_new(_EVP_KDF_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_KDF_CTX_PTR _ret = _g_EVP_KDF_CTX_new(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_KDF_CTX_set_params(_EVP_KDF_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_KDF_CTX_set_params(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_KDF_derive(_EVP_KDF_CTX_PTR _arg0, unsigned char* _arg1, size_t _arg2, const _OSSL_PARAM_PTR _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_KDF_derive(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_KDF_PTR _mkcgo_EVP_KDF_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_KDF_PTR _ret = _g_EVP_KDF_fetch(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8316,7 +8259,6 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_EVP_MAC_CTX_PTR _mkcgo_EVP_MAC_CTX_dup(const _EVP_MAC_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_MAC_CTX_PTR _ret = _g_EVP_MAC_CTX_dup(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8327,56 +8269,48 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_EVP_MAC_CTX_PTR _mkcgo_EVP_MAC_CTX_new(_EVP_MAC_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_MAC_CTX_PTR _ret = _g_EVP_MAC_CTX_new(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_MAC_CTX_set_params(_EVP_MAC_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_MAC_CTX_set_params(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_MAC_PTR _mkcgo_EVP_MAC_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_MAC_PTR _ret = _g_EVP_MAC_fetch(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_MAC_final(_EVP_MAC_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_MAC_final(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_MAC_init(_EVP_MAC_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, const _OSSL_PARAM_PTR _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_MAC_init(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_MAC_update(_EVP_MAC_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_MAC_update(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_MD_CTX_copy(_EVP_MD_CTX_PTR _arg0, const _EVP_MD_CTX_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_MD_CTX_copy(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_MD_CTX_copy_ex(_EVP_MD_CTX_PTR _arg0, const _EVP_MD_CTX_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_MD_CTX_copy_ex(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8387,42 +8321,36 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR _arg0, _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_MD_CTX_get_params(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +const _OSSL_PARAM_PTR _mkcgo_EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	const _OSSL_PARAM_PTR _ret = _g_EVP_MD_CTX_gettable_params(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_MD_CTX_PTR _mkcgo_EVP_MD_CTX_new(mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_MD_CTX_PTR _ret = _g_EVP_MD_CTX_new();
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_MD_CTX_set_params(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +const _OSSL_PARAM_PTR _mkcgo_EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	const _OSSL_PARAM_PTR _ret = _g_EVP_MD_CTX_settable_params(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_MD_PTR _mkcgo_EVP_MD_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_MD_PTR _ret = _g_EVP_MD_fetch(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8453,14 +8381,12 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_EVP_PKEY_CTX_add1_hkdf_info(_EVP_PKEY_CTX_PTR _arg0, const unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_CTX_add1_hkdf_info(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_CTX_ctrl(_EVP_PKEY_CTX_PTR _arg0, int _arg1, int _arg2, int _arg3, int _arg4, void* _arg5, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_CTX_ctrl(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8471,133 +8397,114 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new(_EVP_PKEY_PTR _arg0, _ENGINE_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_PKEY_CTX_PTR _ret = _g_EVP_PKEY_CTX_new(_arg0, _arg1);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_from_pkey(_OSSL_LIB_CTX_PTR _arg0, _EVP_PKEY_PTR _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_PKEY_CTX_PTR _ret = _g_EVP_PKEY_CTX_new_from_pkey(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_id(int _arg0, _ENGINE_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_PKEY_CTX_PTR _ret = _g_EVP_PKEY_CTX_new_id(_arg0, _arg1);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR _arg0, void* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_CTX_set0_rsa_oaep_label(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_CTX_set1_hkdf_key(_EVP_PKEY_CTX_PTR _arg0, const unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_CTX_set1_hkdf_key(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR _arg0, const unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_CTX_set1_hkdf_salt(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR _arg0, const _EVP_MD_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_CTX_set_hkdf_md(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_CTX_set_hkdf_mode(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, const char* _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_Q_keygen(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_Q_keygen(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_RSA(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_Q_keygen(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_assign(_EVP_PKEY_PTR _arg0, int _arg1, void* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_assign(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_decrypt(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_decrypt(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_decrypt_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_decrypt_init(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_derive(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_derive(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_derive_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_derive_init(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_derive_set_peer(_EVP_PKEY_CTX_PTR _arg0, _EVP_PKEY_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_derive_set_peer(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_encrypt(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_encrypt(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_encrypt_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_encrypt_init(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8608,196 +8515,168 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_EVP_PKEY_fromdata(_EVP_PKEY_CTX_PTR _arg0, _EVP_PKEY_PTR* _arg1, int _arg2, _OSSL_PARAM_PTR _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_fromdata(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_fromdata_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_fromdata_init(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_DSA_PTR _mkcgo_EVP_PKEY_get0_DSA(_EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_DSA_PTR _ret = _g_EVP_PKEY_get0_DSA(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EC_KEY_PTR _mkcgo_EVP_PKEY_get0_EC_KEY(_EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EC_KEY_PTR _ret = _g_EVP_PKEY_get0_EC_KEY(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_RSA_PTR _mkcgo_EVP_PKEY_get1_RSA(_EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_RSA_PTR _ret = _g_EVP_PKEY_get1_RSA(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +size_t _mkcgo_EVP_PKEY_get1_encoded_public_key(_EVP_PKEY_PTR _arg0, unsigned char** _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	size_t _ret = _g_EVP_PKEY_get1_encoded_public_key(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_get_bits(const _EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_get_bits(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_get_bn_param(const _EVP_PKEY_PTR _arg0, const char* _arg1, _BIGNUM_PTR* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_get_bn_param(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR _arg0, unsigned char* _arg1, size_t* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_get_raw_private_key(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR _arg0, unsigned char* _arg1, size_t* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_get_raw_public_key(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_get_size(const _EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_get_size(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_keygen(_EVP_PKEY_CTX_PTR _arg0, _EVP_PKEY_PTR* _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_keygen(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_keygen_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_keygen_init(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_new(mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_new();
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_new_raw_private_key(int _arg0, _ENGINE_PTR _arg1, const unsigned char* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_new_raw_private_key(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_new_raw_public_key(int _arg0, _ENGINE_PTR _arg1, const unsigned char* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_new_raw_public_key(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_paramgen(_EVP_PKEY_CTX_PTR _arg0, _EVP_PKEY_PTR* _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_paramgen(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_paramgen_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_paramgen_init(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_private_check(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_private_check(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_public_check_quick(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_public_check_quick(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_set1_EC_KEY(_EVP_PKEY_PTR _arg0, _EC_KEY_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_set1_EC_KEY(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_set1_encoded_public_key(_EVP_PKEY_PTR _arg0, const unsigned char* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_set1_encoded_public_key(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_sign(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_sign(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_sign_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_sign_init(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_up_ref(_EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_up_ref(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_verify(_EVP_PKEY_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_verify(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_EVP_PKEY_verify_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_PKEY_verify_init(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_EVP_SIGNATURE_PTR _mkcgo_EVP_SIGNATURE_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_EVP_SIGNATURE_PTR _ret = _g_EVP_SIGNATURE_fetch(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8856,7 +8735,6 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_EVP_default_properties_enable_fips(_OSSL_LIB_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_EVP_default_properties_enable_fips(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8951,14 +8829,12 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_FIPS_mode_set(int _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_FIPS_mode_set(_arg0);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_HMAC_CTX_copy(_HMAC_CTX_PTR _arg0, _HMAC_CTX_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_HMAC_CTX_copy(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -8969,28 +8845,24 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_HMAC_CTX_PTR _mkcgo_HMAC_CTX_new(mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_HMAC_CTX_PTR _ret = _g_HMAC_CTX_new();
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_HMAC_Final(_HMAC_CTX_PTR _arg0, unsigned char* _arg1, unsigned int* _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_HMAC_Final(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_HMAC_Init_ex(_HMAC_CTX_PTR _arg0, const void* _arg1, int _arg2, const _EVP_MD_PTR _arg3, _ENGINE_PTR _arg4, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_HMAC_Init_ex(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_HMAC_Update(_HMAC_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_HMAC_Update(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -9005,7 +8877,6 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_OPENSSL_init_crypto(uint64_t _arg0, const _OPENSSL_INIT_SETTINGS_PTR _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_OPENSSL_init_crypto(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -9040,42 +8911,36 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_OSSL_PARAM_BLD_PTR _ret = _g_OSSL_PARAM_BLD_new();
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_OSSL_PARAM_BLD_push_BN(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_OSSL_PARAM_BLD_push_BN(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_OSSL_PARAM_BLD_push_int32(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, int32_t _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_OSSL_PARAM_BLD_push_int32(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_OSSL_PARAM_BLD_push_octet_string(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const void* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_OSSL_PARAM_BLD_push_octet_string(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_OSSL_PARAM_BLD_push_utf8_string(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const char* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_OSSL_PARAM_BLD_push_utf8_string(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +_OSSL_PARAM_PTR _mkcgo_OSSL_PARAM_BLD_to_param(_OSSL_PARAM_BLD_PTR _arg0, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_OSSL_PARAM_PTR _ret = _g_OSSL_PARAM_BLD_to_param(_arg0);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -9086,7 +8951,6 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +const _OSSL_PARAM_PTR _mkcgo_OSSL_PARAM_locate_const(const _OSSL_PARAM_PTR _arg0, const char* _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	const _OSSL_PARAM_PTR _ret = _g_OSSL_PARAM_locate_const(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -9101,7 +8965,6 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_OSSL_PROVIDER_PTR _mkcgo_OSSL_PROVIDER_try_load(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_OSSL_PROVIDER_PTR _ret = _g_OSSL_PROVIDER_try_load(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -9120,14 +8983,12 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +int _mkcgo_PKCS5_PBKDF2_HMAC(const char* _arg0, int _arg1, const unsigned char* _arg2, int _arg3, int _arg4, const _EVP_MD_PTR _arg5, int _arg6, unsigned char* _arg7, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_PKCS5_PBKDF2_HMAC(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5, _arg6, _arg7);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_RAND_bytes(unsigned char* _arg0, int _arg1, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_RAND_bytes(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -9150,28 +9011,24 @@ index 00000000000000..1444f551331fb6
 +}
 +
 +_RSA_PTR _mkcgo_RSA_new(mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	_RSA_PTR _ret = _g_RSA_new();
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_RSA_set0_crt_params(_RSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, _BIGNUM_PTR _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_RSA_set0_crt_params(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_RSA_set0_factors(_RSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_RSA_set0_factors(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
 +
 +int _mkcgo_RSA_set0_key(_RSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, _BIGNUM_PTR _arg3, mkcgo_err_state *_err_state) {
-+	mkcgo_err_clear();
 +	int _ret = _g_RSA_set0_key(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -10514,10 +10371,10 @@ index 00000000000000..9079f7a0cffc40
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.h b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.h
 new file mode 100644
-index 00000000000000..ea01eed750a1c5
+index 00000000000000..335d129bb345cd
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.h
-@@ -0,0 +1,337 @@
+@@ -0,0 +1,335 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +#ifndef MKCGO_H // only include this header once
@@ -10610,8 +10467,6 @@ index 00000000000000..ea01eed750a1c5
 +typedef void* mkcgo_err_state;
 +mkcgo_err_state mkcgo_err_retrieve();
 +void mkcgo_err_free(mkcgo_err_state);
-+void mkcgo_err_clear();
-+
 +void __mkcgo_load_(void* handle);
 +void __mkcgo_unload_();
 +void __mkcgo_load_111(void* handle);
@@ -21377,11 +21232,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 8507f01b12f518..918aaab0a32fef 100644
+index 8507f01b12f518..2dd3762ff7ffdd 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,20 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20250619123805-fe4bc89177d7
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20251001121009-b4683d758995
 +## explicit; go 1.22
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -19,7 +19,7 @@ maintain this feature. For more information, see the test files.
  .../testdata/backendtags_openssl/openssl.go   |  3 +
  .../build/testdata/backendtags_system/main.go |  3 +
  .../backendtags_system/systemcrypto.go        |  3 +
- src/internal/buildcfg/exp.go                  | 28 +++++++
+ src/internal/buildcfg/exp.go                  | 42 ++++++++++
  .../goexperiment/exp_cngcrypto_off.go         |  8 ++
  src/internal/goexperiment/exp_cngcrypto_on.go |  8 ++
  .../goexperiment/exp_darwincrypto_off.go      |  8 ++
@@ -29,7 +29,7 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 ++++
- 18 files changed, 387 insertions(+), 4 deletions(-)
+ 18 files changed, 401 insertions(+), 4 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_openssl/main.go
@@ -390,7 +390,35 @@ diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
 index 689ca8ce58a6f2..9b3bafd0fc6cd9 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
-@@ -67,6 +67,18 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -6,6 +6,7 @@ package buildcfg
+ 
+ import (
+ 	"fmt"
++	"os"
+ 	"reflect"
+ 	"strings"
+ 
+@@ -29,6 +30,19 @@ type ExperimentFlags struct {
+ // default in the current toolchain. This is, in effect, the "control"
+ // configuration and any variation from this is an experiment.
+ var Experiment ExperimentFlags = func() ExperimentFlags {
++	if os.Getenv("MS_GO_NOSYSTEMCRYPTO") == "1" {
++		// If MS_GO_NOSYSTEMCRYPTO is set, ensure that nosystemcrypto is in GOEXPERIMENT.
++		// We do it here because it is the earliest point where the toolchain tries to retrive
++		// the GOEXPERIMENT value.
++		// The environment variable is updated rather than appending "nosystemcrypto" to the
++		// result of ParseGOEXPERIMENT because the latter will be moved at some point to
++		// internal/goexperiment, which can't import the os package.
++		v := os.Getenv("GOEXPERIMENT")
++		if v != "" {
++			v += ","
++		}
++		os.Setenv("GOEXPERIMENT", v+"nosystemcrypto")
++	}
+ 	flags, err := ParseGOEXPERIMENT(GOOS, GOARCH, envOr("GOEXPERIMENT", defaultGOEXPERIMENT))
+ 	if err != nil {
+ 		Error = err
+@@ -67,6 +81,18 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  		regabiSupported = true
  	}
  

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -44,7 +44,7 @@ desired goexperiments and build tags.
  .../fips140/requirefips_nosystemcrypto.go     |  15 +
  .../backend/fips140/skipfipscheck_off.go      |   9 +
  .../backend/fips140/skipfipscheck_on.go       |   9 +
- .../internal/opensslsetup/opensslsetup.go     |  70 ++++
+ .../internal/opensslsetup/opensslsetup.go     |  68 ++++
  .../opensslsetup/opensslsetup_test.go         |  92 +++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 251 ++++++++++++
@@ -55,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2310 insertions(+), 22 deletions(-)
+ 46 files changed, 2308 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -160,7 +160,7 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 024050c2dd70c4..f91bf0a7c4ad1c 100644
+index fb70047dd0e81c..bb7ff4a68764da 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
 @@ -1387,6 +1387,80 @@ func toolenv() []string {
@@ -261,7 +261,7 @@ index 024050c2dd70c4..f91bf0a7c4ad1c 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aa09d1eba34be8..c3f3a8324c507c 100644
+index ec4ff649b3815d..6ec763259efee6 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -667,7 +667,7 @@ index 2f46a6b44bffe1..69071289e2de81 100644
  
  ! go build -o $devnull cmd/buildid
 diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index 483a9ec33c6798..fad922e3f844ab 100644
+index 5781276afadba7..f684b73098954c 100644
 --- a/src/cmd/internal/testdir/testdir_test.go
 +++ b/src/cmd/internal/testdir/testdir_test.go
 @@ -118,6 +118,13 @@ func Test(t *testing.T) {
@@ -685,7 +685,7 @@ index 483a9ec33c6798..fad922e3f844ab 100644
  		gorootTestDir: filepath.Join(testenv.GOROOT(t), "test"),
  		runoutputGate: make(chan bool, *runoutputLimit),
 diff --git a/src/cmd/link/internal/ld/main.go b/src/cmd/link/internal/ld/main.go
-index 6a684890be0a03..09554a60b23471 100644
+index d913953944bc43..daa8aa3d964ed0 100644
 --- a/src/cmd/link/internal/ld/main.go
 +++ b/src/cmd/link/internal/ld/main.go
 @@ -44,6 +44,7 @@ import (
@@ -696,7 +696,7 @@ index 6a684890be0a03..09554a60b23471 100644
  	"strconv"
  	"strings"
  )
-@@ -187,7 +188,18 @@ func Main(arch *sys.Arch, theArch Arch) {
+@@ -188,7 +189,18 @@ func Main(arch *sys.Arch, theArch Arch) {
  
  	buildVersion := buildcfg.Version
  	if goexperiment := buildcfg.Experiment.String(); goexperiment != "" {
@@ -717,7 +717,7 @@ index 6a684890be0a03..09554a60b23471 100644
  	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
  
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
-index 2fe32600f1d6c7..f84cbdc5ee25f0 100644
+index a87d452ed39446..c03aba6e415873 100644
 --- a/src/cmd/link/link_test.go
 +++ b/src/cmd/link/link_test.go
 @@ -9,6 +9,7 @@ import (
@@ -1971,10 +1971,10 @@ index 00000000000000..d3d39fd77f98db
 +const isSkipFIPSCheck = true
 diff --git a/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go
 new file mode 100644
-index 00000000000000..c6c1f53e7452ab
+index 00000000000000..d816f1be17b6a1
 --- /dev/null
 +++ b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,68 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1995,9 +1995,7 @@ index 00000000000000..c6c1f53e7452ab
 +// knownVersions is a list of supported and well-known libcrypto.so suffixes in decreasing version order.
 +// FreeBSD library version numbering does not directly align to the version of OpenSSL.
 +// Its preferred search order is 11 -> 111.
-+// Some distributions use 1.0.0 and others (such as Debian) 1.0.2 to refer to the same OpenSSL 1.0.2 version.
-+// Fedora derived distros use different naming for the version 1.0.x.
-+var knownVersions = [...]string{"3", "1.1", "11", "111", "1.0.2", "1.0.0", "10"}
++var knownVersions = [...]string{"3", "1.1", "11", "111"}
 +
 +const lcryptoPrefix = "libcrypto.so."
 +
@@ -2793,7 +2791,7 @@ diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index 9b7613a62b5a31..1997d90f2f20ba 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -348,7 +348,7 @@ var depsRules = `
+@@ -350,7 +350,7 @@ var depsRules = `
  	math/big, go/token
  	< go/constant;
  
@@ -2802,7 +2800,7 @@ index 9b7613a62b5a31..1997d90f2f20ba 100644
  	< internal/buildcfg;
  
  	container/heap, go/constant, go/parser, internal/buildcfg, internal/goversion, internal/types/errors
-@@ -537,6 +537,11 @@ var depsRules = `
+@@ -539,6 +539,11 @@ var depsRules = `
  	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
  	< github.com/microsoft/go-crypto-winnative/cng;
  
@@ -2814,7 +2812,7 @@ index 9b7613a62b5a31..1997d90f2f20ba 100644
  	crypto !< FIPS;
  
  	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
-@@ -545,16 +550,27 @@ var depsRules = `
+@@ -547,16 +552,27 @@ var depsRules = `
  	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
  	sync/atomic < crypto/internal/boring/bcache;
  
@@ -2844,7 +2842,7 @@ index 9b7613a62b5a31..1997d90f2f20ba 100644
  	< crypto/boring
  	< crypto/aes,
  	  crypto/des,
-@@ -578,8 +594,14 @@ var depsRules = `
+@@ -580,8 +596,14 @@ var depsRules = `
  	math/big, github.com/microsoft/go-crypto-darwin/xcrypto < github.com/microsoft/go-crypto-darwin/bbig;
  	math/big, github.com/microsoft/go-crypto-winnative/cng < github.com/microsoft/go-crypto-winnative/cng/bbig;
  
@@ -2862,7 +2860,7 @@ index 9b7613a62b5a31..1997d90f2f20ba 100644
  	< crypto/rand
  	< crypto/ed25519 # depends on crypto/rand.Reader
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index 9b3bafd0fc6cd9..b7cc2bdfa6ffd9 100644
+index 16a25b602b6966..57067754466b0a 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
 @@ -5,11 +5,14 @@
@@ -2880,7 +2878,7 @@ index 9b3bafd0fc6cd9..b7cc2bdfa6ffd9 100644
  )
  
  // ExperimentFlags represents a set of GOEXPERIMENT flags relative to a baseline
-@@ -180,6 +183,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -177,6 +180,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.BoringCrypto {
  		return nil, fmt.Errorf("GOEXPERIMENT boringcrypto is not supported in the Microsoft build of Go")
  	}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -19,7 +19,7 @@ desired goexperiments and build tags.
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/internal/tool/tool.go              |   9 +-
- src/cmd/go/systemcrypto_test.go               | 144 +++++++
+ src/cmd/go/systemcrypto_test.go               | 154 ++++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
  src/cmd/internal/testdir/testdir_test.go      |   7 +
@@ -55,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  54 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   2 +-
- 46 files changed, 2308 insertions(+), 22 deletions(-)
+ 46 files changed, 2318 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -160,7 +160,7 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index fb70047dd0e81c..bb7ff4a68764da 100644
+index 9a7951726f6f04..a09cdd9550cbab 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
 @@ -1387,6 +1387,80 @@ func toolenv() []string {
@@ -261,7 +261,7 @@ index fb70047dd0e81c..bb7ff4a68764da 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index ec4ff649b3815d..6ec763259efee6 100644
+index 1e74438f48db39..6c31b623897048 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -291,7 +291,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  		}
  	}
  
-@@ -749,11 +751,18 @@ func (t *tester) registerTests() {
+@@ -750,11 +752,18 @@ func (t *tester) registerTests() {
  			variant: "jsonv2",
  			env:     []string{"GOEXPERIMENT=jsonv2"},
  			pkg:     "encoding/json/...",
@@ -311,7 +311,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  		t.registerTest("GOOS=ios on darwin/amd64",
  			&goTest{
  				variant:  "amd64ios",
-@@ -863,14 +872,21 @@ func (t *tester) registerTests() {
+@@ -864,14 +873,21 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
@@ -319,7 +319,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
 +		if goos != "windows" {
 +			// Linux and macOS don't support systemcrypto with CGO_ENABLED=0.
 +			tags = append(tags, "ms_skipfipscheck")
-+			env = append(env, "GOEXPERIMENT=nosystemcrypto")
++			env = append(env, "MS_GO_NOSYSTEMCRYPTO=1")
 +		}
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
@@ -334,7 +334,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  			})
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
-@@ -878,9 +894,10 @@ func (t *tester) registerTests() {
+@@ -879,9 +895,10 @@ func (t *tester) registerTests() {
  				timeout:   60 * time.Second,
  				buildmode: "pie",
  				ldflags:   "-linkmode=internal",
@@ -346,7 +346,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-@@ -897,15 +914,22 @@ func (t *tester) registerTests() {
+@@ -898,15 +915,22 @@ func (t *tester) registerTests() {
  
  	if t.extLink() && !t.compileOnly {
  		if goos != "android" { // Android does not support non-PIE linking
@@ -354,7 +354,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
 +			if goos == "darwin" {
 +				// Darwincrypto doesn't support external linking.
 +				tags = append(tags, "ms_skipfipscheck")
-+				env = append(env, "GOEXPERIMENT=nosystemcrypto")
++				env = append(env, "MS_GO_NOSYSTEMCRYPTO=1")
 +			}
  			t.registerTest("external linking, -buildmode=exe",
  				&goTest{
@@ -370,7 +370,7 @@ index ec4ff649b3815d..6ec763259efee6 100644
  				})
  		}
  		if t.externalLinkPIE() && !disablePIE {
-@@ -984,7 +1008,9 @@ func (t *tester) registerTests() {
+@@ -985,7 +1009,9 @@ func (t *tester) registerTests() {
  		t.registerRaceTests()
  	}
  
@@ -382,10 +382,10 @@ index ec4ff649b3815d..6ec763259efee6 100644
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
-index 3e691abe41f702..b799031d598892 100644
+index e4ee9bd1e8d2ec..3bdb6b4d31fe46 100644
 --- a/src/cmd/go/go_test.go
 +++ b/src/cmd/go/go_test.go
-@@ -14,6 +14,7 @@ import (
+@@ -13,6 +13,7 @@ import (
  	"fmt"
  	"go/format"
  	"internal/godebug"
@@ -393,7 +393,7 @@ index 3e691abe41f702..b799031d598892 100644
  	"internal/platform"
  	"internal/testenv"
  	"io"
-@@ -111,6 +112,13 @@ func TestMain(m *testing.M) {
+@@ -110,6 +111,13 @@ func TestMain(m *testing.M) {
  		if v := os.Getenv("TESTGO_TOOLCHAIN_VERSION"); v != "" {
  			work.ToolchainVersion = v
  		}
@@ -407,7 +407,7 @@ index 3e691abe41f702..b799031d598892 100644
  
  		if testGOROOT := os.Getenv("TESTGO_GOROOT"); testGOROOT != "" {
  			// Disallow installs to the GOROOT from which testgo was built.
-@@ -1861,6 +1869,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
+@@ -1860,6 +1868,9 @@ func TestGenerateUsesBuildContext(t *testing.T) {
  }
  
  func TestGoEnv(t *testing.T) {
@@ -495,10 +495,10 @@ index 120ef5339bede0..b7b145fdfc9972 100644
  	buildAndRunTool(ctx, tool, args, runFunc)
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
-index 00000000000000..5ee9c2e050cf24
+index 00000000000000..d12c79c4713e51
 --- /dev/null
 +++ b/src/cmd/go/systemcrypto_test.go
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,154 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -604,30 +604,40 @@ index 00000000000000..5ee9c2e050cf24
 +
 +	type testCase struct {
 +		enabled bool
-+		exp     string
++		env     []string
 +	}
 +	tests := []testCase{
-+		{false, "nosystemcrypto"},
-+		{true, "systemcrypto"},
++		{false, []string{"GOEXPERIMENT=nosystemcrypto"}},
++		{false, []string{"GOEXPERIMENT=systemcrypto,nosystemcrypto"}},
++		{false, []string{"MS_GO_NOSYSTEMCRYPTO=1"}},
++		{true, []string{"GOEXPERIMENT=systemcrypto"}},
++		{true, []string{"GOEXPERIMENT=nosystemcrypto,systemcrypto"}},
 +	}
 +	switch runtime.GOOS {
 +	case "linux":
-+		tests = append(tests, testCase{true, "opensslcrypto"})
++		tests = append(tests, testCase{true, []string{"GOEXPERIMENT=opensslcrypto"}})
 +	case "windows":
 +		switch runtime.GOARCH {
 +		case "amd64", "arm64":
-+			tests = append(tests, testCase{true, "cngcrypto"})
++			tests = append(tests, testCase{true, []string{"GOEXPERIMENT=cngcrypto"}})
 +		}
 +	case "darwin":
-+		tests = append(tests, testCase{true, "darwincrypto"})
++		tests = append(tests, testCase{true, []string{"GOEXPERIMENT=darwincrypto"}})
++	}
++	// Duplicate each test with MS_GO_NOSYSTEMCRYPTO=1, which should always result
++	// in systemcrypto being disabled.
++	n := len(tests)
++	for i := range n {
++		tt := tests[i]
++		tests = append(tests, testCase{false, append(tt.env, "MS_GO_NOSYSTEMCRYPTO=1")})
 +	}
 +	for _, tt := range tests {
-+		t.Run(tt.exp, func(t *testing.T) {
++		t.Run(strings.Join(tt.env, ","), func(t *testing.T) {
 +			t.Parallel()
 +			out := outPath(t)
 +
 +			// Build the binary with the specified GOEXPERIMENT.
-+			_, ok := execGoTool(t, true, []string{"GOEXPERIMENT=" + tt.exp}, "build", "-o", out, file)
++			_, ok := execGoTool(t, true, tt.env, "build", "-o", out, file)
 +			if !ok {
 +				t.Skip("skipping test because GOEXPERIMENT not supported by the current toolchain")
 +			}
@@ -667,7 +677,7 @@ index 2f46a6b44bffe1..69071289e2de81 100644
  
  ! go build -o $devnull cmd/buildid
 diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index 5781276afadba7..f684b73098954c 100644
+index c5aa91ba4732e7..9e838fa785af46 100644
 --- a/src/cmd/internal/testdir/testdir_test.go
 +++ b/src/cmd/internal/testdir/testdir_test.go
 @@ -118,6 +118,13 @@ func Test(t *testing.T) {
@@ -717,7 +727,7 @@ index d913953944bc43..daa8aa3d964ed0 100644
  	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
  
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
-index a87d452ed39446..c03aba6e415873 100644
+index 0125ba8e0f56be..2bc0b65f1035ed 100644
 --- a/src/cmd/link/link_test.go
 +++ b/src/cmd/link/link_test.go
 @@ -9,6 +9,7 @@ import (
@@ -2860,15 +2870,16 @@ index 9b7613a62b5a31..1997d90f2f20ba 100644
  	< crypto/rand
  	< crypto/ed25519 # depends on crypto/rand.Reader
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index 16a25b602b6966..57067754466b0a 100644
+index 6eab28497a3f2e..81296762c7e231 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
-@@ -5,11 +5,14 @@
+@@ -5,12 +5,15 @@
  package buildcfg
  
  import (
 +	"errors"
  	"fmt"
+ 	"os"
  	"reflect"
 +	"slices"
  	"strings"
@@ -2878,7 +2889,7 @@ index 16a25b602b6966..57067754466b0a 100644
  )
  
  // ExperimentFlags represents a set of GOEXPERIMENT flags relative to a baseline
-@@ -177,6 +180,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -192,6 +195,57 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.BoringCrypto {
  		return nil, fmt.Errorf("GOEXPERIMENT boringcrypto is not supported in the Microsoft build of Go")
  	}
@@ -2950,7 +2961,7 @@ index 831ee67afc952d..d2f00d57c10286 100644
 +	return boring_runtime_arg0()
 +}
 diff --git a/src/syscall/exec_linux_test.go b/src/syscall/exec_linux_test.go
-index 69d49169446d1c..e6d344ff67a8aa 100644
+index 69d49169446d1c..0e6360a353f07f 100644
 --- a/src/syscall/exec_linux_test.go
 +++ b/src/syscall/exec_linux_test.go
 @@ -300,7 +300,7 @@ func TestUnshareMountNameSpaceChroot(t *testing.T) {
@@ -2958,7 +2969,7 @@ index 69d49169446d1c..e6d344ff67a8aa 100644
  
  	cmd := testenv.Command(t, testenv.GoToolPath(t), "test", "-c", "-o", x, "syscall")
 -	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0")
-+	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0", "GOEXPERIMENT=nosystemcrypto")
++	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0", "MS_GO_NOSYSTEMCRYPTO=1")
  	if o, err := cmd.CombinedOutput(); err != nil {
  		t.Fatalf("%v: %v\n%s", cmd, err, o)
  	}


### PR DESCRIPTION
This PR backports to Go 1.25 the following changes:

- https://github.com/microsoft/go/pull/1886
- https://github.com/microsoft/go/pull/1881
- https://github.com/golang-fips/openssl/pull/290
 
Closes #1891