### PR TITLE
Fallback to Go crypto when RSA key size is not supported

### DIFF
--- a/eng/doc/CrossPlatformCryptography.md
+++ b/eng/doc/CrossPlatformCryptography.md
@@ -146,8 +146,6 @@ This section includes the following packages:
 
 - [crypto/rsa](https://pkg.go.dev/crypto/rsa)
 
-[rsa.GenerateKey](https://pkg.go.dev/crypto/rsa#GenerateKey) only supports the following key sizes (in bits): 2048, 3072, 4096.
-
 Multi-prime RSA keys are not supported.
 
 The RSA key size is subject to the limitations of the underlying cryptographic library.

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -24,14 +24,14 @@ desired goexperiments and build tags.
  src/cmd/internal/testdir/testdir_test.go      |   7 +
  src/cmd/link/internal/ld/main.go              |  20 +-
  src/cmd/link/link_test.go                     |   8 +
- src/crypto/internal/backend/backend_test.go   |  30 ++
+ src/crypto/internal/backend/backend_test.go   |  56 +++
  src/crypto/internal/backend/bbig/big.go       |  17 +
  src/crypto/internal/backend/bbig/big_cng.go   |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  .../internal/backend/bbig/big_openssl.go      |  12 +
- src/crypto/internal/backend/cng_windows.go    | 422 +++++++++++++++++
+ src/crypto/internal/backend/cng_windows.go    | 425 +++++++++++++++++
  src/crypto/internal/backend/common.go         |  46 ++
- src/crypto/internal/backend/darwin_darwin.go  | 426 ++++++++++++++++++
+ src/crypto/internal/backend/darwin_darwin.go  | 430 ++++++++++++++++++
  src/crypto/internal/backend/fips140/cng.go    |  35 ++
  src/crypto/internal/backend/fips140/darwin.go |  13 +
  .../internal/backend/fips140/fips140.go       |  70 +++
@@ -46,14 +46,14 @@ desired goexperiments and build tags.
  .../opensslsetup/opensslsetup_test.go         |  92 ++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 375 +++++++++++++++
- src/crypto/internal/backend/openssl_linux.go  | 415 +++++++++++++++++
+ src/crypto/internal/backend/openssl_linux.go  | 424 +++++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
  src/crypto/systemcrypto_nocgo_linux.go        |  15 +
  src/go/build/deps_test.go                     |  24 +-
  src/internal/buildcfg/exp.go                  |  57 +++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   4 +
- 44 files changed, 2724 insertions(+), 20 deletions(-)
+ 44 files changed, 2766 insertions(+), 20 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -815,10 +815,10 @@ index 036eda13bc8807..33a79409ecc1fe 100644
  	tmpdir := t.TempDir()
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
 new file mode 100644
-index 00000000000000..c2c06d3bff8c74
+index 00000000000000..093acd82556330
 --- /dev/null
 +++ b/src/crypto/internal/backend/backend_test.go
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,56 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -848,6 +848,32 @@ index 00000000000000..c2c06d3bff8c74
 +// Test that UnreachableExceptTests does not panic (this is a test).
 +func TestUnreachableExceptTests(t *testing.T) {
 +	UnreachableExceptTests()
++}
++
++func TestSupportsRSAPrivateKey(t *testing.T) {
++	if !Enabled {
++		t.Skip("BoringCrypto not enabled")
++	}
++	tests := []struct {
++		bitLen    int
++		numPrimes int
++		supported bool
++	}{
++		{2048, 2, true},
++		{3072, 2, true},
++		{4096, 2, true},
++		{2048, 3, false},
++		{3072, 3, false},
++		{4096, 3, false},
++	}
++	for _, test := range tests {
++		t.Run("", func(t *testing.T) {
++			supported := SupportsRSAPrivateKey(test.bitLen, test.numPrimes)
++			if supported != test.supported {
++				t.Errorf("SupportsRSAPrivateKey(%d, %d) = %v; want %v", test.bitLen, test.numPrimes, supported, test.supported)
++			}
++		})
++	}
 +}
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
 new file mode 100644
@@ -928,10 +954,10 @@ index 00000000000000..e6695dd66b1d02
 +var Dec = bbig.Dec
 diff --git a/src/crypto/internal/backend/cng_windows.go b/src/crypto/internal/backend/cng_windows.go
 new file mode 100644
-index 00000000000000..829f5b62f70a93
+index 00000000000000..0a53f791c34ceb
 --- /dev/null
 +++ b/src/crypto/internal/backend/cng_windows.go
-@@ -0,0 +1,422 @@
+@@ -0,0 +1,425 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1093,9 +1119,12 @@ index 00000000000000..829f5b62f70a93
 +	return cng.VerifyECDSA(pub, hash, r, s)
 +}
 +
-+func SupportsRSAKeyPrimes(primes int) bool {
-+	// CNG only supports 2-prime RSA keys.
-+	return primes == 2
++func SupportsRSAPrivateKey(bits, primes int) bool {
++	return primes == 2 && SupportsRSAPublicKey(bits)
++}
++
++func SupportsRSAPublicKey(bits int) bool {
++	return bits >= 512 && bits%8 == 0 && bits <= 16384
 +}
 +
 +func SupportsRSASaltLength(sign bool, salt int) bool {
@@ -1408,10 +1437,10 @@ index 00000000000000..a9682181ffa154
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..1ac8f2fd8b6339
+index 00000000000000..80b6e9d9f5ec09
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
-@@ -0,0 +1,426 @@
+@@ -0,0 +1,430 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1569,8 +1598,12 @@ index 00000000000000..1ac8f2fd8b6339
 +	return xcrypto.VerifyECDSA(pub, hash, sig)
 +}
 +
-+func SupportsRSAKeyPrimes(primes int) bool {
-+	return primes == 2
++func SupportsRSAPrivateKey(bits, primes int) bool {
++	return primes == 2 && SupportsRSAPublicKey(bits)
++}
++
++func SupportsRSAPublicKey(bits int) bool {
++	return bits >= 1024 && bits%8 == 0 && bits <= 16384
 +}
 +
 +func SupportsRSASaltLength(sign bool, salt int) bool {
@@ -2710,10 +2743,10 @@ index 00000000000000..1c49ff66dc1a2f
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..71d258d86412d2
+index 00000000000000..929afe7f446aa6
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
-@@ -0,0 +1,415 @@
+@@ -0,0 +1,424 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2851,13 +2884,22 @@ index 00000000000000..71d258d86412d2
 +	return openssl.VerifyECDSA(pub, hash, sig)
 +}
 +
-+func SupportsRSAKeyPrimes(primes int) bool {
++func SupportsRSAPrivateKey(bits, primes int) bool {
 +	// The built-in OpenSSL 3 providers and OpenSSL 1 do support n-prime RSA keys,
 +	// but SCOSSL only supports 2-prime RSA keys.
 +	// Only 2-prime RSA keys are FIPS compliant, other n having compatibility
 +	// and security issues. Even crypto/rsa deprecated rsa.GenerateMultiPrimeKey as of Go 1.21.
 +	// Given the above reasons, we only support what SCOSSL supports.
-+	return primes == 2
++	return primes == 2 && SupportsRSAPublicKey(bits)
++}
++
++func SupportsRSAPublicKey(bits int) bool {
++	min := 1024
++	if fips140.Enabled() {
++		// The built-in OpenSSL 3 FIPS provider requires at least 2048 bits for FIPS compliance.
++		min = 2048
++	}
++	return bits >= min && bits%8 == 0 && bits <= 16384
 +}
 +
 +func SupportsRSASaltLength(sign bool, salt int) bool {

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -2362,7 +2362,7 @@ index 00000000000000..3b92bfc5fbabf6
 +package opensslsetup
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 00000000000000..1c49ff66dc1a2f
+index 00000000000000..c8f281d7fd1274
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -0,0 +1,375 @@
@@ -2483,8 +2483,8 @@ index 00000000000000..1c49ff66dc1a2f
 +func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, sig []byte) bool {
 +	panic("cryptobackend: not available")
 +}
-+
-+func SupportsRSAKeyPrimes(primes int) bool           { panic("cryptobackend: not available") }
++func SupportsRSAPrivateKey(bits, primes int) bool    { panic("cryptobackend: not available") }
++func SupportsRSAPublicKey(bits int) bool             { panic("cryptobackend: not available") }
 +func SupportsRSASaltLength(sign bool, salt int) bool { panic("cryptobackend: not available") }
 +
 +type PublicKeyRSA struct{ _ int }

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -65,11 +65,11 @@ Subject: [PATCH] Use crypto backends
  src/crypto/rsa/darwin.go                      |  71 +++++++
  src/crypto/rsa/fips.go                        |  22 +-
  src/crypto/rsa/notboring.go                   |   4 +-
- src/crypto/rsa/pkcs1v15.go                    |  11 +-
+ src/crypto/rsa/pkcs1v15.go                    |  10 +-
  src/crypto/rsa/pkcs1v15_test.go               |   5 +
  src/crypto/rsa/pss_test.go                    |  13 +-
- src/crypto/rsa/rsa.go                         |  13 +-
- src/crypto/rsa/rsa_test.go                    |  12 +-
+ src/crypto/rsa/rsa.go                         |  16 +-
+ src/crypto/rsa/rsa_test.go                    |   7 +-
  src/crypto/sha1/sha1.go                       |   8 +-
  src/crypto/sha1/sha1_test.go                  |  11 +-
  src/crypto/sha256/sha256.go                   |   6 +-
@@ -98,7 +98,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- 94 files changed, 1505 insertions(+), 178 deletions(-)
+ 94 files changed, 1500 insertions(+), 180 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -2391,7 +2391,7 @@ index 00000000000000..1b9c63523ee90e
 +	return builder.Bytes()
 +}
 diff --git a/src/crypto/rsa/fips.go b/src/crypto/rsa/fips.go
-index fb2395886b053b..6b1b6ad96a1366 100644
+index fb2395886b053b..ac0ad4f9490a8b 100644
 --- a/src/crypto/rsa/fips.go
 +++ b/src/crypto/rsa/fips.go
 @@ -6,7 +6,7 @@ package rsa
@@ -2408,7 +2408,7 @@ index fb2395886b053b..6b1b6ad96a1366 100644
  	}
  
 -	if boring.Enabled && rand.IsDefaultReader(random) {
-+	if boring.Enabled && rand.IsDefaultReader(random) && boring.SupportsRSASaltLength(true, opts.saltLength()) && boring.SupportsRSAKeyPrimes(len(priv.Primes)) && boring.SupportsHash(hash) {
++	if boring.Enabled && rand.IsDefaultReader(random) && boring.SupportsRSASaltLength(true, opts.saltLength()) && boring.SupportsRSAPrivateKey(priv.N.BitLen(), len(priv.Primes)) && boring.SupportsHash(hash) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
@@ -2417,7 +2417,7 @@ index fb2395886b053b..6b1b6ad96a1366 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.SupportsRSASaltLength(false, opts.saltLength()) && boring.SupportsHash(hash) {
++	if boring.Enabled && boring.SupportsRSASaltLength(false, opts.saltLength()) && boring.SupportsRSAPublicKey(pub.N.BitLen()) && boring.SupportsHash(hash) {
  		bkey, err := boringPublicKey(pub)
  		if err != nil {
  			return err
@@ -2442,7 +2442,7 @@ index fb2395886b053b..6b1b6ad96a1366 100644
  	defer mgfHash.Reset()
  
 -	if boring.Enabled && rand.IsDefaultReader(random) {
-+	if boring.Enabled && rand.IsDefaultReader(random) && boring.SupportsRSAOAEPLabel(label) && hash == mgfHash {
++	if boring.Enabled && rand.IsDefaultReader(random) && boring.SupportsRSAPublicKey(pub.N.BitLen()) && boring.SupportsRSAOAEPLabel(label) && hash == mgfHash {
  		k := pub.Size()
  		if len(msg) > k-2*hash.Size()-2 {
  			return nil, ErrMessageTooLong
@@ -2451,7 +2451,7 @@ index fb2395886b053b..6b1b6ad96a1366 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.SupportsRSAKeyPrimes(len(priv.Primes)) && boring.SupportsRSAOAEPLabel(label) && hash == mgfHash {
++	if boring.Enabled && boring.SupportsRSAPrivateKey(priv.N.BitLen(), len(priv.Primes)) && boring.SupportsRSAOAEPLabel(label) && hash == mgfHash {
  		k := priv.Size()
  		if len(ciphertext) > k ||
  			k < hash.Size()*2+2 {
@@ -2460,7 +2460,7 @@ index fb2395886b053b..6b1b6ad96a1366 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.SupportsRSAKeyPrimes(len(priv.Primes)) && boring.SupportsRSAPKCS1v15Signature(hash) {
++	if boring.Enabled && boring.SupportsRSAPrivateKey(priv.N.BitLen(), len(priv.Primes)) && boring.SupportsRSAPKCS1v15Signature(hash) {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
@@ -2469,7 +2469,7 @@ index fb2395886b053b..6b1b6ad96a1366 100644
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.SupportsRSAPKCS1v15Signature(hash) {
++	if boring.Enabled && boring.SupportsRSAPublicKey(pub.N.BitLen()) && boring.SupportsRSAPKCS1v15Signature(hash) {
  		bkey, err := boringPublicKey(pub)
  		if err != nil {
  			return err
@@ -2492,52 +2492,51 @@ index 2abc0436405f8a..3e4d6f3eef61e6 100644
  func boringPublicKey(*PublicKey) (*boring.PublicKeyRSA, error) {
  	panic("boringcrypto: not available")
 diff --git a/src/crypto/rsa/pkcs1v15.go b/src/crypto/rsa/pkcs1v15.go
-index 5269d7b971bda7..8edad9da73698a 100644
+index 5269d7b971bda7..003030ec762ebf 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
-@@ -5,7 +5,8 @@
+@@ -5,7 +5,7 @@
  package rsa
  
  import (
 -	"crypto/internal/boring"
-+	"crypto/internal/backend"
 +	boring "crypto/internal/backend"
  	"crypto/internal/fips140/rsa"
  	"crypto/internal/fips140only"
  	"crypto/internal/rand"
-@@ -61,7 +62,7 @@ func EncryptPKCS1v15(random io.Reader, pub *PublicKey, msg []byte) ([]byte, erro
+@@ -61,7 +61,7 @@ func EncryptPKCS1v15(random io.Reader, pub *PublicKey, msg []byte) ([]byte, erro
  		return nil, ErrMessageTooLong
  	}
  
 -	if boring.Enabled && rand.IsDefaultReader(random) {
-+	if boring.Enabled && rand.IsDefaultReader(random) && backend.SupportsRSAPKCS1v15Encryption() {
++	if boring.Enabled && rand.IsDefaultReader(random) && boring.SupportsRSAPublicKey(pub.N.BitLen()) && boring.SupportsRSAPKCS1v15Encryption() {
  		bkey, err := boringPublicKey(pub)
  		if err != nil {
  			return nil, err
-@@ -83,7 +84,7 @@ func EncryptPKCS1v15(random io.Reader, pub *PublicKey, msg []byte) ([]byte, erro
+@@ -83,7 +83,7 @@ func EncryptPKCS1v15(random io.Reader, pub *PublicKey, msg []byte) ([]byte, erro
  	em[len(em)-len(msg)-1] = 0
  	copy(mm, msg)
  
 -	if boring.Enabled {
-+	if boring.Enabled && backend.SupportsRSAPKCS1v15Encryption() {
++	if boring.Enabled && boring.SupportsRSAPublicKey(pub.N.BitLen()) && boring.SupportsRSAPKCS1v15Encryption() {
  		var bkey *boring.PublicKeyRSA
  		bkey, err = boringPublicKey(pub)
  		if err != nil {
-@@ -115,7 +116,7 @@ func DecryptPKCS1v15(random io.Reader, priv *PrivateKey, ciphertext []byte) ([]b
+@@ -115,7 +115,7 @@ func DecryptPKCS1v15(random io.Reader, priv *PrivateKey, ciphertext []byte) ([]b
  		return nil, err
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.SupportsRSAKeyPrimes(len(priv.Primes)) && backend.SupportsRSAPKCS1v15Encryption() {
++	if boring.Enabled && boring.SupportsRSAPrivateKey(priv.N.BitLen(), len(priv.Primes)) && boring.SupportsRSAPKCS1v15Encryption() {
  		bkey, err := boringPrivateKey(priv)
  		if err != nil {
  			return nil, err
-@@ -221,7 +222,7 @@ func decryptPKCS1v15(priv *PrivateKey, ciphertext []byte) (valid int, em []byte,
+@@ -221,7 +221,7 @@ func decryptPKCS1v15(priv *PrivateKey, ciphertext []byte) (valid int, em []byte,
  		return 0, nil, 0, err
  	}
  
 -	if boring.Enabled {
-+	if boring.Enabled && boring.SupportsRSAKeyPrimes(len(priv.Primes)) && backend.SupportsRSAPKCS1v15Encryption() {
++	if boring.Enabled && boring.SupportsRSAPrivateKey(priv.N.BitLen(), len(priv.Primes)) && boring.SupportsRSAPKCS1v15Encryption() {
  		var bkey *boring.PrivateKeyRSA
  		bkey, err = boringPrivateKey(priv)
  		if err != nil {
@@ -2616,7 +2615,7 @@ index e03f4ab06603c6..cd44f3af23b0d4 100644
  		t.Fatal(err)
  	}
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index b94b129867727b..5cbedca4d3888d 100644
+index b94b129867727b..9482325d58fe06 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
 @@ -43,8 +43,8 @@ package rsa
@@ -2647,8 +2646,18 @@ index b94b129867727b..5cbedca4d3888d 100644
  
  	case *PKCS1v15DecryptOptions:
  		if l := opts.SessionKeyLen; l > 0 {
+@@ -314,8 +315,7 @@ func GenerateKey(random io.Reader, bits int) (*PrivateKey, error) {
+ 		return nil, err
+ 	}
+ 
+-	if boring.Enabled && rand.IsDefaultReader(random) &&
+-		(bits == 2048 || bits == 3072 || bits == 4096) {
++	if boring.Enabled && rand.IsDefaultReader(random) && boring.SupportsRSAPublicKey(bits) {
+ 		bN, bE, bD, bP, bQ, bDp, bDq, bQinv, err := boring.GenerateKeyRSA(bits)
+ 		if err != nil {
+ 			return nil, err
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 5ae4c1dd203874..678e94ade86af6 100644
+index 124fba1e8a4faa..af6d8e9291af62 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -8,7 +8,7 @@ import (
@@ -2660,7 +2669,7 @@ index 5ae4c1dd203874..678e94ade86af6 100644
  	"crypto/internal/cryptotest"
  	"crypto/internal/fips140"
  	"crypto/rand"
-@@ -151,6 +151,11 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
+@@ -157,6 +157,11 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  	if priv.D.Cmp(priv.N) > 0 {
  		t.Errorf("private exponent too large")
  	}
@@ -2671,18 +2680,6 @@ index 5ae4c1dd203874..678e94ade86af6 100644
 +	}
  
  	msg := []byte("hi!")
- 	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
-@@ -231,6 +236,11 @@ func testEverything(t *testing.T, priv *PrivateKey) {
- 	if validateErr != nil && len(priv.Primes) >= 2 {
- 		t.Errorf("Validate() failed: %s", validateErr)
- 	}
-+	if boring.Enabled && priv.N.BitLen() < 512 {
-+		// Some crypto backends (e.g. CNG and OpenSSL with SymCrypt) don't support key sizes
-+		// lower than 512 and intentionally fail rather than fall back to Go crypto.
-+		t.Skip("skipping allocations test with BoringCrypto")
-+	}
- 
- 	msg := []byte("test")
  	enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
 diff --git a/src/crypto/sha1/sha1.go b/src/crypto/sha1/sha1.go
 index 46e47df1d32cf2..0fb56a3831c8a2 100644


### PR DESCRIPTION
Go RSA implementation only restricts the minimum RSA key size to 1024 bits (and that can be bypassed by setting (`GODEBUG=rsa1024min=0`). It doesn't limit its maximum value and allow sizes not divisible by 8.

All out backends have a much stricter RSA key size policy. Take them into account when checking if we have to fallback to Go.

This fixes several compatibility issues with a new FIPS provider being developed in AZL3 and allows to unskip some additional tests.