### PR TITLE
[release-branch.go1.26] Correct libc dynamic linker path (riscv64)

### DIFF
--- a/patches/0014-Correct-libc-dynamic-linker-path.patch
+++ b/patches/0014-Correct-libc-dynamic-linker-path.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
+Date: Sat, 17 Jan 2026 12:19:13 +0800
+Subject: [PATCH] Correct libc dynamic linker path
+
+Ref: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/114
+
+Change-Id: I8b575a95ad4e6a7e792514d7fcf9497599c1e404
+---
+ src/cmd/link/internal/riscv64/obj.go | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/cmd/link/internal/riscv64/obj.go b/src/cmd/link/internal/riscv64/obj.go
+index 940a8d611c8c17..87f4986823c4e2 100644
+--- a/src/cmd/link/internal/riscv64/obj.go
++++ b/src/cmd/link/internal/riscv64/obj.go
+@@ -38,7 +38,8 @@ func Init() (*sys.Arch, ld.Arch) {
+ 		Machoreloc1: machoreloc1,
+ 
+ 		ELF: ld.ELFArch{
+-			Linuxdynld: "/lib/ld.so.1",
++			Linuxdynld:     "/lib/ld-linux-riscv64-lp64d.so.1",
++			LinuxdynldMusl: "/lib/ld-musl-riscv64.so.1",
+ 
+ 			Freebsddynld:   "/usr/libexec/ld-elf.so.1",
+ 			Netbsddynld:    "XXX",


### PR DESCRIPTION
Backports https://go-review.googlesource.com/c/go/+/737180