### PR TITLE
Enforce FIPS 140-only mode for ChaCha20Poly1305 in backends

### DIFF
--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -18,16 +18,16 @@ desired goexperiments and build tags.
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/internal/tool/tool.go              |   9 +-
- src/cmd/go/systemcrypto_test.go               | 233 ++++++++++
+ src/cmd/go/systemcrypto_test.go               | 233 +++++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
  src/cmd/internal/testdir/testdir_test.go      |   7 +
  src/cmd/link/internal/ld/main.go              |   2 +-
  src/cmd/link/link_test.go                     |   8 +
- src/crypto/internal/backend/backend_darwin.go | 438 ++++++++++++++++++
- src/crypto/internal/backend/backend_linux.go  | 430 +++++++++++++++++
+ src/crypto/internal/backend/backend_darwin.go | 442 ++++++++++++++++++
+ src/crypto/internal/backend/backend_linux.go  | 434 +++++++++++++++++
  src/crypto/internal/backend/backend_test.go   |  56 +++
- .../internal/backend/backend_windows.go       | 438 ++++++++++++++++++
+ .../internal/backend/backend_windows.go       | 442 ++++++++++++++++++
  src/crypto/internal/backend/bbig/big.go       |  17 +
  .../internal/backend/bbig/big_darwin.go       |  12 +
  src/crypto/internal/backend/bbig/big_linux.go |  12 +
@@ -52,7 +52,7 @@ desired goexperiments and build tags.
  src/go/build/deps_test.go                     |  24 +-
  src/internal/buildcfg/exp.go                  |  47 ++
  src/runtime/runtime_boring.go                 |   5 +
- 43 files changed, 2742 insertions(+), 14 deletions(-)
+ 43 files changed, 2754 insertions(+), 14 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_darwin.go
  create mode 100644 src/crypto/internal/backend/backend_linux.go
@@ -702,7 +702,7 @@ index a4b3a0422f2f41..0140c385e47991 100644
  		if !strings.Contains(buildVersion, "-") { // See go.dev/issue/75953.
  			sep = "-"
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
-index 19607c324ceaef..50439e47260a99 100644
+index ff7842ca3ffd87..164f3883d3f527 100644
 --- a/src/cmd/link/link_test.go
 +++ b/src/cmd/link/link_test.go
 @@ -12,6 +12,7 @@ import (
@@ -736,10 +736,10 @@ index 19607c324ceaef..50439e47260a99 100644
  	tmpdir := t.TempDir()
 diff --git a/src/crypto/internal/backend/backend_darwin.go b/src/crypto/internal/backend/backend_darwin.go
 new file mode 100644
-index 00000000000000..657e27ed74dc99
+index 00000000000000..73830cae246cbd
 --- /dev/null
 +++ b/src/crypto/internal/backend/backend_darwin.go
-@@ -0,0 +1,438 @@
+@@ -0,0 +1,442 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -757,6 +757,7 @@ index 00000000000000..657e27ed74dc99
 +	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
 +	"crypto/internal/fips140only"
++	"errors"
 +	"hash"
 +	"io"
 +	_ "unsafe"
@@ -1176,14 +1177,17 @@ index 00000000000000..657e27ed74dc99
 +}
 +
 +func NewChaCha20Poly1305(key []byte) (cipher.AEAD, error) {
++	if fips140only.Enforced() {
++		return nil, errors.New("chacha20poly1305: use of ChaCha20Poly1305 is not allowed in FIPS 140-only mode")
++	}
 +	return xcrypto.NewChaCha20Poly1305(key)
 +}
 diff --git a/src/crypto/internal/backend/backend_linux.go b/src/crypto/internal/backend/backend_linux.go
 new file mode 100644
-index 00000000000000..a4ca780ebb0251
+index 00000000000000..7a832bd68754df
 --- /dev/null
 +++ b/src/crypto/internal/backend/backend_linux.go
-@@ -0,0 +1,430 @@
+@@ -0,0 +1,434 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1202,6 +1206,7 @@ index 00000000000000..a4ca780ebb0251
 +	_ "crypto/internal/backend/internal/opensslsetup"
 +	"crypto/internal/boring/sig"
 +	"crypto/internal/fips140only"
++	"errors"
 +	"hash"
 +
 +	"github.com/golang-fips/openssl/v2"
@@ -1612,6 +1617,9 @@ index 00000000000000..a4ca780ebb0251
 +}
 +
 +func NewChaCha20Poly1305(key []byte) (cipher.AEAD, error) {
++	if fips140only.Enforced() {
++		return nil, errors.New("chacha20poly1305: use of ChaCha20Poly1305 is not allowed in FIPS 140-only mode")
++	}
 +	return openssl.NewChaCha20Poly1305(key)
 +}
 diff --git a/src/crypto/internal/backend/backend_test.go b/src/crypto/internal/backend/backend_test.go
@@ -1678,10 +1686,10 @@ index 00000000000000..093acd82556330
 +}
 diff --git a/src/crypto/internal/backend/backend_windows.go b/src/crypto/internal/backend/backend_windows.go
 new file mode 100644
-index 00000000000000..26f0e5d79f0588
+index 00000000000000..d25ef26f77013d
 --- /dev/null
 +++ b/src/crypto/internal/backend/backend_windows.go
-@@ -0,0 +1,438 @@
+@@ -0,0 +1,442 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1699,6 +1707,7 @@ index 00000000000000..26f0e5d79f0588
 +	"crypto/internal/backend/fips140"
 +	"crypto/internal/boring/sig"
 +	"crypto/internal/fips140only"
++	"errors"
 +	"hash"
 +	_ "unsafe"
 +
