### PR TITLE
CI: enable native macos arm64 testing

### DIFF
--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -73,7 +73,7 @@ stages:
           - { os: linux, arch: arm64, hostArch: amd64, config: buildandpack }
           - { os: windows, arch: arm64, hostArch: amd64, config: buildandpack }
           - { os: darwin, arch: amd64, config: buildandpack }
-          - { os: darwin, arch: arm64, hostArch: amd64, config: buildandpack }
+          - { os: darwin, arch: arm64, config: buildandpack }
           - ${{ if parameters.includeArm64Host }}:
             - { os: linux, arch: arm64, config: buildandpack }
         - ${{ if parameters.innerloop }}:

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -82,10 +82,10 @@ stages:
           - { experiment: systemcrypto, os: darwin, arch: amd64, config: test }
           - { experiment: systemcrypto, os: darwin, arch: amd64, config: nocgo }
           - { experiment: systemcrypto, os: darwin, arch: amd64, config: test, fips: true }
-          # - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: devscript }
-          # - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: test }
-          # - { experiment: systemcrypto, os: darwin, arch: arm64, config: test }
-          # - { experiment: systemcrypto, os: darwin, arch: arm64, config: test, fips: true }
+          - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: devscript }
+          - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: test }
+          - { experiment: systemcrypto, os: darwin, arch: arm64, config: test }
+          - { experiment: systemcrypto, os: darwin, arch: arm64, config: test, fips: true }
           # - { experiment: nosystemcrypto, os: windows, arch: arm64, config: test }
           - { experiment: nosystemcrypto, os: linux, arch: amd64, config: devscript }
           - { experiment: nosystemcrypto, os: linux, arch: amd64, config: test }

--- a/eng/pipeline/stages/pool-2.yml
+++ b/eng/pipeline/stages/pool-2.yml
@@ -60,5 +60,5 @@ stages:
             vmImage: 'macos-14'
             os: macOS
           ${{ else }}:
-            vmImage: 'macos-latest-internal'
+            vmImage: 'macos-15-arm64'
             os: macOS


### PR DESCRIPTION
macos 15 arm64 runners exist in CI now so we should be running tests with them. Also switched the build from cross compile to native compilation.