### PR TITLE
[release-branch.go1.26] Upgrade openssl backend

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -126,7 +126,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../openssl/v2/internal/ossl/zossl.go         |   67 +
  .../openssl/v2/internal/ossl/zossl.h          |  363 +++
  .../openssl/v2/internal/ossl/zossl_cgo.go     | 1368 ++++++++++
- .../v2/internal/ossl/zossl_cgo_go124.go       |   41 +
+ .../v2/internal/ossl/zossl_cgo_go124.go       |   45 +
  .../openssl/v2/internal/ossl/zossl_nocgo.go   | 2390 +++++++++++++++++
  .../golang-fips/openssl/v2/mlkem.go           |  371 +++
  .../golang-fips/openssl/v2/openssl.go         |  253 ++
@@ -143,7 +143,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../golang-fips/openssl/v2/params.go          |  184 ++
  .../golang-fips/openssl/v2/pbkdf2.go          |   54 +
  .../golang-fips/openssl/v2/provideropenssl.go |  239 ++
- .../openssl/v2/providersymcrypt.go            |  338 +++
+ .../openssl/v2/providersymcrypt.go            |  330 +++
  .../github.com/golang-fips/openssl/v2/rand.go |   21 +
  .../github.com/golang-fips/openssl/v2/rc4.go  |   68 +
  .../github.com/golang-fips/openssl/v2/rsa.go  |  714 +++++
@@ -268,7 +268,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 260 files changed, 33278 insertions(+), 7 deletions(-)
+ 260 files changed, 33274 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -2195,7 +2195,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index efc07451b53448..ccec5d5b821c8c 100644
+index efc07451b53448..a8fc3b2a8237a6 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2204,17 +2204,17 @@ index efc07451b53448..ccec5d5b821c8c 100644
  )
 +
 +require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20260203103936-d61ccf20b60f
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20260209093649-295f210329ab
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260130143703-78cb726ef357
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9
 +)
 diff --git a/src/go.sum b/src/go.sum
-index b6b841b44d8e38..f0076e04140025 100644
+index b6b841b44d8e38..7c3a229e078b22 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20260203103936-d61ccf20b60f h1:1niOn99Euubk0wtGY3dJvgFQh0+KOG3eMtg4AkbjOlg=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20260203103936-d61ccf20b60f/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20260209093649-295f210329ab h1:KdqScmkTRe6k9qClbxj0db4ZS84etcXI8Rm219Rhcnc=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20260209093649-295f210329ab/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260130143703-78cb726ef357 h1:ILqgGD8SGjjtSweSBanrXyX8Aco33yFSJEqsnJgmXHU=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260130143703-78cb726ef357/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9 h1:joliMChkkfHV3vAPKzu9kefdw0K+d89A8r9gTm3MFS4=
@@ -11375,7 +11375,7 @@ index 00000000000000..9d38464e9fb964
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/shims.h b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/shims.h
 new file mode 100644
-index 00000000000000..3ce5eb8435c9fd
+index 00000000000000..d926c6adf17dda
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/shims.h
 @@ -0,0 +1,434 @@
@@ -11597,8 +11597,8 @@ index 00000000000000..3ce5eb8435c9fd
 +int EVP_MD_CTX_copy_ex(_EVP_MD_CTX_PTR out, const _EVP_MD_CTX_PTR in);
 +const _OSSL_PARAM_PTR EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
 +const _OSSL_PARAM_PTR EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
-+int EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR ctx, _OSSL_PARAM_PTR params) __attribute__((tag("3")));
-+int EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
++int EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR ctx, _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
++int EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
 +int EVP_Digest(const void *data, size_t count, unsigned char *md, unsigned int *size, const _EVP_MD_PTR type, _ENGINE_PTR impl) __attribute__((noescape,nocallback,slice("data","count"),slice("md")));
 +int EVP_DigestInit_ex(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type, _ENGINE_PTR impl);
 +int EVP_DigestInit(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type);
