### PR TITLE
hash: implement missing boring logic for SHA512_224/256

### DIFF
--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -31,7 +31,7 @@ desired goexperiments and build tags.
  .../internal/backend/bbig/big_openssl.go      |  12 +
  src/crypto/internal/backend/cng_windows.go    | 425 +++++++++++++++++
  src/crypto/internal/backend/common.go         |  46 ++
- src/crypto/internal/backend/darwin_darwin.go  | 430 ++++++++++++++++++
+ src/crypto/internal/backend/darwin_darwin.go  | 432 ++++++++++++++++++
  src/crypto/internal/backend/fips140/cng.go    |  35 ++
  src/crypto/internal/backend/fips140/darwin.go |  13 +
  .../internal/backend/fips140/fips140.go       |  70 +++
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/go/build/deps_test.go                     |  24 +-
  src/internal/buildcfg/exp.go                  |  47 ++
  src/runtime/runtime_boring.go                 |   5 +
- 43 files changed, 2714 insertions(+), 14 deletions(-)
+ 43 files changed, 2716 insertions(+), 14 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -244,7 +244,7 @@ index e4250e12de8975..feef0080cb12d6 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 4984f930b932c0..b651104235adcc 100644
+index 4396c9de190f1f..91502c9a23f724 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -156,10 +156,12 @@ func (t *tester) run() {
@@ -381,10 +381,10 @@ index e2a77d7d7df85b..aaa3106e5a0e6e 100644
  	appendSetting("-compiler", cfg.BuildContext.Compiler)
  	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
 diff --git a/src/cmd/go/internal/tool/tool.go b/src/cmd/go/internal/tool/tool.go
-index 92e8a803105f8d..95d47b625c28a7 100644
+index 57bcde6da433a3..ce38a989aa87ff 100644
 --- a/src/cmd/go/internal/tool/tool.go
 +++ b/src/cmd/go/internal/tool/tool.go
-@@ -305,6 +305,10 @@ func buildAndRunBuiltinTool(loaderstate *modload.State, ctx context.Context, too
+@@ -309,6 +309,10 @@ func buildAndRunBuiltinTool(loaderstate *modload.State, ctx context.Context, too
  	// Override GOOS and GOARCH for the build to build the tool using
  	// the same GOOS and GOARCH as this go command.
  	cfg.ForceHost()
@@ -395,7 +395,7 @@ index 92e8a803105f8d..95d47b625c28a7 100644
  
  	// Ignore go.mod and go.work: we don't need them, and we want to be able
  	// to run the tool even if there's an issue with the module or workspace the
-@@ -312,8 +316,11 @@ func buildAndRunBuiltinTool(loaderstate *modload.State, ctx context.Context, too
+@@ -316,8 +320,11 @@ func buildAndRunBuiltinTool(loaderstate *modload.State, ctx context.Context, too
  	loaderstate.RootMode = modload.NoRoot
  
  	runFunc := func(b *work.Builder, ctx context.Context, a *work.Action) error {
@@ -1358,10 +1358,10 @@ index 00000000000000..a9682181ffa154
 +}
 diff --git a/src/crypto/internal/backend/darwin_darwin.go b/src/crypto/internal/backend/darwin_darwin.go
 new file mode 100644
-index 00000000000000..6d0aac8021aeb0
+index 00000000000000..a491519e864dc5
 --- /dev/null
 +++ b/src/crypto/internal/backend/darwin_darwin.go
-@@ -0,0 +1,430 @@
+@@ -0,0 +1,432 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1442,16 +1442,18 @@ index 00000000000000..6d0aac8021aeb0
 +func (s *SHAKE) AppendBinary(p []byte) ([]byte, error) { panic("cryptobackend: not available") }
 +func (s *SHAKE) UnmarshalBinary(data []byte) error     { panic("cryptobackend: not available") }
 +
-+func NewMD5() hash.Hash    { return xcrypto.NewMD5() }
-+func NewSHA1() hash.Hash   { return xcrypto.NewSHA1() }
-+func NewSHA224() hash.Hash { panic("cryptobackend: not available") }
-+func NewSHA256() hash.Hash { return xcrypto.NewSHA256() }
-+func NewSHA384() hash.Hash { return xcrypto.NewSHA384() }
-+func NewSHA512() hash.Hash { return xcrypto.NewSHA512() }
-+func NewSHA3_224() *Hash   { panic("cryptobackend: not available") }
-+func NewSHA3_256() *Hash   { return xcrypto.NewSHA3_256() }
-+func NewSHA3_384() *Hash   { return xcrypto.NewSHA3_384() }
-+func NewSHA3_512() *Hash   { return xcrypto.NewSHA3_512() }
++func NewMD5() hash.Hash        { return xcrypto.NewMD5() }
++func NewSHA1() hash.Hash       { return xcrypto.NewSHA1() }
++func NewSHA224() hash.Hash     { panic("cryptobackend: not available") }
++func NewSHA256() hash.Hash     { return xcrypto.NewSHA256() }
++func NewSHA384() hash.Hash     { return xcrypto.NewSHA384() }
++func NewSHA512() hash.Hash     { return xcrypto.NewSHA512() }
++func NewSHA512_224() hash.Hash { panic("cryptobackend: not available") }
++func NewSHA512_256() hash.Hash { panic("cryptobackend: not available") }
++func NewSHA3_224() *Hash       { panic("cryptobackend: not available") }
++func NewSHA3_256() *Hash       { return xcrypto.NewSHA3_256() }
++func NewSHA3_384() *Hash       { return xcrypto.NewSHA3_384() }
++func NewSHA3_512() *Hash       { return xcrypto.NewSHA3_512() }
 +
 +func NewSHAKE128() *SHAKE             { panic("cryptobackend: not available") }
 +func NewSHAKE256() *SHAKE             { panic("cryptobackend: not available") }

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -63,7 +63,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/rc4/rc4.go                         |  18 ++
  src/crypto/rsa/boring.go                      |  13 +-
  src/crypto/rsa/boring_test.go                 |   2 +-
- src/crypto/rsa/darwin.go                      |  71 +++
+ src/crypto/rsa/darwin.go                      |  71 +++++++
  src/crypto/rsa/fips.go                        |  22 +-
  src/crypto/rsa/notboring.go                   |   4 +-
  src/crypto/rsa/pkcs1v15.go                    |  10 +-
@@ -77,7 +77,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/sha256/sha256_test.go              |  44 ++--
  src/crypto/sha3/sha3.go                       | 124 +++++++++--
  src/crypto/sha3/sha3_test.go                  |  18 +-
- src/crypto/sha512/sha512.go                   |   2 +-
+ src/crypto/sha512/sha512.go                   |  14 +-
  src/crypto/sha512/sha512_test.go              |  32 ++-
  src/crypto/tls/auth_test.go                   |   1 +
  src/crypto/tls/cipher_suites.go               |  10 +-
@@ -100,7 +100,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- 96 files changed, 1505 insertions(+), 179 deletions(-)
+ 96 files changed, 1518 insertions(+), 180 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -126,7 +126,7 @@ index f0e3575637c62a..9eab3b4e66e60b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index b651104235adcc..a54fc6124b1e0e 100644
+index 91502c9a23f724..41cde9ef2206af 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
 @@ -720,7 +720,7 @@ func (t *tester) registerTests() {
@@ -138,7 +138,7 @@ index b651104235adcc..a54fc6124b1e0e 100644
  		// Test standard crypto packages with fips140=on.
  		t.registerTest("GOFIPS140=latest go test crypto/...", &goTest{
  			variant: "gofips140",
-@@ -1388,12 +1388,11 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1383,12 +1383,11 @@ func (t *tester) registerCgoTests(heading string) {
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
@@ -1346,7 +1346,7 @@ index c8a23e3246a949..02dc683fa1a1b4 100644
  			t.Errorf("different signature result on line %d: %x vs %x", lineNo, sig, sig2)
  		}
  
-@@ -373,6 +376,11 @@ func TestAllocations(t *testing.T) {
+@@ -371,6 +374,11 @@ func TestAllocations(t *testing.T) {
  	cryptotest.SkipTestAllocations(t)
  	seed := make([]byte, SeedSize)
  	priv := NewKeyFromSeed(seed)
@@ -1358,7 +1358,7 @@ index c8a23e3246a949..02dc683fa1a1b4 100644
  	if allocs := testing.AllocsPerRun(100, func() {
  		message := []byte("Hello, world!")
  		pub := priv.Public().(PublicKey)
-@@ -380,8 +386,8 @@ func TestAllocations(t *testing.T) {
+@@ -378,8 +386,8 @@ func TestAllocations(t *testing.T) {
  		if !Verify(pub, message, signature) {
  			t.Fatal("signature didn't verify")
  		}
@@ -2601,7 +2601,7 @@ diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
 index e03f4ab06603c6..a9d9daba2fd6ce 100644
 --- a/src/crypto/rsa/pss_test.go
 +++ b/src/crypto/rsa/pss_test.go
-@@ -8,6 +8,7 @@ import (
+@@ -8,14 +8,17 @@ import (
  	"bufio"
  	"compress/bzip2"
  	"crypto"
@@ -2609,7 +2609,6 @@ index e03f4ab06603c6..a9d9daba2fd6ce 100644
  	"crypto/internal/fips140"
  	"crypto/rand"
  	. "crypto/rsa"
-@@ -14,8 +15,10 @@ import (
  	"crypto/sha256"
  	"crypto/sha512"
  	"encoding/hex"
@@ -2630,7 +2629,7 @@ index e03f4ab06603c6..a9d9daba2fd6ce 100644
  				t.Error(err)
  			}
  		default:
-@@ -185,6 +191,10 @@ func TestPSSSigning(t *testing.T) {
+@@ -180,6 +186,10 @@ func TestPSSSigning(t *testing.T) {
  			continue
  		}
  
@@ -2641,7 +2640,7 @@ index e03f4ab06603c6..a9d9daba2fd6ce 100644
  		opts.SaltLength = test.verifySaltLength
  		err = VerifyPSS(&rsaPrivateKey.PublicKey, hash, hashed, sig, &opts)
  		good := test.good
-@@ -246,7 +256,9 @@ func fromHex(hexStr string) []byte {
+@@ -241,7 +251,9 @@ func fromHex(hexStr string) []byte {
  
  func TestInvalidPSSSaltLength(t *testing.T) {
  	t.Setenv("GODEBUG", "rsa1024min=0")
@@ -3352,7 +3351,7 @@ index 3973e0afd1b935..4a92e2652a50c4 100644
  	}
  	h.Write(bytes.Repeat([]byte{0}, 200))
 diff --git a/src/crypto/sha512/sha512.go b/src/crypto/sha512/sha512.go
-index 1435eac1f5b5dc..17e8501154762a 100644
+index 1435eac1f5b5dc..ca424cb6b904ba 100644
 --- a/src/crypto/sha512/sha512.go
 +++ b/src/crypto/sha512/sha512.go
 @@ -12,7 +12,7 @@ package sha512
@@ -3364,8 +3363,48 @@ index 1435eac1f5b5dc..17e8501154762a 100644
  	"crypto/internal/fips140/sha512"
  	"hash"
  )
+@@ -58,6 +58,9 @@ func New() hash.Hash {
+ // [encoding.BinaryUnmarshaler] to marshal and unmarshal the internal
+ // state of the hash.
+ func New512_224() hash.Hash {
++	if boring.Enabled && boring.SupportsHash(crypto.SHA512_224) {
++		return boring.NewSHA512_224()
++	}
+ 	return sha512.New512_224()
+ }
+ 
+@@ -66,6 +69,9 @@ func New512_224() hash.Hash {
+ // [encoding.BinaryUnmarshaler] to marshal and unmarshal the internal
+ // state of the hash.
+ func New512_256() hash.Hash {
++	if boring.Enabled && boring.SupportsHash(crypto.SHA512_256) {
++		return boring.NewSHA512_256()
++	}
+ 	return sha512.New512_256()
+ }
+ 
+@@ -106,6 +112,9 @@ func Sum384(data []byte) [Size384]byte {
+ 
+ // Sum512_224 returns the Sum512/224 checksum of the data.
+ func Sum512_224(data []byte) [Size224]byte {
++	if boring.Enabled && boring.SupportsHash(crypto.SHA512_224) {
++		return boring.SHA512_224(data)
++	}
+ 	h := New512_224()
+ 	h.Write(data)
+ 	var sum [Size224]byte
+@@ -115,6 +124,9 @@ func Sum512_224(data []byte) [Size224]byte {
+ 
+ // Sum512_256 returns the Sum512/256 checksum of the data.
+ func Sum512_256(data []byte) [Size256]byte {
++	if boring.Enabled && boring.SupportsHash(crypto.SHA512_256) {
++		return boring.SHA512_256(data)
++	}
+ 	h := New512_256()
+ 	h.Write(data)
+ 	var sum [Size256]byte
 diff --git a/src/crypto/sha512/sha512_test.go b/src/crypto/sha512/sha512_test.go
-index 080bf694f03652..0c899f5c407ffa 100644
+index 080bf694f03652..389e2738a4e885 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -8,9 +8,11 @@ package sha512
@@ -3425,7 +3464,7 @@ index 080bf694f03652..0c899f5c407ffa 100644
  	cryptotest.SkipTestAllocations(t)
 +	expectedAllocations := 0.0
 +	if boring.Enabled {
-+		expectedAllocations = 2
++		expectedAllocations = 10
 +	}
  	if n := testing.AllocsPerRun(10, func() {
  		in := []byte("hello, world!")
@@ -4124,5 +4163,3 @@ index 2746ad8783ab22..c39f32c8fba6fc 100644
  	// Force network usage, to verify the epoll (or whatever) fd
  	// doesn't leak to the child,
  	ln, err := net.Listen("tcp", "127.0.0.1:0")
- 	if err != nil {
- 		t.Fatal(err)


### PR DESCRIPTION
Our docs have incorrectly claimed that we already support these on OpenSSL. We should also probably backport this to our active release branches