### PR TITLE
Align TLS 1.3 cipher suites with the Microsoft policy

### DIFF
--- a/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
+++ b/patches/0012-align-TLS-settings-with-Microsoft-policies.patch
@@ -8,14 +8,16 @@ Subject: [PATCH] align TLS settings with Microsoft policies
  src/crypto/internal/backend/cng_windows.go |   2 +-
  src/crypto/tls/cipher_suites.go            |   2 +-
  src/crypto/tls/defaults.go                 |  17 +-
- src/crypto/tls/defaults_microsoft.go       |  64 ++++
- src/crypto/tls/handshake_client.go         |   4 +-
- src/crypto/tls/handshake_server_tls13.go   |   2 +-
+ src/crypto/tls/defaults_microsoft.go       |  83 ++++
+ src/crypto/tls/handshake_client.go         |  23 +-
+ src/crypto/tls/handshake_client_test.go    |  17 +-
+ src/crypto/tls/handshake_server_tls13.go   |  22 +-
  src/crypto/tls/handshake_test.go           |   3 +
- src/crypto/tls/microsoft_test.go           | 420 +++++++++++++++++++++
+ src/crypto/tls/microsoft_test.go           | 428 +++++++++++++++++++++
+ src/crypto/tls/schannel_windows.go         |   4 +
  src/crypto/tls/tls_test.go                 |   5 +-
  src/internal/godebugs/table.go             |   2 +
- 11 files changed, 522 insertions(+), 8 deletions(-)
+ 13 files changed, 596 insertions(+), 21 deletions(-)
  create mode 100644 src/crypto/tls/defaults_microsoft.go
  create mode 100644 src/crypto/tls/microsoft_test.go
 
@@ -98,10 +100,10 @@ index 8de8d7e0934b07..dd9ab351d56473 100644
  	case tlsmlkem.Value() == "0":
 diff --git a/src/crypto/tls/defaults_microsoft.go b/src/crypto/tls/defaults_microsoft.go
 new file mode 100644
-index 00000000000000..f01920e58bbb62
+index 00000000000000..d89507f7607e60
 --- /dev/null
 +++ b/src/crypto/tls/defaults_microsoft.go
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,83 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -166,8 +168,27 @@ index 00000000000000..f01920e58bbb62
 +		}
 +	}
 +}
++
++// msDefaultCipherSuitesTLS13 is like [defaultCipherSuitesTLS13] with
++// the following changes:
++//
++//   - AES-256 comes before AES-128
++var msDefaultCipherSuitesTLS13 = []uint16{
++	TLS_AES_256_GCM_SHA384,
++	TLS_AES_128_GCM_SHA256,
++	TLS_CHACHA20_POLY1305_SHA256,
++}
++
++// msAllowedCipherSuitesTLS13FIPS is like [allowedCipherSuitesTLS13FIPS] with
++// the following changes:
++//
++//   - AES-256 comes before AES-128
++var msAllowedCipherSuitesTLS13FIPS = []uint16{
++	TLS_AES_256_GCM_SHA384,
++	TLS_AES_128_GCM_SHA256,
++}
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
-index 4f89d96ec5de28..6e48223e720764 100644
+index 4f89d96ec5de28..b9e6188e9241ce 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
 @@ -93,7 +93,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
