### PR TITLE
darwin: update backend to contain fakecgo implementation

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -131,7 +131,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-darwin/bbig/big.go    |   31 +
  .../internal/commoncrypto/commoncrypto.go     |    9 +
  .../internal/commoncrypto/shims.h             |   72 +
- .../internal/commoncrypto/syscall_nocgo.go    |   20 +
+ .../internal/commoncrypto/syscall_nocgo.go    |   15 +
  .../internal/commoncrypto/zcommoncrypto.c     |   47 +
  .../internal/commoncrypto/zcommoncrypto.go    |   50 +
  .../internal/commoncrypto/zcommoncrypto.h     |   71 +
@@ -144,7 +144,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/cryptokit/cryptokit.go           |    8 +
  .../internal/cryptokit/cryptokit_cgo.go       |   10 +
  .../internal/cryptokit/shims.h                |   80 +
- .../internal/cryptokit/syscall_nocgo.go       |   20 +
+ .../internal/cryptokit/syscall_nocgo.go       |   15 +
  .../internal/cryptokit/zcryptokit.c           |  252 ++
  .../internal/cryptokit/zcryptokit.h           |   66 +
  .../internal/cryptokit/zcryptokit.s           |  274 ++
@@ -153,9 +153,29 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/cryptokit/zcryptokit_nocgo.go    |  337 +++
  .../cryptokit/zcryptokit_swift_amd64.go       |  275 ++
  .../cryptokit/zcryptokit_swift_arm64.go       |  274 ++
+ .../internal/fakecgo/abi_amd64.h              |   34 +
+ .../internal/fakecgo/abi_arm64.h              |   39 +
+ .../internal/fakecgo/asm_amd64.s              |   29 +
+ .../internal/fakecgo/asm_arm64.s              |   36 +
+ .../internal/fakecgo/callbacks.go             |   93 +
+ .../go-crypto-darwin/internal/fakecgo/doc.go  |   32 +
+ .../internal/fakecgo/fakecgo.go               |   27 +
+ .../internal/fakecgo/go_darwin.go             |   88 +
+ .../internal/fakecgo/go_libinit.go            |   72 +
+ .../internal/fakecgo/go_setenv.go             |   18 +
+ .../internal/fakecgo/go_util.go               |   37 +
+ .../internal/fakecgo/iscgo.go                 |   19 +
+ .../internal/fakecgo/libcgo.go                |   37 +
+ .../internal/fakecgo/libcgo_darwin.go         |   26 +
+ .../internal/fakecgo/setenv.go                |   19 +
+ .../internal/fakecgo/symbols.go               |  225 ++
+ .../internal/fakecgo/symbols_darwin.go        |   30 +
+ .../internal/fakecgo/trampolines_amd64.s      |  112 +
+ .../internal/fakecgo/trampolines_arm64.s      |   82 +
+ .../internal/fakecgo/trampolines_stubs.s      |   94 +
  .../internal/security/security.go             |    9 +
  .../internal/security/shims.h                 |  107 +
- .../internal/security/syscall_nocgo.go        |   20 +
+ .../internal/security/syscall_nocgo.go        |   15 +
  .../internal/security/zsecurity.c             |  127 +
  .../internal/security/zsecurity.go            |   21 +
  .../internal/security/zsecurity.h             |  100 +
@@ -164,6 +184,14 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/security/zsecurity_cgo_go124.go  |   14 +
  .../internal/security/zsecurity_go124.go      |   13 +
  .../internal/security/zsecurity_nocgo.go      |  453 ++++
+ .../internal/xsyscall/asm_amd64.s             |  108 +
+ .../internal/xsyscall/asm_arm64.s             |   87 +
+ .../go-crypto-darwin/internal/xsyscall/dl.h   |   15 +
+ .../internal/xsyscall/syscall_nocgo.go        |   88 +
+ .../internal/xsyscall/syscall_nocgo_darwin.go |   25 +
+ .../internal/xsyscall/xsyscall.go             |    6 +
+ .../go-crypto-darwin/internal/xsyscall/zdl.s  |   54 +
+ .../internal/xsyscall/zdl_nocgo.go            |   48 +
  .../microsoft/go-crypto-darwin/xcrypto/aes.go |  144 +
  .../microsoft/go-crypto-darwin/xcrypto/big.go |   16 +
  .../go-crypto-darwin/xcrypto/cipher.go        |  114 +
@@ -212,8 +240,8 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/bcrypt/zsyscall_windows.go       |  446 ++++
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
- src/vendor/modules.txt                        |   21 +
- 205 files changed, 28947 insertions(+), 7 deletions(-)
+ src/vendor/modules.txt                        |   23 +
+ 233 files changed, 30514 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -352,6 +380,26 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_nocgo.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_swift_amd64.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_swift_arm64.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/abi_amd64.h
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/abi_arm64.h
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/asm_amd64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/asm_arm64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/callbacks.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/doc.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/fakecgo.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_darwin.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_libinit.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_setenv.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_util.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/iscgo.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/libcgo.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/libcgo_darwin.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/setenv.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/symbols.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/symbols_darwin.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_amd64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_stubs.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/security.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/shims.h
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/syscall_nocgo.go
@@ -363,6 +411,14 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_cgo_go124.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_go124.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_nocgo.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_amd64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_arm64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/dl.h
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_darwin.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl_nocgo.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/big.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/cipher.go
@@ -2072,7 +2128,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index efc07451b53448..726a58d381c07c 100644
+index efc07451b53448..987fa0c8fd398a 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2082,18 +2138,18 @@ index efc07451b53448..726a58d381c07c 100644
 +
 +require (
 +	github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83
-+	github.com/microsoft/go-crypto-darwin v0.0.3-0.20251202082849-356ad09993bc
++	github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215114330-a772e33d86d0
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79
 +)
 diff --git a/src/go.sum b/src/go.sum
-index b6b841b44d8e38..dfc8d0b2794286 100644
+index b6b841b44d8e38..98d8a46eb7c60a 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83 h1:u3WAHp425YzcHygZORNJa9dkyA959Gtti8bUgGYYuiA=
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20251202082849-356ad09993bc h1:bz/6zng2sakr1ETJsKnGoHooH6sBKbQNxk9aeH5tRt0=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20251202082849-356ad09993bc/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215114330-a772e33d86d0 h1:8kRyOO5QwtWJ/dbM8wt631YL0bAklLF7REuDvq5ivcE=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215114330-a772e33d86d0/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79 h1:u3ZftMj7JpCAl4Ku8LUngqfn7pNuQG9mAsNMlSjBvDI=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00 h1:JgcPM1rzpSOZS8y69FQvnY0xN0ciHlpQqwTXJcuZIA4=
@@ -19131,10 +19187,10 @@ index 00000000000000..b186cf8723ed20
 +#endif // _GO_COMMONCRYPTO_SHIMS_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/syscall_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/syscall_nocgo.go
 new file mode 100644
-index 00000000000000..196dbd4dbb4238
+index 00000000000000..fd322bcd1b885c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/syscall_nocgo.go
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,15 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -19143,17 +19199,12 @@ index 00000000000000..196dbd4dbb4238
 +package commoncrypto
 +
 +import (
-+	_ "unsafe"
++	"github.com/microsoft/go-crypto-darwin/internal/xsyscall"
 +)
 +
-+//go:linkname syscall_syscallN syscall.syscalln
-+
-+//go:noescape
-+func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2 uintptr)
-+
 +//go:nosplit
