### PR TITLE
updatecryptodocs: consolidate platform types

### DIFF
--- a/eng/_util/cmd/updatecryptodocs/docs.go
+++ b/eng/_util/cmd/updatecryptodocs/docs.go
@@ -9,34 +9,61 @@ import _ "embed"
 //go:embed header.md
 var header string
 
+type SupportStatus int
+
+const (
+	Supported SupportStatus = iota
+	NotSupported
+	Warn
+	N_A
+)
+
 type PlatformStatus struct {
-	Supported         string
-	MinGoVersion      string
-	Notes             []string
-	MinMacOSVersion   string
-	MinOpenSSLVersion string
+	Supported    SupportStatus
+	MinGoVersion string
+	Notes        []string
+	MinVersion   string
 }
 
 type Item struct {
 	Name         string
 	MinGoVersion string
 	Notes        []string
-	Platforms    map[string]PlatformStatus
+	Platforms    Platforms
+}
+
+var SupportedPlatforms = []string{"windows", "linux", "macos"}
+
+type Platforms struct {
+	Windows PlatformStatus
+	Linux   PlatformStatus
+	MacOS   PlatformStatus
+}
+
+func (s Platforms) Get(platform string) PlatformStatus {
+	switch platform {
+	case "windows":
+		return s.Windows
+	case "linux":
+		return s.Linux
+	case "macos":
+		return s.MacOS
+	default:
+		panic("unknown platform: " + platform)
+	}
 }
 
 type Section struct {
-	Title             string
-	ShortTitle        string
-	ColumnHeader      string
-	Packages          []string
-	Description       string
-	MinGoVersion      string
-	MinMacOSVersion   string
-	MinOpenSSLVersion string
-	Items             []Item
-	Subsections       []Section
-	Footnotes         []string
-	Footer            string
+	Title        string
+	ShortTitle   string
+	ColumnHeader string
+	Packages     []string
+	Description  string
+	MinGoVersion string
+	Items        []Item
+	Subsections  []Section
+	Footnotes    []string
+	Footer       string
 }
 
 type Document struct {
@@ -60,8 +87,8 @@ var doc = Document{
 				{Name: "SHA-1"},
 				{
 					Name: "SHA-2-224",
-					Platforms: map[string]PlatformStatus{
-						"windows": {Supported: "false"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{Name: "SHA-2-256"},
@@ -69,88 +96,82 @@ var doc = Document{
 				{Name: "SHA-2-512"},
 				{
 					Name: "SHA-2-512_224",
-					Platforms: map[string]PlatformStatus{
-						"windows": {Supported: "false"},
-						"linux":   {MinGoVersion: "1.24", MinOpenSSLVersion: "1.1.1"},
-						"macos":   {Supported: "false"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{Supported: NotSupported},
+						Linux:   PlatformStatus{MinGoVersion: "1.24", MinVersion: "1.1.1"},
+						MacOS:   PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
 					Name: "SHA-2-512_256",
-					Platforms: map[string]PlatformStatus{
-						"windows": {Supported: "false"},
-						"linux":   {MinGoVersion: "1.24", MinOpenSSLVersion: "1.1.1"},
-						"macos":   {Supported: "false"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{Supported: NotSupported},
+						Linux:   PlatformStatus{MinGoVersion: "1.24", MinVersion: "1.1.1"},
+						MacOS:   PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
 					Name:         "SHA-3-224",
 					MinGoVersion: "1.26",
-					Platforms: map[string]PlatformStatus{
-						"windows": {Supported: "false"},
-						"linux":   {MinOpenSSLVersion: "1.1.1"},
-						"macos":   {Supported: "false"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{Supported: NotSupported},
+						Linux:   PlatformStatus{MinVersion: "1.1.1"},
+						MacOS:   PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
 					Name:         "SHA-3-256",
 					MinGoVersion: "1.26",
-					Platforms: map[string]PlatformStatus{
-						"windows": {
-							Notes: []string{"Available in Windows 11, version 24H2 or later."},
-						},
-						"linux": {MinOpenSSLVersion: "1.1.1"},
-						"macos": {MinMacOSVersion: "26"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{MinVersion: "11 (24H2)"},
+						Linux:   PlatformStatus{MinVersion: "1.1.1"},
+						MacOS:   PlatformStatus{MinVersion: "26"},
 					},
 				},
 				{
 					Name:         "SHA-3-384",
 					MinGoVersion: "1.26",
-					Platforms: map[string]PlatformStatus{
-						"windows": {
-							Notes: []string{"Available in Windows 11, version 24H2 or later."},
-						},
-						"linux": {MinOpenSSLVersion: "1.1.1"},
-						"macos": {MinMacOSVersion: "26"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{MinVersion: "11 (24H2)"},
+						Linux:   PlatformStatus{MinVersion: "1.1.1"},
+						MacOS:   PlatformStatus{MinVersion: "26"},
 					},
 				},
 				{
 					Name:         "SHA-3-512",
 					MinGoVersion: "1.26",
-					Platforms: map[string]PlatformStatus{
-						"windows": {
-							Notes: []string{"Available in Windows 11, version 24H2 or later."},
-						},
-						"linux": {MinOpenSSLVersion: "1.1.1"},
-						"macos": {MinMacOSVersion: "26"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{MinVersion: "11 (24H2)"},
+						Linux:   PlatformStatus{MinVersion: "1.1.1"},
+						MacOS:   PlatformStatus{MinVersion: "26"},
 					},
 				},
 				{
 					Name: "SHAKE-128",
-					Platforms: map[string]PlatformStatus{
-						"linux": {MinOpenSSLVersion: "3.3"},
-						"macos": {Supported: "false"},
+					Platforms: Platforms{
+						Linux: PlatformStatus{MinVersion: "3.3"},
+						MacOS: PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
 					Name: "SHAKE-256",
-					Platforms: map[string]PlatformStatus{
-						"linux": {MinOpenSSLVersion: "3.3"},
-						"macos": {Supported: "false"},
+					Platforms: Platforms{
+						Linux: PlatformStatus{MinVersion: "3.3"},
+						MacOS: PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
 					Name: "CSHAKE-128",
-					Platforms: map[string]PlatformStatus{
-						"linux": {Supported: "false"},
-						"macos": {Supported: "false"},
+					Platforms: Platforms{
+						Linux: PlatformStatus{Supported: NotSupported},
+						MacOS: PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
 					Name: "CSHAKE-256",
-					Platforms: map[string]PlatformStatus{
-						"linux": {Supported: "false"},
-						"macos": {Supported: "false"},
+					Platforms: Platforms{
+						Linux: PlatformStatus{Supported: NotSupported},
+						MacOS: PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
@@ -171,25 +192,25 @@ var doc = Document{
 				{Name: "AES-CBC"},
 				{
 					Name: "AES-CTR",
-					Platforms: map[string]PlatformStatus{
-						"windows": {Supported: "false"},
-						"macos":   {Supported: "false"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{Supported: NotSupported},
+						MacOS:   PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
 					Name: "AES-CFB",
-					Platforms: map[string]PlatformStatus{
-						"windows": {Supported: "false"},
-						"linux":   {Supported: "false"},
-						"macos":   {Supported: "false"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{Supported: NotSupported},
+						Linux:   PlatformStatus{Supported: NotSupported},
+						MacOS:   PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
 					Name: "AES-OFB",
-					Platforms: map[string]PlatformStatus{
-						"windows": {Supported: "false"},
-						"linux":   {Supported: "false"},
-						"macos":   {Supported: "false"},
+					Platforms: Platforms{
+						Windows: PlatformStatus{Supported: NotSupported},
+						Linux:   PlatformStatus{Supported: NotSupported},
+						MacOS:   PlatformStatus{Supported: NotSupported},
 					},
 				},
 				{
@@ -198,9 +219,9 @@ var doc = Document{
 				},
 				{
 					Name: "DES-CBC",
-					Platforms: map[string]PlatformStatus{
-						"linux": {
-							Supported: "warn",
+					Platforms: Platforms{
+						Linux: PlatformStatus{
+							Supported: Warn,
 							Notes: []string{
 								"When using OpenSSL 3, requires the legacy provider to be enabled.",
 							},
@@ -209,9 +230,9 @@ var doc = Document{
 				},
 				{
 					Name: "DES-ECB",
-					Platforms: map[string]PlatformStatus{
-						"linux": {
-							Supported: "warn",
+					Platforms: Platforms{
+						Linux: PlatformStatus{
+							Supported: Warn,
 							Notes: []string{
 								"When using OpenSSL 3, requires the legacy provider to be enabled.",
 							},
@@ -222,9 +243,9 @@ var doc = Document{
 				{Name: "3DES-CBC"},
 				{
 					Name: "RC4",
-					Platforms: map[string]PlatformStatus{
-						"linux": {
-							Supported: "warn",
+					Platforms: Platforms{
+						Linux: PlatformStatus{
+							Supported: Warn,
 							Notes: []string{
 								"When using OpenSSL 3, requires the legacy provider to be enabled.",
 							},
@@ -246,8 +267,8 @@ var doc = Document{
 					Items: []Item{
 						{
 							Name: "OAEP (MD5)",
-							Platforms: map[string]PlatformStatus{
-								"macos": {
+							Platforms: Platforms{
+								MacOS: PlatformStatus{
 									Notes: []string{
 										"macOS doesn't support passing a custom label to OAEP functions.",
 									},
@@ -256,8 +277,8 @@ var doc = Document{
 						},
 						{
 							Name: "OAEP (SHA-1)",
-							Platforms: map[string]PlatformStatus{
-								"macos": {
+							Platforms: Platforms{
+								MacOS: PlatformStatus{
 									Notes: []string{
 										"macOS doesn't support passing a custom label to OAEP functions.",
 									},
@@ -269,8 +290,8 @@ var doc = Document{
 							Notes: []string{
 								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
 							},
-							Platforms: map[string]PlatformStatus{
-								"macos": {
+							Platforms: Platforms{
+								MacOS: PlatformStatus{
 									Notes: []string{
 										"macOS doesn't support passing a custom label to OAEP functions.",
 									},
@@ -279,34 +300,34 @@ var doc = Document{
 						},
 						{
 							Name: "OAEP (SHA-3)",
-							Platforms: map[string]PlatformStatus{
-								"windows": {Supported: "false"},
-								"linux":   {Supported: "false"},
-								"macos":   {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{Supported: NotSupported},
+								Linux:   PlatformStatus{Supported: NotSupported},
+								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "PSS (MD5)",
-							Platforms: map[string]PlatformStatus{
-								"windows": {
+							Platforms: Platforms{
+								Windows: PlatformStatus{
 									Notes: []string{
-										"On Windows, when verifying a PSS signature, [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.",
+										"Verifying PSS signatures with [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.",
 									},
 								},
-								"macos": {Supported: "false"},
+								MacOS: PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "PSS (SHA-1)",
-							Platforms: map[string]PlatformStatus{
-								"windows": {
+							Platforms: Platforms{
+								Windows: PlatformStatus{
 									Notes: []string{
-										"On Windows, when verifying a PSS signature, [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.",
+										"Verifying PSS signatures with [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.",
 									},
 								},
-								"macos": {
+								MacOS: PlatformStatus{
 									Notes: []string{
-										"On macOS, custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).",
+										"Custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).",
 									},
 								},
 							},
@@ -316,56 +337,56 @@ var doc = Document{
 							Notes: []string{
 								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
 							},
-							Platforms: map[string]PlatformStatus{
-								"windows": {
+							Platforms: Platforms{
+								Windows: PlatformStatus{
 									Notes: []string{
-										"On Windows, when verifying a PSS signature, [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.",
+										"Verifying PSS signatures with [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.",
 									},
 								},
-								"macos": {
+								MacOS: PlatformStatus{
 									Notes: []string{
-										"On macOS, custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).",
+										"Custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).",
 									},
 								},
 							},
 						},
 						{
 							Name: "PSS (SHA-3)",
-							Platforms: map[string]PlatformStatus{
-								"windows": {Supported: "false"},
-								"linux":   {Supported: "false"},
-								"macos":   {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{Supported: NotSupported},
+								Linux:   PlatformStatus{Supported: NotSupported},
+								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{Name: "PKCS1v15 Signature (Unhashed)"},
 						{
 							Name: "PKCS1v15 Signature (RIPMED160)",
-							Platforms: map[string]PlatformStatus{
-								"windows": {Supported: "false"},
-								"linux":   {MinGoVersion: "1.24"},
-								"macos":   {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{Supported: NotSupported},
+								Linux:   PlatformStatus{MinGoVersion: "1.24"},
+								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "PKCS1v15 Signature (MD4)",
-							Platforms: map[string]PlatformStatus{
-								"windows": {Supported: "false"},
-								"linux":   {MinGoVersion: "1.24"},
-								"macos":   {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{Supported: NotSupported},
+								Linux:   PlatformStatus{MinGoVersion: "1.24"},
+								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "PKCS1v15 Signature (MD5)",
-							Platforms: map[string]PlatformStatus{
-								"macos": {Supported: "false"},
+							Platforms: Platforms{
+								MacOS: PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "PKCS1v15 Signature (MD5-SHA1)",
-							Platforms: map[string]PlatformStatus{
-								"windows": {MinGoVersion: "1.24"},
-								"linux":   {MinGoVersion: "1.24"},
-								"macos":   {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{MinGoVersion: "1.24"},
+								Linux:   PlatformStatus{MinGoVersion: "1.24"},
+								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{Name: "PKCS1v15 Signature (SHA-1)"},
@@ -377,10 +398,10 @@ var doc = Document{
 						},
 						{
 							Name: "PKCS1v15 Signature (SHA-3)",
-							Platforms: map[string]PlatformStatus{
-								"windows": {Supported: "false"},
-								"linux":   {Supported: "false"},
-								"macos":   {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{Supported: NotSupported},
+								Linux:   PlatformStatus{Supported: NotSupported},
+								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 					},
@@ -393,8 +414,8 @@ var doc = Document{
 					Items: []Item{
 						{
 							Name: "NIST P-224 (secp224r1)",
-							Platforms: map[string]PlatformStatus{
-								"macos": {Supported: "false"},
+							Platforms: Platforms{
+								MacOS: PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{Name: "NIST P-256 (secp256r1)"},
@@ -410,8 +431,8 @@ var doc = Document{
 					Items: []Item{
 						{
 							Name: "NIST P-224 (secp224r1)",
-							Platforms: map[string]PlatformStatus{
-								"macos": {Supported: "false"},
+							Platforms: Platforms{
+								MacOS: PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{Name: "NIST P-256 (secp256r1)"},
@@ -420,8 +441,8 @@ var doc = Document{
 						{
 							Name:         "X25519 (curve25519)",
 							MinGoVersion: "1.26",
-							Platforms: map[string]PlatformStatus{
-								"linux": {MinOpenSSLVersion: "1.1.1"},
+							Platforms: Platforms{
+								Linux: PlatformStatus{MinVersion: "1.1.1"},
 							},
 						},
 					},
@@ -434,24 +455,24 @@ var doc = Document{
 					Items: []Item{
 						{
 							Name: "Ed25519",
-							Platforms: map[string]PlatformStatus{
-								"windows": {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "Ed25519ctx",
-							Platforms: map[string]PlatformStatus{
-								"windows": {Supported: "false"},
-								"linux":   {Supported: "false"},
-								"macos":   {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{Supported: NotSupported},
+								Linux:   PlatformStatus{Supported: NotSupported},
+								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "Ed25519ph",
-							Platforms: map[string]PlatformStatus{
-								"windows": {Supported: "false"},
-								"linux":   {Supported: "false"},
-								"macos":   {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{Supported: NotSupported},
+								Linux:   PlatformStatus{Supported: NotSupported},
+								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 					},
@@ -462,27 +483,27 @@ var doc = Document{
 					Items: []Item{
 						{
 							Name: "L1024N160",
-							Platforms: map[string]PlatformStatus{
-								"macos": {Supported: "false"},
+							Platforms: Platforms{
+								MacOS: PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "L2048N224",
-							Platforms: map[string]PlatformStatus{
-								"windows": {Supported: "false"},
-								"macos":   {Supported: "false"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{Supported: NotSupported},
+								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "L2048N256",
-							Platforms: map[string]PlatformStatus{
-								"macos": {Supported: "false"},
+							Platforms: Platforms{
+								MacOS: PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
 							Name: "L3072N256",
-							Platforms: map[string]PlatformStatus{
-								"macos": {Supported: "false"},
+							Platforms: Platforms{
+								MacOS: PlatformStatus{Supported: NotSupported},
 							},
 						},
 					},
@@ -520,26 +541,18 @@ var doc = Document{
 					Items: []Item{
 						{
 							Name: "768",
-							Platforms: map[string]PlatformStatus{
-								"windows": {
-									Notes: []string{
-										"Requires Windows Server 2025 or Windows 11 (24H2, 25H2) or later.",
-									},
-								},
-								"linux": {MinOpenSSLVersion: "3.5.0"},
-								"macos": {MinMacOSVersion: "26"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{MinVersion: "11 (24H2)"},
+								Linux:   PlatformStatus{MinVersion: "3.5.0"},
+								MacOS:   PlatformStatus{MinVersion: "26"},
 							},
 						},
 						{
 							Name: "1024",
-							Platforms: map[string]PlatformStatus{
-								"windows": {
-									Notes: []string{
-										"Requires Windows Server 2025 or Windows 11 (24H2, 25H2) or later.",
-									},
-								},
-								"linux": {MinOpenSSLVersion: "3.5.0"},
-								"macos": {MinMacOSVersion: "26"},
+							Platforms: Platforms{
+								Windows: PlatformStatus{MinVersion: "11 (24H2)"},
+								Linux:   PlatformStatus{MinVersion: "3.5.0"},
+								MacOS:   PlatformStatus{MinVersion: "26"},
 							},
 						},
 					},
@@ -568,10 +581,10 @@ var doc = Document{
 								},
 								{
 									Name: "Export-only",
-									Platforms: map[string]PlatformStatus{
-										"windows": {Supported: "N/A"},
-										"linux":   {Supported: "N/A"},
-										"macos":   {Supported: "N/A"},
+									Platforms: Platforms{
+										Windows: PlatformStatus{Supported: N_A},
+										Linux:   PlatformStatus{Supported: N_A},
+										MacOS:   PlatformStatus{Supported: N_A},
 									},
 								},
 							},
@@ -650,22 +663,22 @@ var doc = Document{
 							Items: []Item{
 								{
 									Name: "SSL 3.0",
-									Platforms: map[string]PlatformStatus{
-										"windows": {Supported: "false"},
-										"linux":   {Supported: "false"},
-										"macos":   {Supported: "false"},
+									Platforms: Platforms{
+										Windows: PlatformStatus{Supported: NotSupported},
+										Linux:   PlatformStatus{Supported: NotSupported},
+										MacOS:   PlatformStatus{Supported: NotSupported},
 									},
 								},
 								{
 									Name: "TLS 1.0",
-									Platforms: map[string]PlatformStatus{
-										"macos": {Supported: "false"},
+									Platforms: Platforms{
+										MacOS: PlatformStatus{Supported: NotSupported},
 									},
 								},
 								{
 									Name: "TLS 1.1",
-									Platforms: map[string]PlatformStatus{
-										"macos": {Supported: "false"},
+									Platforms: Platforms{
+										MacOS: PlatformStatus{Supported: NotSupported},
 									},
 								},
 								{Name: "TLS 1.2"},
@@ -679,9 +692,9 @@ var doc = Document{
 							Items: []Item{
 								{
 									Name: "TLS_RSA_WITH_RC4_128_SHA",
-									Platforms: map[string]PlatformStatus{
-										"linux": {
-											Supported: "warn",
+									Platforms: Platforms{
+										Linux: PlatformStatus{
+											Supported: Warn,
 											Notes: []string{
 												"When using OpenSSL 3, requires the legacy provider to be enabled.",
 											},
@@ -690,9 +703,9 @@ var doc = Document{
 								},
 								{
 									Name: "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
-									Platforms: map[string]PlatformStatus{
-										"linux": {
-											Supported: "warn",
+									Platforms: Platforms{
+										Linux: PlatformStatus{
+											Supported: Warn,
 											Notes: []string{
 												"When using OpenSSL 3, requires the legacy provider to be enabled.",
 											},
@@ -706,9 +719,9 @@ var doc = Document{
 								{Name: "TLS_RSA_WITH_AES_256_GCM_SHA384"},
 								{
 									Name: "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
-									Platforms: map[string]PlatformStatus{
-										"linux": {
-											Supported: "warn",
+									Platforms: Platforms{
+										Linux: PlatformStatus{
+											Supported: Warn,
 											Notes: []string{
 												"When using OpenSSL 3, requires the legacy provider to be enabled.",
 											},
@@ -719,9 +732,9 @@ var doc = Document{
 								{Name: "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"},
 								{
 									Name: "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
-									Platforms: map[string]PlatformStatus{
-										"linux": {
-											Supported: "warn",
+									Platforms: Platforms{
+										Linux: PlatformStatus{
+											Supported: Warn,
 											Notes: []string{
 												"When using OpenSSL 3, requires the legacy provider to be enabled.",
 											},
@@ -730,9 +743,9 @@ var doc = Document{
 								},
 								{
 									Name: "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
-									Platforms: map[string]PlatformStatus{
-										"linux": {
-											Supported: "warn",
+									Platforms: Platforms{
+										Linux: PlatformStatus{
+											Supported: Warn,
 											Notes: []string{
 												"When using OpenSSL 3, requires the legacy provider to be enabled.",
 											},
@@ -822,8 +835,8 @@ var doc = Document{
 								{Name: "ECDSAWithP521AndSHA512"},
 								{
 									Name: "Ed25519",
-									Platforms: map[string]PlatformStatus{
-										"windows": {Supported: "false"},
+									Platforms: Platforms{
+										Windows: PlatformStatus{Supported: NotSupported},
 									},
 								},
 							},

--- a/eng/_util/cmd/updatecryptodocs/updatecryptodocs.go
+++ b/eng/_util/cmd/updatecryptodocs/updatecryptodocs.go
@@ -15,7 +15,7 @@ import (
 	"text/tabwriter"
 )
 
-var docPath = filepath.Join("eng", "doc", "CrossPlatformCryptography.md")
+var docPath = flag.String("path", filepath.Join("eng", "doc", "CrossPlatformCryptography.md"), "Path to CrossPlatformCryptography.md")
 
 var useStdout = flag.Bool("stdout", false, "Write to stdout instead of file")
 
@@ -47,7 +47,7 @@ func write() error {
 		fmt.Print(s.String())
 		return nil
 	}
-	return os.WriteFile(docPath, []byte(s.String()), 0o644)
+	return os.WriteFile(*docPath, []byte(s.String()), 0o644)
 }
 
 func printSection(w io.Writer, section Section, level int) {
@@ -81,12 +81,6 @@ func printSection(w io.Writer, section Section, level int) {
 	var versionSentences []string
 	if section.MinGoVersion != "" {
 		versionSentences = append(versionSentences, fmt.Sprintf("%s is available starting from the Microsoft build of Go %s.", section.Title, section.MinGoVersion))
-	}
-	if section.MinOpenSSLVersion != "" {
-		versionSentences = append(versionSentences, fmt.Sprintf("%s requires OpenSSL %s or later.", section.Title, section.MinOpenSSLVersion))
-	}
-	if section.MinMacOSVersion != "" {
-		versionSentences = append(versionSentences, fmt.Sprintf("%s is available starting in macOS %s or later.", section.Title, section.MinMacOSVersion))
 	}
 	if len(versionSentences) > 0 {
 		fmt.Fprintln(w, strings.Join(versionSentences, " "))
@@ -140,7 +134,11 @@ func printTable(w io.Writer, section Section) {
 
 	var wipTable strings.Builder
 	tw := tabwriter.NewWriter(&wipTable, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(tw, "|\t%s\t|\tWindows\t|\tLinux\t|\tmacOS\t|\n", colHeader)
+	platforms := strings.Join(SupportedPlatforms, "\t|\t")
+	platforms = strings.Replace(platforms, "windows", "Windows", 1)
+	platforms = strings.Replace(platforms, "linux", "Linux", 1)
+	platforms = strings.Replace(platforms, "macos", "macOS", 1)
+	fmt.Fprintf(tw, "|\t%s\t|\t%s\t|\n", colHeader, platforms)
 
 	// We skip the "| --- | --- | etc." row for now. We need to know the actual
 	// column lengths to put in the proper number of dashes (for raw source
@@ -187,7 +185,7 @@ func printTable(w io.Writer, section Section) {
 
 		itemNotes := item.Notes
 		if item.MinGoVersion != "" {
-			note := fmt.Sprintf("Available starting in the Microsoft build of Go %s.", item.MinGoVersion)
+			note := fmt.Sprintf("Requires the Microsoft build of Go %s or later.", item.MinGoVersion)
 			itemNotes = append([]string{note}, itemNotes...)
 		}
 
@@ -195,31 +193,40 @@ func printTable(w io.Writer, section Section) {
 
 		row := []string{name + nameNotes}
 
-		for _, platform := range []string{"windows", "linux", "macos"} {
-			status := item.Platforms[platform]
+		for _, platform := range SupportedPlatforms {
+			status := item.Platforms.Get(platform)
 			symbol := ""
 			switch status.Supported {
-			case "N/A":
-				symbol = "N/A"
-			case "true":
+			case Supported:
 				symbol = "✔️"
-			case "warn":
-				symbol = "⚠️"
-			default:
+			case NotSupported:
 				symbol = "❌️"
+			case Warn:
+				symbol = "⚠️"
+			case N_A:
+				symbol = "N/A"
+			default:
+				// Should not happen due to prior validation
+				panic(fmt.Sprintf("unexpected status %q", status.Supported))
 			}
 
 			statusNotes := status.Notes
 			// Prepend version notes in preferred order: minGoVersion, minOpenSSLVersion, minMacOSVersion
 			var versionNotes []string
 			if status.MinGoVersion != "" {
-				versionNotes = append(versionNotes, fmt.Sprintf("Available starting in the Microsoft build of Go %s.", status.MinGoVersion))
+				versionNotes = append(versionNotes, fmt.Sprintf("Requires the Microsoft build of Go %s or later.", status.MinGoVersion))
 			}
-			if status.MinOpenSSLVersion != "" {
-				versionNotes = append(versionNotes, fmt.Sprintf("Requires OpenSSL %s or later.", status.MinOpenSSLVersion))
-			}
-			if status.MinMacOSVersion != "" {
-				versionNotes = append(versionNotes, fmt.Sprintf("Requires macOS %s or later.", status.MinMacOSVersion))
+			if status.MinVersion != "" {
+				switch platform {
+				case "windows":
+					versionNotes = append(versionNotes, fmt.Sprintf("Requires Windows %s or later.", status.MinVersion))
+				case "linux":
+					versionNotes = append(versionNotes, fmt.Sprintf("Requires OpenSSL %s or later.", status.MinVersion))
+				case "macos":
+					versionNotes = append(versionNotes, fmt.Sprintf("Requires macOS %s or later.", status.MinVersion))
+				default:
+					panic("unknown platform" + platform)
+				}
 			}
 			// Remove duplicates from notes
 			filtered := []string{}
@@ -302,21 +309,10 @@ func validateSection(section Section) error {
 			return fmt.Errorf("duplicate item name %q in section %q", item.Name, section.Title)
 		}
 		seenNames[item.Name] = true
-
-		if item.Platforms == nil {
-			item.Platforms = make(map[string]PlatformStatus)
-		}
-		for _, p := range []string{"windows", "linux", "macos"} {
-			status, ok := item.Platforms[p]
-			if !ok {
-				status = PlatformStatus{}
-			}
-			if status.Supported == "" {
-				status.Supported = "true"
-			}
-			item.Platforms[p] = status
+		for _, p := range SupportedPlatforms {
+			status := item.Platforms.Get(p)
 			switch status.Supported {
-			case "true", "false", "warn", "N/A":
+			case Supported, NotSupported, Warn, N_A:
 				// ok
 			default:
 				return fmt.Errorf("invalid supported status %q for item %q on platform %q", status.Supported, item.Name, p)
@@ -325,9 +321,9 @@ func validateSection(section Section) error {
 
 		// Check for notes common to all platforms
 		noteCounts := make(map[string]int)
-		platforms := []string{"windows", "linux", "macos"}
+		platforms := SupportedPlatforms
 		for _, p := range platforms {
-			status := item.Platforms[p]
+			status := item.Platforms.Get(p)
 			for _, note := range status.Notes {
 				noteCounts[note]++
 			}

--- a/eng/_util/cmd/updatecryptodocs/updatecryptodocs.go
+++ b/eng/_util/cmd/updatecryptodocs/updatecryptodocs.go
@@ -185,7 +185,7 @@ func printTable(w io.Writer, section Section) {
 
 		itemNotes := item.Notes
 		if item.MinGoVersion != "" {
-			note := fmt.Sprintf("Requires the Microsoft build of Go %s or later.", item.MinGoVersion)
+			note := fmt.Sprintf("Available starting in the Microsoft build of Go %s.", item.MinGoVersion)
 			itemNotes = append([]string{note}, itemNotes...)
 		}
 
@@ -214,7 +214,7 @@ func printTable(w io.Writer, section Section) {
 			// Prepend version notes in preferred order: minGoVersion, minOpenSSLVersion, minMacOSVersion
 			var versionNotes []string
 			if status.MinGoVersion != "" {
-				versionNotes = append(versionNotes, fmt.Sprintf("Requires the Microsoft build of Go %s or later.", status.MinGoVersion))
+				versionNotes = append(versionNotes, fmt.Sprintf("Available starting in the Microsoft build of Go %s.", status.MinGoVersion))
 			}
 			if status.MinVersion != "" {
 				switch platform {

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -77,13 +77,13 @@ This section includes the following packages:
 | CSHAKE-256            | ✔️             | ❌️               | ❌️             |
 | HMAC<sup>7</sup>      | ✔️             | ✔️               | ✔️             |
 
-<sup>1</sup>Available starting in the Microsoft build of Go 1.24.
+<sup>1</sup>Requires the Microsoft build of Go 1.24 or later.
 
 <sup>2</sup>Requires OpenSSL 1.1.1 or later.
 
-<sup>3</sup>Available starting in the Microsoft build of Go 1.26.
+<sup>3</sup>Requires the Microsoft build of Go 1.26 or later.
 
-<sup>4</sup>Available in Windows 11, version 24H2 or later.
+<sup>4</sup>Requires Windows 11 (24H2) or later.
 
 <sup>5</sup>Requires macOS 26 or later.
 
@@ -179,11 +179,11 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 
 <sup>2</sup>Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).
 
-<sup>3</sup>On Windows, when verifying a PSS signature, [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.
+<sup>3</sup>Verifying PSS signatures with [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.
 
-<sup>4</sup>On macOS, custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).
+<sup>4</sup>Custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).
 
-<sup>5</sup>Available starting in the Microsoft build of Go 1.24.
+<sup>5</sup>Requires the Microsoft build of Go 1.24 or later.
 
 ### ECDSA
 
@@ -217,7 +217,7 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 | NIST P-521 (secp521r1)          | ✔️      | ✔️             | ✔️    |
 | X25519 (curve25519)<sup>1</sup> | ✔️      | ✔️<sup>2</sup> | ✔️    |
 
-<sup>1</sup>Available starting in the Microsoft build of Go 1.26.
+<sup>1</sup>Requires the Microsoft build of Go 1.26 or later.
 
 <sup>2</sup>Requires OpenSSL 1.1.1 or later.
 
@@ -277,7 +277,7 @@ ML-KEM is available starting from the Microsoft build of Go 1.26.
 | 768        | ✔️<sup>1</sup> | ✔️<sup>2</sup> | ✔️<sup>3</sup> |
 | 1024       | ✔️<sup>1</sup> | ✔️<sup>2</sup> | ✔️<sup>3</sup> |
 
-<sup>1</sup>Requires Windows Server 2025 or Windows 11 (24H2, 25H2) or later.
+<sup>1</sup>Requires Windows 11 (24H2) or later.
 
 <sup>2</sup>Requires OpenSSL 3.5.0 or later.
 
@@ -316,7 +316,7 @@ This section includes the following subsections:
 | ChaCha20Poly1305<sup>1</sup> | ✔️      | ✔️    | ✔️    |
 | Export-only                  | N/A     | N/A   | N/A   |
 
-<sup>1</sup>Available starting in the Microsoft build of Go 1.26.
+<sup>1</sup>Requires the Microsoft build of Go 1.26 or later.
 
 #### HPKE Key Derivation Functions (KDFs)
 
@@ -403,7 +403,7 @@ The TLS stack is implemented using native Go code but the crypto primitives are 
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
-<sup>2</sup>Available starting in the Microsoft build of Go 1.26.
+<sup>2</sup>Requires the Microsoft build of Go 1.26 or later.
 
 On Windows, it is possible to restrict and reorder the cipher suites following the [Schannel preferences](https://learn.microsoft.com/en-us/windows/win32/secauthn/cipher-suites-in-schannel) by building with the `ms_tls_config_schannel` goexperiment enabled.
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -77,11 +77,11 @@ This section includes the following packages:
 | CSHAKE-256            | ✔️             | ❌️               | ❌️             |
 | HMAC<sup>7</sup>      | ✔️             | ✔️               | ✔️             |
 
-<sup>1</sup>Requires the Microsoft build of Go 1.24 or later.
+<sup>1</sup>Available starting in the Microsoft build of Go 1.24.
 
 <sup>2</sup>Requires OpenSSL 1.1.1 or later.
 
-<sup>3</sup>Requires the Microsoft build of Go 1.26 or later.
+<sup>3</sup>Available starting in the Microsoft build of Go 1.26.
 
 <sup>4</sup>Requires Windows 11 (24H2) or later.
 
@@ -183,7 +183,7 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 
 <sup>4</sup>Custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).
 
-<sup>5</sup>Requires the Microsoft build of Go 1.24 or later.
+<sup>5</sup>Available starting in the Microsoft build of Go 1.24.
 
 ### ECDSA
 
@@ -217,7 +217,7 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 | NIST P-521 (secp521r1)          | ✔️      | ✔️             | ✔️    |
 | X25519 (curve25519)<sup>1</sup> | ✔️      | ✔️<sup>2</sup> | ✔️    |
 
-<sup>1</sup>Requires the Microsoft build of Go 1.26 or later.
+<sup>1</sup>Available starting in the Microsoft build of Go 1.26.
 
 <sup>2</sup>Requires OpenSSL 1.1.1 or later.
 
@@ -316,7 +316,7 @@ This section includes the following subsections:
 | ChaCha20Poly1305<sup>1</sup> | ✔️      | ✔️    | ✔️    |
 | Export-only                  | N/A     | N/A   | N/A   |
 
-<sup>1</sup>Requires the Microsoft build of Go 1.26 or later.
+<sup>1</sup>Available starting in the Microsoft build of Go 1.26.
 
 #### HPKE Key Derivation Functions (KDFs)
 
@@ -403,7 +403,7 @@ The TLS stack is implemented using native Go code but the crypto primitives are 
 
 <sup>1</sup>When using OpenSSL 3, requires the legacy provider to be enabled.
 
-<sup>2</sup>Requires the Microsoft build of Go 1.26 or later.
+<sup>2</sup>Available starting in the Microsoft build of Go 1.26.
 
 On Windows, it is possible to restrict and reorder the cipher suites following the [Schannel preferences](https://learn.microsoft.com/en-us/windows/win32/secauthn/cipher-suites-in-schannel) by building with the `ms_tls_config_schannel` goexperiment enabled.
 


### PR DESCRIPTION
This pull request refactors how platform support information is represented and stored in the cryptography documentation generator. The changes introduce strongly-typed enums and structs to replace loosely-typed string maps, making the data model more robust, type-safe, and easier to maintain.

Additionally, platform versioning and support notes have been standardized across the documentation data.