### PR TITLE
Upgrade dependencies

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -90,6 +90,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../v2/internal/fakecgo/ztrampolines_stubs.s  |   58 +
  .../openssl/v2/internal/ossl/asm_amd64.s      |  108 +
  .../openssl/v2/internal/ossl/asm_arm64.s      |   87 +
+ .../openssl/v2/internal/ossl/asm_others.s     |    7 +
  .../golang-fips/openssl/v2/internal/ossl/dl.h |   12 +
  .../openssl/v2/internal/ossl/errors.go        |   34 +
  .../openssl/v2/internal/ossl/errors_cgo.go    |   14 +
@@ -248,7 +249,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 240 files changed, 31432 insertions(+), 7 deletions(-)
+ 241 files changed, 31439 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -324,6 +325,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_stubs.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_amd64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_arm64.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_others.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/dl.h
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors_cgo.go
@@ -2150,7 +2152,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index efc07451b53448..7183aa16a655e6 100644
+index efc07451b53448..4333a7155532dc 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2159,17 +2161,17 @@ index efc07451b53448..7183aa16a655e6 100644
  )
 +
 +require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20260115104635-63db5bc96a83
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20260115115456-4e77131fa055
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260114113743-000278575184
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20260114031524-c493765efc5f
 +)
 diff --git a/src/go.sum b/src/go.sum
-index b6b841b44d8e38..223b1d2797cf87 100644
+index b6b841b44d8e38..126eae60f4b991 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20260115104635-63db5bc96a83 h1:QeGy5Zv6lLfxzG+0PCOh06EVYPrYXI6q0UJhj+YXImU=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20260115104635-63db5bc96a83/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20260115115456-4e77131fa055 h1:I6wGxCUkueebFXN3Mn8bPJQV+XkwK9CNNlpgm3nB1O0=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20260115115456-4e77131fa055/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260114113743-000278575184 h1:b0PQtPdldqXsTg7yLqLo9HFUF+4Qp07Vi+ohWwTBNrU=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260114113743-000278575184/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260114031524-c493765efc5f h1:SvZJthaYYoyAxBX87EnmIFn4PmT/UbvKClLiSMhK8uw=
@@ -9286,6 +9288,19 @@ index 00000000000000..025276dffb2aa5
 +	MOVD	R1, libcCallInfo_r2(R3)	// save r2
 +
 +    RET
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_others.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_others.s
+new file mode 100644
+index 00000000000000..dfc38e4106d778
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_others.s
+@@ -0,0 +1,7 @@
++// Copyright 2009 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !cgo && !arm64 && !amd64
++
++// This file silences errors about body-less functions.
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/dl.h b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/dl.h
 new file mode 100644
 index 00000000000000..e94cca9e27e30a
@@ -35404,11 +35419,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b6f6376eac041a..6cb7848a29c00f 100644
+index b6f6376eac041a..42fde54eacaeda 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20260115104635-63db5bc96a83
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20260115115456-4e77131fa055
 +## explicit; go 1.24
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -12,7 +12,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  src/cmd/go.sum                                |    4 +
  .../internal/telemetry/counter/deps_ignore.go |   17 +
  .../microsoft/go-infra/telemetry/LICENSE      |   21 +
- .../microsoft/go-infra/telemetry/README.md    |    7 +
+ .../microsoft/go-infra/telemetry/README.md    |    9 +
  .../go-infra/telemetry/config/LICENSE         |   21 +
  .../go-infra/telemetry/config/config.go       |   11 +
  .../go-infra/telemetry/config/config.json     |   73 +
@@ -28,7 +28,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/appinsights/telemetrycontext.go  |   44 +
  .../internal/appinsights/transmitter.go       |  172 ++
  .../telemetry/internal/config/config.go       |   63 +
- .../telemetry/internal/telemetry/proginfo.go  |   32 +
+ .../telemetry/internal/telemetry/proginfo.go  |   38 +
  .../telemetry/internal/telemetry/telemetry.go |   32 +
  .../microsoft/go-infra/telemetry/telemetry.go |  125 +
  src/cmd/vendor/modules.txt                    |   11 +
@@ -47,7 +47,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../openssl/v2/chacha20poly1305.go            |  149 +
  .../golang-fips/openssl/v2/cipher.go          |  659 +++++
  .../golang-fips/openssl/v2/const.go           |   91 +
- .../golang-fips/openssl/v2/cshake.go          |  231 ++
+ .../golang-fips/openssl/v2/cshake.go          |  253 ++
  .../github.com/golang-fips/openssl/v2/des.go  |  112 +
  .../github.com/golang-fips/openssl/v2/dsa.go  |  308 +++
  .../github.com/golang-fips/openssl/v2/ec.go   |  136 +
@@ -60,36 +60,38 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../golang-fips/openssl/v2/hashclone_go125.go |    9 +
  .../github.com/golang-fips/openssl/v2/hkdf.go |  455 ++++
  .../github.com/golang-fips/openssl/v2/hmac.go |  282 ++
- .../openssl/v2/internal/fakecgo/abi_amd64.h   |   34 +
+ .../openssl/v2/internal/fakecgo/abi_amd64.h   |   99 +
  .../openssl/v2/internal/fakecgo/abi_arm64.h   |   39 +
- .../openssl/v2/internal/fakecgo/asm_amd64.s   |   29 +
+ .../openssl/v2/internal/fakecgo/asm_amd64.s   |   39 +
  .../openssl/v2/internal/fakecgo/asm_arm64.s   |   36 +
  .../openssl/v2/internal/fakecgo/callbacks.go  |   93 +
- .../openssl/v2/internal/fakecgo/doc.go        |   32 +
- .../openssl/v2/internal/fakecgo/fakecgo.go    |   27 +
+ .../openssl/v2/internal/fakecgo/fakecgo.go    |   29 +
+ .../openssl/v2/internal/fakecgo/generate.go   |    3 +
  .../openssl/v2/internal/fakecgo/go_darwin.go  |   88 +
  .../openssl/v2/internal/fakecgo/go_libinit.go |   72 +
  .../openssl/v2/internal/fakecgo/go_linux.go   |  100 +
  .../openssl/v2/internal/fakecgo/go_setenv.go  |   18 +
  .../openssl/v2/internal/fakecgo/go_util.go    |   37 +
  .../openssl/v2/internal/fakecgo/iscgo.go      |   19 +
- .../openssl/v2/internal/fakecgo/libcgo.go     |   38 +
+ .../openssl/v2/internal/fakecgo/libcgo.go     |   39 +
  .../v2/internal/fakecgo/libcgo_darwin.go      |   26 +
  .../v2/internal/fakecgo/libcgo_linux.go       |   20 +
  .../openssl/v2/internal/fakecgo/linux.go      |   34 +
  .../openssl/v2/internal/fakecgo/setenv.go     |   19 +
- .../openssl/v2/internal/fakecgo/symbols.go    |  225 ++
- .../v2/internal/fakecgo/symbols_darwin.go     |   30 +
- .../v2/internal/fakecgo/symbols_linux.go      |  277 ++
- .../v2/internal/fakecgo/trampolines_amd64.s   |  112 +
- .../v2/internal/fakecgo/trampolines_arm64.s   |   82 +
- .../v2/internal/fakecgo/trampolines_stubs.s   |   94 +
+ .../v2/internal/fakecgo/trampolines_amd64.s   |  114 +
+ .../v2/internal/fakecgo/trampolines_arm64.s   |   83 +
+ .../openssl/v2/internal/fakecgo/zsymbols.go   |  175 ++
+ .../v2/internal/fakecgo/zsymbols_darwin.go    |   60 +
+ .../v2/internal/fakecgo/zsymbols_linux.go     |  294 ++
+ .../v2/internal/fakecgo/ztrampolines_darwin.s |   19 +
+ .../v2/internal/fakecgo/ztrampolines_linux.s  |   16 +
  .../fakecgo/ztrampolines_linux_amd64.s        |  103 +
  .../fakecgo/ztrampolines_linux_arm64.s        |   94 +
+ .../v2/internal/fakecgo/ztrampolines_stubs.s  |   58 +
  .../openssl/v2/internal/ossl/asm_amd64.s      |  108 +
  .../openssl/v2/internal/ossl/asm_arm64.s      |   87 +
  .../golang-fips/openssl/v2/internal/ossl/dl.h |   12 +
- .../openssl/v2/internal/ossl/errors.go        |   36 +
+ .../openssl/v2/internal/ossl/errors.go        |   34 +
  .../openssl/v2/internal/ossl/errors_cgo.go    |   14 +
  .../openssl/v2/internal/ossl/errors_nocgo.go  |   16 +
  .../openssl/v2/internal/ossl/ossl.go          |   59 +
@@ -125,7 +127,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../openssl/v2/providersymcrypt.go            |  338 +++
  .../github.com/golang-fips/openssl/v2/rand.go |   21 +
  .../github.com/golang-fips/openssl/v2/rc4.go  |   68 +
- .../github.com/golang-fips/openssl/v2/rsa.go  |  716 +++++
+ .../github.com/golang-fips/openssl/v2/rsa.go  |  714 +++++
  .../golang-fips/openssl/v2/tls1prf.go         |  158 ++
  .../github.com/golang-fips/openssl/v2/zaes.go |   86 +
  .../microsoft/go-crypto-darwin/LICENSE        |   21 +
@@ -170,10 +172,11 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/fakecgo/libcgo_darwin.go         |   26 +
  .../internal/fakecgo/setenv.go                |   19 +
  .../internal/fakecgo/trampolines_amd64.s      |  114 +
- .../internal/fakecgo/trampolines_arm64.s      |   87 +
- .../internal/fakecgo/zsymbols.go              |  225 ++
- .../internal/fakecgo/zsymbols_darwin.go       |   30 +
- .../internal/fakecgo/ztrampolines_stubs.s     |   73 +
+ .../internal/fakecgo/trampolines_arm64.s      |   83 +
+ .../internal/fakecgo/zsymbols.go              |  175 ++
+ .../internal/fakecgo/zsymbols_darwin.go       |   60 +
+ .../internal/fakecgo/ztrampolines_darwin.s    |   19 +
+ .../internal/fakecgo/ztrampolines_stubs.s     |   58 +
  .../internal/security/security.go             |    9 +
  .../internal/security/shims.h                 |  107 +
  .../internal/security/syscall_nocgo.go        |   15 +