-+func syscallN(_ uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
-+	return syscall_syscallN(fn, args...)
++func syscallN(errType uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
++	return xsyscall.SyscallN(errType, fn, args...)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto.c b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto.c
 new file mode 100644
@@ -21661,10 +21712,10 @@ index 00000000000000..3e3b2c3df5e365
 +#endif // _GO_CRYPTOKIT_SHIMS_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/syscall_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/syscall_nocgo.go
 new file mode 100644
-index 00000000000000..abd4d7a9d85957
+index 00000000000000..c83bb8660303f6
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/syscall_nocgo.go
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,15 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -21673,17 +21724,12 @@ index 00000000000000..abd4d7a9d85957
 +package cryptokit
 +
 +import (
-+	_ "unsafe"
++	"github.com/microsoft/go-crypto-darwin/internal/xsyscall"
 +)
 +
-+//go:linkname syscall_syscallN syscall.syscalln
-+
-+//go:noescape
-+func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2 uintptr)
-+
 +//go:nosplit
-+func syscallN(_ uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
-+	return syscall_syscallN(fn, args...)
++func syscallN(errType uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
++	return xsyscall.SyscallN(errType, fn, args...)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit.c b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit.c
 new file mode 100644
@@ -23501,6 +23547,1275 @@ index 00000000000000..ecb3cd3a9e3946
 +//go:cgo_import_dynamic swift_release swift_release ""
 +//go:cgo_import_dynamic swift_retain swift_retain ""
 +//go:cgo_import_dynamic swift_unexpectedError swift_unexpectedError ""
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/abi_amd64.h b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/abi_amd64.h
+new file mode 100644
+index 00000000000000..c646c454a788fd
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/abi_amd64.h
+@@ -0,0 +1,34 @@
++// Copyright 2021 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Macros for transitioning from the host ABI to Go ABI0.
++//
++// These save the frame pointer, so in general, functions that use
++// these should have zero frame size to suppress the automatic frame
++// pointer, though it's harmless to not do this.
++
++#define REGS_HOST_TO_ABI0_STACK (6*8)
++
++// SysV MXCSR matches the Go ABI, so we don't have to set that,
++// and Go doesn't modify it, so we don't have to save it.
++// Both SysV and Go require DF to be cleared, so that's already clear.
++// The SysV and Go frame pointer conventions are compatible.
++#define PUSH_REGS_HOST_TO_ABI0()	\
++	ADJSP	$(REGS_HOST_TO_ABI0_STACK)	\
++	MOVQ	BP, (5*8)(SP)	\
++	LEAQ	(5*8)(SP), BP	\
++	MOVQ	BX, (0*8)(SP)	\
++	MOVQ	R12, (1*8)(SP)	\
++	MOVQ	R13, (2*8)(SP)	\
++	MOVQ	R14, (3*8)(SP)	\
++	MOVQ	R15, (4*8)(SP)
++
++#define POP_REGS_HOST_TO_ABI0()	\
++	MOVQ	(0*8)(SP), BX	\
++	MOVQ	(1*8)(SP), R12	\
++	MOVQ	(2*8)(SP), R13	\
++	MOVQ	(3*8)(SP), R14	\
++	MOVQ	(4*8)(SP), R15	\
++	MOVQ	(5*8)(SP), BP	\
++	ADJSP	$-(REGS_HOST_TO_ABI0_STACK)
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/abi_arm64.h b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/abi_arm64.h
+new file mode 100644
+index 00000000000000..5d5061ec1dbf8c
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/abi_arm64.h
+@@ -0,0 +1,39 @@
++// Copyright 2021 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Macros for transitioning from the host ABI to Go ABI0.
++//
++// These macros save and restore the callee-saved registers
++// from the stack, but they don't adjust stack pointer, so
++// the user should prepare stack space in advance.
++// SAVE_R19_TO_R28(offset) saves R19 ~ R28 to the stack space
++// of ((offset)+0*8)(RSP) ~ ((offset)+9*8)(RSP).
++//
++// SAVE_F8_TO_F15(offset) saves F8 ~ F15 to the stack space
++// of ((offset)+0*8)(RSP) ~ ((offset)+7*8)(RSP).
++//
++// R29 is not saved because Go will save and restore it.
++
++#define SAVE_R19_TO_R28(offset) \
++	STP	(R19, R20), ((offset)+0*8)(RSP) \
++	STP	(R21, R22), ((offset)+2*8)(RSP) \
++	STP	(R23, R24), ((offset)+4*8)(RSP) \
++	STP	(R25, R26), ((offset)+6*8)(RSP) \
++	STP	(R27, g), ((offset)+8*8)(RSP)
++#define RESTORE_R19_TO_R28(offset) \
++	LDP	((offset)+0*8)(RSP), (R19, R20) \
++	LDP	((offset)+2*8)(RSP), (R21, R22) \
++	LDP	((offset)+4*8)(RSP), (R23, R24) \
++	LDP	((offset)+6*8)(RSP), (R25, R26) \
++	LDP	((offset)+8*8)(RSP), (R27, g) /* R28 */
++#define SAVE_F8_TO_F15(offset) \
++	FSTPD	(F8, F9), ((offset)+0*8)(RSP) \
++	FSTPD	(F10, F11), ((offset)+2*8)(RSP) \
++	FSTPD	(F12, F13), ((offset)+4*8)(RSP) \
++	FSTPD	(F14, F15), ((offset)+6*8)(RSP)
++#define RESTORE_F8_TO_F15(offset) \
++	FLDPD	((offset)+0*8)(RSP), (F8, F9) \
++	FLDPD	((offset)+2*8)(RSP), (F10, F11) \
++	FLDPD	((offset)+4*8)(RSP), (F12, F13) \
++	FLDPD	((offset)+6*8)(RSP), (F14, F15)
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/asm_amd64.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/asm_amd64.s
+new file mode 100644
+index 00000000000000..fe133dacac6959
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/asm_amd64.s
+@@ -0,0 +1,29 @@
++// Copyright 2009 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++#include "textflag.h"
++#include "abi_amd64.h"
++
++// Called by C code generated by cmd/cgo.
++// func crosscall2(fn, a unsafe.Pointer, n int32, ctxt uintptr)
++// Saves C callee-saved registers and calls cgocallback with three arguments.
++// fn is the PC of a func(a unsafe.Pointer) function.
++// This signature is known to SWIG, so we can't change it.
++TEXT crosscall2(SB), NOSPLIT, $0-0
++	PUSH_REGS_HOST_TO_ABI0()
++
++	// Make room for arguments to cgocallback.
++	ADJSP $0x18
++
++	MOVQ DI, 0x0(SP) // fn
++	MOVQ SI, 0x8(SP) // arg
++
++	// Skip n in DX.
++	MOVQ CX, 0x10(SP) // ctxt
++
++	CALL runtime·cgocallback(SB)
++
++	ADJSP $-0x18
++	POP_REGS_HOST_TO_ABI0()
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/asm_arm64.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/asm_arm64.s
+new file mode 100644
+index 00000000000000..50e5261d922c56
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/asm_arm64.s
+@@ -0,0 +1,36 @@
++// Copyright 2015 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++#include "textflag.h"
++#include "abi_arm64.h"
++
++// Called by C code generated by cmd/cgo.
++// func crosscall2(fn, a unsafe.Pointer, n int32, ctxt uintptr)
++// Saves C callee-saved registers and calls cgocallback with three arguments.
++// fn is the PC of a func(a unsafe.Pointer) function.
++TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
++/*
++ * We still need to save all callee save register as before, and then
++ *  push 3 args for fn (R0, R1, R3), skipping R2.
++ * Also note that at procedure entry in gc world, 8(RSP) will be the
++ *  first arg.
++ */
++	SUB  $(8*24), RSP
++	STP  (R0, R1), (8*1)(RSP)
++	MOVD R3, (8*3)(RSP)
++
++	SAVE_R19_TO_R28(8*4)
++	SAVE_F8_TO_F15(8*14)
++	STP (R29, R30), (8*22)(RSP)
++
++	// Initialize Go ABI environment
++	BL runtime·load_g(SB)
++	BL runtime·cgocallback(SB)
++
++	RESTORE_R19_TO_R28(8*4)
++	RESTORE_F8_TO_F15(8*14)
++	LDP (8*22)(RSP), (R29, R30)
++
++	ADD $(8*24), RSP
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/callbacks.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/callbacks.go
+new file mode 100644
+index 00000000000000..e48722128a09d7
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/callbacks.go
+@@ -0,0 +1,93 @@
++// Copyright 2011 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !cgo && darwin
++
++package fakecgo
++
++import (
++	_ "unsafe"
++)
++
++// TODO: decide if we need _runtime_cgo_panic_internal
++
++//go:linkname x_cgo_init_trampoline x_cgo_init_trampoline
++//go:linkname _cgo_init _cgo_init
++var x_cgo_init_trampoline byte
++var _cgo_init = &x_cgo_init_trampoline
++
++// Creates a new system thread without updating any Go state.
++//
++// This method is invoked during shared library loading to create a new OS
++// thread to perform the runtime initialization. This method is similar to
++// _cgo_sys_thread_start except that it doesn't update any Go state.
++
++//go:linkname x_cgo_thread_start_trampoline x_cgo_thread_start_trampoline
++//go:linkname _cgo_thread_start _cgo_thread_start
++var x_cgo_thread_start_trampoline byte
++var _cgo_thread_start = &x_cgo_thread_start_trampoline
++
++// Notifies that the runtime has been initialized.
++//
++// We currently block at every CGO entry point (via _cgo_wait_runtime_init_done)
++// to ensure that the runtime has been initialized before the CGO call is
++// executed. This is necessary for shared libraries where we kickoff runtime
++// initialization in a separate thread and return without waiting for this
++// thread to complete the init.
++
++//go:linkname x_cgo_notify_runtime_init_done_trampoline x_cgo_notify_runtime_init_done_trampoline
++//go:linkname _cgo_notify_runtime_init_done _cgo_notify_runtime_init_done
++var x_cgo_notify_runtime_init_done_trampoline byte
++var _cgo_notify_runtime_init_done = &x_cgo_notify_runtime_init_done_trampoline
++
++// Indicates whether a dummy thread key has been created or not.
++//
++// When calling go exported function from C, we register a destructor
++// callback, for a dummy thread key, by using pthread_key_create.
++
++//go:linkname _cgo_pthread_key_created _cgo_pthread_key_created
++var x_cgo_pthread_key_created uintptr
++var _cgo_pthread_key_created = &x_cgo_pthread_key_created
++
++// Set the x_crosscall2_ptr C function pointer variable point to crosscall2.
++// It's for the runtime package to call at init time.
++func set_crosscall2() {
++	// nothing needs to be done here for fakecgo
++	// because it's possible to just call cgocallback directly
++}
++
++//go:linkname _set_crosscall2 runtime.set_crosscall2
++var _set_crosscall2 = set_crosscall2
++
++// Store the g into the thread-specific value.
++// So that pthread_key_destructor will dropm when the thread is exiting.
++
++//go:linkname x_cgo_bindm_trampoline x_cgo_bindm_trampoline
++//go:linkname _cgo_bindm _cgo_bindm
++var x_cgo_bindm_trampoline byte
++var _cgo_bindm = &x_cgo_bindm_trampoline
++
++// TODO: decide if we need x_cgo_set_context_function
++// TODO: decide if we need _cgo_yield
++
++var (
++	// In Go 1.20 the race detector was rewritten to pure Go
++	// on darwin. This means that when CGO_ENABLED=0 is set
++	// fakecgo is built with race detector code. This is not
++	// good since this code is pretending to be C. The go:norace
++	// pragma is not enough, since it only applies to the native
++	// ABIInternal function. The ABIO wrapper (which is necessary,
++	// since all references to text symbols from assembly will use it)
++	// does not inherit the go:norace pragma, so it will still be
++	// instrumented by the race detector.
++	//
++	// To circumvent this issue, using closure calls in the
++	// assembly, which forces the compiler to use the ABIInternal
++	// native implementation (which has go:norace) instead.
++	threadentry_call        = threadentry
++	x_cgo_init_call         = x_cgo_init
++	x_cgo_setenv_call       = x_cgo_setenv
++	x_cgo_unsetenv_call     = x_cgo_unsetenv
++	x_cgo_thread_start_call = x_cgo_thread_start
++)
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/doc.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/doc.go
+new file mode 100644
+index 00000000000000..8ebc46efc78533
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/doc.go
+@@ -0,0 +1,32 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++// Package fakecgo implements the Cgo runtime (runtime/cgo) entirely in Go.
++// This allows code that calls into C to function properly when CGO_ENABLED=0.
++//
++// # Goals
++//
++// fakecgo attempts to replicate the same naming structure as in the runtime.
++// For example, functions that have the prefix "gcc_*" are named "go_*".
++// This makes it easier to port other GOOSs and GOARCHs as well as to keep
++// it in sync with runtime/cgo.
++//
++// # Support
++//
++// Currently, fakecgo only supports macOS on amd64 & arm64. It also cannot
++// be used with -buildmode=c-archive because that requires special initialization
++// that fakecgo does not implement at the moment.
++//
++// # Usage
++//
++// Using fakecgo is easy just import _ "github.com/ebitengine/purego" and then
++// set the environment variable CGO_ENABLED=0.
++// The recommended usage for fakecgo is to prefer using runtime/cgo if possible
++// but if cross-compiling or fast build times are important fakecgo is available.
++// Purego will pick which ever Cgo runtime is available and prefer the one that
++// comes with Go (runtime/cgo).
++package fakecgo
++
++//go:generate go run gen.go
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/fakecgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/fakecgo.go
+new file mode 100644
+index 00000000000000..6adf531c221742
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/fakecgo.go
+@@ -0,0 +1,27 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++package fakecgo
++
++import "unsafe"
++
++// setg_trampoline calls setg with the G provided
++func setg_trampoline(setg uintptr, G uintptr)
++
++// call5 takes fn the C function and 5 arguments and calls the function with those arguments
++func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
++
++// argset matches runtime/cgocall.go:argset.
++type argset struct {
++	args   *uintptr
++	retval uintptr
++}
++
++//go:nosplit
++//go:norace
++func (a *argset) arg(i int) unsafe.Pointer {
++	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
++	return *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(a.args), uintptr(i)*unsafe.Sizeof(uintptr(0))))
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_darwin.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_darwin.go
+new file mode 100644
+index 00000000000000..6bc959b64ce3eb
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_darwin.go
+@@ -0,0 +1,88 @@
++// Copyright 2011 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !cgo && darwin
++
++package fakecgo
++
++import "unsafe"
++
++//go:nosplit
++//go:norace
++func _cgo_sys_thread_start(ts *ThreadStart) {
++	var attr pthread_attr_t
++	var ign, oset sigset_t
++	var p pthread_t
++	var size size_t
++	var err int
++
++	sigfillset(&ign)
++	pthread_sigmask(SIG_SETMASK, &ign, &oset)
++
++	size = pthread_get_stacksize_np(pthread_self())
++	pthread_attr_init(&attr)
++	pthread_attr_setstacksize(&attr, size)
++	// Leave stacklo=0 and set stackhi=size; mstart will do the rest.
++	ts.g.stackhi = uintptr(size)
++
++	err = _cgo_try_pthread_create(&p, &attr, unsafe.Pointer(threadentry_trampolineABI0), ts)
++
++	pthread_sigmask(SIG_SETMASK, &oset, nil)
++
++	if err != 0 {
++		print("fakecgo: pthread_create failed: ")
++		println(err)
++		abort()
++	}
++}
++
++// threadentry_trampolineABI0 maps the C ABI to Go ABI then calls the Go function
++//
++//go:linkname x_threadentry_trampoline threadentry_trampoline
++var x_threadentry_trampoline byte
++var threadentry_trampolineABI0 = &x_threadentry_trampoline
++
++//go:nosplit
++//go:norace
++func threadentry(v unsafe.Pointer) unsafe.Pointer {
++	ts := *(*ThreadStart)(v)
++	free(v)
++
++	// TODO: support ios
++	//#if TARGET_OS_IPHONE
++	//	darwin_arm_init_thread_exception_port();
++	//#endif
++	setg_trampoline(setg_func, uintptr(unsafe.Pointer(ts.g)))
++
++	// faking funcs in go is a bit a... involved - but the following works :)
++	fn := uintptr(unsafe.Pointer(&ts.fn))
++	(*(*func())(unsafe.Pointer(&fn)))()
++
++	return nil
++}
++
++// here we will store a pointer to the provided setg func
++var setg_func uintptr
++
++// x_cgo_init(G *g, void (*setg)(void*)) (runtime/cgo/gcc_linux_amd64.c)
++// This get's called during startup, adjusts stacklo, and provides a pointer to setg_gcc for us
++// Additionally, if we set _cgo_init to non-null, go won't do it's own TLS setup
++// This function can't be go:systemstack since go is not in a state where the systemcheck would work.
++//
++//go:nosplit
++//go:norace
++func x_cgo_init(g *G, setg uintptr) {
++	var size size_t
++
++	setg_func = setg
++	size = pthread_get_stacksize_np(pthread_self())
++	g.stacklo = uintptr(unsafe.Add(unsafe.Pointer(&size), -size+4096))
++
++	//TODO: support ios
++	//#if TARGET_OS_IPHONE
++	//	darwin_arm_init_mach_exception_handler();
++	//	darwin_arm_init_thread_exception_port();
++	//	init_working_dir();
++	//#endif
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_libinit.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_libinit.go
+new file mode 100644
+index 00000000000000..f6fa2328af41bc
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_libinit.go
+@@ -0,0 +1,72 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++package fakecgo
++
++import (
++	"syscall"
++	"unsafe"
++)
++
++var (
++	pthread_g pthread_key_t
++
++	runtime_init_cond = PTHREAD_COND_INITIALIZER
++	runtime_init_mu   = PTHREAD_MUTEX_INITIALIZER
++	runtime_init_done int
++)
++
++//go:nosplit
++//go:norace
++func x_cgo_notify_runtime_init_done() {
++	pthread_mutex_lock(&runtime_init_mu)
++	runtime_init_done = 1
++	pthread_cond_broadcast(&runtime_init_cond)
++	pthread_mutex_unlock(&runtime_init_mu)
++}
++
++// Store the g into a thread-specific value associated with the pthread key pthread_g.
++// And pthread_key_destructor will dropm when the thread is exiting.
++//
++//go:norace
++func x_cgo_bindm(g unsafe.Pointer) {
++	// We assume this will always succeed, otherwise, there might be extra M leaking,
++	// when a C thread exits after a cgo call.
++	// We only invoke this function once per thread in runtime.needAndBindM,
++	// and the next calls just reuse the bound m.
++	pthread_setspecific(pthread_g, g)
++}
++
++// _cgo_try_pthread_create retries pthread_create if it fails with
++// EAGAIN.
++//
++//go:nosplit
++//go:norace
++func _cgo_try_pthread_create(thread *pthread_t, attr *pthread_attr_t, pfn unsafe.Pointer, arg *ThreadStart) int {
++	var ts syscall.Timespec
++	// tries needs to be the same type as syscall.Timespec.Nsec
++	// but the fields are int32 on 32bit and int64 on 64bit.
++	// tries is assigned to syscall.Timespec.Nsec in order to match its type.
++	tries := ts.Nsec
++	var err int
++
++	for tries = 0; tries < 20; tries++ {
++		// inlined this call because it ran out of stack when inlining was disabled
++		err = int(call5(pthread_createABI0, uintptr(unsafe.Pointer(thread)), uintptr(unsafe.Pointer(attr)), uintptr(pfn), uintptr(unsafe.Pointer(arg)), 0))
++		if err == 0 {
++			// inlined this call because it ran out of stack when inlining was disabled
++			call5(pthread_detachABI0, uintptr(*thread), 0, 0, 0, 0)
++			return 0
++		}
++		if err != int(syscall.EAGAIN) {
++			return err
++		}
++		ts.Sec = 0
++		ts.Nsec = (tries + 1) * 1000 * 1000 // Milliseconds.
++		// inlined this call because it ran out of stack when inlining was disabled
++		call5(nanosleepABI0, uintptr(unsafe.Pointer(&ts)), 0, 0, 0, 0)
++	}
++	return int(syscall.EAGAIN)
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_setenv.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_setenv.go
+new file mode 100644
+index 00000000000000..a79441edffbcb9
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_setenv.go
+@@ -0,0 +1,18 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++package fakecgo
++
++//go:nosplit
++//go:norace
++func x_cgo_setenv(arg *[2]*byte) {
++	setenv(arg[0], arg[1], 1)
++}
++
++//go:nosplit
++//go:norace
++func x_cgo_unsetenv(arg *[1]*byte) {
++	unsetenv(arg[0])
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_util.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_util.go
+new file mode 100644
+index 00000000000000..b36bd00d361712
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_util.go
+@@ -0,0 +1,37 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++package fakecgo
++
++import "unsafe"
++
++// _cgo_thread_start is split into three parts in cgo since only one part is system dependent (keep it here for easier handling)
++
++// _cgo_thread_start(ThreadStart *arg) (runtime/cgo/gcc_util.c)
++// This get's called instead of the go code for creating new threads
++// -> pthread_* stuff is used, so threads are setup correctly for C
++// If this is missing, TLS is only setup correctly on thread 1!
++// This function should be go:systemstack instead of go:nosplit (but that requires runtime)
++//
++//go:nosplit
++//go:norace
++func x_cgo_thread_start(arg *ThreadStart) {
++	var ts *ThreadStart
++	// Make our own copy that can persist after we return.
++	//	_cgo_tsan_acquire();
++	ts = (*ThreadStart)(malloc(unsafe.Sizeof(*ts)))
++	//	_cgo_tsan_release();
++	if ts == nil {
++		println("fakecgo: out of memory in thread_start")
++		abort()
++	}
++	// *ts = *arg would cause a writebarrier so copy using slices
++	s1 := unsafe.Slice((*uintptr)(unsafe.Pointer(ts)), unsafe.Sizeof(*ts)/8)
++	s2 := unsafe.Slice((*uintptr)(unsafe.Pointer(arg)), unsafe.Sizeof(*arg)/8)
++	for i := range s2 {
++		s1[i] = s2[i]
++	}
++	_cgo_sys_thread_start(ts) // OS-dependent half
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/iscgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/iscgo.go
+new file mode 100644
+index 00000000000000..76f7ef6dc58c7c
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/iscgo.go
+@@ -0,0 +1,19 @@
++// Copyright 2010 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !cgo && darwin
++
++// The runtime package contains an uninitialized definition
++// for runtime·iscgo. Override it to tell the runtime we're here.
++// There are various function pointers that should be set too,
++// but those depend on dynamic linker magic to get initialized
++// correctly, and sometimes they break. This variable is a
++// backup: it depends only on old C style static linking rules.
++
++package fakecgo
++
++import _ "unsafe" // for go:linkname
++
++//go:linkname _iscgo runtime.iscgo
++var _iscgo bool = true
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/libcgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/libcgo.go
+new file mode 100644
+index 00000000000000..26524ced1c3f0b
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/libcgo.go
+@@ -0,0 +1,37 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++package fakecgo
++
++type (
++	size_t uintptr
++	// Sources:
++	// Darwin (32 bytes) - https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/_types.h#L74
++	sigset_t       [128]byte
++	pthread_attr_t [64]byte
++	pthread_t      int
++	pthread_key_t  uint64
++)
++
++// for pthread_sigmask:
++
++type sighow int32
++
++const (
++	SIG_BLOCK   sighow = 0
++	SIG_UNBLOCK sighow = 1
++	SIG_SETMASK sighow = 2
++)
++
++type G struct {
++	stacklo uintptr
++	stackhi uintptr
++}
++
++type ThreadStart struct {
++	g   *G
++	tls *uintptr
++	fn  uintptr
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/libcgo_darwin.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/libcgo_darwin.go
+new file mode 100644
+index 00000000000000..ecdcb2e7852560
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/libcgo_darwin.go
+@@ -0,0 +1,26 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++package fakecgo
++
++type (
++	pthread_mutex_t struct {
++		sig    int64
++		opaque [56]byte
++	}
++	pthread_cond_t struct {
++		sig    int64
++		opaque [40]byte
++	}
++)
++
++var (
++	PTHREAD_COND_INITIALIZER  = pthread_cond_t{sig: 0x3CB0B1BB}
++	PTHREAD_MUTEX_INITIALIZER = pthread_mutex_t{sig: 0x32AAABA7}
++)
++
++type stack_t struct {
++	/* not implemented */
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/setenv.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/setenv.go
+new file mode 100644
+index 00000000000000..e761fecfb89280
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/setenv.go
+@@ -0,0 +1,19 @@
++// Copyright 2011 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !cgo && darwin
++
++package fakecgo
++
++import _ "unsafe" // for go:linkname
++
++//go:linkname x_cgo_setenv_trampoline x_cgo_setenv_trampoline
++//go:linkname _cgo_setenv runtime._cgo_setenv
++var x_cgo_setenv_trampoline byte
++var _cgo_setenv = &x_cgo_setenv_trampoline
++
++//go:linkname x_cgo_unsetenv_trampoline x_cgo_unsetenv_trampoline
++//go:linkname _cgo_unsetenv runtime._cgo_unsetenv
++var x_cgo_unsetenv_trampoline byte
++var _cgo_unsetenv = &x_cgo_unsetenv_trampoline
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/symbols.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/symbols.go
+new file mode 100644
+index 00000000000000..a18645048960cb
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/symbols.go
+@@ -0,0 +1,225 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++package fakecgo
++
++import (
++	"syscall"
++	"unsafe"
++)
++
++//go:nosplit
++//go:norace
++func malloc(size uintptr) unsafe.Pointer {
++	ret := call5(mallocABI0, uintptr(size), 0, 0, 0, 0)
++	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
++	return *(*unsafe.Pointer)(unsafe.Pointer(&ret))
++}
++
++//go:nosplit
++//go:norace
++func free(ptr unsafe.Pointer) {
++	call5(freeABI0, uintptr(ptr), 0, 0, 0, 0)
++}
++
++//go:nosplit
++//go:norace
++func setenv(name *byte, value *byte, overwrite int32) int32 {
++	return int32(call5(setenvABI0, uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(value)), uintptr(overwrite), 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func unsetenv(name *byte) int32 {
++	return int32(call5(unsetenvABI0, uintptr(unsafe.Pointer(name)), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func sigfillset(set *sigset_t) int32 {
++	return int32(call5(sigfillsetABI0, uintptr(unsafe.Pointer(set)), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func nanosleep(ts *syscall.Timespec, rem *syscall.Timespec) int32 {
++	return int32(call5(nanosleepABI0, uintptr(unsafe.Pointer(ts)), uintptr(unsafe.Pointer(rem)), 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func abort() {
++	call5(abortABI0, 0, 0, 0, 0, 0)
++}
++
++//go:nosplit
++//go:norace
++func sigaltstack(ss *stack_t, old_ss *stack_t) int32 {
++	return int32(call5(sigaltstackABI0, uintptr(unsafe.Pointer(ss)), uintptr(unsafe.Pointer(old_ss)), 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_attr_init(attr *pthread_attr_t) int32 {
++	return int32(call5(pthread_attr_initABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_create(thread *pthread_t, attr *pthread_attr_t, start unsafe.Pointer, arg unsafe.Pointer) int32 {
++	return int32(call5(pthread_createABI0, uintptr(unsafe.Pointer(thread)), uintptr(unsafe.Pointer(attr)), uintptr(start), uintptr(arg), 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_detach(thread pthread_t) int32 {
++	return int32(call5(pthread_detachABI0, uintptr(thread), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_sigmask(how sighow, ign *sigset_t, oset *sigset_t) int32 {
++	return int32(call5(pthread_sigmaskABI0, uintptr(how), uintptr(unsafe.Pointer(ign)), uintptr(unsafe.Pointer(oset)), 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_self() pthread_t {
++	return pthread_t(call5(pthread_selfABI0, 0, 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_get_stacksize_np(thread pthread_t) size_t {
++	return size_t(call5(pthread_get_stacksize_npABI0, uintptr(thread), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
++	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_attr_setstacksize(attr *pthread_attr_t, size size_t) int32 {
++	return int32(call5(pthread_attr_setstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(size), 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_attr_destroy(attr *pthread_attr_t) int32 {
++	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_mutex_lock(mutex *pthread_mutex_t) int32 {
++	return int32(call5(pthread_mutex_lockABI0, uintptr(unsafe.Pointer(mutex)), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_mutex_unlock(mutex *pthread_mutex_t) int32 {
++	return int32(call5(pthread_mutex_unlockABI0, uintptr(unsafe.Pointer(mutex)), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_cond_broadcast(cond *pthread_cond_t) int32 {
++	return int32(call5(pthread_cond_broadcastABI0, uintptr(unsafe.Pointer(cond)), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_setspecific(key pthread_key_t, value unsafe.Pointer) int32 {
++	return int32(call5(pthread_setspecificABI0, uintptr(key), uintptr(value), 0, 0, 0))
++}
++
++//go:linkname _malloc _malloc
++var _malloc uint8
++var mallocABI0 = uintptr(unsafe.Pointer(&_malloc))
++
++//go:linkname _free _free
++var _free uint8
++var freeABI0 = uintptr(unsafe.Pointer(&_free))
++
++//go:linkname _setenv _setenv
++var _setenv uint8
++var setenvABI0 = uintptr(unsafe.Pointer(&_setenv))
++
++//go:linkname _unsetenv _unsetenv
++var _unsetenv uint8
++var unsetenvABI0 = uintptr(unsafe.Pointer(&_unsetenv))
++
++//go:linkname _sigfillset _sigfillset
++var _sigfillset uint8
++var sigfillsetABI0 = uintptr(unsafe.Pointer(&_sigfillset))
++
++//go:linkname _nanosleep _nanosleep
++var _nanosleep uint8
++var nanosleepABI0 = uintptr(unsafe.Pointer(&_nanosleep))
++
++//go:linkname _abort _abort
++var _abort uint8
++var abortABI0 = uintptr(unsafe.Pointer(&_abort))
++
++//go:linkname _sigaltstack _sigaltstack
++var _sigaltstack uint8
++var sigaltstackABI0 = uintptr(unsafe.Pointer(&_sigaltstack))
++
++//go:linkname _pthread_attr_init _pthread_attr_init
++var _pthread_attr_init uint8
++var pthread_attr_initABI0 = uintptr(unsafe.Pointer(&_pthread_attr_init))
++
++//go:linkname _pthread_create _pthread_create
++var _pthread_create uint8
++var pthread_createABI0 = uintptr(unsafe.Pointer(&_pthread_create))
++
++//go:linkname _pthread_detach _pthread_detach
++var _pthread_detach uint8
++var pthread_detachABI0 = uintptr(unsafe.Pointer(&_pthread_detach))
++
++//go:linkname _pthread_sigmask _pthread_sigmask
++var _pthread_sigmask uint8
++var pthread_sigmaskABI0 = uintptr(unsafe.Pointer(&_pthread_sigmask))
++
++//go:linkname _pthread_self _pthread_self
++var _pthread_self uint8
++var pthread_selfABI0 = uintptr(unsafe.Pointer(&_pthread_self))
++
++//go:linkname _pthread_get_stacksize_np _pthread_get_stacksize_np
++var _pthread_get_stacksize_np uint8
++var pthread_get_stacksize_npABI0 = uintptr(unsafe.Pointer(&_pthread_get_stacksize_np))
++
++//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
++var _pthread_attr_getstacksize uint8
++var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
++
++//go:linkname _pthread_attr_setstacksize _pthread_attr_setstacksize
++var _pthread_attr_setstacksize uint8
++var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
++
++//go:linkname _pthread_attr_destroy _pthread_attr_destroy
++var _pthread_attr_destroy uint8
++var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
++
++//go:linkname _pthread_mutex_lock _pthread_mutex_lock
++var _pthread_mutex_lock uint8
++var pthread_mutex_lockABI0 = uintptr(unsafe.Pointer(&_pthread_mutex_lock))
++
++//go:linkname _pthread_mutex_unlock _pthread_mutex_unlock
++var _pthread_mutex_unlock uint8
++var pthread_mutex_unlockABI0 = uintptr(unsafe.Pointer(&_pthread_mutex_unlock))
++
++//go:linkname _pthread_cond_broadcast _pthread_cond_broadcast
++var _pthread_cond_broadcast uint8
++var pthread_cond_broadcastABI0 = uintptr(unsafe.Pointer(&_pthread_cond_broadcast))
++
++//go:linkname _pthread_setspecific _pthread_setspecific
++var _pthread_setspecific uint8
++var pthread_setspecificABI0 = uintptr(unsafe.Pointer(&_pthread_setspecific))
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/symbols_darwin.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/symbols_darwin.go
+new file mode 100644
+index 00000000000000..8c4489f0369c25
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/symbols_darwin.go
+@@ -0,0 +1,30 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++package fakecgo
++
++//go:cgo_import_dynamic purego_malloc malloc "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_free free "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_setenv setenv "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_unsetenv unsetenv "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_sigfillset sigfillset "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_nanosleep nanosleep "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_abort abort "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_sigaltstack sigaltstack "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_attr_init pthread_attr_init "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_create pthread_create "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_detach pthread_detach "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_sigmask pthread_sigmask "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_self pthread_self "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_get_stacksize_np pthread_get_stacksize_np "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_attr_setstacksize pthread_attr_setstacksize "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_mutex_lock pthread_mutex_lock "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_mutex_unlock pthread_mutex_unlock "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_cond_broadcast pthread_cond_broadcast "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "/usr/lib/libSystem.B.dylib"
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_amd64.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_amd64.s
+new file mode 100644
+index 00000000000000..60e70c0a6c6e84
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_amd64.s
+@@ -0,0 +1,112 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++/*
++trampoline for emulating required C functions for cgo in go (see cgo.go)
++(we convert cdecl calling convention to go and vice-versa)
++
++Since we're called from go and call into C we can cheat a bit with the calling conventions:
++ - in go all the registers are caller saved
++ - in C we have a couple of callee saved registers
++
++=> we can use BX, R12, R13, R14, R15 instead of the stack
++
++C Calling convention cdecl used here (we only need integer args):
++1. arg: DI
++2. arg: SI
++3. arg: DX
++4. arg: CX
++5. arg: R8
++6. arg: R9
++We don't need floats with these functions -> AX=0
++return value will be in AX
++*/
++#include "textflag.h"
++#include "go_asm.h"
++#include "abi_amd64.h"
++
++// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
++
++TEXT x_cgo_init_trampoline(SB), NOSPLIT, $16
++	MOVQ DI, AX
++	MOVQ SI, BX
++	MOVQ ·x_cgo_init_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_thread_start_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_setenv_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_unsetenv_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0
++	CALL ·x_cgo_notify_runtime_init_done(SB)
++	RET
++
++TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0
++	CALL ·x_cgo_bindm(SB)
++	RET
++
++// func setg_trampoline(setg uintptr, g uintptr)
++TEXT ·setg_trampoline(SB), NOSPLIT, $0-16
++	MOVQ G+8(FP), DI
++	MOVQ setg+0(FP), BX
++	XORL AX, AX
++	CALL BX
++	RET
++
++TEXT threadentry_trampoline(SB), NOSPLIT, $0
++	// See crosscall2.
++	PUSH_REGS_HOST_TO_ABI0()
++
++	PXOR	X15, X15
++
++	MOVQ DI, AX
++	MOVQ ·threadentry_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++
++	POP_REGS_HOST_TO_ABI0()
++	RET
++
++TEXT ·call5(SB), NOSPLIT, $0-56
++	MOVQ fn+0(FP), BX
++	MOVQ a1+8(FP), DI
++	MOVQ a2+16(FP), SI
++	MOVQ a3+24(FP), DX
++	MOVQ a4+32(FP), CX
++	MOVQ a5+40(FP), R8
++
++	XORL AX, AX // no floats
++
++	PUSHQ BP       // save BP
++	MOVQ  SP, BP   // save SP inside BP bc BP is callee-saved
++	SUBQ  $16, SP  // allocate space for alignment
++	ANDQ  $-16, SP // align on 16 bytes for SSE
++
++	CALL BX
++
++	MOVQ BP, SP // get SP back
++	POPQ BP     // restore BP
++
++	MOVQ AX, ret+48(FP)
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s
+new file mode 100644
+index 00000000000000..24ddb71f946a94
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s
+@@ -0,0 +1,82 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++#include "textflag.h"
++#include "go_asm.h"
++#include "abi_arm64.h"
++
++// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
++
++TEXT x_cgo_init_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_init_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	RET
++
++TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_thread_start_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	RET
++
++TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_setenv_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	RET
++
++TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_unsetenv_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	RET
++
++TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0-0
++	CALL ·x_cgo_notify_runtime_init_done(SB)
++	RET
++
++TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0
++	CALL ·x_cgo_bindm(SB)
++	RET
++
++// func setg_trampoline(setg uintptr, g uintptr)
++TEXT ·setg_trampoline(SB), NOSPLIT, $0-16
++	MOVD G+8(FP), R0
++	MOVD setg+0(FP), R1
++	CALL R1
++	RET
++
++TEXT threadentry_trampoline(SB), NOSPLIT, $0-0
++	// See crosscall2.
++	SUB  $(8*24), RSP
++	STP  (R0, R1), (8*1)(RSP)
++	MOVD R3, (8*3)(RSP)
++
++	SAVE_R19_TO_R28(8*4)
++	SAVE_F8_TO_F15(8*14)
++	STP (R29, R30), (8*22)(RSP)
++
++	MOVD ·threadentry_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	MOVD $0, R0                     // TODO: get the return value from threadentry
++
++	RESTORE_R19_TO_R28(8*4)
++	RESTORE_F8_TO_F15(8*14)
++	LDP (8*22)(RSP), (R29, R30)
++
++	ADD $(8*24), RSP
++	RET
++
++TEXT ·call5(SB), NOSPLIT, $0-0
++	MOVD fn+0(FP), R6
++	MOVD a1+8(FP), R0
++	MOVD a2+16(FP), R1
++	MOVD a3+24(FP), R2
++	MOVD a4+32(FP), R3
++	MOVD a5+40(FP), R4
++	CALL R6
++	MOVD R0, ret+48(FP)
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_stubs.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_stubs.s
+new file mode 100644
+index 00000000000000..061b40ef8af8a6
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_stubs.s
+@@ -0,0 +1,94 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && darwin
++
++#include "textflag.h"
++
++// these stubs are here because it is not possible to go:linkname directly the C functions on darwin arm64
++
++TEXT _malloc(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_malloc(SB)
++	RET
++
++TEXT _free(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_free(SB)
++	RET
++
++TEXT _setenv(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setenv(SB)
++	RET
++
++TEXT _unsetenv(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_unsetenv(SB)
++	RET
++
++TEXT _sigfillset(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_sigfillset(SB)
++	RET
++
++TEXT _nanosleep(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_nanosleep(SB)
++	RET
++
++TEXT _abort(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_abort(SB)
++	RET
++
++TEXT _sigaltstack(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_sigaltstack(SB)
++	RET
++
++TEXT _pthread_attr_init(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_attr_init(SB)
++	RET
++
++TEXT _pthread_create(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_create(SB)
++	RET
++
++TEXT _pthread_detach(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_detach(SB)
++	RET
++
++TEXT _pthread_sigmask(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_sigmask(SB)
++	RET
++
++TEXT _pthread_self(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_self(SB)
++	RET
++
++TEXT _pthread_get_stacksize_np(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_get_stacksize_np(SB)
++	RET
++
++TEXT _pthread_attr_getstacksize(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_attr_getstacksize(SB)
++	RET
++
++TEXT _pthread_attr_setstacksize(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_attr_setstacksize(SB)
++	RET
++
++TEXT _pthread_attr_destroy(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_attr_destroy(SB)
++	RET
++
++TEXT _pthread_mutex_lock(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_mutex_lock(SB)
++	RET
++
++TEXT _pthread_mutex_unlock(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_mutex_unlock(SB)
++	RET
++
++TEXT _pthread_cond_broadcast(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_cond_broadcast(SB)
++	RET
++
++TEXT _pthread_setspecific(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_setspecific(SB)
++	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/security.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/security.go
 new file mode 100644
 index 00000000000000..74ee18d383784e
@@ -23631,10 +24946,10 @@ index 00000000000000..e1ba0ec484288f
 +#endif // _GO_SECURITY_SHIMS_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/syscall_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/syscall_nocgo.go
 new file mode 100644
-index 00000000000000..a432803a70b27b
+index 00000000000000..3a03e583346c1c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/syscall_nocgo.go
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,15 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -23643,17 +24958,12 @@ index 00000000000000..a432803a70b27b
 +package security
 +
 +import (
-+	_ "unsafe"
++	"github.com/microsoft/go-crypto-darwin/internal/xsyscall"
 +)
 +
-+//go:linkname syscall_syscallN syscall.syscalln
-+
-+//go:noescape
-+func syscall_syscallN(fn uintptr, args ...uintptr) (r1, r2 uintptr)
-+
 +//go:nosplit
-+func syscallN(_ uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
-+	return syscall_syscallN(fn, args...)
++func syscallN(errType uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
++	return xsyscall.SyscallN(errType, fn, args...)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity.c b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity.c
 new file mode 100644
@@ -24947,6 +26257,485 @@ index 00000000000000..b10738f5d6ec26
 +func SecRandomCopyBytes(rnd SecRandomRef, bytes []byte) int32 {
 +	r0, _ := syscallN(0, _mkcgo_SecRandomCopyBytes_trampoline_addr, uintptr(rnd), uintptr(len(bytes)), uintptr(unsafe.Pointer(unsafe.SliceData(bytes))))
 +	return int32(r0)
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_amd64.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_amd64.s
+new file mode 100644
+index 00000000000000..59560c7d590f7a
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_amd64.s
+@@ -0,0 +1,108 @@
++// Copyright 2009 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !cgo
++
++#include "go_asm.h"
++#include "textflag.h"
++
++TEXT ·syscallNSystemStack_trampoline(SB),NOSPLIT,$16
++#ifdef GOOS_windows
++	MOVQ	CX, 0(SP)
++#else
++	MOVQ	DI, 0(SP)
++#endif
++	CALL	·syscallNSystemStack(SB)
++	RET
++
++#ifdef GOOS_windows
++#define RegArgsN 4
++#else
++#define RegArgsN 6
++#endif
++
++TEXT ·syscallNAsm(SB),NOSPLIT,$16-8
++	// Load pointer from stack (ABI0 calling convention)
++	// Store argument and original SP in a callee-saved register
++	MOVQ	libcArgs+0(FP), R13
++	MOVQ	SP, R14
++	
++	// Align stack to 16 bytes
++	ANDQ	$~15, SP
++
++	MOVQ	libcCallInfo_fn(R13), R11
++	MOVQ	libcCallInfo_n(R13), CX
++	MOVQ	libcCallInfo_args(R13), R10
++
++	// Fast version, do not store args on the stack.
++	CMPL	CX, $0;	JE	_0args
++	CMPL	CX, $1;	JE	_1args
++	CMPL	CX, $2;	JE	_2args
++	CMPL	CX, $3;	JE	_3args
++	CMPL	CX, $4;	JE	_4args
++#ifndef GOOS_windows // Windows does not pass more than 4 args in registers
++	CMPL	CX, $5;	JE	_5args
++	CMPL	CX, $6;	JE	_6args
++#endif
++
++	// Reserve stack space for remaining args
++	MOVQ	CX, R12
++	SUBQ	$RegArgsN, R12
++	ADDQ	$1, R12 // make even number of words for stack alignment
++	ANDQ	$~1, R12
++	SHLQ	$3, R12
++	SUBQ	R12, SP
++
++	// Copy args to the stack.
++	// CX: count of stack arguments (n-RegArgsN)
++	// SI: &args[RegArgsN]
++	// DI: copy of RSP
++	SUBQ	$RegArgsN, CX
++	MOVQ	R10, SI
++	ADDQ	$(8*RegArgsN), SI
++	MOVQ	SP, DI
++	CLD
++	REP; MOVSQ
++
++#ifndef GOOS_windows
++_6args:
++	MOVQ	(5*8)(R10), R9
++_5args:
++	MOVQ	(4*8)(R10), R8
++#endif
++_4args:
++	MOVQ	(3*8)(R10), CX
++_3args:
++	MOVQ	(2*8)(R10), DX
++_2args:
++	MOVQ	(1*8)(R10), SI
++_1args:
++	MOVQ	(0*8)(R10), DI
++_0args:
++
++	XORL	AX, AX	    // vararg: say "no float args"
++
++#ifdef GOOS_windows
++	// Windows x64 syscall ABI: first four integer args in CX, DX, R8, R9
++	// and 32 bytes of shadow space on the stack.
++	ADJSP	$32
++	MOVQ	CX, R9
++	MOVQ	DX, R8
++	MOVQ	SI, DX
++	MOVQ	DI, CX
++#endif
++
++	CALL	R11
++
++#ifdef GOOS_windows
++	ADJSP	$-32
++#endif
++
++	MOVQ	R14, SP		// free stack space
++
++	// Return result.
++	MOVQ	AX, libcCallInfo_r1(R13)
++	MOVQ	DX, libcCallInfo_r2(R13)
++
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_arm64.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_arm64.s
+new file mode 100644
+index 00000000000000..025276dffb2aa5
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_arm64.s
+@@ -0,0 +1,87 @@
++// Copyright 2015 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !cgo
++
++#include "go_asm.h"
++#include "textflag.h"
++
++TEXT ·syscallNSystemStack_trampoline(SB),NOSPLIT,$16
++	MOVD	R0, 8(RSP)
++	CALL	·syscallNSystemStack(SB)
++	RET
++
++TEXT ·syscallNAsm(SB),NOSPLIT,$0-16
++	// Save original stack pointer
++	MOVD	RSP, R20
++
++	// Load pointer from stack (ABI0 calling convention)
++	MOVD	libcArgs+0(FP), R3
++
++	MOVD	libcCallInfo_args(R3), R12
++	MOVD	libcCallInfo_fn(R3), R13
++	// Do we have more than 8 arguments?
++	MOVD	libcCallInfo_n(R3), R0
++	CMP	$0,	R0; BEQ	_0args
++	CMP	$1,	R0; BEQ	_1args
++	CMP	$2,	R0; BEQ	_2args
++	CMP	$3,	R0; BEQ	_3args
++	CMP	$4,	R0; BEQ	_4args
++	CMP	$5,	R0; BEQ	_5args
++	CMP	$6,	R0; BEQ	_6args
++	CMP	$7,	R0; BEQ	_7args
++	CMP	$8,	R0; BEQ	_8args
++
++	// Reserve stack space for remaining args
++	SUB	$8, R0, R2
++	ADD	$1, R2, R3 // make even number of words for stack alignment
++	AND	$~1, R3
++	LSL	$3, R3
++	SUB	R3, RSP
++
++	// R4: size of stack arguments (n-8)*8
++	// R5: &args[8]
++	// R6: loop counter, from 0 to (n-8)*8
++	// R7: scratch
++	// R8: copy of RSP - (R2)(RSP) assembles as (R2)(ZR)
++	SUB	$8, R0, R4
++	LSL	$3, R4
++	ADD	$(8*8), R12, R5
++	MOVD	$0, R6
++	MOVD	RSP, R8
++stackargs:
++	MOVD	(R6)(R5), R7
++	MOVD	R7, (R6)(R8)
++	ADD	$8, R6
++	CMP	R6, R4
++	BNE	stackargs
++
++_8args:
++	MOVD	(7*8)(R12), R7
++_7args:
++	MOVD	(6*8)(R12), R6
++_6args:
++	MOVD	(5*8)(R12), R5
++_5args:
++	MOVD	(4*8)(R12), R4
++_4args:
++	MOVD	(3*8)(R12), R3
++_3args:
++	MOVD	(2*8)(R12), R2
++_2args:
++	MOVD	(1*8)(R12), R1
++_1args:
++	MOVD	(0*8)(R12), R0
++_0args:
++
++	BL	(R13)
++
++	// Restore original stack pointer
++	MOVD	R20, RSP
++
++	MOVD	libcArgs+0(FP), R3
++	MOVD	R0, libcCallInfo_r1(R3)	// save r1
++	MOVD	R1, libcCallInfo_r2(R3)	// save r2
++
++    RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/dl.h b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/dl.h
+new file mode 100644
+index 00000000000000..9a24f0b6c13b1b
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/dl.h
+@@ -0,0 +1,15 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++// This header file is used by the mkcgo tool to generate cgo and Go bindings for the
++// C APIs. Run "go generate ." to regenerate the bindings.
++
++#ifndef _GO_DL_SHIMS_H // only include this header once
++#define _GO_DL_SHIMS_H
++
++void *dlopen(const char *path, int flags);
++int dlclose(void *handle);
++void *dlsym(void *handle, const char *symbol);
++char *dlerror(void);
++
++#endif // _GO_DL_SHIMS_H
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go
+new file mode 100644
+index 00000000000000..4afefc364b031a
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go
+@@ -0,0 +1,88 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build !cgo
++
++package xsyscall
++
++import (
++	"unsafe"
++)
++
++//go:linkname runtime_cgocall runtime.cgocall
++
++//go:noescape
++func runtime_cgocall(fn uintptr, arg unsafe.Pointer) int32 // from runtime/sys_libc.go
++
++//go:linkname noescape
++//go:nosplit
++func noescape(p unsafe.Pointer) unsafe.Pointer {
++	x := uintptr(p)
++	return unsafe.Pointer(x ^ 0)
++}
++
++type libcCallInfo struct {
++	fn      uintptr
++	n       uintptr // number of parameters
++	args    uintptr // parameters
++	r1, r2  uintptr // return values
++	errType uintptr
++}
++
++//go:noescape
++func syscallNAsm(libcArgs *libcCallInfo)
++
++// syscallNSystemStack performs a syscall on the system stack.
++// It can't allocate Go memory nor grow the stack over the nosplit limit.
++//
++//go:nosplit
++func syscallNSystemStack(libcArgs *libcCallInfo) {
++	syscallNAsm(libcArgs)
++}
++
++var syscallNSystemStack_trampoline byte
++var syscallNSystemStackABIInternal = uintptr(unsafe.Pointer(&syscallNSystemStack_trampoline))
++
++// SyscallN performs a syscall with the given function and arguments.
++//
++// All its parameters and return values must be uintptr in order
++// for the Go compiler to automatically set the //go:uintptrkeepalive
++// directive (which we can't set manually here).
++// See https://github.com/golang/go/blob/9a5a1202f4c4d5a7048b149b65c3e5b82a2de9aa/src/cmd/compile/internal/escape/call.go#L275.
++//
++//go:nosplit
++func SyscallN(errType uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
++	libcArgs := libcCallInfo{
++		fn:      fn,
++		n:       uintptr(len(args)),
++		errType: errType,
++	}
++	if libcArgs.n != 0 {
++		libcArgs.args = uintptr(noescape(unsafe.Pointer(&args[0])))
++	}
++	runtime_cgocall(syscallNSystemStackABIInternal, unsafe.Pointer(&libcArgs))
++	return libcArgs.r1, libcArgs.r2
++}
++
++// Shim syscallN calls SyscallN.
++//
++//go:nosplit
++func syscallN(errType uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
++	return SyscallN(errType, fn, args...)
++}
++
++// syscallNRaw performs a syscall with the given function and arguments,
++// without any error checking nor switching to the system stack.
++//
++//go:nosplit
++func syscallNRaw(fn uintptr, args ...uintptr) uintptr {
++	libcArgs := libcCallInfo{
++		fn: fn,
++		n:  uintptr(len(args)),
++	}
++	if libcArgs.n != 0 {
++		libcArgs.args = uintptr(noescape(unsafe.Pointer(&args[0])))
++	}
++	syscallNAsm(&libcArgs)
++	return libcArgs.r1
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_darwin.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_darwin.go
+new file mode 100644
+index 00000000000000..c7e683e6790a27
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_darwin.go
+@@ -0,0 +1,25 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build !cgo
++
++package xsyscall
++
++import (
++	"unsafe"
++
++	_ "github.com/microsoft/go-crypto-darwin/internal/fakecgo"
++)
++
++//go:cgo_import_dynamic _ _ "/usr/lib/libSystem.B.dylib"
++
++func dlsym(handle unsafe.Pointer, symbol string, optional bool) uintptr {
++	r0 := Dlsym(handle, unsafe.StringData(symbol))
++	if r0 == nil {
++		if !optional {
++			panic("cannot get required symbol " + symbol)
++		}
++		return 0
++	}
++	return uintptr(r0)
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go
+new file mode 100644
+index 00000000000000..458053d55e4541
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go
+@@ -0,0 +1,6 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++package xsyscall
++
++//go:generate go run ../../cmd/mkcgo -out zdl.go -nocgo -mode dynamic -noerrors -package xsyscall -tags "darwin" dl.h
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl.s
+new file mode 100644
+index 00000000000000..9ab8a302416064
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl.s
+@@ -0,0 +1,54 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++// Code generated by mkcgo. DO NOT EDIT.
++
++//go:build !cgo && (darwin)
++
++#include "textflag.h"
++
++
++#ifndef GOARCH_amd64
++#ifndef GOARCH_arm64
++#ifndef GOARCH_riscv64
++#ifndef GOARCH_loong64
++#ifndef GOARCH_mips64
++#ifndef GOARCH_mips64le
++#ifndef GOARCH_ppc64
++#ifndef GOARCH_ppc64le
++#ifndef GOARCH_sparc64
++#define _GOPTRSIZE 4
++#endif
++#endif
++#endif
++#endif
++#endif
++#endif
++#endif
++#endif
++#endif
++
++
++#ifndef _GOPTRSIZE
++#define _GOPTRSIZE 8
++#endif
++TEXT _mkcgo_dlclose_trampoline<>(SB),NOSPLIT,$0-0
++    JMP _mkcgo_dlclose(SB)
++GLOBL   ·_mkcgo_dlclose_trampoline_addr(SB), RODATA, $_GOPTRSIZE
++DATA    ·_mkcgo_dlclose_trampoline_addr(SB)/_GOPTRSIZE, $_mkcgo_dlclose_trampoline<>(SB)
++
++TEXT _mkcgo_dlerror_trampoline<>(SB),NOSPLIT,$0-0
++    JMP _mkcgo_dlerror(SB)
++GLOBL   ·_mkcgo_dlerror_trampoline_addr(SB), RODATA, $_GOPTRSIZE
++DATA    ·_mkcgo_dlerror_trampoline_addr(SB)/_GOPTRSIZE, $_mkcgo_dlerror_trampoline<>(SB)
++
++TEXT _mkcgo_dlopen_trampoline<>(SB),NOSPLIT,$0-0
++    JMP _mkcgo_dlopen(SB)
++GLOBL   ·_mkcgo_dlopen_trampoline_addr(SB), RODATA, $_GOPTRSIZE
++DATA    ·_mkcgo_dlopen_trampoline_addr(SB)/_GOPTRSIZE, $_mkcgo_dlopen_trampoline<>(SB)
++
++TEXT _mkcgo_dlsym_trampoline<>(SB),NOSPLIT,$0-0
++    JMP _mkcgo_dlsym(SB)
++GLOBL   ·_mkcgo_dlsym_trampoline_addr(SB), RODATA, $_GOPTRSIZE
++DATA    ·_mkcgo_dlsym_trampoline_addr(SB)/_GOPTRSIZE, $_mkcgo_dlsym_trampoline<>(SB)
++
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl_nocgo.go
+new file mode 100644
+index 00000000000000..a30d07b27ed848
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl_nocgo.go
+@@ -0,0 +1,48 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++// Code generated by mkcgo. DO NOT EDIT.
++
++//go:build !cgo && darwin
++
++package xsyscall
++
++import (
++	"runtime"
++	"unsafe"
++)
++
++var _ = runtime.GOOS
++
++//go:cgo_import_dynamic _mkcgo_dlclose dlclose ""
++//go:cgo_import_dynamic _mkcgo_dlerror dlerror ""
++//go:cgo_import_dynamic _mkcgo_dlopen dlopen ""
++//go:cgo_import_dynamic _mkcgo_dlsym dlsym ""
++
++var _mkcgo_dlclose_trampoline_addr uintptr
++
++func Dlclose(handle unsafe.Pointer) int32 {
++	r0, _ := syscallN(0, _mkcgo_dlclose_trampoline_addr, uintptr(handle))
++	return int32(r0)
++}
++
++var _mkcgo_dlerror_trampoline_addr uintptr
++
++func Dlerror() *byte {
++	r0, _ := syscallN(0, _mkcgo_dlerror_trampoline_addr)
++	return (*byte)(unsafe.Pointer(r0))
++}
++
++var _mkcgo_dlopen_trampoline_addr uintptr
++
++func Dlopen(path *byte, flags int32) unsafe.Pointer {
++	r0, _ := syscallN(0, _mkcgo_dlopen_trampoline_addr, uintptr(unsafe.Pointer(path)), uintptr(flags))
++	return unsafe.Pointer(r0)
++}
++
++var _mkcgo_dlsym_trampoline_addr uintptr
++
++func Dlsym(handle unsafe.Pointer, symbol *byte) unsafe.Pointer {
++	r0, _ := syscallN(0, _mkcgo_dlsym_trampoline_addr, uintptr(handle), uintptr(unsafe.Pointer(symbol)))
++	return unsafe.Pointer(r0)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/aes.go b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/aes.go
 new file mode 100644
@@ -32564,10 +34353,10 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b6f6376eac041a..ed909c054ed7dc 100644
+index b6f6376eac041a..abbd76905ca2c4 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
-@@ -1,3 +1,24 @@
+@@ -1,3 +1,26 @@
 +# github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83
 +## explicit; go 1.24
 +github.com/golang-fips/openssl/v2
@@ -32575,12 +34364,14 @@ index b6f6376eac041a..ed909c054ed7dc 100644
 +github.com/golang-fips/openssl/v2/internal/fakecgo
 +github.com/golang-fips/openssl/v2/internal/ossl
 +github.com/golang-fips/openssl/v2/osslsetup
-+# github.com/microsoft/go-crypto-darwin v0.0.3-0.20251202082849-356ad09993bc
++# github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215114330-a772e33d86d0
 +## explicit; go 1.24
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/commoncrypto
 +github.com/microsoft/go-crypto-darwin/internal/cryptokit
++github.com/microsoft/go-crypto-darwin/internal/fakecgo
 +github.com/microsoft/go-crypto-darwin/internal/security
++github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
 +# github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79
 +## explicit; go 1.24

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -189,6 +189,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go-crypto-darwin/internal/xsyscall/dl.h   |   15 +
  .../internal/xsyscall/syscall_nocgo.go        |   88 +
  .../internal/xsyscall/syscall_nocgo_darwin.go |   25 +
+ .../internal/xsyscall/syscall_nocgo_others.go |   14 +
  .../internal/xsyscall/xsyscall.go             |    6 +
  .../go-crypto-darwin/internal/xsyscall/zdl.s  |   54 +
  .../internal/xsyscall/zdl_nocgo.go            |   48 +
@@ -241,7 +242,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 233 files changed, 30516 insertions(+), 7 deletions(-)
+ 234 files changed, 30530 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -416,6 +417,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/dl.h
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_darwin.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_others.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl_nocgo.go
@@ -2128,7 +2130,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index efc07451b53448..e31efae65705c0 100644
+index efc07451b53448..4e945511073ecc 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2138,18 +2140,18 @@ index efc07451b53448..e31efae65705c0 100644
 +
 +require (
 +	github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83
-+	github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215134426-d7fa8738280f
++	github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215143607-e068212c5cff
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79
 +)
 diff --git a/src/go.sum b/src/go.sum
-index b6b841b44d8e38..472a3410927490 100644
+index b6b841b44d8e38..e42e19781dd7f2 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83 h1:u3WAHp425YzcHygZORNJa9dkyA959Gtti8bUgGYYuiA=
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215134426-d7fa8738280f h1:Uj26IA3n2m2NWM/IaYpjyVEoF50KrZmK2wXUDoDsxew=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215134426-d7fa8738280f/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215143607-e068212c5cff h1:oerudO/EXeLnT69uP9hbjqwCBZ5RuIwF02vkCOY1nBs=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215143607-e068212c5cff/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79 h1:u3ZftMj7JpCAl4Ku8LUngqfn7pNuQG9mAsNMlSjBvDI=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00 h1:JgcPM1rzpSOZS8y69FQvnY0xN0ciHlpQqwTXJcuZIA4=
@@ -26620,6 +26622,26 @@ index 00000000000000..c7e683e6790a27
 +	}
 +	return uintptr(r0)
 +}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_others.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_others.go
+new file mode 100644
+index 00000000000000..28dba16a23340e
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_others.go
+@@ -0,0 +1,14 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build !cgo && !(amd64 || arm64)
++
++package xsyscall
++
++// Implement a mock version of SyscallN for unsupported architectures.
++// This will simply panic to indicate that the syscall is not supported.
++
++//go:nosplit
++func SyscallN(errType uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
++	panic("SyscallN is not supported on this architecture")
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go
 new file mode 100644
 index 00000000000000..458053d55e4541
@@ -34362,7 +34384,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b6f6376eac041a..adca7d77fdd0e4 100644
+index b6f6376eac041a..94f52f58126855 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
@@ -34373,7 +34395,7 @@ index b6f6376eac041a..adca7d77fdd0e4 100644
 +github.com/golang-fips/openssl/v2/internal/fakecgo
 +github.com/golang-fips/openssl/v2/internal/ossl
 +github.com/golang-fips/openssl/v2/osslsetup
-+# github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215134426-d7fa8738280f
++# github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215143607-e068212c5cff
 +## explicit; go 1.24
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/commoncrypto

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -35,7 +35,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  src/crypto/internal/backend/deps_ignore.go    |   22 +
  src/go.mod                                    |    6 +
  src/go.sum                                    |    6 +
- src/go/build/deps_test.go                     |   53 +-
+ src/go/build/deps_test.go                     |   55 +-
  src/go/build/vendor_test.go                   |    4 +
  .../golang-fips/openssl/v2/.gitignore         |    2 +
  .../golang-fips/openssl/v2/.gitleaks.toml     |    9 +
@@ -241,7 +241,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 233 files changed, 30514 insertions(+), 7 deletions(-)
+ 233 files changed, 30516 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -2128,7 +2128,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index efc07451b53448..987fa0c8fd398a 100644
+index efc07451b53448..e31efae65705c0 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2138,28 +2138,42 @@ index efc07451b53448..987fa0c8fd398a 100644
 +
 +require (
 +	github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83
-+	github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215114330-a772e33d86d0
++	github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215134426-d7fa8738280f
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79
 +)
 diff --git a/src/go.sum b/src/go.sum
-index b6b841b44d8e38..98d8a46eb7c60a 100644
+index b6b841b44d8e38..472a3410927490 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83 h1:u3WAHp425YzcHygZORNJa9dkyA959Gtti8bUgGYYuiA=
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20251205103838-300bb5780a83/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215114330-a772e33d86d0 h1:8kRyOO5QwtWJ/dbM8wt631YL0bAklLF7REuDvq5ivcE=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215114330-a772e33d86d0/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215134426-d7fa8738280f h1:Uj26IA3n2m2NWM/IaYpjyVEoF50KrZmK2wXUDoDsxew=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215134426-d7fa8738280f/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79 h1:u3ZftMj7JpCAl4Ku8LUngqfn7pNuQG9mAsNMlSjBvDI=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20251202082756-9cab7d2d4a79/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00 h1:JgcPM1rzpSOZS8y69FQvnY0xN0ciHlpQqwTXJcuZIA4=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
  golang.org/x/net v0.47.1-0.20251128220604-7c360367ab7e h1:PAAT9cIDvIAIRQVz2txQvUFRt3jOlhiO84ihd8XMGlg=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index f4b7e9dae5f3ae..ec7221ba7150dd 100644
+index f4b7e9dae5f3ae..3f2b2399ec4127 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -548,16 +548,51 @@ var depsRules = `
+@@ -154,6 +154,13 @@ var depsRules = `
+ 	< internal/syscall/execenv
+ 	< SYSCALL;
+ 
++	syscall, unsafe
++	< github.com/microsoft/go-crypto-darwin/internal/fakecgo
++	< github.com/microsoft/go-crypto-darwin/internal/xsyscall
++	< github.com/microsoft/go-crypto-darwin/internal/commoncrypto,
++	  github.com/microsoft/go-crypto-darwin/internal/cryptokit,
++	  github.com/microsoft/go-crypto-darwin/internal/security;
++
+ 	# TIME is SYSCALL plus the core packages about time, including context.
+ 	SYSCALL
+ 	< time/tzdata
+@@ -548,16 +555,46 @@ var depsRules = `
  	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
  	sync/atomic < crypto/internal/boring/bcache;
  
@@ -2171,11 +2185,6 @@ index f4b7e9dae5f3ae..ec7221ba7150dd 100644
 +	< github.com/golang-fips/openssl/v2/internal/fakecgo
 +	< github.com/golang-fips/openssl/v2/internal/ossl
 +	< github.com/golang-fips/openssl/v2/osslsetup;
-+
-+	syscall
-+	< github.com/microsoft/go-crypto-darwin/internal/commoncrypto,
-+	  github.com/microsoft/go-crypto-darwin/internal/security,
-+	  github.com/microsoft/go-crypto-darwin/internal/cryptokit;
 +
 +	syscall, strconv
 +	< github.com/microsoft/go-crypto-winnative/internal/subtle
@@ -2216,7 +2225,7 @@ index f4b7e9dae5f3ae..ec7221ba7150dd 100644
  	< crypto/internal/boring
  	< crypto/boring
  	< crypto/internal/rand
-@@ -579,6 +614,10 @@ var depsRules = `
+@@ -579,6 +616,10 @@ var depsRules = `
  
  	# CRYPTO-MATH is crypto that exposes math/big APIs - no cgo, net; fmt now ok.
  
@@ -2227,7 +2236,7 @@ index f4b7e9dae5f3ae..ec7221ba7150dd 100644
  	CRYPTO, FMT, math/big, internal/saferio
  	< crypto/internal/boring/bbig
  	< crypto/internal/fips140cache
-@@ -925,7 +964,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -925,7 +966,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -2236,7 +2245,7 @@ index f4b7e9dae5f3ae..ec7221ba7150dd 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -935,7 +974,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -935,7 +976,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}
@@ -26488,14 +26497,14 @@ index 00000000000000..9a24f0b6c13b1b
 +#endif // _GO_DL_SHIMS_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go
 new file mode 100644
-index 00000000000000..4afefc364b031a
+index 00000000000000..20f2ae5d853877
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go
 @@ -0,0 +1,88 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
-+//go:build !cgo
++//go:build !cgo && (amd64 || arm64)
 +
 +package xsyscall
 +
@@ -34353,7 +34362,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b6f6376eac041a..abbd76905ca2c4 100644
+index b6f6376eac041a..adca7d77fdd0e4 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
@@ -34364,7 +34373,7 @@ index b6f6376eac041a..abbd76905ca2c4 100644
 +github.com/golang-fips/openssl/v2/internal/fakecgo
 +github.com/golang-fips/openssl/v2/internal/ossl
 +github.com/golang-fips/openssl/v2/osslsetup
-+# github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215114330-a772e33d86d0
++# github.com/microsoft/go-crypto-darwin v0.0.3-0.20251215134426-d7fa8738280f
 +## explicit; go 1.24
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/commoncrypto


### PR DESCRIPTION
In https://github.com/microsoft/go-crypto-darwin/pull/129 we switched from using syscallN to using the purego implementation of fakecgo which aligns more closely with the OpenSSL backend.