### PR TITLE
Remove redundant OS/arch build tags where filename suffix already constrains

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -5,10 +5,10 @@
       "version": "v8",
       "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
     },
-    "github/gh-aw/actions/setup@v0.40.0": {
+    "github/gh-aw/actions/setup@v0.50.2": {
       "repo": "github/gh-aw/actions/setup",
-      "version": "v0.40.0",
-      "sha": "76d37d925abd44fee97379206f105b74b91a285b"
+      "version": "v0.50.2",
+      "sha": "e32435511ac2c5aa0e08b19284a25dc98fadf1e1"
     }
   }
 }

--- a/.github/workflows/patch-consistency-review.md
+++ b/.github/workflows/patch-consistency-review.md
@@ -74,6 +74,8 @@ When a pull request modifies any patch file, review it to ensure:
 2. **Suggest, don't demand**: Frame feedback as suggestions for maintaining consistency
 3. **Skip trivial changes**: Don't flag minor differences like comment styles or variable naming
 4. **Only comment if there are actual consistency issues**: If the PR maintains consistency or only touches one patch's content, acknowledge it positively in a summary comment
+5. **Prefer filename suffix constraints over build tags**: When a Go file targets a specific OS or architecture, use the filename suffix convention (e.g. `_linux.go`, `_windows.go`, `_darwin.go`) rather than duplicating that constraint in a `//go:build` tag. If the filename suffix already implies the OS/arch, the build tag should not repeat it. For example, `foo_linux.go` with `//go:build goexperiment.systemcrypto` is preferred over `foo.go` with `//go:build goexperiment.systemcrypto && linux`.
+6. **Avoid extraneous blank lines in patches**: Patches should not introduce unnecessary blank lines between functions, at the end of files, or between import groups. Keep whitespace consistent with the surrounding code style.
 
 ## Output Format
 

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -26,24 +26,24 @@ desired goexperiments and build tags.
  src/cmd/link/link_test.go                     |   8 +
  src/crypto/internal/backend/backend_test.go   |  56 +++
  src/crypto/internal/backend/bbig/big.go       |  17 +
- src/crypto/internal/backend/bbig/big_cng.go   |  12 +
+ .../internal/backend/bbig/big_windows.go      |  12 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
- .../internal/backend/bbig/big_openssl.go      |  12 +
+ .../internal/backend/bbig/big_linux.go         |  12 +
  src/crypto/internal/backend/cng_windows.go    | 438 ++++++++++++++++++
  src/crypto/internal/backend/common.go         |  46 ++
  src/crypto/internal/backend/darwin_darwin.go  | 438 ++++++++++++++++++
- src/crypto/internal/backend/fips140/cng.go    |  35 ++
- src/crypto/internal/backend/fips140/darwin.go |  13 +
+ .../internal/backend/fips140/cng_windows.go   |  35 ++
+ .../internal/backend/fips140/darwin_darwin.go  |  13 +
  .../internal/backend/fips140/fips140.go       |  70 +++
  .../internal/backend/fips140/isrequirefips.go |   9 +
  .../internal/backend/fips140/norequirefips.go |   9 +
  .../backend/fips140/nosystemcrypto.go         |  13 +
- .../internal/backend/fips140/openssl.go       |  59 +++
+ .../internal/backend/fips140/openssl_linux.go  |  59 +++
  .../fips140/requirefips_nosystemcrypto.go     |  15 +
  .../backend/fips140/skipfipscheck_off.go      |   9 +
  .../backend/fips140/skipfipscheck_on.go       |   9 +
- .../internal/opensslsetup/opensslsetup.go     |  68 +++
- .../opensslsetup/opensslsetup_test.go         |  92 ++++
+ .../opensslsetup/opensslsetup_linux.go        |  68 +++
+ .../opensslsetup/opensslsetup_linux_test.go    |  92 ++++
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 376 +++++++++++++++
  src/crypto/internal/backend/openssl_linux.go  | 430 +++++++++++++++++
@@ -56,24 +56,24 @@ desired goexperiments and build tags.
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
- create mode 100644 src/crypto/internal/backend/bbig/big_cng.go
+ create mode 100644 src/crypto/internal/backend/bbig/big_windows.go
  create mode 100644 src/crypto/internal/backend/bbig/big_darwin.go
- create mode 100644 src/crypto/internal/backend/bbig/big_openssl.go
+ create mode 100644 src/crypto/internal/backend/bbig/big_linux.go
  create mode 100644 src/crypto/internal/backend/cng_windows.go
  create mode 100644 src/crypto/internal/backend/common.go
  create mode 100644 src/crypto/internal/backend/darwin_darwin.go
- create mode 100644 src/crypto/internal/backend/fips140/cng.go
- create mode 100644 src/crypto/internal/backend/fips140/darwin.go
+ create mode 100644 src/crypto/internal/backend/fips140/cng_windows.go
+ create mode 100644 src/crypto/internal/backend/fips140/darwin_darwin.go
  create mode 100644 src/crypto/internal/backend/fips140/fips140.go
  create mode 100644 src/crypto/internal/backend/fips140/isrequirefips.go
  create mode 100644 src/crypto/internal/backend/fips140/norequirefips.go
  create mode 100644 src/crypto/internal/backend/fips140/nosystemcrypto.go
