### PR TITLE
Fix signing diag file consolidation: always run

### DIFF
--- a/eng/_util/cmd/sign/archive.go
+++ b/eng/_util/cmd/sign/archive.go
@@ -465,7 +465,7 @@ func (a *archive) copyToDestination(ctx context.Context) error {
 }
 
 func consolidateDiagnosticFiles() error {
-	// Do as much as possible, accumlating errors to report to the user.
+	// Do as much as possible, accumulating errors to report to the user.
 	var err error
 	// Signing process logs.
 	err = errors.Join(err, copyGlobFilesToDir(

--- a/eng/_util/cmd/sign/archive.go
+++ b/eng/_util/cmd/sign/archive.go
@@ -9,6 +9,7 @@ import (
 	"archive/zip"
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -464,27 +465,25 @@ func (a *archive) copyToDestination(ctx context.Context) error {
 }
 
 func consolidateDiagnosticFiles() error {
+	// Do as much as possible, accumlating errors to report to the user.
+	var err error
 	// Signing process logs.
-	if err := copyGlobFilesToDir(
+	err = errors.Join(err, copyGlobFilesToDir(
 		*consolidateDiagDir,
 		filepath.Join(*signingCsprojDir, "*.log"),
 		filepath.Join(*tempDir, "*.binlog"),
 		filepath.Join(*tempDir, "*.props"),
-	); err != nil {
-		return err
-	}
+	))
 	// .NET diag data, for package versions etc.
-	if err := copyGlobFilesToDir(
+	err = errors.Join(err, copyGlobFilesToDir(
 		filepath.Join(*consolidateDiagDir, "obj"),
 		filepath.Join(*signingCsprojDir, "obj", "*"),
-	); err != nil {
-		return err
-	}
+	))
 
 	// Signing working dirs. These contain the files actually sent to sign. Make
 	// it clear that they're not production-ready files through the filename.
 	cleanTempDir := filepath.Clean(*tempDir)
-	if err := withTarGzCreate(
+	err = errors.Join(err, withTarGzCreate(
 		filepath.Join(*consolidateDiagDir, "sign-work-archives.nonproduction.tar.gz"),
 		func(tw *tar.Writer) error {
 			if err := filepath.WalkDir(cleanTempDir, func(path string, d fs.DirEntry, err error) error {
@@ -531,9 +530,6 @@ func consolidateDiagnosticFiles() error {
 			}
 			return nil
 		},
-	); err != nil {
-		return err
-	}
-
-	return nil
+	))
+	return err
 }

--- a/eng/_util/cmd/sign/sign.go
+++ b/eng/_util/cmd/sign/sign.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -74,7 +75,7 @@ func main() {
 	}
 }
 
-func run() error {
+func run() (err error) {
 	// A context for timeout. This timeout is mainly here to make sure child MSBuild processes are
 	// terminated. There are some ctx.Err() checks sprinkled into the Go code, but canceling
 	// quickly during the packaging/repackaging work in Go is not currently important: the Go work
@@ -87,6 +88,14 @@ func run() error {
 		ctx, cancel = context.WithDeadline(context.Background(), time.Now().Add(*timeout))
 		defer cancel()
 	}
+
+	defer func() {
+		log.Println("Consolidating diagnostic files")
+		log.Printf("Consolidated diagnostic directory: %q", *consolidateDiagDir)
+
+		consolidateErr := consolidateDiagnosticFiles()
+		err = errors.Join(err, consolidateErr)
+	}()
 
 	archives, err := findArchives(ctx, *filesGlob)
 	if err != nil {
@@ -172,13 +181,6 @@ func run() error {
 		if err := checksum.WriteSHA256ChecksumFile(filepath.Join(*destinationDir, a.name)); err != nil {
 			return err
 		}
-	}
-
-	log.Println("Consolidating diagnostic files")
-	log.Printf("Consolidated diagnostic directory: %q", *consolidateDiagDir)
-
-	if err := consolidateDiagnosticFiles(); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
The signing diagnosis artifact was only being created upon success of the main signing process. This works for diagnosing false successes, but not actual errors. Use defer to always create it.

Also, consolidate as many files as possible rather than stopping upon error.

* Spotted while looking at https://github.com/microsoft/go-lab/issues/289