@@ -2118,6 +2127,9 @@ index 00000000000000..26f0e5d79f0588
 +}
 +
 +func NewChaCha20Poly1305(key []byte) (cipher.AEAD, error) {
++	if fips140only.Enforced() {
++		return nil, errors.New("chacha20poly1305: use of ChaCha20Poly1305 is not allowed in FIPS 140-only mode")
++	}
 +	return cng.NewChaCha20Poly1305(key)
 +}
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -50,7 +50,7 @@ Subject: [PATCH] Use crypto backends
  .../internal/cryptotest/implementations.go    |   2 +-
  src/crypto/internal/fips140hash/hash.go       |   3 +-
  .../internal/fips140only/fips140only.go       |  11 +-
- .../internal/fips140only/fips140only_test.go  |  52 +++--
+ .../internal/fips140only/fips140only_test.go  |  45 ++--
  src/crypto/internal/fips140test/acvp_test.go  |   6 +
  src/crypto/internal/fips140test/cast_test.go  |   2 +
  src/crypto/internal/fips140test/fips_test.go  |   2 +-
@@ -103,7 +103,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- 99 files changed, 1628 insertions(+), 249 deletions(-)
+ 99 files changed, 1624 insertions(+), 246 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -176,10 +176,10 @@ index ed0fbf3d53d75b..a2f74c8095d449 100644
  func TestBoringInternalLink(t *testing.T) {
  	tg := testgo(t)
 diff --git a/src/cmd/go/script_test.go b/src/cmd/go/script_test.go
-index 390a36723787f4..0576ea8add72af 100644
+index f6eaddf8fb3f40..48151eee988ba4 100644
 --- a/src/cmd/go/script_test.go
 +++ b/src/cmd/go/script_test.go
-@@ -297,6 +297,8 @@ var extraEnvKeys = []string{
+@@ -296,6 +296,8 @@ var extraEnvKeys = []string{
  	"GO_TESTING_GOTOOLS", // for gccgo testing
  	"GCCGO",              // for gccgo testing
  	"GCCGOTOOLDIR",       // for gccgo testing
@@ -1784,7 +1784,7 @@ index a8d840b17022cc..2a17f7da2d4aaa 100644
 +	return false
  }
 diff --git a/src/crypto/internal/fips140only/fips140only_test.go b/src/crypto/internal/fips140only/fips140only_test.go
-index 96df536d56f345..01613841a3c87e 100644
+index 96df536d56f345..91d2a792d90296 100644
 --- a/src/crypto/internal/fips140only/fips140only_test.go
 +++ b/src/crypto/internal/fips140only/fips140only_test.go
 @@ -17,6 +17,7 @@ import (
@@ -1817,22 +1817,15 @@ index 96df536d56f345..01613841a3c87e 100644
  	expectPanic(t, func() { cipher.NewCTR(notAESBlock, iv) })
  
  	expectPanic(t, func() { cipher.NewOFB(aesBlock, iv) })
-@@ -310,13 +317,16 @@ bXVL8iKLrG91IYQByUHZIn3WVAd2bfi4MfKagRt0ggd4
- 	expectErr(t, errRet2(hpke.DHKEM(ecdh.X25519()).NewPublicKey(make([]byte, 32))))
- 	hpkeK, err := hpke.MLKEM768().GenerateKey()
- 	expectNoErr(t, err)
--	expectErr(t, errRet2(hpke.Seal(hpkeK.PublicKey(), hpke.HKDFSHA256(), hpke.ChaCha20Poly1305(), nil, nil)))
--	expectErr(t, errRet2(hpke.Open(hpkeK, hpke.HKDFSHA256(), hpke.ChaCha20Poly1305(), nil, make([]byte, 2000))))
--
+@@ -313,10 +320,12 @@ bXVL8iKLrG91IYQByUHZIn3WVAd2bfi4MfKagRt0ggd4
+ 	expectErr(t, errRet2(hpke.Seal(hpkeK.PublicKey(), hpke.HKDFSHA256(), hpke.ChaCha20Poly1305(), nil, nil)))
+ 	expectErr(t, errRet2(hpke.Open(hpkeK, hpke.HKDFSHA256(), hpke.ChaCha20Poly1305(), nil, make([]byte, 2000))))
+ 
 -	// fips140=only mode should prevent any operation that would make the FIPS
 -	// 140-3 module set its service indicator to false.
 -	if !fips140.ServiceIndicator() {
 -		t.Errorf("service indicator not set")
 +	if !boring.Enabled {
-+		// TODO implement error handling in backends that check for fips140only.Enforced().
-+		expectErr(t, errRet2(hpke.Seal(hpkeK.PublicKey(), hpke.HKDFSHA256(), hpke.ChaCha20Poly1305(), nil, nil)))
-+		expectErr(t, errRet2(hpke.Open(hpkeK, hpke.HKDFSHA256(), hpke.ChaCha20Poly1305(), nil, make([]byte, 2000))))
-+
 +		// fips140=only mode should prevent any operation that would make the FIPS
 +		// 140-3 module set its service indicator to false.
 +		if !fips140.ServiceIndicator() {
@@ -1841,7 +1834,7 @@ index 96df536d56f345..01613841a3c87e 100644
  	}
  }
  
-@@ -329,16 +339,22 @@ type readerWrap struct {
+@@ -329,16 +338,22 @@ type readerWrap struct {
  }
  
  func withApprovedHash(f func(crypto.Hash)) {


### PR DESCRIPTION
Add fips140only.Enforced() checks to NewChaCha20Poly1305 in all three backend implementations (darwin, linux, windows) so that ChaCha20Poly1305 is rejected in FIPS 140-only mode even when a crypto backend is enabled.

Remove the workaround in fips140only_test.go that skipped the HPKE ChaCha20Poly1305 error checks when a backend was enabled.