### PR TITLE
Support more RSA algorithms on Windows and update support matrix

### DIFF
--- a/eng/_util/cmd/updatecryptodocs/docs.go
+++ b/eng/_util/cmd/updatecryptodocs/docs.go
@@ -303,6 +303,7 @@ var doc = Document{
 							Notes: []string{
 								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
 							},
+							MinGoVersion: "1.26",
 							Platforms: Platforms{
 								MacOS: PlatformStatus{Supported: NotSupported},
 							},

--- a/eng/_util/cmd/updatecryptodocs/docs.go
+++ b/eng/_util/cmd/updatecryptodocs/docs.go
@@ -300,10 +300,11 @@ var doc = Document{
 						},
 						{
 							Name: "OAEP (SHA-3)",
+							Notes: []string{
+								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
+							},
 							Platforms: Platforms{
-								Windows: PlatformStatus{Supported: NotSupported},
-								Linux:   PlatformStatus{Supported: NotSupported},
-								MacOS:   PlatformStatus{Supported: NotSupported},
+								MacOS: PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{
@@ -352,23 +353,17 @@ var doc = Document{
 						},
 						{
 							Name: "PSS (SHA-3)",
+							Notes: []string{
+								"Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).",
+							},
 							Platforms: Platforms{
-								Windows: PlatformStatus{Supported: NotSupported},
-								Linux:   PlatformStatus{Supported: NotSupported},
+								Windows: PlatformStatus{MinGoVersion: "1.26"},
 								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},
 						{Name: "PKCS1v15 Signature (Unhashed)"},
 						{
 							Name: "PKCS1v15 Signature (RIPMED160)",
-							Platforms: Platforms{
-								Windows: PlatformStatus{Supported: NotSupported},
-								Linux:   PlatformStatus{MinGoVersion: "1.24"},
-								MacOS:   PlatformStatus{Supported: NotSupported},
-							},
-						},
-						{
-							Name: "PKCS1v15 Signature (MD4)",
 							Platforms: Platforms{
 								Windows: PlatformStatus{Supported: NotSupported},
 								Linux:   PlatformStatus{MinGoVersion: "1.24"},
@@ -399,8 +394,8 @@ var doc = Document{
 						{
 							Name: "PKCS1v15 Signature (SHA-3)",
 							Platforms: Platforms{
-								Windows: PlatformStatus{Supported: NotSupported},
-								Linux:   PlatformStatus{Supported: NotSupported},
+								Windows: PlatformStatus{MinVersion: "11 (24H2)", MinGoVersion: "1.26"},
+								Linux:   PlatformStatus{MinVersion: "1.1.1"},
 								MacOS:   PlatformStatus{Supported: NotSupported},
 							},
 						},

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -156,24 +156,23 @@ Please refer to the documentation of the underlying cryptographic library for th
 
 Operations that require random numbers (rand io.Reader) only support [rand.Reader](https://pkg.go.dev/crypto/rand#Reader).
 
-| Padding Mode                           | Windows        | Linux          | macOS          |
-| -------------------------------------- | -------------- | -------------- | -------------- |
-| OAEP (MD5)                             | ✔️             | ✔️             | ✔️<sup>1</sup> |
-| OAEP (SHA-1)                           | ✔️             | ✔️             | ✔️<sup>1</sup> |
-| OAEP (SHA-2)<sup>2</sup>               | ✔️             | ✔️             | ✔️<sup>1</sup> |
-| OAEP (SHA-3)                           | ❌️             | ❌️             | ❌️             |
-| PSS (MD5)                              | ✔️<sup>3</sup> | ✔️             | ❌️             |
-| PSS (SHA-1)                            | ✔️<sup>3</sup> | ✔️             | ✔️<sup>4</sup> |
-| PSS (SHA-2)<sup>2</sup>                | ✔️<sup>3</sup> | ✔️             | ✔️<sup>4</sup> |
-| PSS (SHA-3)                            | ❌️             | ❌️             | ❌️             |
-| PKCS1v15 Signature (Unhashed)          | ✔️             | ✔️             | ✔️             |
-| PKCS1v15 Signature (RIPMED160)         | ❌️             | ✔️<sup>5</sup> | ❌️             |
-| PKCS1v15 Signature (MD4)               | ❌️             | ✔️<sup>5</sup> | ❌️             |
-| PKCS1v15 Signature (MD5)               | ✔️             | ✔️             | ❌️             |
-| PKCS1v15 Signature (MD5-SHA1)          | ✔️<sup>5</sup> | ✔️<sup>5</sup> | ❌️             |
-| PKCS1v15 Signature (SHA-1)             | ✔️             | ✔️             | ✔️             |
-| PKCS1v15 Signature (SHA-2)<sup>2</sup> | ✔️             | ✔️             | ✔️             |
-| PKCS1v15 Signature (SHA-3)             | ❌️             | ❌️             | ❌️             |
+| Padding Mode                           | Windows          | Linux          | macOS          |
+| -------------------------------------- | ---------------- | -------------- | -------------- |
+| OAEP (MD5)                             | ✔️               | ✔️             | ✔️<sup>1</sup> |
+| OAEP (SHA-1)                           | ✔️               | ✔️             | ✔️<sup>1</sup> |
+| OAEP (SHA-2)<sup>2</sup>               | ✔️               | ✔️             | ✔️<sup>1</sup> |
+| OAEP (SHA-3)<sup>2</sup>               | ✔️               | ✔️             | ❌️             |
+| PSS (MD5)                              | ✔️<sup>3</sup>   | ✔️             | ❌️             |
+| PSS (SHA-1)                            | ✔️<sup>3</sup>   | ✔️             | ✔️<sup>4</sup> |
+| PSS (SHA-2)<sup>2</sup>                | ✔️<sup>3</sup>   | ✔️             | ✔️<sup>4</sup> |
+| PSS (SHA-3)<sup>2</sup>                | ✔️<sup>5</sup>   | ✔️             | ❌️             |
+| PKCS1v15 Signature (Unhashed)          | ✔️               | ✔️             | ✔️             |
+| PKCS1v15 Signature (RIPMED160)         | ❌️               | ✔️<sup>6</sup> | ❌️             |
+| PKCS1v15 Signature (MD5)               | ✔️               | ✔️             | ❌️             |
+| PKCS1v15 Signature (MD5-SHA1)          | ✔️<sup>6</sup>   | ✔️<sup>6</sup> | ❌️             |
+| PKCS1v15 Signature (SHA-1)             | ✔️               | ✔️             | ✔️             |
+| PKCS1v15 Signature (SHA-2)<sup>2</sup> | ✔️               | ✔️             | ✔️             |
+| PKCS1v15 Signature (SHA-3)             | ✔️<sup>5,7</sup> | ✔️<sup>8</sup> | ❌️             |
 
 <sup>1</sup>macOS doesn't support passing a custom label to OAEP functions.
 
@@ -183,7 +182,13 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 
 <sup>4</sup>Custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).
 
-<sup>5</sup>Available starting in the Microsoft build of Go 1.24.
+<sup>5</sup>Available starting in the Microsoft build of Go 1.26.
+
+<sup>6</sup>Available starting in the Microsoft build of Go 1.24.
+
+<sup>7</sup>Requires Windows 11 (24H2) or later.
+
+<sup>8</sup>Requires OpenSSL 1.1.1 or later.
 
 ### ECDSA
 

--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -161,28 +161,28 @@ Operations that require random numbers (rand io.Reader) only support [rand.Reade
 | OAEP (MD5)                             | ✔️               | ✔️             | ✔️<sup>1</sup> |
 | OAEP (SHA-1)                           | ✔️               | ✔️             | ✔️<sup>1</sup> |
 | OAEP (SHA-2)<sup>2</sup>               | ✔️               | ✔️             | ✔️<sup>1</sup> |
-| OAEP (SHA-3)<sup>2</sup>               | ✔️               | ✔️             | ❌️             |
-| PSS (MD5)                              | ✔️<sup>3</sup>   | ✔️             | ❌️             |
-| PSS (SHA-1)                            | ✔️<sup>3</sup>   | ✔️             | ✔️<sup>4</sup> |
-| PSS (SHA-2)<sup>2</sup>                | ✔️<sup>3</sup>   | ✔️             | ✔️<sup>4</sup> |
-| PSS (SHA-3)<sup>2</sup>                | ✔️<sup>5</sup>   | ✔️             | ❌️             |
+| OAEP (SHA-3)<sup>2,3</sup>             | ✔️               | ✔️             | ❌️             |
+| PSS (MD5)                              | ✔️<sup>4</sup>   | ✔️             | ❌️             |
+| PSS (SHA-1)                            | ✔️<sup>4</sup>   | ✔️             | ✔️<sup>5</sup> |
+| PSS (SHA-2)<sup>2</sup>                | ✔️<sup>4</sup>   | ✔️             | ✔️<sup>5</sup> |
+| PSS (SHA-3)<sup>2</sup>                | ✔️<sup>3</sup>   | ✔️             | ❌️             |
 | PKCS1v15 Signature (Unhashed)          | ✔️               | ✔️             | ✔️             |
 | PKCS1v15 Signature (RIPMED160)         | ❌️               | ✔️<sup>6</sup> | ❌️             |
 | PKCS1v15 Signature (MD5)               | ✔️               | ✔️             | ❌️             |
 | PKCS1v15 Signature (MD5-SHA1)          | ✔️<sup>6</sup>   | ✔️<sup>6</sup> | ❌️             |
 | PKCS1v15 Signature (SHA-1)             | ✔️               | ✔️             | ✔️             |
 | PKCS1v15 Signature (SHA-2)<sup>2</sup> | ✔️               | ✔️             | ✔️             |
-| PKCS1v15 Signature (SHA-3)             | ✔️<sup>5,7</sup> | ✔️<sup>8</sup> | ❌️             |
+| PKCS1v15 Signature (SHA-3)             | ✔️<sup>3,7</sup> | ✔️<sup>8</sup> | ❌️             |
 
 <sup>1</sup>macOS doesn't support passing a custom label to OAEP functions.
 
 <sup>2</sup>Supports only hash algorithms that are [supported as standalone hash functions](#hash-and-message-authentication-algorithms).
 
-<sup>3</sup>Verifying PSS signatures with [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.
+<sup>3</sup>Available starting in the Microsoft build of Go 1.26.
 
-<sup>4</sup>Custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).
+<sup>4</sup>Verifying PSS signatures with [rsa.PSSSaltLengthAuto](https://pkg.go.dev/crypto/rsa#pkg-constants) is not supported.
 
-<sup>5</sup>Available starting in the Microsoft build of Go 1.26.
+<sup>5</sup>Custom salt lengths are not supported. PSS always uses the [`rsa.PSSSaltLengthEqualsHash`](https://pkg.go.dev/crypto/rsa#pkg-constants).
 
 <sup>6</sup>Available starting in the Microsoft build of Go 1.24.
 

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -54,7 +54,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../github.com/golang-fips/openssl/v2/ecdh.go |  343 +++
  .../golang-fips/openssl/v2/ecdsa.go           |  222 ++
  .../golang-fips/openssl/v2/ed25519.go         |  210 ++
- .../github.com/golang-fips/openssl/v2/evp.go  |  600 +++++
+ .../github.com/golang-fips/openssl/v2/evp.go  |  620 +++++
  .../github.com/golang-fips/openssl/v2/hash.go |  502 ++++
  .../golang-fips/openssl/v2/hashclone.go       |   14 +
  .../golang-fips/openssl/v2/hashclone_go125.go |    9 +
@@ -125,7 +125,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../openssl/v2/providersymcrypt.go            |  338 +++
  .../github.com/golang-fips/openssl/v2/rand.go |   21 +
  .../github.com/golang-fips/openssl/v2/rc4.go  |   68 +
- .../github.com/golang-fips/openssl/v2/rsa.go  |  401 +++
+ .../github.com/golang-fips/openssl/v2/rsa.go  |  716 +++++
  .../golang-fips/openssl/v2/tls1prf.go         |  158 ++
  .../github.com/golang-fips/openssl/v2/zaes.go |   86 +
  .../microsoft/go-crypto-darwin/LICENSE        |   21 +
@@ -236,7 +236,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go-crypto-winnative/cng/pbkdf2.go         |   70 +
  .../microsoft/go-crypto-winnative/cng/rand.go |   28 +
  .../microsoft/go-crypto-winnative/cng/rc4.go  |   65 +
- .../microsoft/go-crypto-winnative/cng/rsa.go  |  396 +++
+ .../microsoft/go-crypto-winnative/cng/rsa.go  |  404 +++
  .../microsoft/go-crypto-winnative/cng/sha3.go |  203 ++
  .../go-crypto-winnative/cng/tls1prf.go        |   89 +
  .../internal/bcrypt/bcrypt_windows.go         |  414 +++
@@ -245,7 +245,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 237 files changed, 31035 insertions(+), 7 deletions(-)
+ 237 files changed, 31378 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -2136,7 +2136,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index efc07451b53448..6ef9b5fbcb1146 100644
+index efc07451b53448..ab7ea4a4b915d9 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2145,21 +2145,21 @@ index efc07451b53448..6ef9b5fbcb1146 100644
  )
 +
 +require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20251218145113-52cddb05a262
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20251219133548-db44f2109b85
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20251218120905-3dc2f5f6b182
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20251218121426-ba94af8d2bb8
++	github.com/microsoft/go-crypto-winnative v0.0.0-20251219091053-f9796ee5d078
 +)
 diff --git a/src/go.sum b/src/go.sum
-index b6b841b44d8e38..ed947ea7d43b5f 100644
+index b6b841b44d8e38..104fcfc902e896 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20251218145113-52cddb05a262 h1:fNRFo5bregvphPwnGSPrC0IyGZf6agmeFByo6c88s7E=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20251218145113-52cddb05a262/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20251219133548-db44f2109b85 h1:/IDnd+d+KhBvHD60Jpd1fuTW5S2FbdCfhJVL+w+ecZM=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20251219133548-db44f2109b85/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20251218120905-3dc2f5f6b182 h1:yeHGQpq1zuXcbMG18BPOTENjfYEgqB7ZEUYC/0eM2Lw=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20251218120905-3dc2f5f6b182/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20251218121426-ba94af8d2bb8 h1:lG7y5IdfKZcZI1PWkWTN1W0vpOfFmFHQCjDzx4atIWA=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20251218121426-ba94af8d2bb8/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
++github.com/microsoft/go-crypto-winnative v0.0.0-20251219091053-f9796ee5d078 h1:9M+LVr3rtPCD7xgX/xGFWEsyWdvTA/djZUHh2AyXTB4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20251219091053-f9796ee5d078/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00 h1:JgcPM1rzpSOZS8y69FQvnY0xN0ciHlpQqwTXJcuZIA4=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
  golang.org/x/net v0.47.1-0.20251128220604-7c360367ab7e h1:PAAT9cIDvIAIRQVz2txQvUFRt3jOlhiO84ihd8XMGlg=
@@ -5133,10 +5133,10 @@ index 00000000000000..6413f3e42b4adb
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/evp.go b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 new file mode 100644
-index 00000000000000..1f70c904dc237f
+index 00000000000000..56fae101c4feb4
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
-@@ -0,0 +1,600 @@
+@@ -0,0 +1,620 @@
 +//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
 +
 +package openssl
@@ -5185,6 +5185,14 @@ index 00000000000000..1f70c904dc237f
 +		return h.alg.md
 +	}
 +	return nil
++}
++
++// hashToCryptoHash converts a hash.Hash implementation from this package to a crypto.Hash.
++func hashToCryptoHash(h hash.Hash) crypto.Hash {
++	if h, ok := h.(*Hash); ok {
++		return h.alg.ch
++	}
++	return 0
 +}
 +
 +// hashFuncToMD converts a hash.Hash function to a GOossl.EVP_MD_PTR.
@@ -5433,92 +5441,104 @@ index 00000000000000..1f70c904dc237f
 +	}
 +	// Each padding type has its own requirements in terms of when to apply the padding,
 +	// so it can't be just set at this point.
-+	setPadding := func() error {
-+		_, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, padding, nil)
-+		return err
-+	}
 +	switch padding {
 +	case ossl.RSA_PKCS1_OAEP_PADDING:
-+		md := hashToMD(h)
-+		if md == nil {
-+			return nil, errors.New("crypto/rsa: unsupported hash function")
-+		}
-+		var mgfMD ossl.EVP_MD_PTR
-+		if mgfHash != nil {
-+			// mgfHash is optional, but if it is set it must match a supported hash function.
-+			mgfMD = hashToMD(mgfHash)
-+			if mgfMD == nil {
-+				return nil, errors.New("crypto/rsa: unsupported hash function")
-+			}
-+		}
-+		// setPadding must happen before setting EVP_PKEY_CTRL_RSA_OAEP_MD.
-+		if err := setPadding(); err != nil {
-+			return nil, err
-+		}
-+		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_OAEP_MD, 0, unsafe.Pointer(md)); err != nil {
-+			return nil, err
-+		}
-+		if mgfHash != nil {
-+			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_MGF1_MD, 0, unsafe.Pointer(mgfMD)); err != nil {
-+				return nil, err
-+			}
-+		}
-+		// ctx takes ownership of label, so malloc a copy for OpenSSL to free.
-+		// OpenSSL does not take ownership of the label if the length is zero,
-+		// so better avoid the allocation.
-+		var clabel *byte
-+		if len(label) > 0 {
-+			clabel = (*byte)(cryptoMalloc(len(label)))
-+			copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
-+			var err error
-+			if major() == 3 {
-+				_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Pointer(clabel), int32(len(label)))
-+			} else {
-+				_, err = ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_OAEP_LABEL, int32(len(label)), unsafe.Pointer(clabel))
-+			}
-+			if err != nil {
-+				cryptoFree(unsafe.Pointer(clabel))
-+				return nil, err
-+			}
-+		}
++		err = setOAEPPadding(ctx, h, mgfHash, label)
 +	case ossl.RSA_PKCS1_PSS_PADDING:
-+		alg := loadHash(ch, false)
-+		if alg == nil {
-+			return nil, errors.New("crypto/rsa: unsupported hash function")
-+		}
-+		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
-+			return nil, err
-+		}
-+		// setPadding must happen after setting EVP_PKEY_CTRL_MD.
-+		if err := setPadding(); err != nil {
-+			return nil, err
-+		}
-+		if saltLen != 0 {
-+			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
-+				return nil, err
-+			}
-+		}
-+
++		err = setPSSPadding(ctx, saltLen, ch)
 +	case ossl.RSA_PKCS1_PADDING:
-+		if ch != 0 {
-+			// We support unhashed messages.
-+			alg := loadHash(ch, false)
-+			if alg == nil {
-+				return nil, errors.New("crypto/rsa: unsupported hash function")
-+			}
-+			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, -1, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
-+				return nil, err
-+			}
-+			if err := setPadding(); err != nil {
-+				return nil, err
-+			}
-+		}
++		err = setPKCS1Padding(ctx, ch)
 +	default:
