### PR TITLE
[release-branch.go1.26] Refer to FIPS 1.26 changelog, remove unclear statement

### DIFF
--- a/docs/go1.26.md
+++ b/docs/go1.26.md
@@ -13,10 +13,11 @@ For more information, see [the Additional Features document](https://github.com/
 
 ## Systemcrypto
 
+See the [FIPS documentation Go 1.26 changelog](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/fips/README.md#go-126-feb-2026) for more information.
+
 ### Configuration
 
 You can disable `systemcrypto` at build time by setting the environment variable `MS_GO_NOSYSTEMCRYPTO` to `1`.
-This is now the preferred method for disabling systemcrypto when necessary.
 
 ### Backends
 


### PR DESCRIPTION
Add a link to the changelog for easier access to details.

Remove statement that `MS_GO_NOSYSTEMCRYPTO` is preferred. This is elaborated on in the FIPS readme for readers who are interested in this new feature, and there isn't currently any reason to proactively migrate existing builds to the new env var without understanding what it's actually for first.