### PR TITLE
Add "go" _util command; use it to run getmingw

### DIFF
--- a/eng/_util/cmd/go/go.go
+++ b/eng/_util/cmd/go/go.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,24 +12,15 @@ import (
 	"github.com/microsoft/go-infra/executil"
 )
 
-const description = `
-This command runs the given go command using _util's version of Go with the
-working directory set to the root of the _util module.
-
-All args (except '-h', used to print this help message) pass through to Go.
-`
+// This command runs the given go command using _util's version of Go with the
+// working directory set to the root of the _util module.
+//
+// All args pass through to Go. Unlike other commands, "-h"/"-help" are not
+// handled to give a detailed description of this command. It doesn't seem worth
+// the effort to handle help args in a way that doesn't introduce further edge
+// cases or usability complications.
 
 func main() {
-	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of go:\n")
-		flag.PrintDefaults()
-		fmt.Fprintf(flag.CommandLine.Output(), "%s\n", description)
-	}
-
-	// Handle "-h" using built-in logic. Technically overrides go's handling,
-	// but that's fine: we expect users of these tools to know what's going on.
-	flag.Parse()
-
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -46,6 +36,6 @@ func run() error {
 	return executil.Run(executil.Dir(
 		filepath.Join("eng", "_util"),
 		filepath.Join(stage0Goroot, "bin", "go"),
-		flag.Args()...,
+		os.Args[1:]...,
 	))
 }

--- a/eng/_util/cmd/go/go.go
+++ b/eng/_util/cmd/go/go.go
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/microsoft/go-infra/executil"
+)
+
+const description = `
+This command runs the given go command using _util's version of Go with the
+working directory set to the root of the _util module.
+
+All args (except '-h', used to print this help message) pass through to Go.
+`
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of go:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n", description)
+	}
+
+	// Handle "-h" using built-in logic. Technically overrides go's handling,
+	// but that's fine: we expect users of these tools to know what's going on.
+	flag.Parse()
+
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	stage0Goroot := os.Getenv("STAGE_0_GOROOT")
+	if stage0Goroot == "" {
+		return fmt.Errorf("STAGE_0_GOROOT not set")
+	}
+
+	return executil.Run(executil.Dir(
+		filepath.Join("eng", "_util"),
+		filepath.Join(stage0Goroot, "bin", "go"),
+		flag.Args()...,
+	))
+}

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -226,11 +226,8 @@ stages:
                 displayName: Remove unexpected tools
 
               - pwsh: |
-                  # Use the version of getmingw specified in the util module.
-                  cd eng\_util
-                  go install github.com/microsoft/go-infra/cmd/getmingw
-                  & "$(go env GOPATH)/bin/getmingw" diagnose
-                  & "$(go env GOPATH)/bin/getmingw" run -ci azdo -source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -exception seh -runtime msvcrt
+                  eng/run.ps1 go run github.com/microsoft/go-infra/cmd/getmingw diagnose
+                  eng/run.ps1 go run github.com/microsoft/go-infra/cmd/getmingw run -ci azdo -source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -exception seh -runtime msvcrt
                 displayName: Install MinGW
 
             # Build. This includes retry logic internally if necessary for this builder.


### PR DESCRIPTION
Add `pwsh eng/run.ps1 go [...]`. This runs any `go` command, but uses the stage 0 version of Go, which is the Microsoft build of Go.

Use it during the build to run `github.com/microsoft/go-infra/cmd/getmingw` rather than using an ambiently installed `go`.

This is also useful in general: it's sometimes annoying to work with the `_util` module because it doesn't live in the root of the repo. Now you can use commands like `pwsh eng/run.ps1 go mod tidy` from the root to maintain the _util module.

* Should fix the build cache issue in https://github.com/microsoft/go/pull/2162, but it's the right thing to do regardless.