@@ -245,7 +248,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 237 files changed, 31378 insertions(+), 7 deletions(-)
+ 240 files changed, 31432 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -296,8 +299,8 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_amd64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_arm64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/callbacks.go
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/doc.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/generate.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_darwin.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_libinit.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_linux.go
@@ -309,14 +312,16 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/libcgo_linux.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/linux.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/setenv.go
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols.go
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols_darwin.go
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols_linux.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_amd64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_stubs.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_darwin.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_linux.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_darwin.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_amd64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_arm64.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_stubs.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_amd64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_arm64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/dl.h
@@ -404,6 +409,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/zsymbols.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/zsymbols_darwin.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/ztrampolines_darwin.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/ztrampolines_stubs.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/security.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/shims.h
@@ -477,30 +483,30 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 
 diff --git a/src/cmd/go.mod b/src/cmd/go.mod
-index c7d3cc6136b549..dcabaf112309f9 100644
+index 85e8c4cb5fb305..b6c3222b6c3216 100644
 --- a/src/cmd/go.mod
 +++ b/src/cmd/go.mod
 @@ -4,6 +4,8 @@ go 1.26
  
  require (
  	github.com/google/pprof v0.0.0-20251114195745-4902fdda35c8
-+	github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed
-+	github.com/microsoft/go-infra/telemetry/config v0.0.0-20251104173356-501791671457
++	github.com/microsoft/go-infra/telemetry v0.0.0-20260114110637-9d75809e6980
++	github.com/microsoft/go-infra/telemetry/config v0.0.0-20260114110637-9d75809e6980
  	golang.org/x/arch v0.23.0
  	golang.org/x/build v0.0.0-20251128064159-b9bfd88b30e8
  	golang.org/x/mod v0.30.1-0.20251115032019-269c237cf350
 diff --git a/src/cmd/go.sum b/src/cmd/go.sum
-index b02c469a41d244..7f16513fcb58c7 100644
+index 61c88e52530940..fc869bb61f2fe8 100644
 --- a/src/cmd/go.sum
 +++ b/src/cmd/go.sum
 @@ -4,6 +4,10 @@ github.com/google/pprof v0.0.0-20251114195745-4902fdda35c8 h1:3DsUAV+VNEQa2CUVLx
  github.com/google/pprof v0.0.0-20251114195745-4902fdda35c8/go.mod h1:I6V7YzU0XDpsHqbsyrghnFZLO1gwK6NPTNvmetQIk9U=
  github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b h1:ogbOPx86mIhFy764gGkqnkFC8m5PJA7sPzlk9ppLVQA=
  github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
-+github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed h1:AZR+rR1NvHCXyilk3BMgq2M9uGPibhTU1O4hxNIwFJo=
-+github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed/go.mod h1:XQP+NhZgM1i1+asOSnAFPRzv2HhQibhk6k6FIllx8/Y=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20251104173356-501791671457 h1:VcZzhgedVcPpE+O7y5uAwavh0RxtuugUZgSXRoRpvQI=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20251104173356-501791671457/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
++github.com/microsoft/go-infra/telemetry v0.0.0-20260114110637-9d75809e6980 h1:Xe/6t1ORLxP4YELza1nvuR4P5tT+ATAwfgIOzxZiVLY=
++github.com/microsoft/go-infra/telemetry v0.0.0-20260114110637-9d75809e6980/go.mod h1:XQP+NhZgM1i1+asOSnAFPRzv2HhQibhk6k6FIllx8/Y=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20260114110637-9d75809e6980 h1:xRaYLWEeaYNxkBV9VMnmyGIOX16GExTmNXNMXjkP42g=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20260114110637-9d75809e6980/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
  github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
  github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
  golang.org/x/arch v0.23.0 h1:lKF64A2jF6Zd8L0knGltUnegD62JMFBiCPBmQpToHhg=
@@ -556,11 +562,13 @@ index 00000000000000..9e841e7a26e4eb
 +    SOFTWARE
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
 new file mode 100644
-index 00000000000000..472894e2011f93
+index 00000000000000..5fc9356268f64a
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
-@@ -0,0 +1,7 @@
+@@ -0,0 +1,9 @@
 +# telemetry
++
++[![Go Reference](https://pkg.go.dev/badge/github.com/microsoft/go-infra/telemetry.svg)](https://pkg.go.dev/github.com/microsoft/go-infra/telemetry)
 +
 +This directory, the `telemetry` package, contains the telemetry transmission code for the Microsoft build of Go.
 +It is specialized to work similarly to the upstream telemetry counters.
@@ -613,7 +621,7 @@ index 00000000000000..044268a046a54d
 +var Config []byte
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
 new file mode 100644
-index 00000000000000..52a9687f323fb8
+index 00000000000000..76053296e82470
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
 @@ -0,0 +1,73 @@
@@ -672,7 +680,7 @@ index 00000000000000..52a9687f323fb8
 +					"Name": "go/invocations"
 +				},
 +				{
-+					"Name": "go/goexperiment:{ms_tls_config_schannel,systemcrypto,nosystemcrypto,opensslcrypto,cngcrypto,darwincrypto}"
++					"Name": "go/goexperiment:{ms_tls_config_schannel,systemcrypto,nosystemcrypto,opensslcrypto,cngcrypto,darwincrypto,ms_nocgo_opensslcrypto}"
 +				},
 +				{
 +					"Name": "go/subcommand:{build,install,run}"
@@ -1880,10 +1888,10 @@ index 00000000000000..7980b1505b2caa
 +}
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/telemetry/proginfo.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/telemetry/proginfo.go
 new file mode 100644
-index 00000000000000..1ac9e000e65c77
+index 00000000000000..a4949c6a90ea1b
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/telemetry/proginfo.go
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,38 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -1906,7 +1914,13 @@ index 00000000000000..1ac9e000e65c77
 +func ProgramInfo(info *debug.BuildInfo) (goVers, progPath string) {
 +	goVers = info.GoVersion
 +	if strings.Contains(goVers, "devel") || strings.Contains(goVers, "-") || !version.IsValid(goVers) {
-+		goVers = "devel"
++		if v, _, ok := strings.Cut(goVers, "_microsoft"); ok && version.IsValid(v) {
++			// Schema like "go1.21.1-0_microsoft ABC".
++			// Remove everything after the revision number.
++			goVers = v
++		} else {
++			goVers = "devel"
++		}
 +	}
 +
 +	progPath = info.Path
@@ -2086,14 +2100,14 @@ index 00000000000000..d592037b570130
 +	return ok
 +}
 diff --git a/src/cmd/vendor/modules.txt b/src/cmd/vendor/modules.txt
-index 7c122cd9d171bf..96472efdde403d 100644
+index 9c179c4bcd4c30..0c76f8fac35576 100644
 --- a/src/cmd/vendor/modules.txt
 +++ b/src/cmd/vendor/modules.txt
 @@ -16,6 +16,17 @@ github.com/google/pprof/third_party/svgpan
  # github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b
  ## explicit; go 1.13
  github.com/ianlancetaylor/demangle
-+# github.com/microsoft/go-infra/telemetry v0.0.0-20250728075224-e97e760169ed
++# github.com/microsoft/go-infra/telemetry v0.0.0-20260114110637-9d75809e6980
 +## explicit; go 1.24
 +github.com/microsoft/go-infra/telemetry
 +github.com/microsoft/go-infra/telemetry/counter
@@ -2101,7 +2115,7 @@ index 7c122cd9d171bf..96472efdde403d 100644
 +github.com/microsoft/go-infra/telemetry/internal/appinsights/internal/contracts
 +github.com/microsoft/go-infra/telemetry/internal/config
 +github.com/microsoft/go-infra/telemetry/internal/telemetry
-+# github.com/microsoft/go-infra/telemetry/config v0.0.0-20251104173356-501791671457
++# github.com/microsoft/go-infra/telemetry/config v0.0.0-20260114110637-9d75809e6980
 +## explicit; go 1.24
 +github.com/microsoft/go-infra/telemetry/config
  # golang.org/x/arch v0.23.0
@@ -2136,7 +2150,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index efc07451b53448..ab7ea4a4b915d9 100644
+index efc07451b53448..7183aa16a655e6 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2145,21 +2159,21 @@ index efc07451b53448..ab7ea4a4b915d9 100644
  )
 +
 +require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20251219133548-db44f2109b85
-+	github.com/microsoft/go-crypto-darwin v0.0.3-0.20251218120905-3dc2f5f6b182
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20251219091053-f9796ee5d078
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20260115104635-63db5bc96a83
++	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260114113743-000278575184
++	github.com/microsoft/go-crypto-winnative v0.0.0-20260114031524-c493765efc5f
 +)
 diff --git a/src/go.sum b/src/go.sum
-index b6b841b44d8e38..104fcfc902e896 100644
+index b6b841b44d8e38..223b1d2797cf87 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20251219133548-db44f2109b85 h1:/IDnd+d+KhBvHD60Jpd1fuTW5S2FbdCfhJVL+w+ecZM=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20251219133548-db44f2109b85/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20251218120905-3dc2f5f6b182 h1:yeHGQpq1zuXcbMG18BPOTENjfYEgqB7ZEUYC/0eM2Lw=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20251218120905-3dc2f5f6b182/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20251219091053-f9796ee5d078 h1:9M+LVr3rtPCD7xgX/xGFWEsyWdvTA/djZUHh2AyXTB4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20251219091053-f9796ee5d078/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20260115104635-63db5bc96a83 h1:QeGy5Zv6lLfxzG+0PCOh06EVYPrYXI6q0UJhj+YXImU=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20260115104635-63db5bc96a83/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20260114113743-000278575184 h1:b0PQtPdldqXsTg7yLqLo9HFUF+4Qp07Vi+ohWwTBNrU=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20260114113743-000278575184/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260114031524-c493765efc5f h1:SvZJthaYYoyAxBX87EnmIFn4PmT/UbvKClLiSMhK8uw=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260114031524-c493765efc5f/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00 h1:JgcPM1rzpSOZS8y69FQvnY0xN0ciHlpQqwTXJcuZIA4=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
  golang.org/x/net v0.47.1-0.20251128220604-7c360367ab7e h1:PAAT9cIDvIAIRQVz2txQvUFRt3jOlhiO84ihd8XMGlg=
@@ -2401,11 +2415,11 @@ index 00000000000000..0a6d0d0ef2c0c6
 +This project adopts the Go code of conduct: https://go.dev/conduct.
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/aes.go b/src/vendor/github.com/golang-fips/openssl/v2/aes.go
 new file mode 100644
