### PR TITLE
[release-branch.go1.26] Disable innerloop network isolation

### DIFF
--- a/eng/pipeline/rolling-innerloop-pipeline.yml
+++ b/eng/pipeline/rolling-innerloop-pipeline.yml
@@ -35,6 +35,10 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    featureFlags:
+      # Network Isolation causes standard library net tests on Windows to fail.
+      # See https://github.com/microsoft/go-lab/issues/206
+      disableNetworkIsolation: true
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal


### PR DESCRIPTION
* https://github.com/microsoft/go-lab/issues/206

Apply this to 1.26 branch as well:

* https://github.com/microsoft/go/pull/2115