### PR TITLE
Support cgoless darwin backend

### DIFF
--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -79,6 +79,7 @@ stages:
           - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: devscript }
           - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: test }
           - { experiment: systemcrypto, os: darwin, arch: amd64, config: test }
+          - { experiment: systemcrypto, os: darwin, arch: amd64, config: nocgo }
           - { experiment: systemcrypto, os: darwin, arch: amd64, config: test, fips: true }
           # - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: devscript }
           # - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: test }

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -14,7 +14,7 @@ desired goexperiments and build tags.
  .../compile/internal/ssa/stmtlines_test.go    |   3 +-
  src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  80 +++-
- src/cmd/dist/test.go                          |  47 ++-
+ src/cmd/dist/test.go                          |  30 +-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
@@ -50,13 +50,12 @@ desired goexperiments and build tags.
  src/crypto/internal/backend/nobackend.go      | 251 ++++++++++++
  src/crypto/internal/backend/openssl_linux.go  | 332 ++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
- src/crypto/systemcrypto_nocgo_darwin.go       |  15 +
  src/crypto/systemcrypto_nocgo_linux.go        |  15 +
  src/go/build/deps_test.go                     |  32 +-
  src/internal/buildcfg/exp.go                  |  57 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   4 +
- 47 files changed, 2385 insertions(+), 23 deletions(-)
+ 46 files changed, 2356 insertions(+), 20 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -83,7 +82,6 @@ desired goexperiments and build tags.
  create mode 100644 src/crypto/internal/backend/nobackend.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
  create mode 100644 src/crypto/internal/backend/stub.s
- create mode 100644 src/crypto/systemcrypto_nocgo_darwin.go
  create mode 100644 src/crypto/systemcrypto_nocgo_linux.go
 
 diff --git a/.gitignore b/.gitignore
@@ -272,7 +270,7 @@ index 2fcdb2d3915b9b..c04c50e69e4070 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 1e74438f48db39..1e9844174dbb5c 100644
+index 1e74438f48db39..34c41a7099e1e6 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -302,7 +300,7 @@ index 1e74438f48db39..1e9844174dbb5c 100644
  		}
  	}
  
-@@ -746,15 +748,23 @@ func (t *tester) registerTests() {
+@@ -746,9 +748,15 @@ func (t *tester) registerTests() {
  
  	// Test GOEXPERIMENT=jsonv2.
  	if !strings.Contains(goexperiment, "jsonv2") {
@@ -319,22 +317,13 @@ index 1e74438f48db39..1e9844174dbb5c 100644
  			pkg:     "encoding/json/...",
  		})
  	}
