### PR TITLE
Restrict aw roles

### DIFF
--- a/.github/workflows/patch-consistency-review.md
+++ b/.github/workflows/patch-consistency-review.md
@@ -11,7 +11,7 @@ on:
         description: "PR number to review"
         required: true
         type: string
-roles: all
+roles: [admin, maintainer, write]
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
AW security best practices ([link](https://github.github.com/gh-aw/guides/security/#before-you-begin)) says that `roles: all` should be used carefully:

> By default, workflows restrict execution to users with admin, maintainer, or write permissions. Use roles: all carefully in public repositories.

We better follow this advice until we get more experience with AW. The practical effect is that PRs from external contributors won't trigger the patch consistency review workflow.