### PR TITLE
[release-branch.go1.25] Disable innerloop network isolation

### DIFF
--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -35,6 +35,10 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    featureFlags:
+      # Network Isolation causes standard library net tests on Windows to fail.
+      # See https://github.com/microsoft/go-lab/issues/206
+      disableNetworkIsolation: true
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal


### PR DESCRIPTION
This interrupted the 1.25.7-1 release. Turn off network isolation again so that if the underlying 1ES infra problem isn't fixed by next release, it won't interrupt us again.

This is already turned off in the 1.24 branch.

* https://github.com/microsoft/go-lab/issues/206