### PR TITLE
[release-branch.go1.24] Use useOptimizedSDLTasks: false to fix build break

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -91,6 +91,9 @@ extends:
       name: $(DncEngInternalBuildPool)
       image: 1es-windows-2022
       os: windows
+    featureFlags:
+      # https://github.com/microsoft/go-lab/issues/288
+      useOptimizedSDLTasks: false
     sdl:
       enableProductionSDL: true
       codeql:


### PR DESCRIPTION
(cherry picked from commit 28486dcef2f10fd20cb5c73ebc7401f6b1853b59)

* https://github.com/microsoft/go/pull/2065