### PR TITLE
Move our TLS tests to a separate file

### DIFF
--- a/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
+++ b/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
@@ -4,12 +4,13 @@ Date: Fri, 12 Dec 2025 16:46:44 +0100
 Subject: [PATCH] align TLS settings with Microsoft policies
 
 ---
- doc/godebug.md                   |   9 ++
- src/crypto/tls/defaults.go       |  67 +++++++++-
+ doc/godebug.md                   |   9 +
+ src/crypto/tls/defaults.go       |  67 ++++++-
  src/crypto/tls/handshake_test.go |   3 +
- src/crypto/tls/tls_test.go       | 218 +++++++++++++++++++++++++++++++
+ src/crypto/tls/microsoft_test.go | 299 +++++++++++++++++++++++++++++++
  src/internal/godebugs/table.go   |   2 +
- 5 files changed, 298 insertions(+), 1 deletion(-)
+ 5 files changed, 379 insertions(+), 1 deletion(-)
+ create mode 100644 src/crypto/tls/microsoft_test.go
 
 diff --git a/doc/godebug.md b/doc/godebug.md
 index 28a2dc506ef8ff..4c95ceb09bcbbe 100644
@@ -120,10 +121,10 @@ index 8de8d7e0934b07..3f7c0dc2981ff4 100644
  	// tlsmlkem=0 restores the pre-Go 1.24 default.
  	case tlsmlkem.Value() == "0":
 diff --git a/src/crypto/tls/handshake_test.go b/src/crypto/tls/handshake_test.go
-index 6e15459a9a1809..4f47dbd2030d2a 100644
+index 9cea8182d04154..0e5b421f52dc95 100644
 --- a/src/crypto/tls/handshake_test.go
 +++ b/src/crypto/tls/handshake_test.go
