### PR TITLE
Docs: clarify interaction of backend env vars; add more links

### DIFF
--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -360,6 +360,8 @@ If the change requires further planning and if it's acceptable for your project 
 
 After that, build commands won't encounter errors related to `systemcrypto`, and the resulting program won't attempt to use system-provided cryptography at runtime.
 
+For more information about these options, see [the "Build option to use Go crypto" section of the FIPS README](fips/README.md#build-option-to-use-go-crypto-if-the-backend-compatibility-check-fails).
+
 Alternatively, if you experienced an unexpected auto-update to 1.25 that broke your project, you should downgrade to the latest version of 1.24.
 This will disable `systemcrypto` by default and give you time to plan the migration.
 You can choose to upgrade at your own pace, as long as you complete the migration before 1.24 reaches EOL (End of Life).

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -137,6 +137,8 @@ Setting the `goexperiment.<option>` build tag can be used as an alternative to s
 If a crypto backend is selected but isn't supported, the build fails.
 For example, attempting to use the OpenSSL backend without cgo enabled results in a build error.
 
+For more information about disabling the crypto backend, see [build option to use Go crypto](#build-option-to-use-go-crypto-if-the-backend-compatibility-check-fails).
+
 The next sections describe how to select a crypto backend in some common scenarios.
 
 ### Dockerfile base image
@@ -380,6 +382,10 @@ These are other fixes that may be used on a case-by-case basis:
   - With Go 1.25 or later, set `GOEXPERIMENT=nosystemcrypto`.
   - With Go 1.24, either set `GOEXPERIMENT=nosystemcrypto` or remove the `GOEXPERIMENT` setting entirely.
 - Refactor the code to not use a `crypto` package. For example, when computing a hash for non-cryptographic purposes, there are several alternatives in the Go standard library that don't require a crypto backend, such as `hash/fnv` or `hash/maphash`.
+
+> [!NOTE]
+> `MS_GO_NOSYSTEMCRYPTO=1` has precedence over `GOEXPERIMENT` values.
+> For example, setting `MS_GO_NOSYSTEMCRYPTO=1` and `GOEXPERIMENT=systemcrypto` builds a program that uses Go standard library cryptography.
 
 > [!IMPORTANT]
 > Individual crypto calls may fall back to standard Go crypto at runtime if the selected backend doesn't support an API or the arguments used. See the [FIPS User Guide](UserGuide.md) for more information.


### PR DESCRIPTION
In another project I caught some code that made the assumption that setting `GOEXPERIMENT=systemcrypto` is enough to make sure that systemcrypto will be used, but it isn't anymore if `MS_GO_NOSYSTEMCRYPTO=1` is being used. Making a quick update the docs and pointing other docs to the update in the FIPS docs to make it reasonable to find the note.