### PR TITLE
[release-branch.go1.26] remove Windows Server 2019 testing

### DIFF
--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -104,7 +104,6 @@ stages:
           - { experiment: nosystemcrypto, os: windows, arch: amd64, config: test }
           - { experiment: systemcrypto, os: windows, arch: amd64, config: test }
           - { experiment: systemcrypto, os: windows, arch: amd64, config: test, fips: true }
-          - { experiment: systemcrypto, os: windows, arch: amd64, config: test, distro: '2019', broken: true } # Affected by https://golang.org/issue/10842.
           - { experiment: ms_tls_config_schannel, os: windows, arch: amd64, config: test }
           # Test that buildandpack works on Windows x86-32, but don't release it.
           - { experiment: nosystemcrypto, os: windows, hostArch: amd64, arch: 386, config: buildandpack }


### PR DESCRIPTION
We now have an SFI item telling us to stop running running CI with this deprecated platform so we'll have to remove it now