### PR TITLE
 [release-branch.go1.26] Update release notes for 1.26

### DIFF
--- a/docs/go1.26.md
+++ b/docs/go1.26.md
@@ -1,3 +1,79 @@
 # Microsoft build of Go 1.26 release notes
 
 After the release of 1.26, 1.24 is no longer supported, per the [Go release policy](https://go.dev/doc/devel/release).
+
+## Toolchain
+
+The `GOCACHE` environment variable now defaults to `os.UserCacheDir()/ms-go-build` instead of `os.UserCacheDir()/go-build`.
+
+## Systemcrypto
+
+### Configuration
+
+You can disable `systemcrypto` at build time by setting the environment variable `MS_GO_NOSYSTEMCRYPTO` to `1`.
+This is now the preferred method for disabling systemcrypto when necessary.
+
+### Backends
+
+#### Windows
+
+Setting the FIPS preference to enabled will no longer cause a panic when the Windows FIPS policy is disabled.
+
+#### OpenSSL
+
+Improved support for the Fedora OpenSSL FIPS provider.
+Binaries can now be built without using cgo by setting `GOEXPERIMENT=ms_nocgo_opensslcrypto`.
+
+#### Darwin
+
+The backend is no longer in preview and is now fully supported.
+It is enabled by default on macOS.
+
+Binaries can now be built without using cgo.
+
+### Supported Algorithms
+
+The following hash functions are now implemented using the systemcrypto backends:
+
+- SHA-3-224
+- SHA-3-256
+- SHA-3-384
+- SHA-3-512
+- SHAKE-128
+- SHAKE-256
+
+The following ECDH curves are now implemented using the systemcrypto backends:
+
+- X25519
+
+The following ML-KEM sizes are now implemented using the systemcrypto backends:
+
+- 768
+- 1024
+
+The following TLS groups are now implemented using the systemcrypto backends:
+
+- X25519
+- X25519MLKEM768
+- SecP256r1MLKEM768
+- SecP384r1MLKEM1024
+
+The following TLS cipher suites are now implemented using the systemcrypto backends:
+
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+- TLS_CHACHA20_POLY1305_SHA256
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+
+## TLS Settings
+
+The TLS curves X25519 and X25519MLKEM768 can be disabled using the GODEBUG setting `ms_tlsx25519=0`.
+
+The TLS default settings have been aligned with Microsoft TLS policies.
+This behavior can be disabled using the GODEBUG setting `ms_tlsprofile=off`.
+The following changes have been made:
+
+- TLS cipher suites using AES-256 are now preferred over those using AES-128.
+- TLS cipher suites using CHACHA20_POLY1305 are no longer preferred over AES-GCM cipher suites when the client or server supports hardware acceleration for AES.
+- TLS groups supported by the systemcrypto backends are now preferred over those that are not.


### PR DESCRIPTION
Add GOCACHE and several crypto/systemcrypto changes to the Go 1.26 release notes.

Go version changes are left for #2078