### PR TITLE
[release-branch.go1.25] remove Windows Server 2019 testing

### DIFF
--- a/.github/workflows/patch-build.yml
+++ b/.github/workflows/patch-build.yml
@@ -11,8 +11,8 @@ on:
     branches: [ microsoft/* ]
 
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/microsoft/main' }}
+  group: "${{ github.ref }}-${{ github.workflow}}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_patches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ on:
 
 # Cancel existing runs if user makes another push.
 concurrency:
-  group: "${{ github.ref }}"
+  group: "${{ github.ref }}-${{ github.workflow}}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -97,7 +97,6 @@ stages:
           - { experiment: nosystemcrypto, os: windows, arch: amd64, config: test }
           - { experiment: systemcrypto, os: windows, arch: amd64, config: test }
           - { experiment: systemcrypto, os: windows, arch: amd64, config: test, fips: true }
-          - { experiment: systemcrypto, os: windows, arch: amd64, config: test, distro: '2019', broken: true } # Affected by https://golang.org/issue/10842.
           - { experiment: ms_tls_config_schannel, os: windows, arch: amd64, config: test }
           # Test that buildandpack works on Windows x86-32, but don't release it.
           - { experiment: nosystemcrypto, os: windows, hostArch: amd64, arch: 386, config: buildandpack }


### PR DESCRIPTION
We now have an SFI item telling us to stop running running CI with this deprecated platform so we'll have to remove it now

Also cherry-picks a GitHub CI concurrency fix that we have in 1.26+