-index 00000000000000..71b94b31aa9d3f
+index 00000000000000..654566d2bff4e0
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/aes.go
 @@ -0,0 +1,145 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -2612,11 +2626,11 @@ index 00000000000000..6461f241f863fc
 +type BigInt []uint
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/chacha20poly1305.go b/src/vendor/github.com/golang-fips/openssl/v2/chacha20poly1305.go
 new file mode 100644
-index 00000000000000..1c6af181cd3496
+index 00000000000000..29f9ecc6e2f1fa
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/chacha20poly1305.go
 @@ -0,0 +1,149 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -2767,11 +2781,11 @@ index 00000000000000..1c6af181cd3496
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cipher.go b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
 new file mode 100644
-index 00000000000000..bb2f0cbbc71232
+index 00000000000000..3bcd7538d95f05
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
 @@ -0,0 +1,659 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -3529,11 +3543,11 @@ index 00000000000000..e4f8f5b5d0c4a7
 +)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cshake.go b/src/vendor/github.com/golang-fips/openssl/v2/cshake.go
 new file mode 100644
-index 00000000000000..a7e923a86979fa
+index 00000000000000..9ae41b4f5990b8
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cshake.go
-@@ -0,0 +1,231 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
+@@ -0,0 +1,253 @@
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -3586,6 +3600,8 @@ index 00000000000000..a7e923a86979fa
 +	return out
 +}
 +
++var shakeSupported sync.Map
++
 +// SupportsSHAKE returns true if the SHAKE extendable output functions
 +// with the given securityBits are supported.
 +func SupportsSHAKE(securityBits int) bool {
@@ -3595,7 +3611,27 @@ index 00000000000000..a7e923a86979fa
 +		// and we need it to implement [sha3.SHAKE].
 +		return false
 +	}
-+	return loadShake(securityBits) != nil
++	if v, ok := shakeSupported.Load(securityBits); ok {
++		return v.(bool)
++	}
++	alg := loadShake(securityBits)
++	if alg == nil {
++		shakeSupported.Store(securityBits, false)
++		return false
++	}
++	// EVP_MD objects can be non-nil but the underlying provider may not
++	// support EVP_DigestSqueeze. We need to test it.
++	var supported bool
++	if ctx, _ := ossl.EVP_MD_CTX_new(); ctx != nil {
++		defer ossl.EVP_MD_CTX_free(ctx)
++		if _, err := ossl.EVP_DigestInit_ex(ctx, alg.md, nil); err == nil {
++			var tmp [1]byte
++			_, err := ossl.EVP_DigestSqueeze(ctx, tmp[:])
++			supported = err == nil
++		}
++	}
++	shakeSupported.Store(securityBits, supported)
++	return supported
 +}
 +
 +// SupportsCSHAKE returns true if the CSHAKE extendable output functions
@@ -3766,11 +3802,11 @@ index 00000000000000..a7e923a86979fa
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/des.go b/src/vendor/github.com/golang-fips/openssl/v2/des.go
 new file mode 100644
-index 00000000000000..177c5bdb1afa2a
+index 00000000000000..772800a73e3389
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/des.go
 @@ -0,0 +1,112 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -3884,11 +3920,11 @@ index 00000000000000..177c5bdb1afa2a
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/dsa.go b/src/vendor/github.com/golang-fips/openssl/v2/dsa.go
 new file mode 100644
-index 00000000000000..ded266b3784191
+index 00000000000000..24ba60258c3b23
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/dsa.go
 @@ -0,0 +1,308 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -4198,11 +4234,11 @@ index 00000000000000..ded266b3784191
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ec.go b/src/vendor/github.com/golang-fips/openssl/v2/ec.go
 new file mode 100644
-index 00000000000000..ef1a181f6fcf29
+index 00000000000000..ad74a4b2038e59
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ec.go
 @@ -0,0 +1,136 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -4340,11 +4376,11 @@ index 00000000000000..ef1a181f6fcf29
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ecdh.go b/src/vendor/github.com/golang-fips/openssl/v2/ecdh.go
 new file mode 100644
-index 00000000000000..bf5935bd478bbd
+index 00000000000000..303ce47cab30a5
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ecdh.go
 @@ -0,0 +1,343 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -4689,11 +4725,11 @@ index 00000000000000..bf5935bd478bbd
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go b/src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go
 new file mode 100644
-index 00000000000000..d364cc0cde0dfc
+index 00000000000000..d0c29b5b821f92
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go
 @@ -0,0 +1,222 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -4917,11 +4953,11 @@ index 00000000000000..d364cc0cde0dfc
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go b/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
 new file mode 100644
-index 00000000000000..6413f3e42b4adb
+index 00000000000000..8377d7495e0731
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
 @@ -0,0 +1,210 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -5133,11 +5169,11 @@ index 00000000000000..6413f3e42b4adb
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/evp.go b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 new file mode 100644
-index 00000000000000..56fae101c4feb4
+index 00000000000000..4c70cd75a1a553
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 @@ -0,0 +1,620 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -5759,11 +5795,11 @@ index 00000000000000..56fae101c4feb4
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hash.go b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
 new file mode 100644
-index 00000000000000..203cc9a8020212
+index 00000000000000..eb0a84acf2232f
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
 @@ -0,0 +1,502 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -6302,11 +6338,11 @@ index 00000000000000..f1f2364c7246d4
 +type HashCloner = hash.Cloner
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
 new file mode 100644
-index 00000000000000..1b5744dd5b1806
+index 00000000000000..7e059d023ef00b
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
 @@ -0,0 +1,455 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -6763,11 +6799,11 @@ index 00000000000000..1b5744dd5b1806
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hmac.go b/src/vendor/github.com/golang-fips/openssl/v2/hmac.go
 new file mode 100644
-index 00000000000000..6c7940ffec1684
+index 00000000000000..14ffe51d6fefce
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hmac.go
 @@ -0,0 +1,282 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -7051,10 +7087,10 @@ index 00000000000000..6c7940ffec1684
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_amd64.h b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_amd64.h
 new file mode 100644
-index 00000000000000..c646c454a788fd
+index 00000000000000..9949435fe9e0ae
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_amd64.h
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,99 @@
 +// Copyright 2021 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -7064,6 +7100,69 @@ index 00000000000000..c646c454a788fd
 +// These save the frame pointer, so in general, functions that use
 +// these should have zero frame size to suppress the automatic frame
 +// pointer, though it's harmless to not do this.
++
++#ifdef GOOS_windows
++
++// REGS_HOST_TO_ABI0_STACK is the stack bytes used by
++// PUSH_REGS_HOST_TO_ABI0.
++#define REGS_HOST_TO_ABI0_STACK (28*8 + 8)
++
++// PUSH_REGS_HOST_TO_ABI0 prepares for transitioning from
++// the host ABI to Go ABI0 code. It saves all registers that are
++// callee-save in the host ABI and caller-save in Go ABI0 and prepares
++// for entry to Go.
++//
++// Save DI SI BP BX R12 R13 R14 R15 X6-X15 registers and the DF flag.
++// Clear the DF flag for the Go ABI.
++// MXCSR matches the Go ABI, so we don't have to set that,
++// and Go doesn't modify it, so we don't have to save it.
++#define PUSH_REGS_HOST_TO_ABI0()	\
++	PUSHFQ			\
++	CLD			\
++	ADJSP	$(REGS_HOST_TO_ABI0_STACK - 8)	\
++	MOVQ	DI, (0*0)(SP)	\
++	MOVQ	SI, (1*8)(SP)	\
++	MOVQ	BP, (2*8)(SP)	\
++	MOVQ	BX, (3*8)(SP)	\
++	MOVQ	R12, (4*8)(SP)	\
++	MOVQ	R13, (5*8)(SP)	\
++	MOVQ	R14, (6*8)(SP)	\
++	MOVQ	R15, (7*8)(SP)	\
++	MOVUPS	X6, (8*8)(SP)	\
++	MOVUPS	X7, (10*8)(SP)	\
++	MOVUPS	X8, (12*8)(SP)	\
++	MOVUPS	X9, (14*8)(SP)	\
++	MOVUPS	X10, (16*8)(SP)	\
++	MOVUPS	X11, (18*8)(SP)	\
++	MOVUPS	X12, (20*8)(SP)	\
++	MOVUPS	X13, (22*8)(SP)	\
++	MOVUPS	X14, (24*8)(SP)	\
++	MOVUPS	X15, (26*8)(SP)
++
++#define POP_REGS_HOST_TO_ABI0()	\
++	MOVQ	(0*0)(SP), DI	\
++	MOVQ	(1*8)(SP), SI	\
++	MOVQ	(2*8)(SP), BP	\
++	MOVQ	(3*8)(SP), BX	\
++	MOVQ	(4*8)(SP), R12	\
++	MOVQ	(5*8)(SP), R13	\
++	MOVQ	(6*8)(SP), R14	\
++	MOVQ	(7*8)(SP), R15	\
++	MOVUPS	(8*8)(SP), X6	\
++	MOVUPS	(10*8)(SP), X7	\
++	MOVUPS	(12*8)(SP), X8	\
++	MOVUPS	(14*8)(SP), X9	\
++	MOVUPS	(16*8)(SP), X10	\
++	MOVUPS	(18*8)(SP), X11	\
++	MOVUPS	(20*8)(SP), X12	\
++	MOVUPS	(22*8)(SP), X13	\
++	MOVUPS	(24*8)(SP), X14	\
++	MOVUPS	(26*8)(SP), X15	\
++	ADJSP	$-(REGS_HOST_TO_ABI0_STACK - 8)	\
++	POPFQ
++
++#else
++// SysV ABI
 +
 +#define REGS_HOST_TO_ABI0_STACK (6*8)
 +
@@ -7089,6 +7188,8 @@ index 00000000000000..c646c454a788fd
 +	MOVQ	(4*8)(SP), R15	\
 +	MOVQ	(5*8)(SP), BP	\
 +	ADJSP	$-(REGS_HOST_TO_ABI0_STACK)
++
++#endif
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_arm64.h b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_arm64.h
 new file mode 100644
 index 00000000000000..5d5061ec1dbf8c
@@ -7136,10 +7237,10 @@ index 00000000000000..5d5061ec1dbf8c
 +	FLDPD	((offset)+6*8)(RSP), (F14, F15)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_amd64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_amd64.s
 new file mode 100644