- 
- 	// Test ios/amd64 for the iOS simulator.
--	if goos == "darwin" && goarch == "amd64" && t.cgoEnabled {
-+	if goos == "darwin" && goarch == "amd64" && t.cgoEnabled &&
-+		// IOS is not supported with darwincrypto.
-+		!(strings.Contains(goexperiment, "systemcrypto") || strings.Contains(goexperiment, "darwincrypto")) {
- 		t.registerTest("GOOS=ios on darwin/amd64",
- 			&goTest{
- 				variant:  "amd64ios",
-@@ -864,14 +874,21 @@ func (t *tester) registerTests() {
+@@ -864,14 +872,21 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
 +		var tags, env []string
-+		if goos == "darwin" || (goos == "linux" && !strings.Contains(goexperiment, "ms_nocgo_opensslcrypto")) {
-+			// Linux and macOS don't support systemcrypto with CGO_ENABLED=0.
++		if goos == "linux" && !strings.Contains(goexperiment, "ms_nocgo_opensslcrypto") {
++			// Linux doesn't support systemcrypto with CGO_ENABLED=0.
 +			tags = append(tags, "ms_skipfipscheck")
 +			env = append(env, "MS_GO_NOSYSTEMCRYPTO=1")
 +		}
@@ -351,7 +340,7 @@ index 1e74438f48db39..1e9844174dbb5c 100644
  			})
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
-@@ -879,9 +896,10 @@ func (t *tester) registerTests() {
+@@ -879,9 +894,10 @@ func (t *tester) registerTests() {
  				timeout:   60 * time.Second,
  				buildmode: "pie",
  				ldflags:   "-linkmode=internal",
@@ -363,41 +352,6 @@ index 1e74438f48db39..1e9844174dbb5c 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
-@@ -898,15 +916,22 @@ func (t *tester) registerTests() {
- 
- 	if t.extLink() && !t.compileOnly {
- 		if goos != "android" { // Android does not support non-PIE linking
-+			var tags, env []string
-+			if goos == "darwin" {
-+				// Darwincrypto doesn't support external linking.
-+				tags = append(tags, "ms_skipfipscheck")
-+				env = append(env, "MS_GO_NOSYSTEMCRYPTO=1")
-+			}
- 			t.registerTest("external linking, -buildmode=exe",
- 				&goTest{
- 					variant:   "exe_external",
- 					timeout:   60 * time.Second,
- 					buildmode: "exe",
- 					ldflags:   "-linkmode=external",
--					env:       []string{"CGO_ENABLED=1"},
-+					env:       append([]string{"CGO_ENABLED=1"}, env...),
- 					pkg:       "crypto/internal/fips140test",
- 					runTests:  "TestFIPSCheck",
-+					tags:      tags,
- 				})
- 		}
- 		if t.externalLinkPIE() && !disablePIE {
-@@ -985,7 +1010,9 @@ func (t *tester) registerTests() {
- 		t.registerRaceTests()
- 	}
- 
--	if goos != "android" && !t.iOS() {
-+	// cmd/internal/testdir uses -buildmode=exe on darwin,
-+	// which is not supported by darwincrypto.
-+	if goos != "android" && !t.iOS() && !(strings.Contains(goexperiment, "systemcrypto") || strings.Contains(goexperiment, "darwincrypto")) {
- 		// Only start multiple test dir shards on builders,
- 		// where they get distributed to multiple machines.
- 		// See issues 20141 and 31834.
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
 index e4ee9bd1e8d2ec..3bdb6b4d31fe46 100644
 --- a/src/cmd/go/go_test.go
@@ -512,7 +466,7 @@ index 75a8fab78ad31b..57f1d79e89f36e 100644
  	buildAndRunTool(loaderstate, ctx, tool, args, runFunc)
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
-index 00000000000000..c4129cd74ee73d
+index 00000000000000..7335b47c237fd9
 --- /dev/null
 +++ b/src/cmd/go/systemcrypto_test.go
 @@ -0,0 +1,197 @@
@@ -608,9 +562,9 @@ index 00000000000000..c4129cd74ee73d
 +		{"linux", "arm", "ms_nocgo_cngcrypto", false},         // cgoless OpenSSL not supported on linux/arm
 +		{"linux", "amd64", "ms_nocgo_opensslcrypto", true},
 +		{"linux", "arm64", "ms_nocgo_opensslcrypto", true},
-+		{"darwin", "amd64", "", false}, // cgoless system crypto not supported on darwin/amd64
-+		{"darwin", "arm64", "", false}, // cgoless system crypto not supported on darwin/arm64
-+		{"windows", "386", "", false},  // cgoless system crypto not supported on windows/386
++		{"darwin", "amd64", "", true}, // cgoless system crypto not supported on darwin/amd64
++		{"darwin", "arm64", "", true}, // cgoless system crypto not supported on darwin/arm64
++		{"windows", "386", "", false}, // cgoless system crypto not supported on windows/386
 +		{"windows", "amd64", "", true},
 +		{"windows", "arm64", "", true},
 +	}
@@ -857,7 +811,7 @@ index 00000000000000..c2c06d3bff8c74
 +}
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
 new file mode 100644
-index 00000000000000..ab3f30825dcfa1
+index 00000000000000..20251a290dc2e0
 --- /dev/null
 +++ b/src/crypto/internal/backend/bbig/big.go
 @@ -0,0 +1,17 @@
@@ -865,7 +819,7 @@ index 00000000000000..ab3f30825dcfa1
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !goexperiment.systemcrypto || (goexperiment.darwincrypto && !cgo)
++//go:build !goexperiment.systemcrypto
 +
 +package bbig
 +
@@ -898,7 +852,7 @@ index 00000000000000..92623031fd87d0
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/bbig/big_darwin.go b/src/crypto/internal/backend/bbig/big_darwin.go
 new file mode 100644
-index 00000000000000..77f3ca5d262769
+index 00000000000000..4ff10194a06e86
 --- /dev/null
 +++ b/src/crypto/internal/backend/bbig/big_darwin.go
 @@ -0,0 +1,12 @@
@@ -906,7 +860,7 @@ index 00000000000000..77f3ca5d262769
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.darwincrypto && cgo
++//go:build goexperiment.darwincrypto
 +
 +package bbig
 +
@@ -1337,7 +1291,7 @@ index 00000000000000..a9682181ffa154
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..fea0f284de2439
+index 00000000000000..aeed096c193d9f
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
 @@ -0,0 +1,372 @@
@@ -1345,7 +1299,7 @@ index 00000000000000..fea0f284de2439
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.darwincrypto && darwin && cgo
++//go:build goexperiment.darwincrypto && darwin
 +
 +// Package darwin provides access to DarwinCrypto implementation functions.
 +// Check the variable Enabled to find out whether DarwinCrypto is available.
@@ -2227,7 +2181,7 @@ index 00000000000000..3b92bfc5fbabf6
 +package opensslsetup
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..a59c6cc736c6da
+index 00000000000000..fbd649dd105b8b
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -0,0 +1,251 @@
@@ -2235,7 +2189,7 @@ index 00000000000000..a59c6cc736c6da
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !goexperiment.systemcrypto || (goexperiment.opensslcrypto && !(cgo || goexperiment.ms_nocgo_opensslcrypto)) || (goexperiment.darwincrypto && !cgo)
++//go:build !goexperiment.systemcrypto || (goexperiment.opensslcrypto && !(cgo || goexperiment.ms_nocgo_opensslcrypto))
 +
 +package backend
 +
@@ -2836,27 +2790,6 @@ index 00000000000000..5e4b436554d44d
 +// Having this assembly file keeps the go command
 +// from complaining about the missing body
 +// (because the implementation might be here).
-diff --git a/src/crypto/systemcrypto_nocgo_darwin.go b/src/crypto/systemcrypto_nocgo_darwin.go
-new file mode 100644
-index 00000000000000..aed8fc5e152405
---- /dev/null
-+++ b/src/crypto/systemcrypto_nocgo_darwin.go
-@@ -0,0 +1,15 @@
-+// Copyright 2025 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build goexperiment.darwincrypto && !cgo
-+
-+package crypto
-+
-+func init() {
-+	`
-+	Using GOEXPERIMENT=systemcrypto on Darwin requires CGO_ENABLED=1.
-+	
-+	For more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-+	`
-+}
 diff --git a/src/crypto/systemcrypto_nocgo_linux.go b/src/crypto/systemcrypto_nocgo_linux.go
 new file mode 100644
 index 00000000000000..b79491c6cb7c08
@@ -2879,7 +2812,7 @@ index 00000000000000..b79491c6cb7c08
 +	`
 +}
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index db5e6ba6d64978..569a7084c46f11 100644
+index 373efd8319c675..1f245d570092a3 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -355,7 +355,7 @@ var depsRules = `
@@ -2891,7 +2824,7 @@ index db5e6ba6d64978..569a7084c46f11 100644
  	< internal/buildcfg;
  
  	container/heap, go/constant, go/parser, internal/buildcfg, internal/goversion, internal/types/errors
-@@ -547,6 +547,11 @@ var depsRules = `
+@@ -549,6 +549,11 @@ var depsRules = `
  	< github.com/microsoft/go-crypto-winnative/internal/bcrypt
  	< github.com/microsoft/go-crypto-winnative/cng;
  
@@ -2903,7 +2836,7 @@ index db5e6ba6d64978..569a7084c46f11 100644
  	crypto !< FIPS;
  
  	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
-@@ -555,16 +560,27 @@ var depsRules = `
+@@ -557,16 +562,27 @@ var depsRules = `
  	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
  	sync/atomic < crypto/internal/boring/bcache;
  
@@ -2933,7 +2866,7 @@ index db5e6ba6d64978..569a7084c46f11 100644
  	< crypto/boring
  	< crypto/aes,
  	  crypto/des,
-@@ -588,8 +604,14 @@ var depsRules = `
+@@ -590,8 +606,14 @@ var depsRules = `
  	math/big, github.com/microsoft/go-crypto-darwin/xcrypto < github.com/microsoft/go-crypto-darwin/bbig;
  	math/big, github.com/microsoft/go-crypto-winnative/cng < github.com/microsoft/go-crypto-winnative/cng/bbig;
  

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -14,7 +14,7 @@ desired goexperiments and build tags.
  .../compile/internal/ssa/stmtlines_test.go    |   3 +-
  src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  80 +++-
- src/cmd/dist/test.go                          |  38 +-
+ src/cmd/dist/test.go                          |  43 +-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
@@ -55,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  57 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   4 +
- 46 files changed, 2362 insertions(+), 22 deletions(-)
+ 46 files changed, 2367 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -270,7 +270,7 @@ index 2fcdb2d3915b9b..c04c50e69e4070 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 1e74438f48db39..372306e655a516 100644
+index 1e74438f48db39..ffaea9fb1e54f7 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -372,6 +372,18 @@ index 1e74438f48db39..372306e655a516 100644
  		// Only start multiple test dir shards on builders,
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
+@@ -1186,6 +1206,11 @@ func (t *tester) internalLink() bool {
+ 	if goos == "windows" && goarch == "arm64" {
+ 		return false
+ 	}
++	if goos == "darwin" && (strings.Contains(goexperiment, "systemcrypto") || strings.Contains(goexperiment, "darwincrypto")) {
++		// linkmode=internal isn't supported with system/darwin crypto.
++		// see https://github.com/microsoft/go-crypto-darwin/issues/33
++		return false
++	}
+ 	// Internally linking cgo is incomplete on some architectures.
+ 	// https://golang.org/issue/10373
+ 	// https://golang.org/issue/14449
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
 index e4ee9bd1e8d2ec..3bdb6b4d31fe46 100644
 --- a/src/cmd/go/go_test.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -14,7 +14,7 @@ desired goexperiments and build tags.
  .../compile/internal/ssa/stmtlines_test.go    |   3 +-
  src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  80 +++-
- src/cmd/dist/test.go                          |  30 +-
+ src/cmd/dist/test.go                          |  38 +-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
@@ -55,7 +55,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  57 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   4 +
- 46 files changed, 2356 insertions(+), 20 deletions(-)
+ 46 files changed, 2362 insertions(+), 22 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -270,7 +270,7 @@ index 2fcdb2d3915b9b..c04c50e69e4070 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 1e74438f48db39..34c41a7099e1e6 100644
+index 1e74438f48db39..372306e655a516 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -300,7 +300,7 @@ index 1e74438f48db39..34c41a7099e1e6 100644
  		}
  	}
  
-@@ -746,9 +748,15 @@ func (t *tester) registerTests() {
+@@ -746,15 +748,23 @@ func (t *tester) registerTests() {
  
  	// Test GOEXPERIMENT=jsonv2.
  	if !strings.Contains(goexperiment, "jsonv2") {
@@ -317,7 +317,16 @@ index 1e74438f48db39..34c41a7099e1e6 100644
  			pkg:     "encoding/json/...",
  		})
  	}
-@@ -864,14 +872,21 @@ func (t *tester) registerTests() {
+ 
+ 	// Test ios/amd64 for the iOS simulator.
+-	if goos == "darwin" && goarch == "amd64" && t.cgoEnabled {
++	if goos == "darwin" && goarch == "amd64" && t.cgoEnabled &&
++		// IOS is not supported with darwincrypto.
++		!(strings.Contains(goexperiment, "systemcrypto") || strings.Contains(goexperiment, "darwincrypto")) {
+ 		t.registerTest("GOOS=ios on darwin/amd64",
+ 			&goTest{
+ 				variant:  "amd64ios",
+@@ -864,14 +874,21 @@ func (t *tester) registerTests() {
  
  	// Test internal linking of PIE binaries where it is supported.
  	if t.internalLinkPIE() && !disablePIE {
@@ -340,7 +349,7 @@ index 1e74438f48db39..34c41a7099e1e6 100644
  			})
  		t.registerTest("internal linking, -buildmode=pie",
  			&goTest{
-@@ -879,9 +894,10 @@ func (t *tester) registerTests() {
+@@ -879,9 +896,10 @@ func (t *tester) registerTests() {
  				timeout:   60 * time.Second,
  				buildmode: "pie",
  				ldflags:   "-linkmode=internal",
@@ -352,6 +361,17 @@ index 1e74438f48db39..34c41a7099e1e6 100644
  			})
  		// Also test a cgo package.
  		if t.cgoEnabled && t.internalLink() && !disablePIE {
+@@ -985,7 +1003,9 @@ func (t *tester) registerTests() {
+ 		t.registerRaceTests()
+ 	}
+ 
+-	if goos != "android" && !t.iOS() {
++	// cmd/internal/testdir uses -buildmode=exe on darwin,
++	// which is not supported by darwincrypto.
++	if goos != "android" && !t.iOS() && !(strings.Contains(goexperiment, "systemcrypto") || strings.Contains(goexperiment, "darwincrypto")) {
+ 		// Only start multiple test dir shards on builders,
+ 		// where they get distributed to multiple machines.
+ 		// See issues 20141 and 31834.
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
 index e4ee9bd1e8d2ec..3bdb6b4d31fe46 100644
 --- a/src/cmd/go/go_test.go

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -270,7 +270,7 @@ index 2fcdb2d3915b9b..c04c50e69e4070 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 1e74438f48db39..ffaea9fb1e54f7 100644
+index 1e74438f48db39..c4b80436db2e85 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -376,7 +376,7 @@ index 1e74438f48db39..ffaea9fb1e54f7 100644
  	if goos == "windows" && goarch == "arm64" {
  		return false
  	}
-+	if goos == "darwin" && (strings.Contains(goexperiment, "systemcrypto") || strings.Contains(goexperiment, "darwincrypto")) {
++	if goos == "darwin" && t.cgoEnabled && (strings.Contains(goexperiment, "systemcrypto") || strings.Contains(goexperiment, "darwincrypto")) {
 +		// linkmode=internal isn't supported with system/darwin crypto.
 +		// see https://github.com/microsoft/go-crypto-darwin/issues/33
 +		return false

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Use crypto backends
 
 ---
  src/cmd/api/boring_test.go                    |   2 +-
- src/cmd/dist/test.go                          |  10 +-
- src/cmd/go/go_boring_test.go                  |  11 +-
+ src/cmd/dist/test.go                          |   5 +-
+ src/cmd/go/go_boring_test.go                  |   6 +-
  src/cmd/go/script_test.go                     |   2 +
  src/cmd/go/testdata/script/darwin_no_cgo.txt  |   2 +
  .../go/testdata/script/gopath_std_vendor.txt  |   9 +
  src/cmd/link/internal/ld/config.go            |   8 +
- src/cmd/link/internal/ld/lib.go               |   2 +
+ src/cmd/link/internal/ld/lib.go               |   5 +
  src/crypto/aes/aes.go                         |   2 +-
  src/crypto/aes/aes_test.go                    |   2 +-
  src/crypto/boring/boring.go                   |   4 +-
@@ -92,8 +92,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- src/runtime/pprof/vminfo_darwin_test.go       |   6 +
- 89 files changed, 1172 insertions(+), 119 deletions(-)
+ 88 files changed, 1159 insertions(+), 119 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -119,7 +118,7 @@ index f0e3575637c62a..9eab3b4e66e60b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 6c31b623897048..6db889494bae8e 100644
+index 34c41a7099e1e6..86eec2c9eec8dd 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -720,7 +720,7 @@ func (t *tester) registerTests() {
@@ -131,19 +130,7 @@ index 6c31b623897048..6db889494bae8e 100644
  		// Test standard crypto packages with fips140=on.
  		t.registerTest("GOFIPS140=latest go test crypto/...", &goTest{
  			variant: "gofips140",
-@@ -1212,6 +1212,11 @@ func (t *tester) internalLink() bool {
- 	if goos == "windows" && goarch == "arm64" {
- 		return false
- 	}
-+	if goos == "darwin" && (strings.Contains(goexperiment, "systemcrypto") || strings.Contains(goexperiment, "darwincrypto")) {
-+		// linkmode=internal isn't supported with system/darwin crypto.
-+		// see https://github.com/microsoft/go-crypto-darwin/issues/33
-+		return false
-+	}
- 	// Internally linking cgo is incomplete on some architectures.
- 	// https://golang.org/issue/10373
- 	// https://golang.org/issue/14449
-@@ -1375,12 +1380,11 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1365,12 +1365,11 @@ func (t *tester) registerCgoTests(heading string) {
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
@@ -158,10 +145,10 @@ index 6c31b623897048..6db889494bae8e 100644
  			if goos != "android" && p != "netbsd/arm" && !t.msan && !t.asan {
  				// TODO(#56629): Why does this fail on netbsd-arm?
 diff --git a/src/cmd/go/go_boring_test.go b/src/cmd/go/go_boring_test.go
-index ed0fbf3d53d75b..8111b143a1295b 100644
+index ed0fbf3d53d75b..a2f74c8095d449 100644
 --- a/src/cmd/go/go_boring_test.go
 +++ b/src/cmd/go/go_boring_test.go
-@@ -2,13 +2,20 @@
+@@ -2,11 +2,13 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
  
@@ -172,18 +159,11 @@ index ed0fbf3d53d75b..8111b143a1295b 100644
  
 -import "testing"
 +import (
-+	"internal/goexperiment"
 +	"testing"
 +)
  
  func TestBoringInternalLink(t *testing.T) {
-+	if goexperiment.DarwinCrypto {
-+		// https://github.com/microsoft/go-crypto-darwin/issues/33
-+		t.Skip("skipping on Darwin")
-+	}
  	tg := testgo(t)
- 	defer tg.cleanup()
- 	tg.parallel()
 diff --git a/src/cmd/go/script_test.go b/src/cmd/go/script_test.go
 index 390a36723787f4..0576ea8add72af 100644
 --- a/src/cmd/go/script_test.go
@@ -256,13 +236,16 @@ index 802fb35aee4e65..4416731b69ec26 100644
  			*mode = BuildModePIE
  		default:
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index 2c861129b52f9a..851e6ad02dc722 100644
+index 2c861129b52f9a..c889aef01e6cb6 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
-@@ -1176,6 +1176,8 @@ var hostobj []Hostobj
+@@ -1176,6 +1176,11 @@ var hostobj []Hostobj
  // These packages can use internal linking mode.
  // Others trigger external mode.
  var internalpkg = []string{
++	"vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit",
++	"vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto",
++	"vendor/github.com/microsoft/go-crypto-darwin/internal/security",
 +	"vendor/github.com/golang-fips/openssl/v2/internal/ossl",
 +	"vendor/github.com/golang-fips/openssl/v2",
  	"crypto/internal/boring",
@@ -317,7 +300,7 @@ index 097c37e343fdb8..a5d603896d3890 100644
  // Enabled reports whether BoringCrypto handles supported crypto operations.
  func Enabled() bool {
 diff --git a/src/crypto/cipher/ctr_aes_test.go b/src/crypto/cipher/ctr_aes_test.go
-index 33942467784ad3..0282ffa9fa23c8 100644
+index 9b7d30e2164422..b08132d1c7568a 100644
 --- a/src/crypto/cipher/ctr_aes_test.go
 +++ b/src/crypto/cipher/ctr_aes_test.go
 @@ -14,7 +14,7 @@ import (
@@ -2051,7 +2034,7 @@ index b6b94a79bbca51..32abaf174bfb5b 100644
  	"crypto/internal/fips140/rsa"
  	"crypto/internal/fips140only"
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 0d5b6e08f0e223..b4d4c819fe3deb 100644
+index b9e85bd8ff8f37..5014ae3965c252 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -8,7 +8,7 @@ import (
@@ -2075,7 +2058,7 @@ index 0d5b6e08f0e223..b4d4c819fe3deb 100644
  
  	msg := []byte("hi!")
  	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
-@@ -232,6 +237,11 @@ func testEverything(t *testing.T, priv *PrivateKey) {
+@@ -231,6 +236,11 @@ func testEverything(t *testing.T, priv *PrivateKey) {
  	if validateErr != nil && len(priv.Primes) >= 2 {
  		t.Errorf("Validate() failed: %s", validateErr)
  	}
@@ -2087,7 +2070,7 @@ index 0d5b6e08f0e223..b4d4c819fe3deb 100644
  
  	msg := []byte("test")
  	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
-@@ -940,6 +950,9 @@ func TestDecryptOAEP(t *testing.T) {
+@@ -939,6 +949,9 @@ func TestDecryptOAEP(t *testing.T) {
  }
  
  func Test2DecryptOAEP(t *testing.T) {
@@ -2586,7 +2569,7 @@ index 7018bb2336b8f3..d5e02272d7afe1 100644
  	"hash"
  	"slices"
 diff --git a/src/crypto/tls/handshake_server.go b/src/crypto/tls/handshake_server.go
-index 088c66fadb2a44..ca33ba92665d44 100644
+index a2cf176a86c0d8..b2edd0246016a1 100644
 --- a/src/crypto/tls/handshake_server.go
 +++ b/src/crypto/tls/handshake_server.go
 @@ -63,7 +63,15 @@ func (c *Conn) serverHandshake(ctx context.Context) error {
@@ -2940,7 +2923,7 @@ index e7369542a73270..ff52175e4ac636 100644
  	}
  }
 diff --git a/src/crypto/x509/verify_test.go b/src/crypto/x509/verify_test.go
-index 5595f99ea5e43a..e1a87fa839033a 100644
+index 60a4cea9146adf..0961c5b376bab9 100644
 --- a/src/crypto/x509/verify_test.go
 +++ b/src/crypto/x509/verify_test.go
 @@ -3119,7 +3119,7 @@ func dsaSelfSignedCNX(t *testing.T) []byte {
@@ -2953,7 +2936,7 @@ index 5595f99ea5e43a..e1a87fa839033a 100644
  
  	var dsaPriv dsa.PrivateKey
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index e1dd6331d96052..1cfca2f1634837 100644
+index 1f245d570092a3..b3d1383b925161 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -526,7 +526,7 @@ var depsRules = `
@@ -2965,7 +2948,7 @@ index e1dd6331d96052..1cfca2f1634837 100644
  
  	FIPS, hash < crypto/internal/fips140only;
  	crypto/internal/fips140/subtle,	hash < crypto;
-@@ -551,6 +551,8 @@ var depsRules = `
+@@ -554,6 +554,8 @@ var depsRules = `
  	< crypto/internal/backend/internal/opensslsetup
  	< crypto/internal/backend/fips140;
  
@@ -2974,7 +2957,7 @@ index e1dd6331d96052..1cfca2f1634837 100644
  	crypto !< FIPS;
  
  	# CRYPTO is core crypto algorithms - no cgo, fmt, net.
-@@ -593,6 +595,7 @@ var depsRules = `
+@@ -596,6 +598,7 @@ var depsRules = `
  	  crypto/pbkdf2,
  	  crypto/ecdh,
  	  crypto/mlkem
@@ -3048,10 +3031,10 @@ index 00000000000000..11dc691600b110
 +
 +const boringEnabled = false
 diff --git a/src/net/lookup_test.go b/src/net/lookup_test.go
-index 514cbd098ae772..8ec689416dde1d 100644
+index 2a774100a8ec67..a0cabb42b19484 100644
 --- a/src/net/lookup_test.go
 +++ b/src/net/lookup_test.go
-@@ -1501,6 +1501,9 @@ func TestLookupPortIPNetworkString(t *testing.T) {
+@@ -1499,6 +1499,9 @@ func TestLookupPortIPNetworkString(t *testing.T) {
  }
  
  func TestLookupNoSuchHost(t *testing.T) {
@@ -3062,7 +3045,7 @@ index 514cbd098ae772..8ec689416dde1d 100644
  
  	const testNXDOMAIN = "invalid.invalid."
 diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index 3bded3dea604fb..64fa1960ae9891 100644
+index 1decebdc222d23..c095fa280b2f83 100644
 --- a/src/os/exec/exec_test.go
 +++ b/src/os/exec/exec_test.go
 @@ -14,6 +14,7 @@ import (
@@ -3088,27 +3071,3 @@ index 3bded3dea604fb..64fa1960ae9891 100644
  	// Force network usage, to verify the epoll (or whatever) fd
  	// doesn't leak to the child,
  	ln, err := net.Listen("tcp", "127.0.0.1:0")
-diff --git a/src/runtime/pprof/vminfo_darwin_test.go b/src/runtime/pprof/vminfo_darwin_test.go
-index 6d375c5d53368a..39154b000ddc67 100644
---- a/src/runtime/pprof/vminfo_darwin_test.go
-+++ b/src/runtime/pprof/vminfo_darwin_test.go
-@@ -11,6 +11,7 @@ import (
- 	"bytes"
- 	"fmt"
- 	"internal/abi"
-+	"internal/goexperiment"
- 	"internal/testenv"
- 	"os"
- 	"os/exec"
-@@ -21,6 +22,11 @@ import (
- )
- 
- func TestVMInfo(t *testing.T) {
-+	if goexperiment.DarwinCrypto {
-+		// Fails on macOS when using system crypto.
-+		// https://github.com/microsoft/go/issues/1466
-+		t.Skip("skipping on Darwin")
-+	}
- 	var begin, end, offset uint64
- 	var filename string
- 	first := true

--- a/patches/0011-support-weak-binding-on-darwin.patch
+++ b/patches/0011-support-weak-binding-on-darwin.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
+Date: Fri, 24 Oct 2025 13:03:01 +0200
+Subject: [PATCH] support weak binding on darwin
+
+Remove once https://go-review.googlesource.com/c/go/+/713760 is merged.
+
+---
+ src/cmd/link/internal/ld/macho.go          |  8 +++++++-
+ src/cmd/link/internal/loader/loader.go     | 13 +++++++++++++
+ src/cmd/link/internal/loadmacho/ldmacho.go |  3 +++
+ 3 files changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/src/cmd/link/internal/ld/macho.go b/src/cmd/link/internal/ld/macho.go
+index 8e059f299ffa73..1aa9042dc7a20f 100644
+--- a/src/cmd/link/internal/ld/macho.go
++++ b/src/cmd/link/internal/ld/macho.go
+@@ -180,6 +180,8 @@ const (
+ 	BIND_SPECIAL_DYLIB_FLAT_LOOKUP     = -2
+ 	BIND_SPECIAL_DYLIB_WEAK_LOOKUP     = -3
+ 
++	BIND_SYMBOL_FLAGS_WEAK_IMPORT = 0x1
++
+ 	BIND_OPCODE_MASK                                         = 0xF0
+ 	BIND_IMMEDIATE_MASK                                      = 0x0F
+ 	BIND_OPCODE_DONE                                         = 0x00
+@@ -1429,7 +1431,11 @@ func machoDyldInfo(ctxt *Link) {
+ 			bind.AddUint8(BIND_OPCODE_SET_DYLIB_SPECIAL_IMM | uint8(d)&0xf)
+ 		}
+ 
+-		bind.AddUint8(BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM)
++		flags := uint8(0)
++		if ldr.SymWeakBinding(r.targ) {
++			flags |= BIND_SYMBOL_FLAGS_WEAK_IMPORT
++		}
++		bind.AddUint8(BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM | flags)
+ 		// target symbol name as a C string, with _ prefix
+ 		bind.AddUint8('_')
+ 		bind.Addstring(ldr.SymExtname(r.targ))
+diff --git a/src/cmd/link/internal/loader/loader.go b/src/cmd/link/internal/loader/loader.go
+index cef17fae781798..90661cb6cc7be5 100644
+--- a/src/cmd/link/internal/loader/loader.go
++++ b/src/cmd/link/internal/loader/loader.go
+@@ -241,6 +241,7 @@ type Loader struct {
+ 	plt         map[Sym]int32       // stores dynimport for pe objects
+ 	got         map[Sym]int32       // stores got for pe objects
+ 	dynid       map[Sym]int32       // stores Dynid for symbol
++	weakBinding map[Sym]bool        // stores whether a symbol has a weak binding
+ 
+ 	relocVariant map[relocId]sym.RelocVariant // stores variant relocs
+ 
+@@ -326,6 +327,7 @@ func NewLoader(flags uint32, reporter *ErrorReporter) *Loader {
+ 		plt:                  make(map[Sym]int32),
+ 		got:                  make(map[Sym]int32),
+ 		dynid:                make(map[Sym]int32),
++		weakBinding:          make(map[Sym]bool),
+ 		attrCgoExportDynamic: make(map[Sym]struct{}),
+ 		attrCgoExportStatic:  make(map[Sym]struct{}),
+ 		deferReturnTramp:     make(map[Sym]bool),
+@@ -1450,6 +1452,17 @@ func (l *Loader) SetSymExtname(i Sym, value string) {
+ 	}
+ }
+ 
++func (l *Loader) SymWeakBinding(i Sym) bool {
++	return l.weakBinding[i]
++}
++func (l *Loader) SetSymWeakBinding(i Sym, v bool) {
++	// reject bad symbols
++	if i >= Sym(len(l.objSyms)) || i == 0 {
++		panic("bad symbol index in SetSymWeakBinding")
++	}
++	l.weakBinding[i] = v
++}
++
+ // SymElfType returns the previously recorded ELF type for a symbol
+ // (used only for symbols read from shared libraries by ldshlibsyms).
+ // It is not set for symbols defined by the packages being linked or
+diff --git a/src/cmd/link/internal/loadmacho/ldmacho.go b/src/cmd/link/internal/loadmacho/ldmacho.go
+index 5e8022ce69bb36..dcb0fd92c1f357 100644
+--- a/src/cmd/link/internal/loadmacho/ldmacho.go
++++ b/src/cmd/link/internal/loadmacho/ldmacho.go
+@@ -613,6 +613,9 @@ func Load(l *loader.Loader, arch *sys.Arch, localSymVersion int, f *bio.Reader,
+ 		}
+ 		if machsym.desc&(N_WEAK_REF|N_WEAK_DEF) != 0 {
+ 			l.SetAttrDuplicateOK(s, true)
++			if machsym.desc&N_WEAK_REF != 0 {
++				l.SetSymWeakBinding(s, true)
++			}
+ 		}
+ 		machsym.sym = s
+ 		if machsym.sectnum == 0 { // undefined

--- a/patches/0011-support-weak-binding-on-darwin.patch
+++ b/patches/0011-support-weak-binding-on-darwin.patch
@@ -4,7 +4,6 @@ Date: Fri, 24 Oct 2025 13:03:01 +0200
 Subject: [PATCH] support weak binding on darwin
 
 Remove once https://go-review.googlesource.com/c/go/+/713760 is merged.
-
 ---
  src/cmd/link/internal/ld/macho.go          |  8 +++++++-
  src/cmd/link/internal/loader/loader.go     | 13 +++++++++++++


### PR DESCRIPTION
The Darwin backend is prepared to support building with `CGO_ENABLED=0`, we just need to allow it.

Closes #1466 