@@ -15969,10 +15969,10 @@ index 00000000000000..059562f35df7b3
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo_go124.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo_go124.go
 new file mode 100644
-index 00000000000000..7ced663df8a562
+index 00000000000000..677ef1d157a670
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo_go124.go
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,45 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +//go:build go1.24 && !cmd_go_bootstrap
@@ -16004,6 +16004,10 @@ index 00000000000000..7ced663df8a562
 +#cgo nocallback _mkcgo_EVP_EncryptFinal_ex
 +#cgo noescape _mkcgo_EVP_EncryptUpdate
 +#cgo nocallback _mkcgo_EVP_EncryptUpdate
++#cgo noescape _mkcgo_EVP_MD_CTX_get_params
++#cgo nocallback _mkcgo_EVP_MD_CTX_get_params
++#cgo noescape _mkcgo_EVP_MD_CTX_set_params
++#cgo nocallback _mkcgo_EVP_MD_CTX_set_params
 +#cgo noescape _mkcgo_EVP_PKEY_derive
 +#cgo nocallback _mkcgo_EVP_PKEY_derive
 +#cgo noescape _mkcgo_EVP_PKEY_get_raw_private_key
@@ -20181,10 +20185,10 @@ index 00000000000000..e366c7a7a833fa
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/providersymcrypt.go b/src/vendor/github.com/golang-fips/openssl/v2/providersymcrypt.go
 new file mode 100644
-index 00000000000000..cc6e108e948727
+index 00000000000000..bdba34f1378e9c
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/providersymcrypt.go
-@@ -0,0 +1,338 @@
+@@ -0,0 +1,330 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -20192,7 +20196,6 @@ index 00000000000000..cc6e108e948727
 +import (
 +	"crypto"
 +	"errors"
-+	"runtime"
 +	"unsafe"
 +
 +	"github.com/golang-fips/openssl/v2/internal/ossl"
@@ -20380,9 +20383,6 @@ index 00000000000000..cc6e108e948727
 +func symCryptHashAppendBinary(ctx ossl.EVP_MD_CTX_PTR, ch crypto.Hash, magic string, buf []byte) ([]byte, error) {
 +	size, typ := symCryptHashStateInfo(ch)
 +	state := make([]byte, size, _SYMCRYPT_SHA512_STATE_EXPORT_SIZE) // 512 is the largest size
-+	var pinner runtime.Pinner
-+	pinner.Pin(&state[0])
-+	defer pinner.Unpin()
 +	params := [2]ossl.OSSL_PARAM{
 +		ossl.OSSL_PARAM_construct_octet_string(_SCOSSL_DIGEST_PARAM_STATE.ptr(), unsafe.Pointer(&state[0]), len(state)),
 +		ossl.OSSL_PARAM_construct_end(),
@@ -20458,10 +20458,6 @@ index 00000000000000..cc6e108e948727
 +		panic("unsupported hash " + ch.String())
 +	}
 +	var checksum int32 = 1
-+	var pinner runtime.Pinner
-+	pinner.Pin(blobPtr)
-+	pinner.Pin(&checksum)
-+	defer pinner.Unpin()
 +	params := [3]ossl.OSSL_PARAM{
 +		ossl.OSSL_PARAM_construct_octet_string(_SCOSSL_DIGEST_PARAM_STATE.ptr(), blobPtr, int(hdr.size)),
 +		ossl.OSSL_PARAM_construct_int32(_SCOSSL_DIGEST_PARAM_RECOMPUTE_CHECKSUM.ptr(), &checksum),
@@ -37426,11 +37422,11 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b6f6376eac041a..1dd28f425e6901 100644
+index b6f6376eac041a..5e6086aba7e37a 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20260203103936-d61ccf20b60f
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20260209093649-295f210329ab
 +## explicit; go 1.24
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig


### PR DESCRIPTION
Bring the following PR:

https://github.com/golang-fips/openssl/pull/369