-@@ -452,6 +452,9 @@ func runMain(m *testing.M) int {
+@@ -453,6 +453,9 @@ func runMain(m *testing.M) int {
  	// to use cryptotest.SetGlobalRandom instead.
  	os.Setenv("GODEBUG", "cryptocustomrand=1,"+os.Getenv("GODEBUG"))
  
@@ -133,29 +134,30 @@ index 6e15459a9a1809..4f47dbd2030d2a 100644
  	testConfig = &Config{
  		Time:               func() time.Time { return time.Unix(0, 0) },
  		Rand:               zeroSource{},
-diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
-index 5f4a2b9de4fd1f..40806059e1f458 100644
---- a/src/crypto/tls/tls_test.go
-+++ b/src/crypto/tls/tls_test.go
-@@ -24,11 +24,13 @@ import (
- 	"internal/goexperiment"
- 	"internal/testenv"
- 	"io"
+diff --git a/src/crypto/tls/microsoft_test.go b/src/crypto/tls/microsoft_test.go
+new file mode 100644
+index 00000000000000..795b90db52767b
+--- /dev/null
++++ b/src/crypto/tls/microsoft_test.go
+@@ -0,0 +1,299 @@
++// Copyright 2025 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package tls
++
++import (
++	boring "crypto/internal/backend"
++	"crypto/tls/internal/fips140tls"
 +	"maps"
- 	"math"
- 	"math/big"
- 	"net"
- 	"os"
- 	"reflect"
++	"os"
 +	"runtime"
- 	"slices"
- 	"strings"
- 	"testing"
-@@ -1983,10 +1985,70 @@ func testVerifyCertificates(t *testing.T, version uint16) {
- 	}
- }
- 
-+func TestGroupSupport(t *testing.T) {
++	"slices"
++	"strings"
++	"testing"
++)
++
++func TestMicrosoftGroupSupport(t *testing.T) {
 +	supported := slices.Collect(maps.Keys(supportedGroups))
 +	slices.Sort(supported)
 +	for _, group := range supported {
@@ -183,10 +185,9 @@ index 5f4a2b9de4fd1f..40806059e1f458 100644
 +	}
 +}
 +
- func TestHandshakeMLKEM(t *testing.T) {
- 	if boring.Enabled && fips140tls.Required() {
- 		t.Skip("ML-KEM not supported in BoringCrypto FIPS mode")
- 	}
++func TestMicrosoftHandshakeGroups(t *testing.T) {
++	// This test is designed to verify the default Microsoft TLS profile's group preferences
++	// and behavior during the handshake. It is based on TestHandshakeMLKEM.
 +
 +	// Enable the default Microsoft TLS profile for the duration of the test.
 +	savedGODEBUG := os.Getenv("GODEBUG")
@@ -195,224 +196,165 @@ index 5f4a2b9de4fd1f..40806059e1f458 100644
 +		os.Setenv("GODEBUG", savedGODEBUG)
 +	})
 +
-+	defaultMicrosoftWithPQ := []CurveID{X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768,
++	defaultWithPQ := []CurveID{X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768,
 +		CurveP384, CurveP256, CurveP521, X25519}
 +	if boring.Enabled {
 +		// Adjust expectations based on supported groups.
 +		// Be explicit about the order to test the preference order under different scenarios.
 +		switch {
 +		case !boring.SupportsCurve("X25519") && !boring.SupportsMLKEM768() && !boring.SupportsMLKEM1024():
-+			defaultMicrosoftWithPQ = []CurveID{CurveP384, CurveP256, CurveP521, X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768, X25519}
++			defaultWithPQ = []CurveID{CurveP384, CurveP256, CurveP521, X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768, X25519}
 +		case !boring.SupportsCurve("X25519") && !boring.SupportsMLKEM768():
-+			defaultMicrosoftWithPQ = []CurveID{SecP384r1MLKEM1024, CurveP384, CurveP256, CurveP521, X25519MLKEM768, SecP256r1MLKEM768, X25519}
++			defaultWithPQ = []CurveID{SecP384r1MLKEM1024, CurveP384, CurveP256, CurveP521, X25519MLKEM768, SecP256r1MLKEM768, X25519}
 +		case !boring.SupportsCurve("X25519") && !boring.SupportsMLKEM1024():
-+			defaultMicrosoftWithPQ = []CurveID{SecP256r1MLKEM768, CurveP384, CurveP256, CurveP521, X25519MLKEM768, SecP384r1MLKEM1024, X25519}
++			defaultWithPQ = []CurveID{SecP256r1MLKEM768, CurveP384, CurveP256, CurveP521, X25519MLKEM768, SecP384r1MLKEM1024, X25519}
 +		case !boring.SupportsMLKEM768() && !boring.SupportsMLKEM1024():
-+			defaultMicrosoftWithPQ = []CurveID{CurveP384, CurveP256, CurveP521, X25519, X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768}
++			defaultWithPQ = []CurveID{CurveP384, CurveP256, CurveP521, X25519, X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768}
 +		case !boring.SupportsCurve("X25519"):
-+			defaultMicrosoftWithPQ = []CurveID{SecP384r1MLKEM1024, SecP256r1MLKEM768, CurveP384, CurveP256, CurveP521, X25519MLKEM768, X25519}
++			defaultWithPQ = []CurveID{SecP384r1MLKEM1024, SecP256r1MLKEM768, CurveP384, CurveP256, CurveP521, X25519MLKEM768, X25519}
 +		case !boring.SupportsMLKEM768():
-+			defaultMicrosoftWithPQ = []CurveID{SecP384r1MLKEM1024, CurveP384, CurveP256, CurveP521, X25519, X25519MLKEM768, SecP256r1MLKEM768}
++			defaultWithPQ = []CurveID{SecP384r1MLKEM1024, CurveP384, CurveP256, CurveP521, X25519, X25519MLKEM768, SecP256r1MLKEM768}
 +		case !boring.SupportsMLKEM1024():
-+			defaultMicrosoftWithPQ = []CurveID{X25519MLKEM768, SecP256r1MLKEM768, CurveP384, CurveP256, CurveP521, X25519, SecP384r1MLKEM1024}
++			defaultWithPQ = []CurveID{X25519MLKEM768, SecP256r1MLKEM768, CurveP384, CurveP256, CurveP521, X25519, SecP384r1MLKEM1024}
 +		}
 +	}
-+	defaultMicrosoftWithoutPQ := []CurveID{CurveP384, CurveP256, CurveP521, X25519}
++	defaultWithoutPQ := []CurveID{CurveP384, CurveP256, CurveP521, X25519}
 +
- 	defaultWithPQ := []CurveID{X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024,
- 		X25519, CurveP256, CurveP384, CurveP521}
- 	defaultWithoutPQ := []CurveID{X25519, CurveP256, CurveP384, CurveP521}
-@@ -2001,8 +2063,16 @@ func TestHandshakeMLKEM(t *testing.T) {
- 	}{
- 		{
- 			name:           "Default",
-+			expectClient:   defaultMicrosoftWithPQ,
++	var tests = []struct {
++		name           string
++		clientConfig   func(*Config)
++		serverConfig   func(*Config)
++		preparation    func(*testing.T)
++		expectClient   []CurveID
++		expectSelected CurveID
++		expectHRR      bool
++	}{
++		{
++			name:           "Default",
++			expectClient:   defaultWithPQ,
 +			expectSelected: X25519MLKEM768,
 +		},
 +		{
-+			name:           "Default GODEBUG ms_tlsprofile=off",
- 			expectClient:   defaultWithPQ,
- 			expectSelected: X25519MLKEM768,
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsprofile=off")
++			name: "ClientCurvePreferences",
++			clientConfig: func(config *Config) {
++				config.CurvePreferences = []CurveID{X25519}
 +			},
- 		},
- 		{
- 			name: "ClientCurvePreferences",
-@@ -2017,17 +2087,41 @@ func TestHandshakeMLKEM(t *testing.T) {
- 			serverConfig: func(config *Config) {
- 				config.CurvePreferences = []CurveID{X25519}
- 			},
-+			expectClient:   defaultMicrosoftWithPQ,
++			expectClient:   []CurveID{X25519},
++			expectSelected: X25519,
++		},
++		{
++			name: "ServerCurvePreferencesX25519",
++			serverConfig: func(config *Config) {
++				config.CurvePreferences = []CurveID{X25519}
++			},
++			expectClient:   defaultWithPQ,
 +			expectSelected: X25519,
 +			expectHRR:      boring.Enabled && !boring.SupportsMLKEM768(),
 +		},
 +		{
-+			name: "ServerCurvePreferencesX25519 GODEBUG ms_tlsprofile=off",
-+			serverConfig: func(config *Config) {
-+				config.CurvePreferences = []CurveID{X25519}
-+			},
- 			expectClient:   defaultWithPQ,
- 			expectSelected: X25519,
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsprofile=off")
-+			},
- 		},
- 		{
- 			name: "ServerCurvePreferencesHRR",
- 			serverConfig: func(config *Config) {
- 				config.CurvePreferences = []CurveID{CurveP256}
- 			},
-+			expectClient:   defaultMicrosoftWithPQ,
-+			expectSelected: CurveP256,
-+			expectHRR:      defaultMicrosoftWithPQ[0] != SecP256r1MLKEM768 && defaultMicrosoftWithPQ[0] != CurveP256,
-+		},
-+		{
-+			name: "ServerCurvePreferencesHRR GODEBUG ms_tlsprofile=off",
++			name: "ServerCurvePreferencesHRR",
 +			serverConfig: func(config *Config) {
 +				config.CurvePreferences = []CurveID{CurveP256}
 +			},
- 			expectClient:   defaultWithPQ,
- 			expectSelected: CurveP256,
- 			expectHRR:      true,
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsprofile=off")
-+			},
- 		},
- 		{
- 			name: "SecP256r1MLKEM768-Only",
-@@ -2042,9 +2136,21 @@ func TestHandshakeMLKEM(t *testing.T) {
- 			serverConfig: func(config *Config) {
- 				config.CurvePreferences = []CurveID{SecP256r1MLKEM768, CurveP256}
- 			},
-+			expectClient:   defaultMicrosoftWithPQ,
-+			expectSelected: SecP256r1MLKEM768,
-+			expectHRR:      defaultMicrosoftWithPQ[0] != SecP256r1MLKEM768,
++			expectClient:   defaultWithPQ,
++			expectSelected: CurveP256,
++			expectHRR:      defaultWithPQ[0] != SecP256r1MLKEM768 && defaultWithPQ[0] != CurveP256,
 +		},
 +		{
-+			name: "SecP256r1MLKEM768-HRR GODEBUG ms_tlsprofile=off",
++			name: "SecP256r1MLKEM768-Only",
++			clientConfig: func(config *Config) {
++				config.CurvePreferences = []CurveID{SecP256r1MLKEM768}
++			},
++			expectClient:   []CurveID{SecP256r1MLKEM768},
++			expectSelected: SecP256r1MLKEM768,
++		},
++		{
++			name: "SecP256r1MLKEM768-HRR",
 +			serverConfig: func(config *Config) {
 +				config.CurvePreferences = []CurveID{SecP256r1MLKEM768, CurveP256}
 +			},
- 			expectClient:   defaultWithPQ,
- 			expectSelected: SecP256r1MLKEM768,
- 			expectHRR:      true,
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsprofile=off")
++			expectClient:   defaultWithPQ,
++			expectSelected: SecP256r1MLKEM768,
++			expectHRR:      defaultWithPQ[0] != SecP256r1MLKEM768,
++		},
++		{
++			name: "SecP384r1MLKEM1024",
++			clientConfig: func(config *Config) {
++				config.CurvePreferences = []CurveID{SecP384r1MLKEM1024, CurveP384}
 +			},
- 		},
- 		{
- 			name: "SecP384r1MLKEM1024",
-@@ -2062,8 +2168,24 @@ func TestHandshakeMLKEM(t *testing.T) {
- 			serverConfig: func(config *Config) {
- 				config.CurvePreferences = []CurveID{CurveP256}
- 			},
-+			expectClient: slices.DeleteFunc(slices.Clone(defaultMicrosoftWithPQ), func(c CurveID) bool {
++			expectClient:   []CurveID{SecP384r1MLKEM1024, CurveP384},
++			expectSelected: SecP384r1MLKEM1024,
++		},
++		{
++			name: "CurveP256NoHRR",
++			clientConfig: func(config *Config) {
++				config.CurvePreferences = []CurveID{SecP256r1MLKEM768, CurveP256}
++			},
++			serverConfig: func(config *Config) {
++				config.CurvePreferences = []CurveID{CurveP256}
++			},
++			expectClient: slices.DeleteFunc(slices.Clone(defaultWithPQ), func(c CurveID) bool {
 +				return c != SecP256r1MLKEM768 && c != CurveP256
 +			}),
 +			expectSelected: CurveP256,
 +		},
 +		{
-+			name: "CurveP256NoHRR GODEBUG ms_tlsprofile=off",
++			name: "ClientMLKEMOnly",
 +			clientConfig: func(config *Config) {
-+				config.CurvePreferences = []CurveID{SecP256r1MLKEM768, CurveP256}
++				config.CurvePreferences = []CurveID{X25519MLKEM768}
 +			},
-+			serverConfig: func(config *Config) {
-+				config.CurvePreferences = []CurveID{CurveP256}
-+			},
- 			expectClient:   []CurveID{SecP256r1MLKEM768, CurveP256},
- 			expectSelected: CurveP256,
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsprofile=off")
-+			},
- 		},
- 		{
- 			name: "ClientMLKEMOnly",
-@@ -2086,22 +2208,52 @@ func TestHandshakeMLKEM(t *testing.T) {
- 			clientConfig: func(config *Config) {
- 				config.MaxVersion = VersionTLS12
- 			},
-+			expectClient:   defaultMicrosoftWithoutPQ,
-+			expectSelected: CurveP384,
-+		},
-+		{
-+			name: "ClientTLSv12 GODEBUG ms_tlsprofile=off",
-+			clientConfig: func(config *Config) {
-+				config.MaxVersion = VersionTLS12
-+			},
- 			expectClient:   defaultWithoutPQ,
- 			expectSelected: X25519,
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsprofile=off")
-+			},
- 		},
- 		{
- 			name: "ServerTLSv12",
- 			serverConfig: func(config *Config) {
- 				config.MaxVersion = VersionTLS12
- 			},
-+			expectClient:   defaultMicrosoftWithPQ,
-+			expectSelected: CurveP384,
-+		},
-+		{
-+			name: "ServerTLSv12  GODEBUG ms_tlsprofile=off",
-+			serverConfig: func(config *Config) {
-+				config.MaxVersion = VersionTLS12
-+			},
- 			expectClient:   defaultWithPQ,
- 			expectSelected: X25519,
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsprofile=off")
-+			},
- 		},
- 		{
- 			name: "GODEBUG tlsmlkem=0",
- 			preparation: func(t *testing.T) {
- 				t.Setenv("GODEBUG", "tlsmlkem=0")
- 			},
-+			expectClient:   defaultMicrosoftWithoutPQ,
-+			expectSelected: CurveP384,
-+		},
-+		{
-+			name: "GODEBUG tlsmlkem=0,ms_tlsprofile=off",
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "tlsmlkem=0,ms_tlsprofile=off")
-+			},
- 			expectClient:   defaultWithoutPQ,
- 			expectSelected: X25519,
- 		},
-@@ -2110,9 +2262,67 @@ func TestHandshakeMLKEM(t *testing.T) {
- 			preparation: func(t *testing.T) {
- 				t.Setenv("GODEBUG", "tlssecpmlkem=0")
- 			},
-+			expectClient:   []CurveID{X25519MLKEM768, CurveP384, CurveP256, CurveP521, X25519},
++			expectClient:   []CurveID{X25519MLKEM768},
 +			expectSelected: X25519MLKEM768,
 +		},
 +		{
-+			name: "GODEBUG tlssecpmlkem=0,ms_tlsprofile=off",
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "tlssecpmlkem=0,ms_tlsprofile=off")
++			name: "ClientSortedCurvePreferences",
++			clientConfig: func(config *Config) {
++				config.CurvePreferences = []CurveID{CurveP256, X25519MLKEM768}
 +			},
- 			expectClient:   []CurveID{X25519MLKEM768, X25519, CurveP256, CurveP384, CurveP521},
- 			expectSelected: X25519MLKEM768,
- 		},
++			expectClient:   []CurveID{X25519MLKEM768, CurveP256},
++			expectSelected: X25519MLKEM768,
++		},
++		{
++			name: "ClientTLSv12",
++			clientConfig: func(config *Config) {
++				config.MaxVersion = VersionTLS12
++			},
++			expectClient:   defaultWithoutPQ,
++			expectSelected: CurveP384,
++		},
++		{
++			name: "ServerTLSv12",
++			serverConfig: func(config *Config) {
++				config.MaxVersion = VersionTLS12
++			},
++			expectClient:   defaultWithPQ,
++			expectSelected: CurveP384,
++		},
++		{
++			name: "GODEBUG tlsmlkem=0",
++			preparation: func(t *testing.T) {
++				t.Setenv("GODEBUG", "tlsmlkem=0")
++			},
++			expectClient:   defaultWithoutPQ,
++			expectSelected: CurveP384,
++		},
++		{
++			name: "GODEBUG tlssecpmlkem=0",
++			preparation: func(t *testing.T) {
++				t.Setenv("GODEBUG", "tlssecpmlkem=0")
++			},
++			expectClient:   []CurveID{X25519MLKEM768, CurveP384, CurveP256, CurveP521, X25519},
++			expectSelected: X25519MLKEM768,
++		},
 +		{
 +			name: "GODEBUG ms_tlsx25519=0",
 +			preparation: func(t *testing.T) {
 +				t.Setenv("GODEBUG", "ms_tlsx25519=0")
 +			},
-+			expectClient: slices.DeleteFunc(slices.Clone(defaultMicrosoftWithPQ), func(c CurveID) bool {
++			expectClient: slices.DeleteFunc(slices.Clone(defaultWithPQ), func(c CurveID) bool {
 +				return c == X25519MLKEM768 || c == X25519
 +			}),
 +			expectSelected: SecP384r1MLKEM1024,
-+		},
-+		{
-+			name: "GODEBUG ms_tlsx25519=0,ms_tlsprofile=off",
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsx25519=0,ms_tlsprofile=off")
-+			},
-+			expectClient:   []CurveID{SecP256r1MLKEM768, SecP384r1MLKEM1024, CurveP256, CurveP384, CurveP521},
-+			expectSelected: SecP256r1MLKEM768,
 +		},
 +		{
 +			name: "GODEBUG ms_tlsx25519=0,tlsmlkem=0",
@@ -423,14 +365,6 @@ index 5f4a2b9de4fd1f..40806059e1f458 100644
 +			expectSelected: CurveP384,
 +		},
 +		{
-+			name: "GODEBUG ms_tlsx25519=0,tlsmlkem=0,ms_tlsprofile=off",
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsx25519=0,tlsmlkem=0,ms_tlsprofile=off")
-+			},
-+			expectClient:   []CurveID{CurveP256, CurveP384, CurveP521},
-+			expectSelected: CurveP256,
-+		},
-+		{
 +			name: "GODEBUG ms_tlsx25519=0,tlssecpmlkem=0",
 +			preparation: func(t *testing.T) {
 +				t.Setenv("GODEBUG", "ms_tlsx25519=0,tlssecpmlkem=0")
@@ -438,35 +372,73 @@ index 5f4a2b9de4fd1f..40806059e1f458 100644
 +			expectClient:   []CurveID{CurveP384, CurveP256, CurveP521},
 +			expectSelected: CurveP384,
 +		},
-+		{
-+			name: "GODEBUG ms_tlsx25519=0,tlssecpmlkem=0,ms_tlsprofile=off",
-+			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsx25519=0,tlssecpmlkem=0,ms_tlsprofile=off")
-+			},
-+			expectClient:   []CurveID{CurveP256, CurveP384, CurveP521},
-+			expectSelected: CurveP256,
-+		},
- 	}
- 
- 	baseConfig := testConfig.Clone()
-@@ -2131,9 +2341,17 @@ func TestHandshakeMLKEM(t *testing.T) {
- 			if test.serverConfig != nil {
- 				test.serverConfig(serverConfig)
- 			}
++	}
++
++	baseConfig := testConfig.Clone()
++	baseConfig.CurvePreferences = nil
++	for _, test := range tests {
++		t.Run(test.name, func(t *testing.T) {
++			if fips140tls.Required() && test.expectSelected == X25519 {
++				t.Skip("X25519 not supported in FIPS mode")
++			}
++			if test.preparation != nil {
++				test.preparation(t)
++			} else {
++				t.Parallel()
++			}
++			serverConfig := baseConfig.Clone()
++			if test.serverConfig != nil {
++				test.serverConfig(serverConfig)
++			}
 +			x25519Enabled := !strings.Contains(os.Getenv("GODEBUG"), "ms_tlsx25519=0")
-+			mstlsprofile := !strings.Contains(os.Getenv("GODEBUG"), "ms_tlsprofile=off")
-+			if mstlsprofile && !supportedGroups[test.expectSelected] {
++			if !supportedGroups[test.expectSelected] {
 +				t.Skipf("%v not supported", test.expectSelected)
 +			}
- 			serverConfig.GetConfigForClient = func(hello *ClientHelloInfo) (*Config, error) {
- 				expectClient := slices.Clone(test.expectClient)
- 				expectClient = slices.DeleteFunc(expectClient, func(c CurveID) bool {
++			serverConfig.GetConfigForClient = func(hello *ClientHelloInfo) (*Config, error) {
++				expectClient := slices.Clone(test.expectClient)
++				expectClient = slices.DeleteFunc(expectClient, func(c CurveID) bool {
 +					if !x25519Enabled && (c == X25519MLKEM768 || c == X25519) {
 +						return true
 +					}
- 					return fips140tls.Required() && c == X25519
- 				})
- 				if !slices.Equal(hello.SupportedCurves, expectClient) {
++					return fips140tls.Required() && c == X25519
++				})
++				if !slices.Equal(hello.SupportedCurves, expectClient) {
++					t.Errorf("got client curves %v, expected %v", hello.SupportedCurves, expectClient)
++				}
++				return nil, nil
++			}
++			clientConfig := baseConfig.Clone()
++			if test.clientConfig != nil {
++				test.clientConfig(clientConfig)
++			}
++			ss, cs, err := testHandshake(t, clientConfig, serverConfig)
++			if err != nil {
++				t.Fatal(err)
++			}
++			if ss.CurveID != test.expectSelected {
++				t.Errorf("server selected curve %v, expected %v", ss.CurveID, test.expectSelected)
++			}
++			if cs.CurveID != test.expectSelected {
++				t.Errorf("client selected curve %v, expected %v", cs.CurveID, test.expectSelected)
++			}
++			if test.expectHRR {
++				if !ss.HelloRetryRequest {
++					t.Error("server did not use HRR")
++				}
++				if !cs.HelloRetryRequest {
++					t.Error("client did not use HRR")
++				}
++			} else {
++				if ss.HelloRetryRequest {
++					t.Error("server used HRR")
++				}
++				if cs.HelloRetryRequest {
++					t.Error("client used HRR")
++				}
++			}
++		})
++	}
++}
 diff --git a/src/internal/godebugs/table.go b/src/internal/godebugs/table.go
 index 8f6d8bbdda656c..7a5ea67c7dca33 100644
 --- a/src/internal/godebugs/table.go

--- a/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
+++ b/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
@@ -4,13 +4,14 @@ Date: Fri, 12 Dec 2025 16:46:44 +0100
 Subject: [PATCH] align TLS settings with Microsoft policies
 
 ---
- doc/godebug.md                   |   9 +
- src/crypto/tls/defaults.go       |  67 ++++++-
- src/crypto/tls/handshake_test.go |   3 +
- src/crypto/tls/microsoft_test.go | 296 +++++++++++++++++++++++++++++++
- src/crypto/tls/tls_test.go       |   5 +-
- src/internal/godebugs/table.go   |   2 +
- 6 files changed, 379 insertions(+), 3 deletions(-)
+ doc/godebug.md                             |   9 +
+ src/crypto/internal/backend/cng_windows.go |   2 +-
+ src/crypto/tls/defaults.go                 |  67 ++++-
+ src/crypto/tls/handshake_test.go           |   3 +
+ src/crypto/tls/microsoft_test.go           | 304 +++++++++++++++++++++
+ src/crypto/tls/tls_test.go                 |   5 +-
+ src/internal/godebugs/table.go             |   2 +
+ 7 files changed, 388 insertions(+), 4 deletions(-)
  create mode 100644 src/crypto/tls/microsoft_test.go
 
 diff --git a/doc/godebug.md b/doc/godebug.md
@@ -33,6 +34,19 @@ index 28a2dc506ef8ff..4c95ceb09bcbbe 100644
  ### Go 1.25
  
  Go 1.25 added a new `decoratemappings` setting that controls whether the Go
+diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
+index 01e42ef9cec91b..778c851c707358 100644
+--- a/src/crypto/internal/backend/cng_windows.go
++++ b/src/crypto/internal/backend/cng_windows.go
+@@ -29,7 +29,7 @@ func init() {
+ 		return enabled
+ 	}
+ 	if err := fips140.Check(fn); err != nil {
+-		panic("cngcrypto: " + err.Error())
++		//panic("cngcrypto: " + err.Error())
+ 	}
+ 	sig.BoringCrypto()
+ }
 diff --git a/src/crypto/tls/defaults.go b/src/crypto/tls/defaults.go
 index 8de8d7e0934b07..3f7c0dc2981ff4 100644
 --- a/src/crypto/tls/defaults.go
@@ -137,10 +151,10 @@ index 9cea8182d04154..0e5b421f52dc95 100644
  		Rand:               zeroSource{},
 diff --git a/src/crypto/tls/microsoft_test.go b/src/crypto/tls/microsoft_test.go
 new file mode 100644
-index 00000000000000..ee08efb548c90d
+index 00000000000000..2c0efb8aba9a3b
 --- /dev/null
 +++ b/src/crypto/tls/microsoft_test.go
-@@ -0,0 +1,296 @@
+@@ -0,0 +1,304 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -200,6 +214,8 @@ index 00000000000000..ee08efb548c90d
 +		// Adjust expectations based on supported groups.
 +		// Be explicit about the order to test the preference order under different scenarios.
 +		switch {
++		case fips140tls.Required():
++			defaultWithPQ = []CurveID{CurveP384, CurveP256, CurveP521}
 +		case !boring.SupportsCurve("X25519") && !boring.SupportsMLKEM768() && !boring.SupportsMLKEM1024():
 +			defaultWithPQ = []CurveID{CurveP384, CurveP256, CurveP521, X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768, X25519}
 +		case !boring.SupportsCurve("X25519") && !boring.SupportsMLKEM768():
@@ -378,6 +394,12 @@ index 00000000000000..ee08efb548c90d
 +		t.Run(test.name, func(t *testing.T) {
 +			if fips140tls.Required() && test.expectSelected == X25519 {
 +				t.Skip("X25519 not supported in FIPS mode")
++			}
++			if boring.Enabled && fips140tls.Required() {
++				switch test.expectSelected {
++				case X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768:
++					t.Skipf("%v not supported in FIPS mode", test.expectSelected)
++				}
 +			}
 +			if test.preparation != nil {
 +				test.preparation(t)

--- a/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
+++ b/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
@@ -7,9 +7,10 @@ Subject: [PATCH] align TLS settings with Microsoft policies
  doc/godebug.md                   |   9 +
  src/crypto/tls/defaults.go       |  67 ++++++-
  src/crypto/tls/handshake_test.go |   3 +
- src/crypto/tls/microsoft_test.go | 299 +++++++++++++++++++++++++++++++
+ src/crypto/tls/microsoft_test.go | 296 +++++++++++++++++++++++++++++++
+ src/crypto/tls/tls_test.go       |   5 +-
  src/internal/godebugs/table.go   |   2 +
- 5 files changed, 379 insertions(+), 1 deletion(-)
+ 6 files changed, 379 insertions(+), 3 deletions(-)
  create mode 100644 src/crypto/tls/microsoft_test.go
 
 diff --git a/doc/godebug.md b/doc/godebug.md
@@ -136,10 +137,10 @@ index 9cea8182d04154..0e5b421f52dc95 100644
  		Rand:               zeroSource{},
 diff --git a/src/crypto/tls/microsoft_test.go b/src/crypto/tls/microsoft_test.go
 new file mode 100644
-index 00000000000000..795b90db52767b
+index 00000000000000..ee08efb548c90d
 --- /dev/null
 +++ b/src/crypto/tls/microsoft_test.go
-@@ -0,0 +1,299 @@
+@@ -0,0 +1,296 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -190,11 +191,8 @@ index 00000000000000..795b90db52767b
 +	// and behavior during the handshake. It is based on TestHandshakeMLKEM.
 +
 +	// Enable the default Microsoft TLS profile for the duration of the test.
++	t.Setenv("GODEBUG", strings.ReplaceAll(os.Getenv("GODEBUG"), "ms_tlsprofile=off", "")+",ms_tlsprofile=default")
 +	savedGODEBUG := os.Getenv("GODEBUG")
-+	os.Setenv("GODEBUG", strings.ReplaceAll(savedGODEBUG, "ms_tlsprofile=off", "")+",ms_tlsprofile=default")
-+	t.Cleanup(func() {
-+		os.Setenv("GODEBUG", savedGODEBUG)
-+	})
 +
 +	defaultWithPQ := []CurveID{X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768,
 +		CurveP384, CurveP256, CurveP521, X25519}
@@ -333,7 +331,7 @@ index 00000000000000..795b90db52767b
 +		{
 +			name: "GODEBUG tlsmlkem=0",
 +			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "tlsmlkem=0")
++				t.Setenv("GODEBUG", savedGODEBUG+","+"tlsmlkem=0")
 +			},
 +			expectClient:   defaultWithoutPQ,
 +			expectSelected: CurveP384,
@@ -341,7 +339,7 @@ index 00000000000000..795b90db52767b
 +		{
 +			name: "GODEBUG tlssecpmlkem=0",
 +			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "tlssecpmlkem=0")
++				t.Setenv("GODEBUG", savedGODEBUG+","+"tlssecpmlkem=0")
 +			},
 +			expectClient:   []CurveID{X25519MLKEM768, CurveP384, CurveP256, CurveP521, X25519},
 +			expectSelected: X25519MLKEM768,
@@ -349,7 +347,7 @@ index 00000000000000..795b90db52767b
 +		{
 +			name: "GODEBUG ms_tlsx25519=0",
 +			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsx25519=0")
++				t.Setenv("GODEBUG", savedGODEBUG+","+"ms_tlsx25519=0")
 +			},
 +			expectClient: slices.DeleteFunc(slices.Clone(defaultWithPQ), func(c CurveID) bool {
 +				return c == X25519MLKEM768 || c == X25519
@@ -359,7 +357,7 @@ index 00000000000000..795b90db52767b
 +		{
 +			name: "GODEBUG ms_tlsx25519=0,tlsmlkem=0",
 +			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsx25519=0,tlsmlkem=0")
++				t.Setenv("GODEBUG", savedGODEBUG+","+"ms_tlsx25519=0,tlsmlkem=0")
 +			},
 +			expectClient:   []CurveID{CurveP384, CurveP256, CurveP521},
 +			expectSelected: CurveP384,
@@ -367,7 +365,7 @@ index 00000000000000..795b90db52767b
 +		{
 +			name: "GODEBUG ms_tlsx25519=0,tlssecpmlkem=0",
 +			preparation: func(t *testing.T) {
-+				t.Setenv("GODEBUG", "ms_tlsx25519=0,tlssecpmlkem=0")
++				t.Setenv("GODEBUG", savedGODEBUG+","+"ms_tlsx25519=0,tlssecpmlkem=0")
 +			},
 +			expectClient:   []CurveID{CurveP384, CurveP256, CurveP521},
 +			expectSelected: CurveP384,
@@ -439,6 +437,36 @@ index 00000000000000..795b90db52767b
 +		})
 +	}
 +}
+diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
+index 5f4a2b9de4fd1f..4f67758ded932d 100644
+--- a/src/crypto/tls/tls_test.go
++++ b/src/crypto/tls/tls_test.go
+@@ -1990,6 +1990,7 @@ func TestHandshakeMLKEM(t *testing.T) {
+ 	defaultWithPQ := []CurveID{X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024,
+ 		X25519, CurveP256, CurveP384, CurveP521}
+ 	defaultWithoutPQ := []CurveID{X25519, CurveP256, CurveP384, CurveP521}
++	savedGODEBUG := os.Getenv("GODEBUG")
+ 	var tests = []struct {
+ 		name           string
+ 		clientConfig   func(*Config)
+@@ -2100,7 +2101,7 @@ func TestHandshakeMLKEM(t *testing.T) {
+ 		{
+ 			name: "GODEBUG tlsmlkem=0",
+ 			preparation: func(t *testing.T) {
+-				t.Setenv("GODEBUG", "tlsmlkem=0")
++				t.Setenv("GODEBUG", savedGODEBUG+","+"tlsmlkem=0")
+ 			},
+ 			expectClient:   defaultWithoutPQ,
+ 			expectSelected: X25519,
+@@ -2108,7 +2109,7 @@ func TestHandshakeMLKEM(t *testing.T) {
+ 		{
+ 			name: "GODEBUG tlssecpmlkem=0",
+ 			preparation: func(t *testing.T) {
+-				t.Setenv("GODEBUG", "tlssecpmlkem=0")
++				t.Setenv("GODEBUG", savedGODEBUG+","+"tlssecpmlkem=0")
+ 			},
+ 			expectClient:   []CurveID{X25519MLKEM768, X25519, CurveP256, CurveP384, CurveP521},
+ 			expectSelected: X25519MLKEM768,
 diff --git a/src/internal/godebugs/table.go b/src/internal/godebugs/table.go
 index 8f6d8bbdda656c..7a5ea67c7dca33 100644
 --- a/src/internal/godebugs/table.go


### PR DESCRIPTION
Having a dedicated file in `crypto/tls` for the Microsoft-specific test makes them easier to extend and maintain, basically due to less conflicts and more clarity about who owns each line (us or upstream).