- create mode 100644 src/crypto/internal/backend/fips140/openssl.go
+ create mode 100644 src/crypto/internal/backend/fips140/openssl_linux.go
  create mode 100644 src/crypto/internal/backend/fips140/requirefips_nosystemcrypto.go
  create mode 100644 src/crypto/internal/backend/fips140/skipfipscheck_off.go
  create mode 100644 src/crypto/internal/backend/fips140/skipfipscheck_on.go
- create mode 100644 src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go
- create mode 100644 src/crypto/internal/backend/internal/opensslsetup/opensslsetup_test.go
+ create mode 100644 src/crypto/internal/backend/internal/opensslsetup/opensslsetup_linux.go
+ create mode 100644 src/crypto/internal/backend/internal/opensslsetup/opensslsetup_linux_test.go
  create mode 100644 src/crypto/internal/backend/internal/opensslsetup/stub.go
  create mode 100644 src/crypto/internal/backend/nobackend.go
  create mode 100644 src/crypto/internal/backend/openssl_linux.go
@@ -819,17 +819,17 @@ index 00000000000000..20251a290dc2e0
 +func Dec(b []uint) *big.Int {
 +	return nil
 +}
-diff --git a/src/crypto/internal/backend/bbig/big_cng.go b/src/crypto/internal/backend/bbig/big_cng.go
+diff --git a/src/crypto/internal/backend/bbig/big_windows.go b/src/crypto/internal/backend/bbig/big_windows.go
 new file mode 100644
 index 00000000000000..9331c34d402ba2
 --- /dev/null
-+++ b/src/crypto/internal/backend/bbig/big_cng.go
++++ b/src/crypto/internal/backend/bbig/big_windows.go
 @@ -0,0 +1,12 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && windows
++//go:build goexperiment.systemcrypto
 +
 +package bbig
 +
@@ -847,7 +847,7 @@ index 00000000000000..e8884576d05427
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && darwin
++//go:build goexperiment.systemcrypto
 +
 +package bbig
 +
@@ -855,17 +855,17 @@ index 00000000000000..e8884576d05427
 +
 +var Enc = bbig.Enc
 +var Dec = bbig.Dec
-diff --git a/src/crypto/internal/backend/bbig/big_openssl.go b/src/crypto/internal/backend/bbig/big_openssl.go
+diff --git a/src/crypto/internal/backend/bbig/big_linux.go b/src/crypto/internal/backend/bbig/big_linux.go
 new file mode 100644
 index 00000000000000..51396c3db1a871
 --- /dev/null
-+++ b/src/crypto/internal/backend/bbig/big_openssl.go
++++ b/src/crypto/internal/backend/bbig/big_linux.go
 @@ -0,0 +1,12 @@
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && linux
++//go:build goexperiment.systemcrypto
 +
 +package bbig
 +
@@ -883,7 +883,7 @@ index 00000000000000..9bc7525be1e462
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && windows
++//go:build goexperiment.systemcrypto
 +
 +// Package cng provides access to CNGCrypto implementation functions.
 +// Check the variable Enabled to find out whether CNGCrypto is available.
@@ -1379,7 +1379,7 @@ index 00000000000000..805e95c926a1a1
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && darwin
++//go:build goexperiment.systemcrypto
 +
 +// Package darwin provides access to DarwinCrypto implementation functions.
 +// Check the variable Enabled to find out whether DarwinCrypto is available.
@@ -1813,17 +1813,17 @@ index 00000000000000..805e95c926a1a1
 +func NewChaCha20Poly1305(key []byte) (cipher.AEAD, error) {
 +	return xcrypto.NewChaCha20Poly1305(key)
 +}
-diff --git a/src/crypto/internal/backend/fips140/cng.go b/src/crypto/internal/backend/fips140/cng.go
+diff --git a/src/crypto/internal/backend/fips140/cng_windows.go b/src/crypto/internal/backend/fips140/cng_windows.go
 new file mode 100644
 index 00000000000000..d74cffe462b234
 --- /dev/null
-+++ b/src/crypto/internal/backend/fips140/cng.go
++++ b/src/crypto/internal/backend/fips140/cng_windows.go
 @@ -0,0 +1,35 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && windows
++//go:build goexperiment.systemcrypto
 +
 +package fips140
 +
@@ -1854,17 +1854,17 @@ index 00000000000000..d74cffe462b234
 +	}
 +	return enabled != 0
 +}
-diff --git a/src/crypto/internal/backend/fips140/darwin.go b/src/crypto/internal/backend/fips140/darwin.go
+diff --git a/src/crypto/internal/backend/fips140/darwin_darwin.go b/src/crypto/internal/backend/fips140/darwin_darwin.go
 new file mode 100644
 index 00000000000000..be7c416b531e58
 --- /dev/null