-index 00000000000000..fe133dacac6959
+index 00000000000000..2b7eb57f8ae783
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_amd64.s
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,39 @@
 +// Copyright 2009 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -7158,11 +7259,21 @@ index 00000000000000..fe133dacac6959
 +	// Make room for arguments to cgocallback.
 +	ADJSP $0x18
 +
++#ifndef GOOS_windows
 +	MOVQ DI, 0x0(SP) // fn
 +	MOVQ SI, 0x8(SP) // arg
 +
 +	// Skip n in DX.
 +	MOVQ CX, 0x10(SP) // ctxt
++
++#else
++	MOVQ CX, 0x0(SP) // fn
++	MOVQ DX, 0x8(SP) // arg
++
++	// Skip n in R8.
++	MOVQ R9, 0x10(SP) // ctxt
++
++#endif
 +
 +	CALL runtime·cgocallback(SB)
 +
@@ -7310,58 +7421,22 @@ index 00000000000000..5f70632fa7cc33
 +	x_cgo_unsetenv_call     = x_cgo_unsetenv
 +	x_cgo_thread_start_call = x_cgo_thread_start
 +)
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/doc.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/doc.go
-new file mode 100644
-index 00000000000000..84159b1b1eb914
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/doc.go
-@@ -0,0 +1,32 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo && (darwin || linux)
-+
-+// Package fakecgo implements the Cgo runtime (runtime/cgo) entirely in Go.
-+// This allows code that calls into C to function properly when CGO_ENABLED=0.
-+//
-+// # Goals
-+//
-+// fakecgo attempts to replicate the same naming structure as in the runtime.
-+// For example, functions that have the prefix "gcc_*" are named "go_*".
-+// This makes it easier to port other GOOSs and GOARCHs as well as to keep
-+// it in sync with runtime/cgo.
-+//
-+// # Support
-+//
-+// Currently, fakecgo only supports macOS on amd64 & arm64. It also cannot
-+// be used with -buildmode=c-archive because that requires special initialization
-+// that fakecgo does not implement at the moment.
-+//
-+// # Usage
-+//
-+// Using fakecgo is easy just import _ "github.com/ebitengine/purego" and then
-+// set the environment variable CGO_ENABLED=0.
-+// The recommended usage for fakecgo is to prefer using runtime/cgo if possible
-+// but if cross-compiling or fast build times are important fakecgo is available.
-+// Purego will pick which ever Cgo runtime is available and prefer the one that
-+// comes with Go (runtime/cgo).
-+package fakecgo
-+
-+//go:generate go run gen.go
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.go
 new file mode 100644
-index 00000000000000..59c8c1674baa67
+index 00000000000000..7927deb2785263
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.go
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,29 @@
 +// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++// SPDX-FileCopyrightText: 2025 The Ebitengine Authors
 +
 +//go:build !cgo && (darwin || linux)
 +
 +package fakecgo
 +
-+import "unsafe"
++import (
++	"unsafe"
++)
 +
 +// setg_trampoline calls setg with the G provided
 +func setg_trampoline(setg uintptr, G uintptr)
@@ -7381,6 +7456,15 @@ index 00000000000000..59c8c1674baa67
 +	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
 +	return *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(a.args), uintptr(i)*unsafe.Sizeof(uintptr(0))))
 +}
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/generate.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/generate.go
+new file mode 100644
+index 00000000000000..ca8d5f843f8421
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/generate.go
+@@ -0,0 +1,3 @@
++package fakecgo
++
++//go:generate go run update_tool.go
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_darwin.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_darwin.go
 new file mode 100644
 index 00000000000000..d0868f0f790351
@@ -7753,10 +7837,10 @@ index 00000000000000..ba142ec481d026
 +var _iscgo bool = true
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/libcgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/libcgo.go
 new file mode 100644
-index 00000000000000..1d56bf2b83f4b4
+index 00000000000000..8a0790faf1d5d9
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/libcgo.go
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,39 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
@@ -7768,6 +7852,7 @@ index 00000000000000..1d56bf2b83f4b4
 +	size_t uintptr
 +	// Sources:
 +	// Darwin (32 bytes) - https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/_types.h#L74
++	// FreeBSD (32 bytes) - https://github.com/DoctorWkt/xv6-freebsd/blob/d2a294c2a984baed27676068b15ed9a29b06ab6f/include/signal.h#L98C9-L98C21
 +	// Linux (128 bytes) - https://github.com/torvalds/linux/blob/ab75170520d4964f3acf8bb1f91d34cbc650688e/arch/x86/include/asm/signal.h#L25
 +	sigset_t       [128]byte
 +	pthread_attr_t [64]byte
@@ -7918,12 +8003,221 @@ index 00000000000000..8d7b9831d31fae
 +//go:linkname _cgo_unsetenv runtime._cgo_unsetenv
 +var x_cgo_unsetenv_trampoline byte
 +var _cgo_unsetenv = &x_cgo_unsetenv_trampoline
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols.go
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_amd64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_amd64.s
 new file mode 100644
-index 00000000000000..52e7e7e3824dcb
+index 00000000000000..e4a61f5978515b
 --- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols.go
-@@ -0,0 +1,225 @@
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_amd64.s
+@@ -0,0 +1,114 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && (darwin || linux)
++
++/*
++trampoline for emulating required C functions for cgo in go (see cgo.go)
++(we convert cdecl calling convention to go and vice-versa)
++
++Since we're called from go and call into C we can cheat a bit with the calling conventions:
++ - in go all the registers are caller saved
++ - in C we have a couple of callee saved registers
++
++=> we can use BX, R12, R13, R14, R15 instead of the stack
++
++C Calling convention cdecl used here (we only need integer args):
++1. arg: DI
++2. arg: SI
++3. arg: DX
++4. arg: CX
++5. arg: R8
++6. arg: R9
++We don't need floats with these functions -> AX=0
++return value will be in AX
++*/
++#include "textflag.h"
++#include "go_asm.h"
++#include "abi_amd64.h"
++
++// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
++
++TEXT x_cgo_init_trampoline(SB), NOSPLIT, $16
++	MOVQ DI, AX
++	MOVQ SI, BX
++	MOVQ ·x_cgo_init_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_thread_start_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_setenv_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_unsetenv_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0
++	CALL ·x_cgo_notify_runtime_init_done(SB)
++	RET
++
++TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0
++	CALL ·x_cgo_bindm(SB)
++	RET
++
++// func setg_trampoline(setg uintptr, g uintptr)
++TEXT ·setg_trampoline(SB), NOSPLIT, $0-16
++	MOVQ G+8(FP), DI
++	MOVQ setg+0(FP), BX
++	XORL AX, AX
++	CALL BX
++	RET
++
++TEXT threadentry_trampoline(SB), NOSPLIT, $0
++	// See crosscall2.
++	PUSH_REGS_HOST_TO_ABI0()
++
++	// X15 is designated by Go as a fixed zero register.
++	// Calling directly into ABIInternal, ensure it is zero.
++	PXOR X15, X15
++
++	MOVQ DI, AX
++	MOVQ ·threadentry_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++
++	POP_REGS_HOST_TO_ABI0()
++	RET
++
++TEXT ·call5(SB), NOSPLIT, $0-56
++	MOVQ fn+0(FP), BX
++	MOVQ a1+8(FP), DI
++	MOVQ a2+16(FP), SI
++	MOVQ a3+24(FP), DX
++	MOVQ a4+32(FP), CX
++	MOVQ a5+40(FP), R8
++
++	XORL AX, AX // no floats
++
++	PUSHQ BP       // save BP
++	MOVQ  SP, BP   // save SP inside BP bc BP is callee-saved
++	SUBQ  $16, SP  // allocate space for alignment
++	ANDQ  $-16, SP // align on 16 bytes for SSE
++
++	CALL BX
++
++	MOVQ BP, SP // get SP back
++	POPQ BP     // restore BP
++
++	MOVQ AX, ret+48(FP)
++	RET
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s
+new file mode 100644
+index 00000000000000..1ebee99617dbde
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s
+@@ -0,0 +1,83 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && (darwin || linux)
++
++#include "textflag.h"
++#include "go_asm.h"
++#include "abi_arm64.h"
++
++// These trampolines map the gcc ABI to Go ABIInternal and then calls into the Go equivalent functions.
++// Note that C arguments are passed in R0-R7, which matches Go ABIInternal for the first eight arguments.
++
++TEXT x_cgo_init_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_init_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	RET
++
++TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_thread_start_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	RET
++
++TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_setenv_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	RET
++
++TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_unsetenv_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	RET
++
++TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0-0
++	CALL ·x_cgo_notify_runtime_init_done(SB)
++	RET
++
++TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0
++	CALL ·x_cgo_bindm(SB)
++	RET
++
++// func setg_trampoline(setg uintptr, g uintptr)
++TEXT ·setg_trampoline(SB), NOSPLIT, $0-16
++	MOVD G+8(FP), R0
++	MOVD setg+0(FP), R1
++	CALL R1
++	RET
++
++TEXT threadentry_trampoline(SB), NOSPLIT, $0-0
++	// See crosscall2.
++	SUB  $(8*24), RSP
++	STP  (R0, R1), (8*1)(RSP)
++	MOVD R3, (8*3)(RSP)
++
++	SAVE_R19_TO_R28(8*4)
++	SAVE_F8_TO_F15(8*14)
++	STP (R29, R30), (8*22)(RSP)
++
++	MOVD ·threadentry_call(SB), R26
++	MOVD (R26), R2
++	CALL (R2)
++	MOVD $0, R0                     // TODO: get the return value from threadentry
++
++	RESTORE_R19_TO_R28(8*4)
++	RESTORE_F8_TO_F15(8*14)
++	LDP (8*22)(RSP), (R29, R30)
++
++	ADD $(8*24), RSP
++	RET
++
++TEXT ·call5(SB), NOSPLIT, $0-0
++	MOVD fn+0(FP), R6
++	MOVD a1+8(FP), R0
++	MOVD a2+16(FP), R1
++	MOVD a3+24(FP), R2
++	MOVD a4+32(FP), R3
++	MOVD a5+40(FP), R4
++	CALL R6
++	MOVD R0, ret+48(FP)
++	RET
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols.go
+new file mode 100644
+index 00000000000000..c5df904098e92a
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols.go
+@@ -0,0 +1,175 @@
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -8014,36 +8308,6 @@ index 00000000000000..52e7e7e3824dcb
 +
 +//go:nosplit
 +//go:norace
