### PR TITLE
[release-branch.go1.25] Backport infrastructure fixes

### DIFF
--- a/eng/pipeline/stages/pool-2.yml
+++ b/eng/pipeline/stages/pool-2.yml
@@ -49,7 +49,7 @@ stages:
               image: 1es-ubuntu-2204
               os: linux
             ${{ elseif parameters.public }}:
-              demands: ImageOverride -equals 1es-ubuntu-2004-open
+              demands: ImageOverride -equals build.ubuntu.2204.amd64.open
             ${{ else }}:
               demands: ImageOverride -equals 1es-ubuntu-2204
               os: linux


### PR DESCRIPTION
(cherry picked from commit fb5efb0d82e5facf62b65fd8a0cf05a47de63c49)

* In main as part of https://github.com/microsoft/go/pull/2126
* In 1.26 as part of https://github.com/microsoft/go/pull/2146

The old 1ES image was removed without the upgrade available yet. Switch to a different image that serves us fine.

https://teams.microsoft.com/l/message/19:a88bb61ffc1a4392ad38ebbc526c86f8@thread.skype/1770832238493?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1770832238493&teamName=.NET%20Core%20Eng%20Services%20Partners&channelName=General&createdTime=1770832238493