-+++ b/src/crypto/internal/backend/fips140/darwin.go
++++ b/src/crypto/internal/backend/fips140/darwin_darwin.go
 @@ -0,0 +1,13 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && darwin
++//go:build goexperiment.systemcrypto
 +
 +package fips140
 +
@@ -2000,17 +2000,17 @@ index 00000000000000..289d6594eac54b
 +func systemFIPSMode() bool {
 +	return false
 +}
-diff --git a/src/crypto/internal/backend/fips140/openssl.go b/src/crypto/internal/backend/fips140/openssl.go
+diff --git a/src/crypto/internal/backend/fips140/openssl_linux.go b/src/crypto/internal/backend/fips140/openssl_linux.go
 new file mode 100644
 index 00000000000000..95c93093d0b707
 --- /dev/null
-+++ b/src/crypto/internal/backend/fips140/openssl.go
++++ b/src/crypto/internal/backend/fips140/openssl_linux.go
 @@ -0,0 +1,59 @@
 +// Copyright 2024 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && linux
++//go:build goexperiment.systemcrypto
 +
 +package fips140
 +
@@ -2116,17 +2116,17 @@ index 00000000000000..d3d39fd77f98db
 +package fips140
 +
 +const isSkipFIPSCheck = true
-diff --git a/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go
+diff --git a/src/crypto/internal/backend/internal/opensslsetup/opensslsetup_linux.go b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup_linux.go
 new file mode 100644
 index 00000000000000..ef97d994841717
 --- /dev/null
-+++ b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup.go
++++ b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup_linux.go
 @@ -0,0 +1,68 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && linux
++//go:build goexperiment.systemcrypto
 +
 +// opensslsetup is a package that initializes the OpenSSL library.
 +// It doesn't export any symbol, but blank importing it has the
@@ -2190,17 +2190,17 @@ index 00000000000000..ef97d994841717
 +	}
 +	return lcryptoFallback
 +}
-diff --git a/src/crypto/internal/backend/internal/opensslsetup/opensslsetup_test.go b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup_test.go
+diff --git a/src/crypto/internal/backend/internal/opensslsetup/opensslsetup_linux_test.go b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup_linux_test.go
 new file mode 100644
 index 00000000000000..7276cc2b871b85
 --- /dev/null
-+++ b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup_test.go
++++ b/src/crypto/internal/backend/internal/opensslsetup/opensslsetup_linux_test.go
 @@ -0,0 +1,92 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && linux && cgo
++//go:build goexperiment.systemcrypto && cgo
 +
 +package opensslsetup
 +
@@ -2694,7 +2694,7 @@ index 00000000000000..ccac6ce8ad0b35
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && linux
++//go:build goexperiment.systemcrypto
 +
 +// Package openssl provides access to OpenSSLCrypto implementation functions.
 +// Check the variable Enabled to find out whether OpenSSLCrypto is available.
@@ -3146,7 +3146,7 @@ index 00000000000000..1461a5f75b3b06
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && linux && !(cgo || 386 || amd64 || arm || arm64 || loong64 || ppc64le || riscv64 || s390x)
++//go:build goexperiment.systemcrypto && !(cgo || 386 || amd64 || arm || arm64 || loong64 || ppc64le || riscv64 || s390x)
 +
 +package crypto
 +

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -67,7 +67,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/rc4/rc4.go                         |  18 ++
  src/crypto/rsa/boring.go                      |  13 +-
  src/crypto/rsa/boring_test.go                 |   2 +-
- src/crypto/rsa/darwin.go                      |  71 +++++++
+ src/crypto/rsa/darwin_darwin.go                |  71 +++++++
  src/crypto/rsa/fips.go                        |  84 ++++----
  src/crypto/rsa/notboring.go                   |   4 +-
  src/crypto/rsa/pkcs1v15.go                    |  10 +-
@@ -109,7 +109,7 @@ Subject: [PATCH] Use crypto backends
  create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
- create mode 100644 src/crypto/rsa/darwin.go
+ create mode 100644 src/crypto/rsa/darwin_darwin.go
  create mode 100644 src/crypto/tls/internal/tls13/doc.go
  create mode 100644 src/crypto/tls/internal/tls13/tls13.go
  create mode 100644 src/hash/boring_test.go
@@ -2564,17 +2564,17 @@ index 838fcc1244bdbe..d89f732345e8a3 100644
  
  // Note: Can run these tests against the non-BoringCrypto
  // version of the code by using "CGO_ENABLED=0 go test".
-diff --git a/src/crypto/rsa/darwin.go b/src/crypto/rsa/darwin.go
+diff --git a/src/crypto/rsa/darwin_darwin.go b/src/crypto/rsa/darwin_darwin.go
 new file mode 100644
 index 00000000000000..bff8ac449c9a3b
 --- /dev/null
-+++ b/src/crypto/rsa/darwin.go
++++ b/src/crypto/rsa/darwin_darwin.go
 @@ -0,0 +1,71 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build goexperiment.systemcrypto && darwin
++//go:build goexperiment.systemcrypto
 +
 +package rsa
 +


### PR DESCRIPTION
Also updates our agent workflow to check for this in future PRs.