@@ -179,28 +200,95 @@ index 4f89d96ec5de28..6e48223e720764 100644
  	// Don't advertise TLS 1.2-only cipher suites unless we're attempting TLS 1.2.
  	if maxVersion < VersionTLS12 {
  		hello.cipherSuites = slices.DeleteFunc(hello.cipherSuites, func(id uint16) bool {
-@@ -132,7 +132,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
+@@ -130,12 +130,21 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
+ 			hello.cipherSuites = nil
+ 		}
  
- 		if fips140tls.Required() {
- 			hello.cipherSuites = append(hello.cipherSuites, allowedCipherSuitesTLS13FIPS...)
+-		if fips140tls.Required() {
+-			hello.cipherSuites = append(hello.cipherSuites, allowedCipherSuitesTLS13FIPS...)
 -		} else if hasAESGCMHardwareSupport {
-+		} else if hasAESGCMHardwareSupport || ms_tlsprofile.Value() != "off" {
- 			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13...)
- 		} else {
- 			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13NoAES...)
+-			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13...)
+-		} else {
+-			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13NoAES...)
++		switch ms_tlsprofile.Value() {
++		case "default", "":
++			if fips140tls.Required() {
++				hello.cipherSuites = append(hello.cipherSuites, msAllowedCipherSuitesTLS13FIPS...)
++			} else {
++				hello.cipherSuites = append(hello.cipherSuites, msDefaultCipherSuitesTLS13...)
++			}
++		case "off":
++			if fips140tls.Required() {
++				hello.cipherSuites = append(hello.cipherSuites, allowedCipherSuitesTLS13FIPS...)
++			} else if hasAESGCMHardwareSupport {
++				hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13...)
++			} else {
++				hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13NoAES...)
++			}
+ 		}
+ 
+ 		if len(hello.supportedCurves) == 0 {
+diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
+index e7de0b59119b8a..d9d1406371d13c 100644
+--- a/src/crypto/tls/handshake_client_test.go
++++ b/src/crypto/tls/handshake_client_test.go
+@@ -2704,9 +2704,20 @@ func testTLS13OnlyClientHelloCipherSuite(t *testing.T, ciphers []uint16) {
+ 	serverConfig := &Config{
+ 		Certificates: testConfig.Certificates,
+ 		GetConfigForClient: func(chi *ClientHelloInfo) (*Config, error) {
+-			expectedCiphersuites := defaultCipherSuitesTLS13NoAES
+-			if fips140tls.Required() {
+-				expectedCiphersuites = allowedCipherSuitesTLS13FIPS
++			var expectedCiphersuites []uint16
++			switch ms_tlsprofile.Value() {
++			case "default", "":
++				if fips140tls.Required() {
++					expectedCiphersuites = msAllowedCipherSuitesTLS13FIPS
++				} else {
++					expectedCiphersuites = msDefaultCipherSuitesTLS13
++				}
++			case "off":
++				if fips140tls.Required() {
++					expectedCiphersuites = allowedCipherSuitesTLS13FIPS
++				} else {
++					expectedCiphersuites = defaultCipherSuitesTLS13NoAES
++				}
+ 			}
+ 			if len(chi.CipherSuites) != len(expectedCiphersuites) {
+ 				t.Errorf("only TLS 1.3 suites should be advertised, got=%x", chi.CipherSuites)
 diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
-index c81d0e56598634..ebd5c146757814 100644
+index c81d0e56598634..11fbfc58af3959 100644
 --- a/src/crypto/tls/handshake_server_tls13.go
 +++ b/src/crypto/tls/handshake_server_tls13.go
-@@ -176,7 +176,7 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
+@@ -175,12 +175,22 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
+ 	hs.hello.sessionId = hs.clientHello.sessionId
  	hs.hello.compressionMethod = compressionNone
  
- 	preferenceList := defaultCipherSuitesTLS13
+-	preferenceList := defaultCipherSuitesTLS13
 -	if !hasAESGCMHardwareSupport || !isAESGCMPreferred(hs.clientHello.cipherSuites) {
-+	if (!hasAESGCMHardwareSupport && ms_tlsprofile.Value() == "off") || !isAESGCMPreferred(hs.clientHello.cipherSuites) {
- 		preferenceList = defaultCipherSuitesTLS13NoAES
+-		preferenceList = defaultCipherSuitesTLS13NoAES
+-	}
+-	if fips140tls.Required() {
+-		preferenceList = allowedCipherSuitesTLS13FIPS
++	var preferenceList []uint16
++	switch ms_tlsprofile.Value() {
++	case "default", "":
++		if fips140tls.Required() {
++			preferenceList = msAllowedCipherSuitesTLS13FIPS
++		} else {
++			preferenceList = msDefaultCipherSuitesTLS13
++		}
++	case "off":
++		preferenceList = defaultCipherSuitesTLS13
++		if !hasAESGCMHardwareSupport || !isAESGCMPreferred(hs.clientHello.cipherSuites) {
++			preferenceList = defaultCipherSuitesTLS13NoAES
++		}
++		if fips140tls.Required() {
++			preferenceList = allowedCipherSuitesTLS13FIPS
++		}
  	}
- 	if fips140tls.Required() {
+ 	for _, suiteID := range preferenceList {
+ 		hs.suite = mutualCipherSuiteTLS13(hs.clientHello.cipherSuites, suiteID)
 diff --git a/src/crypto/tls/handshake_test.go b/src/crypto/tls/handshake_test.go
 index 9cea8182d04154..0e5b421f52dc95 100644
 --- a/src/crypto/tls/handshake_test.go
@@ -217,10 +305,10 @@ index 9cea8182d04154..0e5b421f52dc95 100644
  		Rand:               zeroSource{},
 diff --git a/src/crypto/tls/microsoft_test.go b/src/crypto/tls/microsoft_test.go
 new file mode 100644
-index 00000000000000..b91c4cc4917dbe
+index 00000000000000..7e7d8ba37c2df9
 --- /dev/null
 +++ b/src/crypto/tls/microsoft_test.go
-@@ -0,0 +1,420 @@
+@@ -0,0 +1,428 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -270,8 +358,7 @@ index 00000000000000..b91c4cc4917dbe
 +	// This test is designed to verify the default Microsoft TLS profile's group preferences
 +	// and behavior during the handshake. It is based on TestHandshakeMLKEM.
 +
-+	// Enable the default Microsoft TLS profile for the duration of the test.
-+	t.Setenv("GODEBUG", strings.ReplaceAll(os.Getenv("GODEBUG"), "ms_tlsprofile=off", "")+",ms_tlsprofile=default")
++	enableMicrosoftProfile(t)
 +	savedGODEBUG := os.Getenv("GODEBUG")
 +
 +	defaultWithPQ := []CurveID{X25519MLKEM768, SecP384r1MLKEM1024, SecP256r1MLKEM768,
@@ -523,8 +610,7 @@ index 00000000000000..b91c4cc4917dbe
 +		t.Skip("ChaCha20Poly1305 cipher suites not supported in FIPS mode")
 +	}
 +
-+	// Enable the default Microsoft TLS profile for the duration of the test.
-+	t.Setenv("GODEBUG", strings.ReplaceAll(os.Getenv("GODEBUG"), "ms_tlsprofile=off", "")+",ms_tlsprofile=default")
++	enableMicrosoftProfile(t)
 +
 +	t.Run("TLS13", func(t *testing.T) {
 +		t.Parallel()
@@ -641,6 +727,31 @@ index 00000000000000..b91c4cc4917dbe
 +		}
 +	})
 +}
++
++func TestMicrosoftTLS13OnlyClientHelloCipherSuite(t *testing.T) {
++	enableMicrosoftProfile(t)
++
++	testTLS13OnlyClientHelloCipherSuite(t, nil)
++}
++
++func enableMicrosoftProfile(t *testing.T) {
++	t.Setenv("GODEBUG", strings.ReplaceAll(os.Getenv("GODEBUG"), "ms_tlsprofile=off", "")+",ms_tlsprofile=default")
++}
+diff --git a/src/crypto/tls/schannel_windows.go b/src/crypto/tls/schannel_windows.go
+index cccfb8866f88ab..72111aa2a26f22 100644
+--- a/src/crypto/tls/schannel_windows.go
++++ b/src/crypto/tls/schannel_windows.go
+@@ -40,6 +40,10 @@ func setSchannelCipherSuites(suites, versions []uint16) {
+ 	defaultCipherSuitesTLS13 = filterCipherSuites(suites, defaultCipherSuitesTLS13)
+ 	allowedCipherSuitesTLS13FIPS = filterCipherSuites(suites, allowedCipherSuitesTLS13FIPS)
+ 
++	// Update MS-specific variables too.
++	msDefaultCipherSuitesTLS13 = defaultCipherSuitesTLS13
++	msAllowedCipherSuitesTLS13FIPS = allowedCipherSuitesTLS13FIPS
++
+ 	// Schannel doesn't have a separate preference order without AES.
+ 	cipherSuitesPreferenceOrderNoAES = cipherSuitesPreferenceOrder
+ 	defaultCipherSuitesTLS13NoAES = defaultCipherSuitesTLS13
 diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
 index 9bb2d0801111c2..76092416618ca0 100644
 --- a/src/crypto/tls/tls_test.go


### PR DESCRIPTION
TLS 1.3 cipher suites now prefer AES-256 over AES-128. This behavior can be disabled setting `GODEBUG=ms_tlsprofile=off`

Updates #1995