-+		if err := setPadding(); err != nil {
-+			return nil, err
-+		}
++		_, err = ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, padding, nil)
++	}
++	if err != nil {
++		return nil, err
 +	}
 +	return ctx, nil
++}
++
++func setPSSPadding(ctx ossl.EVP_PKEY_CTX_PTR, saltLen int32, ch crypto.Hash) error {
++	alg := loadHash(ch, false)
++	if alg == nil {
++		return errors.New("crypto/rsa: unsupported hash function")
++	}
++	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
++		return err
++	}
++	// setPadding must happen after setting EVP_PKEY_CTRL_MD.
++	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PSS_PADDING, nil); err != nil {
++		return err
++	}
++	if saltLen != 0 {
++		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
++			return err
++		}
++	}
++	return nil
++}
++
++func setPKCS1Padding(ctx ossl.EVP_PKEY_CTX_PTR, ch crypto.Hash) error {
++	if ch == 0 {
++		// We support unhashed messages.
++		return nil
++	}
++	alg := loadHash(ch, false)
++	if alg == nil {
++		return errors.New("crypto/rsa: unsupported hash function")
++	}
++	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, -1, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
++		return err
++	}
++	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PADDING, nil); err != nil {
++		return err
++	}
++	return nil
++}
++
++func setOAEPPadding(ctx ossl.EVP_PKEY_CTX_PTR, h, mgfHash hash.Hash, label []byte) error {
++	md := hashToMD(h)
++	if md == nil {
++		return errors.New("crypto/rsa: unsupported hash function")
++	}
++	var mgfMD ossl.EVP_MD_PTR
++	if mgfHash != nil {
++		// mgfHash is optional, but if it is set it must match a supported hash function.
++		mgfMD = hashToMD(mgfHash)
++		if mgfMD == nil {
++			return errors.New("crypto/rsa: unsupported hash function")
++		}
++	}
++	// setPadding must happen before setting EVP_PKEY_CTRL_RSA_OAEP_MD.
++	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_OAEP_PADDING, nil); err != nil {
++		return err
++	}
++	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_OAEP_MD, 0, unsafe.Pointer(md)); err != nil {
++		return err
++	}
++	if mgfHash != nil {
++		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_MGF1_MD, 0, unsafe.Pointer(mgfMD)); err != nil {
++			return err
++		}
++	}
++	// ctx takes ownership of label, so malloc a copy for OpenSSL to free.
++	// OpenSSL does not take ownership of the label if the length is zero,
++	// so better avoid the allocation.
++	var clabel *byte
++	if len(label) > 0 {
++		clabel = (*byte)(cryptoMalloc(len(label)))
++		copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
++		var err error
++		if major() == 3 {
++			_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Pointer(clabel), int32(len(label)))
++		} else {
++			_, err = ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_OAEP_LABEL, int32(len(label)), unsafe.Pointer(clabel))
++		}
++		if err != nil {
++			cryptoFree(unsafe.Pointer(clabel))
++			return err
++		}
++	}
++	return nil
 +}
 +
 +func cryptEVP(withKey withKeyFunc, padding int32,
@@ -18588,10 +18608,10 @@ index 00000000000000..e933228919296d
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rsa.go b/src/vendor/github.com/golang-fips/openssl/v2/rsa.go
 new file mode 100644
-index 00000000000000..f1cddf8b5103db
+index 00000000000000..e989da8db9cfa6
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/rsa.go
-@@ -0,0 +1,401 @@
+@@ -0,0 +1,716 @@
 +//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
 +
 +package openssl
@@ -18959,16 +18979,9 @@ index 00000000000000..f1cddf8b5103db
 +	return newEvpFromParams(ossl.EVP_PKEY_RSA, int32(selection), params)
 +}
 +
