### PR TITLE
Include newline at end of GOTOOLCHAIN warning

### DIFF
--- a/patches/0005-Disable-GOTOOLCHAIN-support.patch
+++ b/patches/0005-Disable-GOTOOLCHAIN-support.patch
@@ -29,7 +29,7 @@ index 6ff2b921d464bc..36c3bdfc9b6087 100644
 -GOTOOLCHAIN=auto
 +GOTOOLCHAIN=local
 diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
-index 10ee92536b96cd..200ba17202276f 100644
+index 10ee92536b96cd..93e52f78b56dd4 100644
 --- a/src/cmd/go/internal/cfg/cfg.go
 +++ b/src/cmd/go/internal/cfg/cfg.go
 @@ -452,6 +452,24 @@ func Getenv(key string) string {
@@ -50,7 +50,7 @@ index 10ee92536b96cd..200ba17202276f 100644
 +			if v := os.Getenv("MS_GOTOOLCHAIN_ALLOW_NON_LOCAL"); v != "1" {
 +				println("GOTOOLCHAIN is set to \"" + val + "\" but only \"local\" is allowed.")
 +				println("To allow this, set MS_GOTOOLCHAIN_ALLOW_NON_LOCAL=1 in your environment.")
-+				print("Take into account that that could cause the go command to use a different toolchain than the Microsoft build of Go.")
++				println("Take into account that that could cause the go command to use a different toolchain than the Microsoft build of Go.")
 +				os.Exit(1)
 +			}
 +		}


### PR DESCRIPTION
I noticed that the GOTOOLCHAIN warning doesn't have a newline at the end, which is confusing in a shell because it looks like it isn't ready for the next command at first glance:

```
dagood@dagood-3:~/git/go$ GOTOOLCHAIN=auto msgo version
GOTOOLCHAIN is set to "auto" but only "local" is allowed.
To allow this, set MS_GOTOOLCHAIN_ALLOW_NON_LOCAL=1 in your environment.
Take into account that that could cause the go command to use a different toolchain than the Microsoft build of Go.dagood@dagood-3:~/git/go$
```

(Note the prompt appearing at the end of the last line rather than on a new one.)

New behavior:

```
dagood@dagood-3:~/git/go$ GOTOOLCHAIN=auto go/bin/go version
GOTOOLCHAIN is set to "auto" but only "local" is allowed.
To allow this, set MS_GOTOOLCHAIN_ALLOW_NON_LOCAL=1 in your environment.
Take into account that that could cause the go command to use a different toolchain than the Microsoft build of Go.
dagood@dagood-3:~/git/go$
```