-+func pthread_self() pthread_t {
-+	return pthread_t(call5(pthread_selfABI0, 0, 0, 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_get_stacksize_np(thread pthread_t) size_t {
-+	return size_t(call5(pthread_get_stacksize_npABI0, uintptr(thread), 0, 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
-+	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_attr_setstacksize(attr *pthread_attr_t, size size_t) int32 {
-+	return int32(call5(pthread_attr_setstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(size), 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_attr_destroy(attr *pthread_attr_t) int32 {
-+	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
 +func pthread_mutex_lock(mutex *pthread_mutex_t) int32 {
 +	return int32(call5(pthread_mutex_lockABI0, uintptr(unsafe.Pointer(mutex)), 0, 0, 0, 0))
 +}
@@ -8114,26 +8378,6 @@ index 00000000000000..52e7e7e3824dcb
 +var _pthread_sigmask uint8
 +var pthread_sigmaskABI0 = uintptr(unsafe.Pointer(&_pthread_sigmask))
 +
-+//go:linkname _pthread_self _pthread_self
-+var _pthread_self uint8
-+var pthread_selfABI0 = uintptr(unsafe.Pointer(&_pthread_self))
-+
-+//go:linkname _pthread_get_stacksize_np _pthread_get_stacksize_np
-+var _pthread_get_stacksize_np uint8
-+var pthread_get_stacksize_npABI0 = uintptr(unsafe.Pointer(&_pthread_get_stacksize_np))
-+
-+//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
-+var _pthread_attr_getstacksize uint8
-+var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
-+
-+//go:linkname _pthread_attr_setstacksize _pthread_attr_setstacksize
-+var _pthread_attr_setstacksize uint8
-+var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
-+
-+//go:linkname _pthread_attr_destroy _pthread_attr_destroy
-+var _pthread_attr_destroy uint8
-+var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
-+
 +//go:linkname _pthread_mutex_lock _pthread_mutex_lock
 +var _pthread_mutex_lock uint8
 +var pthread_mutex_lockABI0 = uintptr(unsafe.Pointer(&_pthread_mutex_lock))
@@ -8149,12 +8393,12 @@ index 00000000000000..52e7e7e3824dcb
 +//go:linkname _pthread_setspecific _pthread_setspecific
 +var _pthread_setspecific uint8
 +var pthread_setspecificABI0 = uintptr(unsafe.Pointer(&_pthread_setspecific))
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols_darwin.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols_darwin.go
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_darwin.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_darwin.go
 new file mode 100644
-index 00000000000000..8c4489f0369c25
+index 00000000000000..08a7601c2ed0ff
 --- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols_darwin.go
-@@ -0,0 +1,30 @@
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_darwin.go
+@@ -0,0 +1,60 @@
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -8163,6 +8407,8 @@ index 00000000000000..8c4489f0369c25
 +//go:build !cgo
 +
 +package fakecgo
++
++import "unsafe"
 +
 +//go:cgo_import_dynamic purego_malloc malloc "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_free free "/usr/lib/libSystem.B.dylib"
@@ -8176,21 +8422,49 @@ index 00000000000000..8c4489f0369c25
 +//go:cgo_import_dynamic purego_pthread_create pthread_create "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_detach pthread_detach "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_sigmask pthread_sigmask "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_self pthread_self "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_get_stacksize_np pthread_get_stacksize_np "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_attr_setstacksize pthread_attr_setstacksize "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_mutex_lock pthread_mutex_lock "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_mutex_unlock pthread_mutex_unlock "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_cond_broadcast pthread_cond_broadcast "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "/usr/lib/libSystem.B.dylib"
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols_linux.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols_linux.go
++//go:cgo_import_dynamic purego_pthread_self pthread_self "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_get_stacksize_np pthread_get_stacksize_np "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_attr_setstacksize pthread_attr_setstacksize "/usr/lib/libSystem.B.dylib"
++
++//go:nosplit
++//go:norace
++func pthread_self() pthread_t {
++	return pthread_t(call5(pthread_selfABI0, 0, 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_get_stacksize_np(thread pthread_t) size_t {
++	return size_t(call5(pthread_get_stacksize_npABI0, uintptr(thread), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_attr_setstacksize(attr *pthread_attr_t, size size_t) int32 {
++	return int32(call5(pthread_attr_setstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(size), 0, 0, 0))
++}
++
++//go:linkname _pthread_self _pthread_self
++var _pthread_self uint8
++var pthread_selfABI0 = uintptr(unsafe.Pointer(&_pthread_self))
++
++//go:linkname _pthread_get_stacksize_np _pthread_get_stacksize_np
++var _pthread_get_stacksize_np uint8
++var pthread_get_stacksize_npABI0 = uintptr(unsafe.Pointer(&_pthread_get_stacksize_np))
++
++//go:linkname _pthread_attr_setstacksize _pthread_attr_setstacksize
++var _pthread_attr_setstacksize uint8
++var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_linux.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_linux.go
 new file mode 100644
-index 00000000000000..85728bb394c248
+index 00000000000000..38ee622a366042
 --- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/symbols_linux.go
-@@ -0,0 +1,277 @@
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_linux.go
+@@ -0,0 +1,294 @@
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -8224,15 +8498,32 @@ index 00000000000000..85728bb394c248
 +//go:cgo_import_dynamic purego_pthread_create pthread_create "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_detach pthread_detach "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_sigmask pthread_sigmask "libpthread.so.0"
-+//go:cgo_import_dynamic purego_pthread_self pthread_self "libpthread.so.0"
-+//go:cgo_import_dynamic purego_pthread_get_stacksize_np pthread_get_stacksize_np "libpthread.so.0"
-+//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "libpthread.so.0"
-+//go:cgo_import_dynamic purego_pthread_attr_setstacksize pthread_attr_setstacksize "libpthread.so.0"
-+//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_mutex_lock pthread_mutex_lock "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_mutex_unlock pthread_mutex_unlock "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_cond_broadcast pthread_cond_broadcast "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "libpthread.so.0"
++//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "libpthread.so.0"
++//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "libpthread.so.0"
++
++//go:nosplit
++//go:norace
++func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
++	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_attr_destroy(attr *pthread_attr_t) int32 {
++	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
++}
++
++//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
++var _pthread_attr_getstacksize uint8
++var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
++
++//go:linkname _pthread_attr_destroy _pthread_attr_destroy
++var _pthread_attr_destroy uint8
++var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
 +
 +//go:nosplit
 +//go:norace
@@ -8468,312 +8759,53 @@ index 00000000000000..85728bb394c248
 +		c.retval = uintptr(ret)
 +	}
 +}
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_amd64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_amd64.s
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_darwin.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_darwin.s
 new file mode 100644
-index 00000000000000..7c72b78a866bbd
+index 00000000000000..35ef7ac11cb955
 --- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_amd64.s
-@@ -0,0 +1,112 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo && (darwin || linux)
-+
-+/*
-+trampoline for emulating required C functions for cgo in go (see cgo.go)
-+(we convert cdecl calling convention to go and vice-versa)
-+
-+Since we're called from go and call into C we can cheat a bit with the calling conventions:
-+ - in go all the registers are caller saved
-+ - in C we have a couple of callee saved registers
-+
-+=> we can use BX, R12, R13, R14, R15 instead of the stack
-+
-+C Calling convention cdecl used here (we only need integer args):
-+1. arg: DI
-+2. arg: SI
-+3. arg: DX
-+4. arg: CX
-+5. arg: R8
-+6. arg: R9
-+We don't need floats with these functions -> AX=0
-+return value will be in AX
-+*/
-+#include "textflag.h"
-+#include "go_asm.h"
-+#include "abi_amd64.h"
-+
-+// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
-+
-+TEXT x_cgo_init_trampoline(SB), NOSPLIT, $16
-+	MOVQ DI, AX
-+	MOVQ SI, BX
-+	MOVQ ·x_cgo_init_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_thread_start_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_setenv_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_unsetenv_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0
-+	CALL ·x_cgo_notify_runtime_init_done(SB)
-+	RET
-+
-+TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0
-+	CALL ·x_cgo_bindm(SB)
-+	RET
-+
-+// func setg_trampoline(setg uintptr, g uintptr)
-+TEXT ·setg_trampoline(SB), NOSPLIT, $0-16
-+	MOVQ G+8(FP), DI
-+	MOVQ setg+0(FP), BX
-+	XORL AX, AX
-+	CALL BX
-+	RET
-+
-+TEXT threadentry_trampoline(SB), NOSPLIT, $0
-+	// See crosscall2.
-+	PUSH_REGS_HOST_TO_ABI0()
-+
-+	PXOR	X15, X15
-+
-+	MOVQ DI, AX
-+	MOVQ ·threadentry_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+
-+	POP_REGS_HOST_TO_ABI0()
-+	RET
-+
-+TEXT ·call5(SB), NOSPLIT, $0-56
-+	MOVQ fn+0(FP), BX
-+	MOVQ a1+8(FP), DI
-+	MOVQ a2+16(FP), SI
-+	MOVQ a3+24(FP), DX
-+	MOVQ a4+32(FP), CX
-+	MOVQ a5+40(FP), R8
-+
-+	XORL AX, AX // no floats
-+
-+	PUSHQ BP       // save BP
-+	MOVQ  SP, BP   // save SP inside BP bc BP is callee-saved
-+	SUBQ  $16, SP  // allocate space for alignment
-+	ANDQ  $-16, SP // align on 16 bytes for SSE
-+
-+	CALL BX
-+
-+	MOVQ BP, SP // get SP back
-+	POPQ BP     // restore BP
-+
-+	MOVQ AX, ret+48(FP)
-+	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s
-new file mode 100644
-index 00000000000000..2a03bc53f1c39c
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s
-@@ -0,0 +1,82 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo && (darwin || linux)
-+
-+#include "textflag.h"
-+#include "go_asm.h"
-+#include "abi_arm64.h"
-+
-+// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
-+
-+TEXT x_cgo_init_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_init_call(SB), R26
-+	MOVD (R26), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_thread_start_call(SB), R26
-+	MOVD (R26), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_setenv_call(SB), R26
-+	MOVD (R26), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_unsetenv_call(SB), R26
-+	MOVD (R26), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0-0
-+	CALL ·x_cgo_notify_runtime_init_done(SB)
-+	RET
-+
-+TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0
-+	CALL ·x_cgo_bindm(SB)
-+	RET
-+
-+// func setg_trampoline(setg uintptr, g uintptr)
-+TEXT ·setg_trampoline(SB), NOSPLIT, $0-16
-+	MOVD G+8(FP), R0
-+	MOVD setg+0(FP), R1
-+	CALL R1
-+	RET
-+
-+TEXT threadentry_trampoline(SB), NOSPLIT, $0-0
-+	// See crosscall2.
-+	SUB  $(8*24), RSP
-+	STP  (R0, R1), (8*1)(RSP)
-+	MOVD R3, (8*3)(RSP)
-+
-+	SAVE_R19_TO_R28(8*4)
-+	SAVE_F8_TO_F15(8*14)
-+	STP (R29, R30), (8*22)(RSP)
-+
-+	MOVD ·threadentry_call(SB), R26
-+	MOVD (R26), R2
-+	CALL (R2)
-+	MOVD $0, R0                     // TODO: get the return value from threadentry
-+
-+	RESTORE_R19_TO_R28(8*4)
-+	RESTORE_F8_TO_F15(8*14)
-+	LDP (8*22)(RSP), (R29, R30)
-+
-+	ADD $(8*24), RSP
-+	RET
-+
-+TEXT ·call5(SB), NOSPLIT, $0-0
-+	MOVD fn+0(FP), R6
-+	MOVD a1+8(FP), R0
-+	MOVD a2+16(FP), R1
-+	MOVD a3+24(FP), R2
-+	MOVD a4+32(FP), R3
-+	MOVD a5+40(FP), R4
-+	CALL R6
-+	MOVD R0, ret+48(FP)
-+	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_stubs.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_stubs.s
-new file mode 100644
-index 00000000000000..dcd1412237a0a3
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_stubs.s
-@@ -0,0 +1,94 @@
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_darwin.s
+@@ -0,0 +1,19 @@
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo
 +
 +#include "textflag.h"
 +
-+// these stubs are here because it is not possible to go:linkname directly the C functions on darwin arm64
-+
-+TEXT _malloc(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_malloc(SB)
-+	RET
-+
-+TEXT _free(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_free(SB)
-+	RET
-+
-+TEXT _setenv(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setenv(SB)
-+	RET
-+
-+TEXT _unsetenv(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_unsetenv(SB)
-+	RET
-+
-+TEXT _sigfillset(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_sigfillset(SB)
-+	RET
-+
-+TEXT _nanosleep(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_nanosleep(SB)
-+	RET
-+
-+TEXT _abort(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_abort(SB)
-+	RET
-+
-+TEXT _sigaltstack(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_sigaltstack(SB)
-+	RET
-+
-+TEXT _pthread_attr_init(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_attr_init(SB)
-+	RET
-+
-+TEXT _pthread_create(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_create(SB)
-+	RET
-+
-+TEXT _pthread_detach(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_detach(SB)
-+	RET
-+
-+TEXT _pthread_sigmask(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_sigmask(SB)
-+	RET
++// these stubs are here because it is not possible to go:linkname directly the C functions
 +
 +TEXT _pthread_self(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_self(SB)
-+	RET
 +
 +TEXT _pthread_get_stacksize_np(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_get_stacksize_np(SB)
-+	RET
-+
-+TEXT _pthread_attr_getstacksize(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_attr_getstacksize(SB)
-+	RET
 +
 +TEXT _pthread_attr_setstacksize(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_attr_setstacksize(SB)
-+	RET
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux.s
+new file mode 100644
+index 00000000000000..da07005c0bc988
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux.s
+@@ -0,0 +1,16 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++#include "textflag.h"
++
++// these stubs are here because it is not possible to go:linkname directly the C functions
++
++TEXT _pthread_attr_getstacksize(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_attr_getstacksize(SB)
 +
 +TEXT _pthread_attr_destroy(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_attr_destroy(SB)
-+	RET
-+
-+TEXT _pthread_mutex_lock(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_mutex_lock(SB)
-+	RET
-+
-+TEXT _pthread_mutex_unlock(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_mutex_unlock(SB)
-+	RET
-+
-+TEXT _pthread_cond_broadcast(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_cond_broadcast(SB)
-+	RET
-+
-+TEXT _pthread_setspecific(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_setspecific(SB)
-+	RET
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_amd64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_amd64.s
 new file mode 100644
 index 00000000000000..603cd6802eea20
@@ -8983,9 +9015,73 @@ index 00000000000000..b5aeb4b47a2e55
 +TEXT _setgroups(SB), NOSPLIT, $0-0
 +	JMP purego_setgroups(SB)
 +
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_stubs.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_stubs.s
+new file mode 100644
+index 00000000000000..8417ba55e1e5cf
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_stubs.s
+@@ -0,0 +1,58 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo && (darwin || linux)
++
++#include "textflag.h"
++
++// these stubs are here because it is not possible to go:linkname directly the C functions
++
++TEXT _malloc(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_malloc(SB)
++
++TEXT _free(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_free(SB)
++
++TEXT _setenv(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setenv(SB)
++
++TEXT _unsetenv(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_unsetenv(SB)
++
++TEXT _sigfillset(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_sigfillset(SB)
++
++TEXT _nanosleep(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_nanosleep(SB)
++
++TEXT _abort(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_abort(SB)
++
++TEXT _sigaltstack(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_sigaltstack(SB)
++
++TEXT _pthread_attr_init(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_attr_init(SB)
++
++TEXT _pthread_create(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_create(SB)
++
++TEXT _pthread_detach(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_detach(SB)
++
++TEXT _pthread_sigmask(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_sigmask(SB)
++
++TEXT _pthread_mutex_lock(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_mutex_lock(SB)
++
++TEXT _pthread_mutex_unlock(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_mutex_unlock(SB)
++
++TEXT _pthread_cond_broadcast(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_cond_broadcast(SB)
++
++TEXT _pthread_setspecific(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_setspecific(SB)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_amd64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_amd64.s
 new file mode 100644
-index 00000000000000..8c86ce392c8323
+index 00000000000000..59560c7d590f7a
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_amd64.s
 @@ -0,0 +1,108 @@
@@ -8993,7 +9089,7 @@ index 00000000000000..8c86ce392c8323
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !cgo && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo
 +
 +#include "go_asm.h"
 +#include "textflag.h"
@@ -9099,7 +9195,7 @@ index 00000000000000..8c86ce392c8323
 +	RET
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_arm64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_arm64.s
 new file mode 100644
-index 00000000000000..10f3da0ab4e951
+index 00000000000000..025276dffb2aa5
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_arm64.s
 @@ -0,0 +1,87 @@
@@ -9107,7 +9203,7 @@ index 00000000000000..10f3da0ab4e951
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !cgo && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo
 +
 +#include "go_asm.h"
 +#include "textflag.h"
@@ -9210,12 +9306,10 @@ index 00000000000000..e94cca9e27e30a
 +#endif // _GO_DL_SHIMS_H
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors.go
 new file mode 100644
-index 00000000000000..faefd9c97109ff
+index 00000000000000..4b8fd49edd2d40
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors.go
-@@ -0,0 +1,36 @@
-+//go:build cgo || goexperiment.ms_nocgo_opensslcrypto
-+
+@@ -0,0 +1,34 @@
 +package ossl
 +
 +import (
@@ -9272,11 +9366,11 @@ index 00000000000000..ef1d99652e3bae
 +import "C"
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors_nocgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors_nocgo.go
 new file mode 100644
-index 00000000000000..04178991217173
+index 00000000000000..822ff8fbbdf9a1
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/errors_nocgo.go
 @@ -0,0 +1,16 @@
-+//go:build !cgo && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo
 +
 +package ossl
 +
@@ -9294,7 +9388,7 @@ index 00000000000000..04178991217173
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/ossl.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/ossl.go
 new file mode 100644
-index 00000000000000..bb8ea6fafdc4d9
+index 00000000000000..9d38464e9fb964
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/ossl.go
 @@ -0,0 +1,59 @@
@@ -9302,8 +9396,8 @@ index 00000000000000..bb8ea6fafdc4d9
 +package ossl
 +
 +//go:generate go run ../../cmd/mkcgo -out zossl.go -mode dynload -package ossl shims.h
-+//go:generate go run ../../cmd/mkcgo -out zossl.go -nocgo -mode dynload -package ossl -tags goexperiment.ms_nocgo_opensslcrypto shims.h
-+//go:generate go run ../../cmd/mkcgo -out zdl.go -nocgo -mode dynamic -noerrors -package ossl -tags "unix && goexperiment.ms_nocgo_opensslcrypto" dl.h
++//go:generate go run ../../cmd/mkcgo -out zossl.go -nocgo -mode dynload -package ossl shims.h
++//go:generate go run ../../cmd/mkcgo -out zdl.go -nocgo -mode dynamic -noerrors -package ossl -tags unix dl.h
 +
 +import "unsafe"
 +
@@ -9799,11 +9893,11 @@ index 00000000000000..3ce5eb8435c9fd
 +#endif // _GO_OSSL_SHIMS_H
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo.go
 new file mode 100644
-index 00000000000000..2fa7bd4c66b3fb
+index 00000000000000..0e3e6ca7d87db2
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo.go
 @@ -0,0 +1,84 @@
-+//go:build !cgo && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo
 +
 +package ossl
 +
@@ -9889,33 +9983,33 @@ index 00000000000000..2fa7bd4c66b3fb
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_darwin.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_darwin.go
 new file mode 100644
-index 00000000000000..dffedf87367375
+index 00000000000000..d6a7523ba10197
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_darwin.go
 @@ -0,0 +1,5 @@
-+//go:build !cgo && darwin && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo && darwin
 +
 +package ossl
 +
 +//go:cgo_import_dynamic _ _ "/usr/lib/libSystem.B.dylib"
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_linux.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_linux.go
 new file mode 100644
-index 00000000000000..63a5798fe55a75
+index 00000000000000..20cb4556a12aa8
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_linux.go
 @@ -0,0 +1,5 @@
-+//go:build !cgo && linux && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo && linux
 +
 +package ossl
 +
 +//go:cgo_import_dynamic _ _ "libdl.so.2"
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_unix.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_unix.go
 new file mode 100644
-index 00000000000000..6c2ae8d47bac94
+index 00000000000000..9564b3a7033521
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_unix.go
 @@ -0,0 +1,20 @@
-+//go:build !cgo && unix && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo && unix
 +
 +package ossl
 +
@@ -9937,11 +10031,11 @@ index 00000000000000..6c2ae8d47bac94
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_windows.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_windows.go
 new file mode 100644
-index 00000000000000..0e541464f568cb
+index 00000000000000..48640cdcbf558f
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/syscall_nocgo_windows.go
 @@ -0,0 +1,22 @@
-+//go:build !cgo && windows && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo && windows
 +
 +package ossl
 +
@@ -9965,13 +10059,13 @@ index 00000000000000..0e541464f568cb
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zdl.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zdl.s
 new file mode 100644
-index 00000000000000..4d03a5f97cec27
+index 00000000000000..25b9fddfbc888b
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zdl.s
 @@ -0,0 +1,51 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
-+//go:build !cgo && (unix && goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cgo && unix
 +
 +#include "textflag.h"
 +
@@ -10022,13 +10116,13 @@ index 00000000000000..4d03a5f97cec27
 +
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zdl_nocgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zdl_nocgo.go
 new file mode 100644
-index 00000000000000..fb345aac77ea48
+index 00000000000000..e4d870cecde36c
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zdl_nocgo.go
 @@ -0,0 +1,45 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
-+//go:build !cgo && unix && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo && unix
 +
 +package ossl
 +
@@ -13998,13 +14092,13 @@ index 00000000000000..7ced663df8a562
 +import "C"
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_nocgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_nocgo.go
 new file mode 100644
-index 00000000000000..a8ff682b06c5c4
+index 00000000000000..56b1f871c7fcbf
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_nocgo.go
 @@ -0,0 +1,2390 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
-+//go:build !cgo && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo
 +
 +package ossl
 +
@@ -16394,11 +16488,11 @@ index 00000000000000..a8ff682b06c5c4
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/mlkem.go b/src/vendor/github.com/golang-fips/openssl/v2/mlkem.go
 new file mode 100644
-index 00000000000000..f1248bb3ccd7a6
+index 00000000000000..38ed8f5d69d946
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/mlkem.go
 @@ -0,0 +1,371 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -16771,11 +16865,11 @@ index 00000000000000..f1248bb3ccd7a6
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/openssl.go b/src/vendor/github.com/golang-fips/openssl/v2/openssl.go
 new file mode 100644
-index 00000000000000..34bffbf4f723a7
+index 00000000000000..30ed1f38392629
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/openssl.go
 @@ -0,0 +1,253 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +// Package openssl provides access to OpenSSL cryptographic functions.
 +package openssl
@@ -17052,11 +17146,11 @@ index 00000000000000..c35f1bdcbef80b
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/openssl_nocgo.go b/src/vendor/github.com/golang-fips/openssl/v2/openssl_nocgo.go
 new file mode 100644
-index 00000000000000..c464f41a5076fb
+index 00000000000000..47bfafa9d4c63f
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/openssl_nocgo.go
 @@ -0,0 +1,32 @@
-+//go:build !cgo && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo
 +
 +package openssl
 +
@@ -17090,11 +17184,11 @@ index 00000000000000..c464f41a5076fb
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/fips.go b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/fips.go
 new file mode 100644
-index 00000000000000..be03becaaeeeb7
+index 00000000000000..de987d68d364a6
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/fips.go
 @@ -0,0 +1,165 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package osslsetup
 +
@@ -17261,11 +17355,11 @@ index 00000000000000..be03becaaeeeb7
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/init.go b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/init.go
 new file mode 100644
-index 00000000000000..faa9c37742133e
+index 00000000000000..fa00950e79da39
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/init.go
 @@ -0,0 +1,160 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package osslsetup
 +
@@ -17464,11 +17558,11 @@ index 00000000000000..0e61cc128ef981
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/init_nocgo_unix.go b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/init_nocgo_unix.go
 new file mode 100644
-index 00000000000000..26962b73dcd3a8
+index 00000000000000..1a2f48ed510326
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/init_nocgo_unix.go
 @@ -0,0 +1,32 @@
-+//go:build unix && !cmd_go_bootstrap && !cgo && goexperiment.ms_nocgo_opensslcrypto
++//go:build unix && !cmd_go_bootstrap && !cgo
 +
 +package osslsetup
 +
@@ -17544,11 +17638,11 @@ index 00000000000000..c4981aef84b42f
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/osslsetup.go b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/osslsetup.go
 new file mode 100644
-index 00000000000000..53b53586a05812
+index 00000000000000..63eb1994606e8e
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/osslsetup.go
 @@ -0,0 +1,74 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package osslsetup
 +
@@ -17641,11 +17735,11 @@ index 00000000000000..810ccaa4fc3330
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/osslsetup_nocgo.go b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/osslsetup_nocgo.go
 new file mode 100644
-index 00000000000000..089f15899b1a01
+index 00000000000000..fd1cad5692a0bc
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/osslsetup/osslsetup_nocgo.go
 @@ -0,0 +1,21 @@
-+//go:build !cgo && goexperiment.ms_nocgo_opensslcrypto
++//go:build !cgo
 +
 +package osslsetup
 +
@@ -17668,11 +17762,11 @@ index 00000000000000..089f15899b1a01
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/params.go b/src/vendor/github.com/golang-fips/openssl/v2/params.go
 new file mode 100644
-index 00000000000000..a9310fd6ec4721
+index 00000000000000..3bdc8037c0c9af
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/params.go
 @@ -0,0 +1,184 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -17858,11 +17952,11 @@ index 00000000000000..a9310fd6ec4721
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/pbkdf2.go b/src/vendor/github.com/golang-fips/openssl/v2/pbkdf2.go
 new file mode 100644
-index 00000000000000..ab4bb9b2348dab
+index 00000000000000..c12c0119e99767
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/pbkdf2.go
 @@ -0,0 +1,54 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -17918,11 +18012,11 @@ index 00000000000000..ab4bb9b2348dab
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/provideropenssl.go b/src/vendor/github.com/golang-fips/openssl/v2/provideropenssl.go
 new file mode 100644
-index 00000000000000..afbb7f4d0d6f5e
+index 00000000000000..e366c7a7a833fa
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/provideropenssl.go
 @@ -0,0 +1,239 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -18163,11 +18257,11 @@ index 00000000000000..afbb7f4d0d6f5e
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/providersymcrypt.go b/src/vendor/github.com/golang-fips/openssl/v2/providersymcrypt.go
 new file mode 100644
-index 00000000000000..125404e395d198
+index 00000000000000..cc6e108e948727
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/providersymcrypt.go
 @@ -0,0 +1,338 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -18507,11 +18601,11 @@ index 00000000000000..125404e395d198
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rand.go b/src/vendor/github.com/golang-fips/openssl/v2/rand.go
 new file mode 100644
-index 00000000000000..3c70b19cce3513
+index 00000000000000..bcc58f2e42ec86
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/rand.go
 @@ -0,0 +1,21 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -18534,11 +18628,11 @@ index 00000000000000..3c70b19cce3513
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rc4.go b/src/vendor/github.com/golang-fips/openssl/v2/rc4.go
 new file mode 100644
-index 00000000000000..e933228919296d
+index 00000000000000..25fa08d0152e81
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/rc4.go
 @@ -0,0 +1,68 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -18608,11 +18702,11 @@ index 00000000000000..e933228919296d
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rsa.go b/src/vendor/github.com/golang-fips/openssl/v2/rsa.go
 new file mode 100644
-index 00000000000000..e989da8db9cfa6
+index 00000000000000..935a3962b9d00f
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/rsa.go
-@@ -0,0 +1,716 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
+@@ -0,0 +1,714 @@
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -18948,23 +19042,21 @@ index 00000000000000..e989da8db9cfa6
 +	bld.addBigInt(_OSSL_PKEY_PARAM_RSA_E, e, false)
 +	bld.addBigInt(_OSSL_PKEY_PARAM_RSA_D, d, false)
 +
-+	if p != nil && q != nil {
-+		allPrecomputedExists := dp != nil && dq != nil && qinv != nil
-+		// The precomputed values should only be passed if P and Q are present
-+		// and every precomputed value is present. (If any precomputed value is
-+		// missing, don't pass any of them.)
-+		//
-+		// In OpenSSL 3.0 and 3.1, we must also omit P and Q if any precomputed
-+		// value is missing. See https://github.com/openssl/openssl/pull/22334
-+		if minor() >= 2 || allPrecomputedExists {
-+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_FACTOR1, p, true)
-+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_FACTOR2, q, true)
-+		}
-+		if allPrecomputedExists {
-+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_EXPONENT1, dp, true)
-+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_EXPONENT2, dq, true)
-+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv, true)
-+		}
++	// OpenSSL 3.0 and 3.1 required all the precomputed values if
++	// P and Q are present. See:
++	// https://github.com/openssl/openssl/pull/22334
++	//
++	// We could only set P and Q if they exist when using OpenSSL 3.2
++	// or newer, but the RSA provider might be built with an older
++	// OpenSSL version, in which case it would still require all the
++	// precomputed values. So better always provide all the values or
++	// none of them.
++	if p != nil && q != nil && dp != nil && dq != nil && qinv != nil {
++		bld.addBigInt(_OSSL_PKEY_PARAM_RSA_FACTOR1, p, true)
++		bld.addBigInt(_OSSL_PKEY_PARAM_RSA_FACTOR2, q, true)
++		bld.addBigInt(_OSSL_PKEY_PARAM_RSA_EXPONENT1, dp, true)
++		bld.addBigInt(_OSSL_PKEY_PARAM_RSA_EXPONENT2, dq, true)
++		bld.addBigInt(_OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv, true)
 +	}
 +
 +	params, err := bld.build()
@@ -19330,11 +19422,11 @@ index 00000000000000..e989da8db9cfa6
 +})
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/tls1prf.go b/src/vendor/github.com/golang-fips/openssl/v2/tls1prf.go
 new file mode 100644
-index 00000000000000..5a0aa905f03e43
+index 00000000000000..57930900c2bfa8
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/tls1prf.go
 @@ -0,0 +1,158 @@
-+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -19494,13 +19586,13 @@ index 00000000000000..5a0aa905f03e43
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/zaes.go b/src/vendor/github.com/golang-fips/openssl/v2/zaes.go
 new file mode 100644
-index 00000000000000..a40affbb5d6273
+index 00000000000000..4d945290e3bdff
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/zaes.go
 @@ -0,0 +1,86 @@
 +// Code generated by cmd/genaesmodes. DO NOT EDIT.
 +
-+//go:build (cgo || goexperiment.ms_nocgo_opensslcrypto) && !cmd_go_bootstrap
++//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
@@ -24607,7 +24699,7 @@ index 00000000000000..88c4cdf9ec04cc
 +//go:generate go run update_tool.go
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_darwin.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_darwin.go
 new file mode 100644
-index 00000000000000..6bc959b64ce3eb
+index 00000000000000..d0868f0f790351
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/go_darwin.go
 @@ -0,0 +1,88 @@
@@ -24615,7 +24707,7 @@ index 00000000000000..6bc959b64ce3eb
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !cgo && darwin
++//go:build !cgo
 +
 +package fakecgo
 +
@@ -25093,10 +25185,10 @@ index 00000000000000..c0a759bfb849c3
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s
 new file mode 100644
-index 00000000000000..bf407d4427633a
+index 00000000000000..959dafa43dc6b8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,83 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
@@ -25106,32 +25198,28 @@ index 00000000000000..bf407d4427633a
 +#include "go_asm.h"
 +#include "abi_arm64.h"
 +
-+// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
++// These trampolines map the gcc ABI to Go ABIInternal and then calls into the Go equivalent functions.
++// Note that C arguments are passed in R0-R7, which matches Go ABIInternal for the first eight arguments.
 +
 +TEXT x_cgo_init_trampoline(SB), NOSPLIT, $0-0
-+	MOVD R0, 8(RSP)
-+	MOVD R1, 16(RSP)
 +	MOVD ·x_cgo_init_call(SB), R26
 +	MOVD (R26), R2
 +	CALL (R2)
 +	RET
 +
 +TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $0-0
-+	MOVD R0, 8(RSP)
 +	MOVD ·x_cgo_thread_start_call(SB), R26
 +	MOVD (R26), R2
 +	CALL (R2)
 +	RET
 +
 +TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $0-0
-+	MOVD R0, 8(RSP)
 +	MOVD ·x_cgo_setenv_call(SB), R26
 +	MOVD (R26), R2
 +	CALL (R2)
 +	RET
 +
 +TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $0-0
-+	MOVD R0, 8(RSP)
 +	MOVD ·x_cgo_unsetenv_call(SB), R26
 +	MOVD (R26), R2
 +	CALL (R2)
@@ -25186,10 +25274,10 @@ index 00000000000000..bf407d4427633a
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/zsymbols.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/zsymbols.go
 new file mode 100644
-index 00000000000000..a18645048960cb
+index 00000000000000..9349ba86bc82bb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/zsymbols.go
-@@ -0,0 +1,225 @@
+@@ -0,0 +1,175 @@
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -25280,36 +25368,6 @@ index 00000000000000..a18645048960cb
 +
 +//go:nosplit
 +//go:norace
-+func pthread_self() pthread_t {
-+	return pthread_t(call5(pthread_selfABI0, 0, 0, 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_get_stacksize_np(thread pthread_t) size_t {
-+	return size_t(call5(pthread_get_stacksize_npABI0, uintptr(thread), 0, 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
-+	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_attr_setstacksize(attr *pthread_attr_t, size size_t) int32 {
-+	return int32(call5(pthread_attr_setstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(size), 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_attr_destroy(attr *pthread_attr_t) int32 {
-+	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
 +func pthread_mutex_lock(mutex *pthread_mutex_t) int32 {
 +	return int32(call5(pthread_mutex_lockABI0, uintptr(unsafe.Pointer(mutex)), 0, 0, 0, 0))
 +}
@@ -25380,26 +25438,6 @@ index 00000000000000..a18645048960cb
 +var _pthread_sigmask uint8
 +var pthread_sigmaskABI0 = uintptr(unsafe.Pointer(&_pthread_sigmask))
 +
-+//go:linkname _pthread_self _pthread_self
-+var _pthread_self uint8
-+var pthread_selfABI0 = uintptr(unsafe.Pointer(&_pthread_self))
-+
-+//go:linkname _pthread_get_stacksize_np _pthread_get_stacksize_np
-+var _pthread_get_stacksize_np uint8
-+var pthread_get_stacksize_npABI0 = uintptr(unsafe.Pointer(&_pthread_get_stacksize_np))
-+
-+//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
-+var _pthread_attr_getstacksize uint8
-+var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
-+
-+//go:linkname _pthread_attr_setstacksize _pthread_attr_setstacksize
-+var _pthread_attr_setstacksize uint8
-+var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
-+
-+//go:linkname _pthread_attr_destroy _pthread_attr_destroy
-+var _pthread_attr_destroy uint8
-+var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
-+
 +//go:linkname _pthread_mutex_lock _pthread_mutex_lock
 +var _pthread_mutex_lock uint8
 +var pthread_mutex_lockABI0 = uintptr(unsafe.Pointer(&_pthread_mutex_lock))
@@ -25417,10 +25455,10 @@ index 00000000000000..a18645048960cb
 +var pthread_setspecificABI0 = uintptr(unsafe.Pointer(&_pthread_setspecific))
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/zsymbols_darwin.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/zsymbols_darwin.go
 new file mode 100644
-index 00000000000000..8c4489f0369c25
+index 00000000000000..08a7601c2ed0ff
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/zsymbols_darwin.go
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,60 @@
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -25429,6 +25467,8 @@ index 00000000000000..8c4489f0369c25
 +//go:build !cgo
 +
 +package fakecgo
++
++import "unsafe"
 +
 +//go:cgo_import_dynamic purego_malloc malloc "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_free free "/usr/lib/libSystem.B.dylib"
@@ -25442,21 +25482,74 @@ index 00000000000000..8c4489f0369c25
 +//go:cgo_import_dynamic purego_pthread_create pthread_create "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_detach pthread_detach "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_sigmask pthread_sigmask "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_self pthread_self "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_get_stacksize_np pthread_get_stacksize_np "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_attr_setstacksize pthread_attr_setstacksize "/usr/lib/libSystem.B.dylib"
-+//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_mutex_lock pthread_mutex_lock "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_mutex_unlock pthread_mutex_unlock "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_cond_broadcast pthread_cond_broadcast "/usr/lib/libSystem.B.dylib"
 +//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_self pthread_self "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_get_stacksize_np pthread_get_stacksize_np "/usr/lib/libSystem.B.dylib"
++//go:cgo_import_dynamic purego_pthread_attr_setstacksize pthread_attr_setstacksize "/usr/lib/libSystem.B.dylib"
++
++//go:nosplit
++//go:norace
++func pthread_self() pthread_t {
++	return pthread_t(call5(pthread_selfABI0, 0, 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_get_stacksize_np(thread pthread_t) size_t {
++	return size_t(call5(pthread_get_stacksize_npABI0, uintptr(thread), 0, 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_attr_setstacksize(attr *pthread_attr_t, size size_t) int32 {
++	return int32(call5(pthread_attr_setstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(size), 0, 0, 0))
++}
++
++//go:linkname _pthread_self _pthread_self
++var _pthread_self uint8
++var pthread_selfABI0 = uintptr(unsafe.Pointer(&_pthread_self))
++
++//go:linkname _pthread_get_stacksize_np _pthread_get_stacksize_np
++var _pthread_get_stacksize_np uint8
++var pthread_get_stacksize_npABI0 = uintptr(unsafe.Pointer(&_pthread_get_stacksize_np))
++
++//go:linkname _pthread_attr_setstacksize _pthread_attr_setstacksize
++var _pthread_attr_setstacksize uint8
++var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/ztrampolines_darwin.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/ztrampolines_darwin.s
+new file mode 100644
+index 00000000000000..35ef7ac11cb955
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/ztrampolines_darwin.s
+@@ -0,0 +1,19 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++#include "textflag.h"
++
++// these stubs are here because it is not possible to go:linkname directly the C functions
++
++TEXT _pthread_self(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_self(SB)
++
++TEXT _pthread_get_stacksize_np(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_get_stacksize_np(SB)
++
++TEXT _pthread_attr_setstacksize(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_pthread_attr_setstacksize(SB)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/ztrampolines_stubs.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/ztrampolines_stubs.s
 new file mode 100644
-index 00000000000000..3351b7b623822a
+index 00000000000000..c63651b123f1bc
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/ztrampolines_stubs.s
-@@ -0,0 +1,73 @@
+@@ -0,0 +1,58 @@
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -25466,7 +25559,7 @@ index 00000000000000..3351b7b623822a
 +
 +#include "textflag.h"
 +
-+// these stubs are here because it is not possible to go:linkname directly the C functions on darwin arm64
++// these stubs are here because it is not possible to go:linkname directly the C functions
 +
 +TEXT _malloc(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_malloc(SB)
@@ -25503,21 +25596,6 @@ index 00000000000000..3351b7b623822a
 +
 +TEXT _pthread_sigmask(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_sigmask(SB)
-+
-+TEXT _pthread_self(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_self(SB)
-+
-+TEXT _pthread_get_stacksize_np(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_get_stacksize_np(SB)
-+
-+TEXT _pthread_attr_getstacksize(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_attr_getstacksize(SB)
-+
-+TEXT _pthread_attr_setstacksize(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_attr_setstacksize(SB)
-+
-+TEXT _pthread_attr_destroy(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_pthread_attr_destroy(SB)
 +
 +TEXT _pthread_mutex_lock(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_mutex_lock(SB)
@@ -35326,18 +35404,18 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b6f6376eac041a..0fb122073acdff 100644
+index b6f6376eac041a..6cb7848a29c00f 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20251219133548-db44f2109b85
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20260115104635-63db5bc96a83
 +## explicit; go 1.24
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
 +github.com/golang-fips/openssl/v2/internal/fakecgo
 +github.com/golang-fips/openssl/v2/internal/ossl
 +github.com/golang-fips/openssl/v2/osslsetup
-+# github.com/microsoft/go-crypto-darwin v0.0.3-0.20251218120905-3dc2f5f6b182
++# github.com/microsoft/go-crypto-darwin v0.0.3-0.20260114113743-000278575184
 +## explicit; go 1.24
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/commoncrypto
@@ -35346,7 +35424,7 @@ index b6f6376eac041a..0fb122073acdff 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20251219091053-f9796ee5d078
++# github.com/microsoft/go-crypto-winnative v0.0.0-20260114031524-c493765efc5f
 +## explicit; go 1.24
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
Upgrade all our dependencies. Main improvements:

- Enhanced OpenSSL built-in FIPS provider support
- Upload telemetry counter for the `ms_nocgo_opensslcrypto` goexperiment