-+// SupportsRSAPKCS1Encryption returns true if the RSA PKCS1 v1.5 padding is supported for encryption and decryption.
-+var SupportsRSAPKCS1Encryption = sync.OnceValue(func() bool {
-+	// Generate a temporary key to check for support.
-+	// 2048 bits is a safe default that should be supported by all providers.
-+	pkey, err := generateEVPPKey(ossl.EVP_PKEY_RSA, 2048, "")
-+	if err != nil {
-+		return false
-+	}
-+	defer ossl.EVP_PKEY_free(pkey)
-+
++// SupportsRSAPKCS1v15Encryption returns true if the RSA PKCS1 v1.5 padding is supported for encryption and decryption.
++var SupportsRSAPKCS1v15Encryption = sync.OnceValue(func() bool {
++	pkey := testRSAPrivateKey()
 +	ctx, err := ossl.EVP_PKEY_CTX_new(pkey, nil)
 +	if err != nil {
 +		return false
@@ -18990,8 +19003,330 @@ index 00000000000000..f1cddf8b5103db
 +	if _, err := ossl.EVP_PKEY_encrypt(ctx, nil, &outLen, &in[0], len(in)); err != nil {
 +		return false
 +	}
-+
 +	return true
++})
++
++var rsaPKCS1SignatureSupport sync.Map
++
++// SupportsRSAPKCS1v15Signature returns true if the RSA PKCS1 v1.5 padding is supported for signatures with the given hash.
++func SupportsRSAPKCS1v15Signature(ch crypto.Hash) (supported bool) {
++	v, ok := rsaPKCS1SignatureSupport.Load(ch)
++	if ok {
++		return v.(bool)
++	}
++	defer func() {
++		rsaPKCS1SignatureSupport.Store(ch, supported)
++	}()
++
++	pkey := testRSAPrivateKey()
++	ctx, err := ossl.EVP_PKEY_CTX_new(pkey, nil)
++	if err != nil {
++		return false
++	}
++	defer ossl.EVP_PKEY_CTX_free(ctx)
++	if _, err := ossl.EVP_PKEY_sign_init(ctx); err != nil {
++		return false
++	}
++	if setPKCS1Padding(ctx, ch) != nil {
++		return false
++	}
++	// In FIPS mode, setting the padding might succeed, but the actual signature will fail.
++	// So we need to try to sign something to be sure.
++	size := 1
++	if ch != 0 {
++		size = ch.Size()
++	}
++	in := make([]byte, size, maxHashSize)
++	var outLen int
++	if _, err := ossl.EVP_PKEY_sign(ctx, nil, &outLen, &in[0], len(in)); err != nil {
++		return false
++	}
++	return true
++}
++
++var rsaPSSSupport sync.Map
++
++// SupportsRSAPSS returns true if the RSA PSS padding is supported for signatures with the given hash.
++func SupportsRSAPSS(ch crypto.Hash) (supported bool) {
++	v, ok := rsaPSSSupport.Load(ch)
++	if ok {
++		return v.(bool)
++	}
++	defer func() {
++		rsaPSSSupport.Store(ch, supported)
++	}()
++
++	if !SupportsHash(ch) {
++		// Short-circuit if the hash itself is not supported.
++		return false
++	}
++
++	pkey := testRSAPrivateKey()
++	ctx, err := ossl.EVP_PKEY_CTX_new(pkey, nil)
++	if err != nil {
++		return false
++	}
++	defer ossl.EVP_PKEY_CTX_free(ctx)
++	if _, err := ossl.EVP_PKEY_sign_init(ctx); err != nil {
++		return false
++	}
++	if setPSSPadding(ctx, 0, ch) != nil {
++		return false
++	}
++	// In FIPS mode, setting the padding might succeed, but the actual signature will fail.
++	// So we need to try to sign something to be sure.
++	in := make([]byte, ch.Size(), maxHashSize)
++	var outLen int
++	if _, err := ossl.EVP_PKEY_sign(ctx, nil, &outLen, &in[0], len(in)); err != nil {
++		return false
++	}
++	return true
++}
++
++var rsaOAEPSupport sync.Map
++
++type rsaOAEPSupportEntry struct {
++	ch      crypto.Hash
++	mgfHash crypto.Hash
++}
++
++// SupportsRSAOAEP returns true if the RSA OAEP padding is supported for encryption/decryption
++// with the given hash and MGF hash.
++func SupportsRSAOAEP(h, mgfHash hash.Hash) (supported bool) {
++	ch := hashToCryptoHash(h)
++	if ch == 0 {
++		return false
++	}
++	mgfCh := hashToCryptoHash(mgfHash)
++	if mgfCh == 0 {
++		return false
++	}
++	entry := rsaOAEPSupportEntry{ch, mgfCh}
++	v, ok := rsaOAEPSupport.Load(entry)
++	if ok {
++		return v.(bool)
++	}
++	defer func() {
++		rsaOAEPSupport.Store(entry, supported)
++	}()
++
++	if !SupportsHash(ch) {
++		// Short-circuit if the hash itself is not supported.
++		return false
++	}
++
++	pkey := testRSAPrivateKey()
++	ctx, err := ossl.EVP_PKEY_CTX_new(pkey, nil)
++	if err != nil {
++		return false
++	}
++	defer ossl.EVP_PKEY_CTX_free(ctx)
++
++	if _, err := ossl.EVP_PKEY_encrypt_init(ctx); err != nil {
++		return false
++	}
++
++	if setOAEPPadding(ctx, h, mgfHash, nil) != nil {
++		return false
++	}
++
++	// In FIPS mode, setting the padding might succeed, but the actual encryption will fail.
++	// So we need to try to encrypt something to be sure.
++	in := []byte("test")
++	var outLen int
++	if _, err := ossl.EVP_PKEY_encrypt(ctx, nil, &outLen, &in[0], len(in)); err != nil {
++		return false
++	}
++	return true
++}
++
++// testRSAPrivateKey returns a test RSA private key for use in capability probing functions.
++//
++// The key is constructed from hard-coded parameters to avoid
++// spurious failures due to key generation issues and to avoid the speed cost of
++// key generation.
++var testRSAPrivateKey = sync.OnceValue(func() ossl.EVP_PKEY_PTR {
++	// RSA-2048 key "testRSA2048":
++	// https://www.rfc-editor.org/rfc/rfc9500.html#section-2.1
++	N := []byte{
++		0xB0, 0xF9, 0xE8, 0x19, 0x43, 0xA7, 0xAE, 0x98,
++		0x92, 0xAA, 0xDE, 0x17, 0xCA, 0x7C, 0x40, 0xF8,
++		0x74, 0x4F, 0xED, 0x2F, 0x81, 0x48, 0xE6, 0xC8,
++		0xEA, 0xA2, 0x7B, 0x7D, 0x00, 0x15, 0x48, 0xFB,
++		0x51, 0x92, 0xAB, 0x28, 0xB5, 0x6C, 0x50, 0x60,
++		0xB1, 0x18, 0xCC, 0xD1, 0x31, 0xE5, 0x94, 0x87,
++		0x4C, 0x6C, 0xA9, 0x89, 0xB5, 0x6C, 0x27, 0x29,
++		0x6F, 0x09, 0xFB, 0x93, 0xA0, 0x34, 0xDF, 0x32,
++		0xE9, 0x7C, 0x6F, 0xF0, 0x99, 0x8C, 0xFD, 0x8E,
++		0x6F, 0x42, 0xDD, 0xA5, 0x8A, 0xCD, 0x1F, 0xA9,
++		0x79, 0x86, 0xF1, 0x44, 0xF3, 0xD1, 0x54, 0xD6,
++		0x76, 0x50, 0x17, 0x5E, 0x68, 0x54, 0xB3, 0xA9,
++		0x52, 0x00, 0x3B, 0xC0, 0x68, 0x87, 0xB8, 0x45,
++		0x5A, 0xC2, 0xB1, 0x9F, 0x7B, 0x2F, 0x76, 0x50,
++		0x4E, 0xBC, 0x98, 0xEC, 0x94, 0x55, 0x71, 0xB0,
++		0x78, 0x92, 0x15, 0x0D, 0xDC, 0x6A, 0x74, 0xCA,
++		0x0F, 0xBC, 0xD3, 0x54, 0x97, 0xCE, 0x81, 0x53,
++		0x4D, 0xAF, 0x94, 0x18, 0x84, 0x4B, 0x13, 0xAE,
++		0xA3, 0x1F, 0x9D, 0x5A, 0x6B, 0x95, 0x57, 0xBB,
++		0xDF, 0x61, 0x9E, 0xFD, 0x4E, 0x88, 0x7F, 0x2D,
++		0x42, 0xB8, 0xDD, 0x8B, 0xC9, 0x87, 0xEA, 0xE1,
++		0xBF, 0x89, 0xCA, 0xB8, 0x5E, 0xE2, 0x1E, 0x35,
++		0x63, 0x05, 0xDF, 0x6C, 0x07, 0xA8, 0x83, 0x8E,
++		0x3E, 0xF4, 0x1C, 0x59, 0x5D, 0xCC, 0xE4, 0x3D,
++		0xAF, 0xC4, 0x91, 0x23, 0xEF, 0x4D, 0x8A, 0xBB,
++		0xA9, 0x3D, 0x39, 0x05, 0xE4, 0x02, 0x8D, 0x7B,
++		0xA9, 0x14, 0x84, 0xA2, 0x75, 0x96, 0xE0, 0x7B,
++		0x4B, 0x6E, 0xD9, 0x92, 0xF0, 0x77, 0xB5, 0x24,
++		0xD3, 0xDC, 0xFE, 0x7D, 0xDD, 0x55, 0x49, 0xBE,
++		0x7C, 0xCE, 0x8D, 0xA0, 0x35, 0xCF, 0xA0, 0xB3,
++		0xFB, 0x8F, 0x9E, 0x46, 0xF7, 0x32, 0xB2, 0xA8,
++		0x6B, 0x46, 0x01, 0x65, 0xC0, 0x8F, 0x53, 0x13}
++	E := []byte{0x01, 0x00, 0x01}
++	d := []byte{
++		0x41, 0x18, 0x8B, 0x20, 0xCF, 0xDB, 0xDB, 0xC2,
++		0xCF, 0x1F, 0xFE, 0x75, 0x2D, 0xCB, 0xAA, 0x72,
++		0x39, 0x06, 0x35, 0x2E, 0x26, 0x15, 0xD4, 0x9D,
++		0xCE, 0x80, 0x59, 0x7F, 0xCF, 0x0A, 0x05, 0x40,
++		0x3B, 0xEF, 0x00, 0xFA, 0x06, 0x51, 0x82, 0xF7,
++		0x2D, 0xEC, 0xFB, 0x59, 0x6F, 0x4B, 0x0C, 0xE8,
++		0xFF, 0x59, 0x70, 0xBA, 0xF0, 0x7A, 0x89, 0xA5,
++		0x19, 0xEC, 0xC8, 0x16, 0xB2, 0xF4, 0xFF, 0xAC,
++		0x50, 0x69, 0xAF, 0x1B, 0x06, 0xBF, 0xEF, 0x7B,
++		0xF6, 0xBC, 0xD7, 0x9E, 0x4E, 0x81, 0xC8, 0xC5,
++		0xA3, 0xA7, 0xD9, 0x13, 0x0D, 0xC3, 0xCF, 0xBA,
++		0xDA, 0xE5, 0xF6, 0xD2, 0x88, 0xF9, 0xAE, 0xE3,
++		0xF6, 0xFF, 0x92, 0xFA, 0xE0, 0xF8, 0x1A, 0xF5,
++		0x97, 0xBE, 0xC9, 0x6A, 0xE9, 0xFA, 0xB9, 0x40,
++		0x2C, 0xD5, 0xFE, 0x41, 0xF7, 0x05, 0xBE, 0xBD,
++		0xB4, 0x7B, 0xB7, 0x36, 0xD3, 0xFE, 0x6C, 0x5A,
++		0x51, 0xE0, 0xE2, 0x07, 0x32, 0xA9, 0x7B, 0x5E,
++		0x46, 0xC1, 0xCB, 0xDB, 0x26, 0xD7, 0x48, 0x54,
++		0xC6, 0xB6, 0x60, 0x4A, 0xED, 0x46, 0x37, 0x35,
++		0xFF, 0x90, 0x76, 0x04, 0x65, 0x57, 0xCA, 0xF9,
++		0x49, 0xBF, 0x44, 0x88, 0x95, 0xC2, 0x04, 0x32,
++		0xC1, 0xE0, 0x9C, 0x01, 0x4E, 0xA7, 0x56, 0x60,
++		0x43, 0x4F, 0x1A, 0x0F, 0x3B, 0xE2, 0x94, 0xBA,
++		0xBC, 0x5D, 0x53, 0x0E, 0x6A, 0x10, 0x21, 0x3F,
++		0x53, 0xB6, 0x03, 0x75, 0xFC, 0x84, 0xA7, 0x57,
++		0x3F, 0x2A, 0xF1, 0x21, 0x55, 0x84, 0xF5, 0xB4,
++		0xBD, 0xA6, 0xD4, 0xE8, 0xF9, 0xE1, 0x7A, 0x78,
++		0xD9, 0x7E, 0x77, 0xB8, 0x6D, 0xA4, 0xA1, 0x84,
++		0x64, 0x75, 0x31, 0x8A, 0x7A, 0x10, 0xA5, 0x61,
++		0x01, 0x4E, 0xFF, 0xA2, 0x3A, 0x81, 0xEC, 0x56,
++		0xE9, 0xE4, 0x10, 0x9D, 0xEF, 0x8C, 0xB3, 0xF7,
++		0x97, 0x22, 0x3F, 0x7D, 0x8D, 0x0D, 0x43, 0x51}
++	p := []byte{
++		0xDD, 0x10, 0x57, 0x02, 0x38, 0x2F, 0x23, 0x2B,
++		0x36, 0x81, 0xF5, 0x37, 0x91, 0xE2, 0x26, 0x17,
++		0xC7, 0xBF, 0x4E, 0x9A, 0xCB, 0x81, 0xED, 0x48,
++		0xDA, 0xF6, 0xD6, 0x99, 0x5D, 0xA3, 0xEA, 0xB6,
++		0x42, 0x83, 0x9A, 0xFF, 0x01, 0x2D, 0x2E, 0xA6,
++		0x28, 0xB9, 0x0A, 0xF2, 0x79, 0xFD, 0x3E, 0x6F,
++		0x7C, 0x93, 0xCD, 0x80, 0xF0, 0x72, 0xF0, 0x1F,
++		0xF2, 0x44, 0x3B, 0x3E, 0xE8, 0xF2, 0x4E, 0xD4,
++		0x69, 0xA7, 0x96, 0x13, 0xA4, 0x1B, 0xD2, 0x40,
++		0x20, 0xF9, 0x2F, 0xD1, 0x10, 0x59, 0xBD, 0x1D,
++		0x0F, 0x30, 0x1B, 0x5B, 0xA7, 0xA9, 0xD3, 0x63,
++		0x7C, 0xA8, 0xD6, 0x5C, 0x1A, 0x98, 0x15, 0x41,
++		0x7D, 0x8E, 0xAB, 0x73, 0x4B, 0x0B, 0x4F, 0x3A,
++		0x2C, 0x66, 0x1D, 0x9A, 0x1A, 0x82, 0xF3, 0xAC,
++		0x73, 0x4C, 0x40, 0x53, 0x06, 0x69, 0xAB, 0x8E,
++		0x47, 0x30, 0x45, 0xA5, 0x8E, 0x65, 0x53, 0x9D}
++	q := []byte{
++		0xCC, 0xF1, 0xE5, 0xBB, 0x90, 0xC8, 0xE9, 0x78,
++		0x1E, 0xA7, 0x5B, 0xEB, 0xF1, 0x0B, 0xC2, 0x52,
++		0xE1, 0x1E, 0xB0, 0x23, 0xA0, 0x26, 0x0F, 0x18,
++		0x87, 0x55, 0x2A, 0x56, 0x86, 0x3F, 0x4A, 0x64,
++		0x21, 0xE8, 0xC6, 0x00, 0xBF, 0x52, 0x3D, 0x6C,
++		0xB1, 0xB0, 0xAD, 0xBD, 0xD6, 0x5B, 0xFE, 0xE4,
++		0xA8, 0x8A, 0x03, 0x7E, 0x3D, 0x1A, 0x41, 0x5E,
++		0x5B, 0xB9, 0x56, 0x48, 0xDA, 0x5A, 0x0C, 0xA2,
++		0x6B, 0x54, 0xF4, 0xA6, 0x39, 0x48, 0x52, 0x2C,
++		0x3D, 0x5F, 0x89, 0xB9, 0x4A, 0x72, 0xEF, 0xFF,
++		0x95, 0x13, 0x4D, 0x59, 0x40, 0xCE, 0x45, 0x75,
++		0x8F, 0x30, 0x89, 0x80, 0x90, 0x89, 0x56, 0x58,
++		0x8E, 0xEF, 0x57, 0x5B, 0x3E, 0x4B, 0xC4, 0xC3,
++		0x68, 0xCF, 0xE8, 0x13, 0xEE, 0x9C, 0x25, 0x2C,
++		0x2B, 0x02, 0xE0, 0xDF, 0x91, 0xF1, 0xAA, 0x01,
++		0x93, 0x8D, 0x38, 0x68, 0x5D, 0x60, 0xBA, 0x6F}
++	qInv := []byte{
++		0x0A, 0x81, 0xD8, 0xA6, 0x18, 0x31, 0x4A, 0x80,
++		0x3A, 0xF6, 0x1C, 0x06, 0x71, 0x1F, 0x2C, 0x39,
++		0xB2, 0x66, 0xFF, 0x41, 0x4D, 0x53, 0x47, 0x6D,
++		0x1D, 0xA5, 0x2A, 0x43, 0x18, 0xAA, 0xFE, 0x4B,
++		0x96, 0xF0, 0xDA, 0x07, 0x15, 0x5F, 0x8A, 0x51,
++		0x34, 0xDA, 0xB8, 0x8E, 0xE2, 0x9E, 0x81, 0x68,
++		0x07, 0x6F, 0xCD, 0x78, 0xCA, 0x79, 0x1A, 0xC6,
++		0x34, 0x42, 0xA8, 0x1C, 0xD0, 0x69, 0x39, 0x27,
++		0xD8, 0x08, 0xE3, 0x35, 0xE8, 0xD8, 0xCB, 0xF2,
++		0x12, 0x19, 0x07, 0x50, 0x9A, 0x57, 0x75, 0x9B,
++		0x4F, 0x9A, 0x18, 0xFA, 0x3A, 0x7B, 0x33, 0x37,
++		0x79, 0xED, 0xDE, 0x7A, 0x45, 0x93, 0x84, 0xF8,
++		0x44, 0x4A, 0xDA, 0xEC, 0xFF, 0xEC, 0x95, 0xFD,
++		0x55, 0x2B, 0x0C, 0xFC, 0xB6, 0xC7, 0xF6, 0x92,
++		0x62, 0x6D, 0xDE, 0x1E, 0xF2, 0x68, 0xA4, 0x0D,
++		0x2F, 0x67, 0xB5, 0xC8, 0xAA, 0x38, 0x7F, 0xF7}
++	dP := []byte{
++		0x09, 0xED, 0x54, 0xEA, 0xED, 0x98, 0xF8, 0x4C,
++		0x55, 0x7B, 0x4A, 0x86, 0xBF, 0x4F, 0x57, 0x84,
++		0x93, 0xDC, 0xBC, 0x6B, 0xE9, 0x1D, 0xA1, 0x89,
++		0x37, 0x04, 0x04, 0xA9, 0x08, 0x72, 0x76, 0xF4,
++		0xCE, 0x51, 0xD8, 0xA1, 0x00, 0xED, 0x85, 0x7D,
++		0xC2, 0xB0, 0x64, 0x94, 0x74, 0xF3, 0xF1, 0x5C,
++		0xD2, 0x4C, 0x54, 0xDB, 0x28, 0x71, 0x10, 0xE5,
++		0x6E, 0x5C, 0xB0, 0x08, 0x68, 0x2F, 0x91, 0x68,
++		0xAA, 0x81, 0xF3, 0x14, 0x58, 0xB7, 0x43, 0x1E,
++		0xCC, 0x1C, 0x44, 0x90, 0x6F, 0xDA, 0x87, 0xCA,
++		0x89, 0x47, 0x10, 0xC3, 0x71, 0xE9, 0x07, 0x6C,
++		0x1D, 0x49, 0xFB, 0xAE, 0x51, 0x27, 0x69, 0x34,
++		0xF2, 0xAD, 0x78, 0x77, 0x89, 0xF4, 0x2D, 0x0F,
++		0xA0, 0xB4, 0xC9, 0x39, 0x85, 0x5D, 0x42, 0x12,
++		0x09, 0x6F, 0x70, 0x28, 0x0A, 0x4E, 0xAE, 0x7C,
++		0x8A, 0x27, 0xD9, 0xC8, 0xD0, 0x77, 0x2E, 0x65}
++	dQ := []byte{
++		0x8C, 0xB6, 0x85, 0x7A, 0x7B, 0xD5, 0x46, 0x5F,
++		0x80, 0x04, 0x7E, 0x9B, 0x87, 0xBC, 0x00, 0x27,
++		0x31, 0x84, 0x05, 0x81, 0xE0, 0x62, 0x61, 0x39,
++		0x01, 0x2A, 0x5B, 0x50, 0x5F, 0x0A, 0x33, 0x84,
++		0x7E, 0xB7, 0xB8, 0xC3, 0x28, 0x99, 0x49, 0xAD,
++		0x48, 0x6F, 0x3B, 0x4B, 0x3D, 0x53, 0x9A, 0xB5,
++		0xDA, 0x76, 0x30, 0x21, 0xCB, 0xC8, 0x2C, 0x1B,
++		0xA2, 0x34, 0xA5, 0x66, 0x8D, 0xED, 0x08, 0x01,
++		0xB8, 0x59, 0xF3, 0x43, 0xF1, 0xCE, 0x93, 0x04,
++		0xE6, 0xFA, 0xA2, 0xB0, 0x02, 0xCA, 0xD9, 0xB7,
++		0x8C, 0xDE, 0x5C, 0xDC, 0x2C, 0x1F, 0xB4, 0x17,
++		0x1C, 0x42, 0x42, 0x16, 0x70, 0xA6, 0xAB, 0x0F,
++		0x50, 0xCC, 0x4A, 0x19, 0x4E, 0xB3, 0x6D, 0x1C,
++		0x91, 0xE9, 0x35, 0xBA, 0x01, 0xB9, 0x59, 0xD8,
++		0x72, 0x8B, 0x9E, 0x64, 0x42, 0x6B, 0x3F, 0xC3,
++		0xA7, 0x50, 0x6D, 0xEB, 0x52, 0x39, 0xA8, 0xA7}
++
++	// Convert []byte to BigInt using BN_bin2bn and bnToBig
++	bytesToBigInt := func(b []byte) BigInt {
++		bn, err := ossl.BN_bin2bn(base(b), int32(len(b)), nil)
++		if err != nil {
++			panic(err)
++		}
++		defer ossl.BN_free(bn)
++		return bnToBig(bn)
++	}
++
++	priv, err := NewPrivateKeyRSA(
++		bytesToBigInt(N),
++		bytesToBigInt(E),
++		bytesToBigInt(d),
++		bytesToBigInt(p),
++		bytesToBigInt(q),
++		bytesToBigInt(dP),
++		bytesToBigInt(dQ),
++		bytesToBigInt(qInv),
++	)
++	if err != nil {
++		panic("failed to create test RSA private key: " + err.Error())
++	}
++	// Prevent finalization to avoid freeing OpenSSL objects.
++	runtime.SetFinalizer(priv, nil)
++	return priv._pkey
 +})
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/tls1prf.go b/src/vendor/github.com/golang-fips/openssl/v2/tls1prf.go
 new file mode 100644
@@ -33264,10 +33599,10 @@ index 00000000000000..f484a3e2211e04
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
 new file mode 100644
-index 00000000000000..0269f9cf86539e
+index 00000000000000..42f995a480e0fe
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
-@@ -0,0 +1,396 @@
+@@ -0,0 +1,404 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -33651,6 +33986,8 @@ index 00000000000000..0269f9cf86539e
 +
 +func cryptoHashToID(ch crypto.Hash) string {
 +	switch ch {
++	case crypto.MD4:
++		return bcrypt.MD4_ALGORITHM
 +	case crypto.MD5:
 +		return bcrypt.MD5_ALGORITHM
 +	case crypto.SHA1:
@@ -33661,6 +33998,12 @@ index 00000000000000..0269f9cf86539e
 +		return bcrypt.SHA384_ALGORITHM
 +	case crypto.SHA512:
 +		return bcrypt.SHA512_ALGORITHM
++	case crypto.SHA3_256:
++		return bcrypt.SHA3_256_ALGORITHM
++	case crypto.SHA3_384:
++		return bcrypt.SHA3_384_ALGORITHM
++	case crypto.SHA3_512:
++		return bcrypt.SHA3_512_ALGORITHM
 +	}
 +	return ""
 +}
@@ -34983,11 +35326,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b6f6376eac041a..cc1444536adb31 100644
+index b6f6376eac041a..0fb122073acdff 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20251218145113-52cddb05a262
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20251219133548-db44f2109b85
 +## explicit; go 1.24
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
@@ -35003,7 +35346,7 @@ index b6f6376eac041a..cc1444536adb31 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20251218121426-ba94af8d2bb8
++# github.com/microsoft/go-crypto-winnative v0.0.0-20251219091053-f9796ee5d078
 +## explicit; go 1.24
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
Upgrade the Windows backend to add support for RSA-PSS-SHA3 and RSA-PKCS1-SHA3 and update the cross platform cryptography docs accordingly.

While here, fix some erratas in the doc:

- Windows and Linux gained support for RSA-OAEP-SHA3 in a previous Go 1.26 commit.
- Go does not support RSA-PKCS1-MD4, so there is no need to name it.