### PR TITLE
Fix container job init failures in NetCore1ESPool-Internal innerloop pipeline

### DIFF
--- a/eng/pipeline/stages/pool-2.yml
+++ b/eng/pipeline/stages/pool-2.yml
@@ -46,12 +46,12 @@ stages:
           # The arm64 pool doesn't need demands: it runs on a uniform pool.
           ${{ if ne(parameters.name, 'Docker-Linux-Arm-Internal') }}:
             ${{ if parameters.ctx['Go1ESOfficial'] }}:
-              image: 1es-ubuntu-2004
+              image: 1es-ubuntu-2204
               os: linux
             ${{ elseif parameters.public }}:
               demands: ImageOverride -equals 1es-ubuntu-2004-open
             ${{ else }}:
-              demands: ImageOverride -equals 1es-ubuntu-2004
+              demands: ImageOverride -equals 1es-ubuntu-2204
               os: linux
 
         ${{ elseif eq(parameters.os, 'darwin') }}:


### PR DESCRIPTION
* https://github.com/microsoft/go-lab/issues/262

Update to newest image listed in https://helix.dot.net/#1esPools.

Fixes:

`Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: procReady not received: unknown`

Test internal build with fix: https://dev.azure.com/dnceng/internal/_build/results?buildId=2812261&view=results