### PR TITLE
crypto doc: prevent duplicate notes across all platforms

### DIFF
--- a/eng/_util/cmd/updatecryptodocs/docs.go
+++ b/eng/_util/cmd/updatecryptodocs/docs.go
@@ -496,42 +496,14 @@ var doc = Document{
 			Items: []Item{
 				{
 					Name: "PBKDF2",
-					Platforms: map[string]PlatformStatus{
-						"windows": {
-							Notes: []string{
-								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
-							},
-						},
-						"linux": {
-							Notes: []string{
-								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
-							},
-						},
-						"macos": {
-							Notes: []string{
-								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
-							},
-						},
+					Notes: []string{
+						"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
 					},
 				},
 				{
 					Name: "HKDF",
-					Platforms: map[string]PlatformStatus{
-						"windows": {
-							Notes: []string{
-								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
-							},
-						},
-						"linux": {
-							Notes: []string{
-								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
-							},
-						},
-						"macos": {
-							Notes: []string{
-								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
-							},
-						},
+					Notes: []string{
+						"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
 					},
 				},
 			},

--- a/eng/_util/cmd/updatecryptodocs/updatecryptodocs.go
+++ b/eng/_util/cmd/updatecryptodocs/updatecryptodocs.go
@@ -322,6 +322,22 @@ func validateSection(section Section) error {
 				return fmt.Errorf("invalid supported status %q for item %q on platform %q", status.Supported, item.Name, p)
 			}
 		}
+
+		// Check for notes common to all platforms
+		noteCounts := make(map[string]int)
+		platforms := []string{"windows", "linux", "macos"}
+		for _, p := range platforms {
+			status := item.Platforms[p]
+			for _, note := range status.Notes {
+				noteCounts[note]++
+			}
+		}
+
+		for note, count := range noteCounts {
+			if count == len(platforms) {
+				return fmt.Errorf("note %q appears in all platforms for item %q; move it to the item level", note, item.Name)
+			}
+		}
 	}
 	for _, sub := range section.Subsections {
 		if err := validateSection(sub); err != nil {

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -251,10 +251,10 @@ This section includes the following packages:
 - [crypto/hkdf](https://pkg.go.dev/crypto/hkdf)
 - [crypto/pbkdf2](https://pkg.go.dev/crypto/pbkdf2)
 
-| Functions | Windows        | Linux          | macOS          |
-| --------- | -------------- | -------------- | -------------- |
-| PBKDF2    | ✔️<sup>1</sup> | ✔️<sup>1</sup> | ✔️<sup>1</sup> |
-| HKDF      | ✔️<sup>1</sup> | ✔️<sup>1</sup> | ✔️<sup>1</sup> |
+| Functions          | Windows | Linux | macOS |
+| ------------------ | ------- | ----- | ----- |
+| PBKDF2<sup>1</sup> | ✔️      | ✔️    | ✔️    |
+| HKDF<sup>1</sup>   | ✔️      | ✔️    | ✔️    |
 
 <sup>1</sup>Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).
 


### PR DESCRIPTION
We should avoid having duplicate footnotes for all platforms.