### PR TITLE
Fix nocgo build-time checks

### DIFF
--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -14,7 +14,7 @@ desired goexperiments and build tags.
  .../compile/internal/ssa/stmtlines_test.go    |   1 -
  src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  80 +++-
- src/cmd/dist/test.go                          |  44 ++-
+ src/cmd/dist/test.go                          |  47 ++-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
@@ -56,7 +56,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  57 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   4 +
- 47 files changed, 2382 insertions(+), 21 deletions(-)
+ 47 files changed, 2384 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -263,7 +263,7 @@ index 2fcdb2d3915b9b..c04c50e69e4070 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 1e74438f48db39..53e2bc09d4ee6d 100644
+index 1e74438f48db39..1e9844174dbb5c 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -293,15 +293,21 @@ index 1e74438f48db39..53e2bc09d4ee6d 100644
  		}
  	}
  
-@@ -750,11 +752,18 @@ func (t *tester) registerTests() {
+@@ -746,15 +748,23 @@ func (t *tester) registerTests() {
+ 
+ 	// Test GOEXPERIMENT=jsonv2.
+ 	if !strings.Contains(goexperiment, "jsonv2") {
++		// Don't override existing GOEXPERIMENTs.
++		goexperiment := goexperiment
++		if goexperiment != "" {
++			goexperiment += ","
++		}
++		goexperiment += "jsonv2"
+ 		t.registerTest("GOEXPERIMENT=jsonv2 go test encoding/json/...", &goTest{
  			variant: "jsonv2",
- 			env:     []string{"GOEXPERIMENT=jsonv2"},
+-			env:     []string{"GOEXPERIMENT=jsonv2"},
++			env:     []string{"GOEXPERIMENT=" + goexperiment},
  			pkg:     "encoding/json/...",
-+			// Skip FIPS checks. The test overrides GOEXPERIMENT,
-+			// so if we have been executed with GOEXPERIMENT=systemcrypto
-+			// and FIPS mode is required, then the test will fail because
-+			// the systemcrypto package will not be available.
-+			tags: []string{"ms_skipfipscheck"},
  		})
  	}
  
@@ -313,7 +319,7 @@ index 1e74438f48db39..53e2bc09d4ee6d 100644
  		t.registerTest("GOOS=ios on darwin/amd64",
  			&goTest{
  				variant:  "amd64ios",
-@@ -864,14 +873,21 @@ func (t *tester) registerTests() {
+@@ -864,14 +874,21 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
@@ -336,7 +342,7 @@ index 1e74438f48db39..53e2bc09d4ee6d 100644
  			})
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
-@@ -879,9 +895,10 @@ func (t *tester) registerTests() {
+@@ -879,9 +896,10 @@ func (t *tester) registerTests() {
  				timeout:   60 * time.Second,
  				buildmode: "pie",
  				ldflags:   "-linkmode=internal",
@@ -348,7 +354,7 @@ index 1e74438f48db39..53e2bc09d4ee6d 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-@@ -898,15 +915,22 @@ func (t *tester) registerTests() {
+@@ -898,15 +916,22 @@ func (t *tester) registerTests() {
  
  	if t.extLink() && !t.compileOnly {
  		if goos != "android" { // Android does not support non-PIE linking
@@ -372,7 +378,7 @@ index 1e74438f48db39..53e2bc09d4ee6d 100644
  				})
  		}
  		if t.externalLinkPIE() && !disablePIE {
-@@ -985,7 +1009,9 @@ func (t *tester) registerTests() {
+@@ -985,7 +1010,9 @@ func (t *tester) registerTests() {
  		t.registerRaceTests()
  	}
  

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -19,7 +19,7 @@ desired goexperiments and build tags.
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/internal/tool/tool.go              |   9 +-
- src/cmd/go/systemcrypto_test.go               | 154 ++++++++
+ src/cmd/go/systemcrypto_test.go               | 197 ++++++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
  src/cmd/internal/testdir/testdir_test.go      |   7 +
@@ -56,7 +56,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  57 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   4 +
- 47 files changed, 2339 insertions(+), 21 deletions(-)
+ 47 files changed, 2382 insertions(+), 21 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -162,7 +162,7 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index 9a7951726f6f04..53a2da17665ecc 100644
+index 2fcdb2d3915b9b..c04c50e69e4070 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
 @@ -1387,6 +1387,80 @@ func toolenv() []string {
@@ -454,7 +454,7 @@ index a4edd854f1d35a..10ee92536b96cd 100644
  	// This will also update the BuildContext's tool tags to include the new
  	// experiment tags.
 diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
-index 135d7579d65dff..687a781693b779 100644
+index cfaece2072dbb9..a8ef746a6a2048 100644
 --- a/src/cmd/go/internal/load/pkg.go
 +++ b/src/cmd/go/internal/load/pkg.go
 @@ -2412,6 +2412,9 @@ func (p *Package) setBuildInfo(ctx context.Context, autoVCS bool) {
@@ -468,7 +468,7 @@ index 135d7579d65dff..687a781693b779 100644
  	appendSetting("-compiler", cfg.BuildContext.Compiler)
  	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
 diff --git a/src/cmd/go/internal/tool/tool.go b/src/cmd/go/internal/tool/tool.go
-index e25c06a8f046bd..6192880b654cb5 100644
+index e95b07d8c813aa..8d93a5fc310b49 100644
 --- a/src/cmd/go/internal/tool/tool.go
 +++ b/src/cmd/go/internal/tool/tool.go
 @@ -304,6 +304,10 @@ func buildAndRunBuiltinTool(ctx context.Context, toolName, tool string, args []s
@@ -497,10 +497,10 @@ index e25c06a8f046bd..6192880b654cb5 100644
  	buildAndRunTool(ctx, tool, args, runFunc)
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
-index 00000000000000..d12c79c4713e51
+index 00000000000000..c4129cd74ee73d
 --- /dev/null
 +++ b/src/cmd/go/systemcrypto_test.go
-@@ -0,0 +1,154 @@
+@@ -0,0 +1,197 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -574,6 +574,49 @@ index 00000000000000..d12c79c4713e51
 +func outPath(t *testing.T) string {
 +	t.Helper()
 +	return filepath.Join(t.TempDir(), "out")
++}
++
++func TestSystemCryptoNoCgoChecks(t *testing.T) {
++	t.Parallel()
++
++	cryptoFile := writeFile(t, fileWithCrypto)
++
++	tt := []struct {
++		goos    string
++		goarch  string
++		goexp   string
++		succeed bool
++	}{
++		{"linux", "amd64", "noms_nocgo_opensslcrypto", false}, // cgoless OpenSSL requires ms_nocgo_opensslcrypto on linux/amd64
++		{"linux", "arm64", "noms_nocgo_opensslcrypto", false}, // cgoless OpenSSL requires ms_nocgo_opensslcrypto on linux/arm64
++		{"linux", "ppc64le", "ms_nocgo_cngcrypto", false},     // cgoless OpenSSL not supported on linux/ppc64le
++		{"linux", "arm", "ms_nocgo_cngcrypto", false},         // cgoless OpenSSL not supported on linux/arm
++		{"linux", "amd64", "ms_nocgo_opensslcrypto", true},
++		{"linux", "arm64", "ms_nocgo_opensslcrypto", true},
++		{"darwin", "amd64", "", false}, // cgoless system crypto not supported on darwin/amd64
++		{"darwin", "arm64", "", false}, // cgoless system crypto not supported on darwin/arm64
++		{"windows", "386", "", false},  // cgoless system crypto not supported on windows/386
++		{"windows", "amd64", "", true},
++		{"windows", "arm64", "", true},
++	}
++	for _, tc := range tt {
++		t.Run(tc.goos+"/"+tc.goarch+"/"+tc.goexp, func(t *testing.T) {
++			t.Parallel()
++			if tc.goexp == "" {
++				tc.goexp = "systemcrypto"
++			} else {
++				tc.goexp += ",systemcrypto"
++			}
++			env := []string{"CGO_ENABLED=0", "GOOS=" + tc.goos, "GOARCH=" + tc.goarch, "GOEXPERIMENT=" + tc.goexp}
++			if out, ok := execGoTool(t, true, env, "build", "-o", outPath(t), cryptoFile); ok != tc.succeed {
++				if tc.succeed {
++					t.Fatalf("expected success, got failure: %s", out)
++				} else {
++					t.Fatalf("expected failure, got success")
++				}
++			}
++		})
++	}
 +}
 +
 +func TestSystemCryptoFIPS(t *testing.T) {
@@ -729,7 +772,7 @@ index d913953944bc43..3349e53cd07809 100644
  	addstrdata1(ctxt, "runtime.buildVersion="+buildVersion)
  
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
-index 0125ba8e0f56be..2bc0b65f1035ed 100644
+index 31822d21f39d31..71d23e76f91e1b 100644
 --- a/src/cmd/link/link_test.go
 +++ b/src/cmd/link/link_test.go
 @@ -9,6 +9,7 @@ import (
@@ -2801,7 +2844,7 @@ index 00000000000000..aed8fc5e152405
 +}
 diff --git a/src/crypto/systemcrypto_nocgo_linux.go b/src/crypto/systemcrypto_nocgo_linux.go
 new file mode 100644
-index 00000000000000..0d8474217df59e
+index 00000000000000..b79491c6cb7c08
 --- /dev/null
 +++ b/src/crypto/systemcrypto_nocgo_linux.go
 @@ -0,0 +1,15 @@
@@ -2809,7 +2852,7 @@ index 00000000000000..0d8474217df59e
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.opensslcrypto && !(cgo || goexperiment.ms_nocgo_opensslcrypto) && !amd64 && !arm64
++//go:build goexperiment.opensslcrypto && !(cgo || (goexperiment.ms_nocgo_opensslcrypto && (amd64 || arm64)))
 +
 +package crypto
 +


### PR DESCRIPTION
I got the build tags wrong in the file that checks whether building with `CGO_ENABLED=0` is supported or not.

New tests have been added to catch regressions.

Fixes #1915.