### PR TITLE
Prefer AES GCM over CHACHA even when hardware AES is not supported

### DIFF
--- a/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
+++ b/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
@@ -11,10 +11,10 @@ Subject: [PATCH] align TLS settings with Microsoft policies
  src/crypto/tls/handshake_client.go         |   4 +-
  src/crypto/tls/handshake_server_tls13.go   |   2 +-
  src/crypto/tls/handshake_test.go           |   3 +
- src/crypto/tls/microsoft_test.go           | 424 +++++++++++++++++++++
+ src/crypto/tls/microsoft_test.go           | 428 +++++++++++++++++++++
  src/crypto/tls/tls_test.go                 |   5 +-
  src/internal/godebugs/table.go             |   2 +
- 10 files changed, 512 insertions(+), 8 deletions(-)
+ 10 files changed, 516 insertions(+), 8 deletions(-)
  create mode 100644 src/crypto/tls/microsoft_test.go
 
 diff --git a/doc/godebug.md b/doc/godebug.md
@@ -202,10 +202,10 @@ index 9cea8182d04154..0e5b421f52dc95 100644
  		Rand:               zeroSource{},
 diff --git a/src/crypto/tls/microsoft_test.go b/src/crypto/tls/microsoft_test.go
 new file mode 100644
-index 00000000000000..4871547d88068c
+index 00000000000000..248801f0680d24
 --- /dev/null
 +++ b/src/crypto/tls/microsoft_test.go
-@@ -0,0 +1,424 @@
+@@ -0,0 +1,428 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -512,6 +512,10 @@ index 00000000000000..4871547d88068c
 +}
 +
 +func TestMicrosoftCipherSuiteNoAES(t *testing.T) {
++	if fips140tls.Required() {
++		t.Skip("ChaCha20Poly1305 cipher suites not supported in FIPS mode")
++	}
++
 +	// Enable the default Microsoft TLS profile for the duration of the test.
 +	t.Setenv("GODEBUG", strings.ReplaceAll(os.Getenv("GODEBUG"), "ms_tlsprofile=off", "")+",ms_tlsprofile=default")
 +

--- a/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
+++ b/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
@@ -6,12 +6,15 @@ Subject: [PATCH] align TLS settings with Microsoft policies
 ---
  doc/godebug.md                             |   9 +
  src/crypto/internal/backend/cng_windows.go |   2 +-
- src/crypto/tls/defaults.go                 |  67 ++++-
+ src/crypto/tls/cipher_suites.go            |   2 +-
+ src/crypto/tls/defaults.go                 |  67 +++-
+ src/crypto/tls/handshake_client.go         |   4 +-
+ src/crypto/tls/handshake_server_tls13.go   |   2 +-
  src/crypto/tls/handshake_test.go           |   3 +
- src/crypto/tls/microsoft_test.go           | 304 +++++++++++++++++++++
+ src/crypto/tls/microsoft_test.go           | 424 +++++++++++++++++++++
  src/crypto/tls/tls_test.go                 |   5 +-
  src/internal/godebugs/table.go             |   2 +
- 7 files changed, 388 insertions(+), 4 deletions(-)
+ 10 files changed, 512 insertions(+), 8 deletions(-)
  create mode 100644 src/crypto/tls/microsoft_test.go
 
 diff --git a/doc/godebug.md b/doc/godebug.md
@@ -47,6 +50,19 @@ index 01e42ef9cec91b..778c851c707358 100644
  	}
  	sig.BoringCrypto()
  }
+diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
+index 48f37264e61e71..d17eb19d5caee3 100644
+--- a/src/crypto/tls/cipher_suites.go
++++ b/src/crypto/tls/cipher_suites.go
+@@ -391,7 +391,7 @@ var aesgcmCiphers = map[uint16]bool{
+ // first known cipher in the peer's preference list is an AES-GCM cipher,
+ // implying the peer also has hardware support for it.
+ func isAESGCMPreferred(ciphers []uint16) bool {
+-	if !hasAESGCMHardwareSupport {
++	if !hasAESGCMHardwareSupport && ms_tlsprofile.Value() == "off" {
+ 		return false
+ 	}
+ 	for _, cID := range ciphers {
 diff --git a/src/crypto/tls/defaults.go b/src/crypto/tls/defaults.go
 index 8de8d7e0934b07..3f7c0dc2981ff4 100644
 --- a/src/crypto/tls/defaults.go
@@ -135,6 +151,41 @@ index 8de8d7e0934b07..3f7c0dc2981ff4 100644
  	switch {
  	// tlsmlkem=0 restores the pre-Go 1.24 default.
  	case tlsmlkem.Value() == "0":
+diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
+index 4f89d96ec5de28..6e48223e720764 100644
+--- a/src/crypto/tls/handshake_client.go
++++ b/src/crypto/tls/handshake_client.go
+@@ -93,7 +93,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
+ 		hello.secureRenegotiation = c.clientFinished[:]
+ 	}
+ 
+-	hello.cipherSuites = config.cipherSuites(hasAESGCMHardwareSupport)
++	hello.cipherSuites = config.cipherSuites(hasAESGCMHardwareSupport || ms_tlsprofile.Value() != "off")
+ 	// Don't advertise TLS 1.2-only cipher suites unless we're attempting TLS 1.2.
+ 	if maxVersion < VersionTLS12 {
+ 		hello.cipherSuites = slices.DeleteFunc(hello.cipherSuites, func(id uint16) bool {
+@@ -132,7 +132,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
+ 
+ 		if fips140tls.Required() {
+ 			hello.cipherSuites = append(hello.cipherSuites, allowedCipherSuitesTLS13FIPS...)
+-		} else if hasAESGCMHardwareSupport {
++		} else if hasAESGCMHardwareSupport || ms_tlsprofile.Value() != "off" {
+ 			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13...)
+ 		} else {
+ 			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13NoAES...)
+diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
+index c81d0e56598634..ebd5c146757814 100644
+--- a/src/crypto/tls/handshake_server_tls13.go
++++ b/src/crypto/tls/handshake_server_tls13.go
+@@ -176,7 +176,7 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
+ 	hs.hello.compressionMethod = compressionNone
+ 
+ 	preferenceList := defaultCipherSuitesTLS13
+-	if !hasAESGCMHardwareSupport || !isAESGCMPreferred(hs.clientHello.cipherSuites) {
++	if (!hasAESGCMHardwareSupport && ms_tlsprofile.Value() == "off") || !isAESGCMPreferred(hs.clientHello.cipherSuites) {
+ 		preferenceList = defaultCipherSuitesTLS13NoAES
+ 	}
+ 	if fips140tls.Required() {
 diff --git a/src/crypto/tls/handshake_test.go b/src/crypto/tls/handshake_test.go
 index 9cea8182d04154..0e5b421f52dc95 100644
 --- a/src/crypto/tls/handshake_test.go
@@ -151,10 +202,10 @@ index 9cea8182d04154..0e5b421f52dc95 100644
  		Rand:               zeroSource{},
 diff --git a/src/crypto/tls/microsoft_test.go b/src/crypto/tls/microsoft_test.go
 new file mode 100644
-index 00000000000000..2c0efb8aba9a3b
+index 00000000000000..4871547d88068c
 --- /dev/null
 +++ b/src/crypto/tls/microsoft_test.go
-@@ -0,0 +1,304 @@
+@@ -0,0 +1,424 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -458,6 +509,126 @@ index 00000000000000..2c0efb8aba9a3b
 +			}
 +		})
 +	}
++}
++
++func TestMicrosoftCipherSuiteNoAES(t *testing.T) {
++	// Enable the default Microsoft TLS profile for the duration of the test.
++	t.Setenv("GODEBUG", strings.ReplaceAll(os.Getenv("GODEBUG"), "ms_tlsprofile=off", "")+",ms_tlsprofile=default")
++
++	t.Run("TLS13", func(t *testing.T) {
++		t.Parallel()
++		clientConfig := testConfig.Clone()
++		clientConfig.MaxVersion = VersionTLS13
++
++		serverConfig := testConfig.Clone()
++		serverConfig.MaxVersion = VersionTLS13
++
++		// Check cipher suite order in ClientHello
++		// With Microsoft TLS profile, TLS 1.3 should always prefer AES over ChaCha20
++		serverConfig.GetConfigForClient = func(hello *ClientHelloInfo) (*Config, error) {
++			if len(hello.CipherSuites) == 0 {
++				t.Error("no cipher suites advertised")
++				return nil, nil
++			}
++
++			aes128Index := -1
++			aes256Index := -1
++			chachaIndex := -1
++			for i, cs := range hello.CipherSuites {
++				if cs == TLS_AES_128_GCM_SHA256 {
++					aes128Index = i
++				}
++				if cs == TLS_AES_256_GCM_SHA384 {
++					aes256Index = i
++				}
++				if cs == TLS_CHACHA20_POLY1305_SHA256 {
++					chachaIndex = i
++				}
++			}
++
++			// Microsoft profile should prefer AES over ChaCha20 in TLS 1.3
++			if chachaIndex != -1 {
++				if (aes128Index != -1 && aes128Index > chachaIndex) || (aes256Index != -1 && aes256Index > chachaIndex) {
++					t.Errorf("TLS 1.3 with Microsoft profile: AES cipher suites should come before CHACHA20_POLY1305_SHA256, got AES_128 at %d, AES_256 at %d, ChaCha at %d", aes128Index, aes256Index, chachaIndex)
++				}
++			}
++			return nil, nil
++		}
++
++		ss, cs, err := testHandshake(t, clientConfig, serverConfig)
++		if err != nil {
++			t.Fatal(err)
++		}
++
++		if ss.CipherSuite != TLS_AES_128_GCM_SHA256 &&
++			ss.CipherSuite != TLS_AES_256_GCM_SHA384 &&
++			ss.CipherSuite != TLS_CHACHA20_POLY1305_SHA256 {
++			t.Errorf("unexpected TLS 1.3 cipher suite: %x", ss.CipherSuite)
++		}
++		if ss.CipherSuite != cs.CipherSuite {
++			t.Errorf("cipher suite mismatch: server=%x, client=%x", ss.CipherSuite, cs.CipherSuite)
++		}
++	})
++
++	t.Run("TLS12", func(t *testing.T) {
++		t.Parallel()
++		clientConfig := testConfig.Clone()
++		clientConfig.MaxVersion = VersionTLS12
++
++		serverConfig := testConfig.Clone()
++		serverConfig.MaxVersion = VersionTLS12
++
++		// For TLS 1.2, cipher suite ordering depends on hardware AES support.
++		// We verify that the handshake works and appropriate cipher suites are used.
++		serverConfig.GetConfigForClient = func(hello *ClientHelloInfo) (*Config, error) {
++			if len(hello.CipherSuites) == 0 {
++				t.Error("no cipher suites advertised")
++				return nil, nil
++			}
++
++			// Verify that both AES and ChaCha20 cipher suites are present
++			hasAES := false
++			hasChaCha := false
++			for _, cs := range hello.CipherSuites {
++				if cs == TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ||
++					cs == TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ||
++					cs == TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 ||
++					cs == TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 {
++					hasAES = true
++				}
++				if cs == TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 ||
++					cs == TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 {
++					hasChaCha = true
++				}
++			}
++
++			if !hasAES {
++				t.Error("TLS 1.2: no AES-GCM cipher suites advertised")
++			}
++			if !hasChaCha {
++				t.Error("TLS 1.2: no ChaCha20 cipher suites advertised")
++			}
++			return nil, nil
++		}
++
++		ss, cs, err := testHandshake(t, clientConfig, serverConfig)
++		if err != nil {
++			t.Fatal(err)
++		}
++
++		// Verify a reasonable TLS 1.2 cipher suite was selected
++		if ss.CipherSuite != TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 &&
++			ss.CipherSuite != TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 &&
++			ss.CipherSuite != TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 &&
++			ss.CipherSuite != TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 &&
++			ss.CipherSuite != TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 &&
++			ss.CipherSuite != TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 {
++			t.Errorf("unexpected TLS 1.2 cipher suite: %x", ss.CipherSuite)
++		}
++		if ss.CipherSuite != cs.CipherSuite {
++			t.Errorf("cipher suite mismatch: server=%x, client=%x", ss.CipherSuite, cs.CipherSuite)
++		}
++	})
 +}
 diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
 index 5f4a2b9de4fd1f..4f67758ded932d 100644


### PR DESCRIPTION
`CHACHA20_POLY1305_SHA256` is not allowed by the Microsoft crypto policies, but we are using it when the hardware doesn't support AES instruction. All hardware build after 2010 should have those instructions, but disable the preferred CHACHA cipher suite paths just in case.

This change can be reverted by setting `GODEBUG=ms_tlsprofile=off`.