### PR TITLE
implement Installation.md and document using setup-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,18 @@ There are a few additional support resources internal to Microsoft:
 
 ## Download and install
 
-We build the forked Go toolset with the following list of OS/Arch combinations:
+We build the Microsoft build of Go toolset with the following OS/Arch combinations:
 
-* `linux_amd64`
-* `linux_armv6l`
-* `linux_arm64`
-* `windows_amd64`
-* `windows_arm64`
-* `darwin_amd64`
-* `darwin_arm64`
+| OS | `amd64` | `arm64` | `armv6l` |
+| --- | :---: | :---: | :---: |
+| `linux` | ✓ | ✓ | ✓ |
+| `windows` | ✓ | ✓ | |
+| `darwin` (macOS) | ✓ | ✓ | |
 
-Visit the [Migration Guide](eng/doc/MigrationGuide.md) for guidance about how we
-recommend migrating existing Go projects to use the Microsoft build of Go. This
-guide also helps resolve commonly encountered issues.
+Visit the [Migration Guide](eng/doc/MigrationGuide.md) for guidance about how we recommend migrating existing Go projects to use the Microsoft build of Go.
+This guide also helps resolve commonly encountered issues.
 
-The following installation methods are available. See [Installation](eng/doc/Installation.md) for full details.
+The [Installation](eng/doc/Installation.md) documentation contains sections describing each of the following installation methods:
 
 * [Docker Container Images](eng/doc/Installation.md#docker-container-images)
 * [Azure Linux](eng/doc/Installation.md#azure-linux)

--- a/README.md
+++ b/README.md
@@ -71,81 +71,16 @@ Visit the [Migration Guide](eng/doc/MigrationGuide.md) for guidance about how we
 recommend migrating existing Go projects to use the Microsoft build of Go. This
 guide also helps resolve commonly encountered issues.
 
-The following sections list the ways to get the Microsoft build of Go.
+The following installation methods are available. See [Installation](eng/doc/Installation.md) for full details.
 
-> [!NOTE]
-> Don't see an option that works for you? Let us know!  
-> File a GitHub issue, or comment on an existing issue in this tag:
-  [![](https://img.shields.io/github/labels/microsoft/go/Area-Acquisition)](https://github.com/microsoft/go/labels/Area-Acquisition)
-
-### Docker Container Images
-
-**[microsoft/go-images](https://github.com/microsoft/go-images)** maintains and
-documents container images that are available on Microsoft Artifact Registry.
-
-### Azure Linux
-
-The **[Azure Linux](https://github.com/microsoft/azurelinux)** distribution
-includes the `golang` package, a build of this fork of Go.
-
-For more information about how to manage the `systemcrypto` migration from 1.24
-to 1.25 in Azure Linux 3, see
-[the `systemcrypto` section of the Migration Guide](eng/doc/MigrationGuide.md#migration-to-systemcrypto).
-
-### Ubuntu
-
-To install the Microsoft build of Go using an Ubuntu package, first set up the [Linux package repository for Microsoft Products](https://learn.microsoft.com/en-us/linux/packages).
-Packages are available in the Ubuntu 22.04 and 24.04 repositories.
-
-After the repository is added, install the Microsoft build of Go by running the following commands:
-
-```bash
-sudo apt-get update && sudo apt-get install msft-golang
-```
-
-### Azure Pipelines `GoTool@0` task
-
-The [`GoTool@0`](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/go-tool-v0) Azure Pipelines build task supports installing the Microsoft build of Go.
-For more details, see [the GoTool@0 section of the Migration Guide](eng/doc/MigrationGuide.md#the-gotool0-azure-pipelines-task).
-
-### The `go-install.ps1` script
-
-The [cross-platform `go-install.ps1` script](https://github.com/microsoft/go-infra/tree/main/goinstallscript) installs the Microsoft build of Go.
-It can install specific versions or the latest releases.
-
-If you use Azure Pipelines, try running the script in a [script step](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/cmd-line-v2?view=azure-pipelines) and pass the `-AzurePipelinePath` argument to automatically set up `go` in the environment for future steps.
-
-### Binary archive
-
-[Signed builds of Go](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/Downloads.md)
-for several platforms are available as `zip` and `tar.gz` files.
-
-### Build from source
-
-#### Pre-patched source tarball
-
-[The microsoft/go GitHub releases](https://github.com/microsoft/go/releases)
-include a source tarball file ending in `.src.tar.gz`. After downloading and
-extracting the tar.gz file, build it using the
-[upstream instructions](https://go.dev/doc/install/source).
-
-> [!NOTE]
-> The `zip` file that GitHub offers for download on the [microsoft/go releases page](https://github.com/microsoft/go/releases) is incomplete: it doesn't include the `go` submodule.
-> Make sure to download the `.src.tar.gz` file instead, or [clone the repository using Git and set up the patched submodule](#clone-and-build).
-
-#### Clone and build
-
-First, clone this repository using Git and check out the desired tag or commit.
-
-If you want to contribute to the Microsoft build of Go project, read the [Developer Guide](eng/doc/DeveloperGuide.md).
-It lists the steps we recommend to set up a Microsoft build of Go development environment, execute your first build, run the standard library test suite, and contribute a PR.
-
-If you just want to build on your own machine, you may find it more
-convenient to use the tools provided by the `eng/run.ps1` script. We use this
-script for CI builds. See [eng/README.md](eng/README.md) for more details about
-`eng/run.ps1` and other repository infrastructure.
-
-Once built, the Microsoft build of Go binary is found at `go/bin/go`.
+* [Docker Container Images](eng/doc/Installation.md#docker-container-images)
+* [Azure Linux](eng/doc/Installation.md#azure-linux)
+* [Ubuntu](eng/doc/Installation.md#ubuntu)
+* [Azure Pipelines `GoTool@0` task](eng/doc/Installation.md#azure-pipelines-gotool0-task)
+* [GitHub Actions `setup-go`](eng/doc/Installation.md#github-actions-setup-go)
+* [The `go-install.ps1` script](eng/doc/Installation.md#the-go-installps1-script)
+* [Binary archive](eng/doc/Installation.md#binary-archive)
+* [Build from source](eng/doc/Installation.md#build-from-source)
 
 ## Contributing
 

--- a/eng/doc/Installation.md
+++ b/eng/doc/Installation.md
@@ -36,7 +36,7 @@ The [`GoTool@0`](https://learn.microsoft.com/azure/devops/pipelines/tasks/refere
 
 To use it, set these parameters:
 
-* `version`: the task supports the version formats `1.X`, `1.X.Y`, and `1.X.Y-Z`, and if there is a partial match, it installs the latest matching version. We recommend using the latest major version, currently `1.26`.
+* `version`: the task supports the version formats `1.X`, `1.X.Y`, and `1.X.Y-Z`, and if there is a partial match, it installs the latest matching version.
 * `goDownloadUrl`: use `https://aka.ms/golang/release/latest` to select the Microsoft build of Go.
 
 The resulting step in a yml-based Azure Pipeline looks like this:

--- a/eng/doc/Installation.md
+++ b/eng/doc/Installation.md
@@ -19,10 +19,6 @@ documents container images that are available on Microsoft Artifact Registry.
 The **[Azure Linux](https://github.com/microsoft/azurelinux)** distribution
 includes the `golang` package, a build of this fork of Go.
 
-For more information about how to manage the `systemcrypto` migration from 1.24
-to 1.25 in Azure Linux 3, see
-[the `systemcrypto` section of the Migration Guide](MigrationGuide.md#migration-to-systemcrypto).
-
 ## Ubuntu
 
 To install the Microsoft build of Go using an Ubuntu package, first set up the [Linux package repository for Microsoft Products](https://learn.microsoft.com/en-us/linux/packages).

--- a/eng/doc/Installation.md
+++ b/eng/doc/Installation.md
@@ -1,0 +1,113 @@
+# Installation
+
+Visit the [Migration Guide](MigrationGuide.md) for guidance about how we
+recommend migrating existing Go projects to use the Microsoft build of Go. This
+guide also helps resolve commonly encountered issues.
+
+> [!NOTE]
+> Don't see an option that works for you? Let us know!  
+> File a GitHub issue, or comment on an existing issue in this tag:
+  [![](https://img.shields.io/github/labels/microsoft/go/Area-Acquisition)](https://github.com/microsoft/go/labels/Area-Acquisition)
+
+## Docker Container Images
+
+**[microsoft/go-images](https://github.com/microsoft/go-images)** maintains and
+documents container images that are available on Microsoft Artifact Registry.
+
+## Azure Linux
+
+The **[Azure Linux](https://github.com/microsoft/azurelinux)** distribution
+includes the `golang` package, a build of this fork of Go.
+
+For more information about how to manage the `systemcrypto` migration from 1.24
+to 1.25 in Azure Linux 3, see
+[the `systemcrypto` section of the Migration Guide](MigrationGuide.md#migration-to-systemcrypto).
+
+## Ubuntu
+
+To install the Microsoft build of Go using an Ubuntu package, first set up the [Linux package repository for Microsoft Products](https://learn.microsoft.com/en-us/linux/packages).
+Packages are available in the Ubuntu 22.04 and 24.04 repositories.
+
+After the repository is added, install the Microsoft build of Go by running the following commands:
+
+```bash
+sudo apt-get update && sudo apt-get install msft-golang
+```
+
+## Azure Pipelines `GoTool@0` task
+
+The [`GoTool@0`](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/go-tool-v0) Azure Pipelines build task supports installing the Microsoft build of Go.
+
+To use it, set these parameters:
+
+* `version`: the task supports the version formats `1.X`, `1.X.Y`, and `1.X.Y-Z`, and if there is a partial match, it installs the latest matching version. We recommend using the latest major version, currently `1.26`.
+* `goDownloadUrl`: use `https://aka.ms/golang/release/latest` to select the Microsoft build of Go.
+
+The resulting step in a yml-based Azure Pipeline looks like this:
+
+```yml
+- task: GoTool@0
+  displayName: 'Install Go'
+  inputs:
+    version: '1.26'
+    goDownloadUrl: 'https://aka.ms/golang/release/latest'
+```
+
+## GitHub Actions `setup-go`
+
+The [`actions/setup-go`](https://github.com/actions/setup-go) GitHub Action supports installing the Microsoft build of Go.
+
+To use it, set these parameters:
+
+* `version`: the version of Go to install.
+* `go-download-base-url`: use `https://aka.ms/golang/release/latest` to select the Microsoft build of Go.
+
+The resulting step in a GitHub Actions workflow looks like this:
+
+```yml
+- uses: actions/setup-go@v6
+  with:
+    go-version: '1.26'
+    go-download-base-url: 'https://aka.ms/golang/release/latest'
+```
+
+## The `go-install.ps1` script
+
+The [cross-platform `go-install.ps1` script](https://github.com/microsoft/go-infra/tree/main/goinstallscript) installs the Microsoft build of Go.
+It can install specific versions or the latest releases.
+
+If you use Azure Pipelines, try running the script in a [script step](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/cmd-line-v2?view=azure-pipelines) and pass the `-AzurePipelinePath` argument to automatically set up `go` in the environment for future steps.
+
+If you use GitHub Actions, pass the `-GitHubActionsPath` argument to automatically set up `go` in the environment for future steps.
+
+## Binary archive
+
+[Signed builds of Go](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/Downloads.md)
+for several platforms are available as `zip` and `tar.gz` files.
+
+## Build from source
+
+### Pre-patched source tarball
+
+[The microsoft/go GitHub releases](https://github.com/microsoft/go/releases)
+include a source tarball file ending in `.src.tar.gz`. After downloading and
+extracting the tar.gz file, build it using the
+[upstream instructions](https://go.dev/doc/install/source).
+
+> [!NOTE]
+> The `zip` file that GitHub offers for download on the [microsoft/go releases page](https://github.com/microsoft/go/releases) is incomplete: it doesn't include the `go` submodule.
+> Make sure to download the `.src.tar.gz` file instead, or [clone the repository using Git and set up the patched submodule](#clone-and-build).
+
+### Clone and build
+
+First, clone this repository using Git and check out the desired tag or commit.
+
+If you want to contribute to the Microsoft build of Go project, read the [Developer Guide](DeveloperGuide.md).
+It lists the steps we recommend to set up a Microsoft build of Go development environment, execute your first build, run the standard library test suite, and contribute a PR.
+
+If you just want to build on your own machine, you may find it more
+convenient to use the tools provided by the `eng/run.ps1` script. We use this
+script for CI builds. See [eng/README.md](../../eng/README.md) for more details about
+`eng/run.ps1` and other repository infrastructure.
+
+Once built, the Microsoft build of Go binary is found at `go/bin/go`.

--- a/eng/doc/Installation.md
+++ b/eng/doc/Installation.md
@@ -59,7 +59,7 @@ The [`actions/setup-go`](https://github.com/actions/setup-go) GitHub Action supp
 
 To use it, set these parameters:
 
-* `version`: the version of Go to install.
+* `go-version`: the version of Go to install.
 * `go-download-base-url`: use `https://aka.ms/golang/release/latest` to select the Microsoft build of Go.
 
 The resulting step in a GitHub Actions workflow looks like this:
@@ -82,7 +82,7 @@ If you use GitHub Actions, pass the `-GitHubActionsPath` argument to automatical
 
 ## Binary archive
 
-[Signed builds of Go](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/Downloads.md)
+[Signed builds of Go](Downloads.md)
 for several platforms are available as `zip` and `tar.gz` files.
 
 ## Build from source

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -57,29 +57,17 @@ For a detailed description of every feature, see the [Additional Features](./Add
 This section describes some migration scenarios we know about and the path we recommend following for each one.
 
 > [!NOTE]
-> Any method of installing the Microsoft build of Go specified [in the project README file](/README.md#download-and-install) is valid.
+> Any method of installing the Microsoft build of Go specified [in the Installation guide](Installation.md) is valid.
 > If you see a good fit, go ahead and use it.
 >
 > The scenarios in the following sections simply offer targeted guidance to help find the easiest approach.
 
-### The `GoTool@0` Azure Pipelines task
+### A CI task or action that installs Go
 
-The [GoTool@0](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/go-tool-v0) Azure Pipelines build task supports installing the Microsoft build of Go.
+If your CI system has a built-in task or action that installs Go, it may support installing the Microsoft build of Go:
 
-To use it, set these parameters:
-
-* `version`: the task supports the version formats `1.X`, `1.X.Y`, and `1.X.Y-Z`, and if there is a partial match, it installs the latest matching version. We recommend using the latest major version, currently `1.26`.
-* `goDownloadUrl`: use `https://aka.ms/golang/release/latest` to select the Microsoft build of Go.
-
-The resulting step in a yml-based Azure Pipeline looks like this:
-
-```yml
-- task: GoTool@0
-  displayName: 'Install Go'
-  inputs:
-    version: '1.26'
-    goDownloadUrl: 'https://aka.ms/golang/release/latest'
-```
+* **Azure Pipelines:** use the [`GoTool@0` task](Installation.md#azure-pipelines-gotool0-task).
+* **GitHub Actions:** use the [`actions/setup-go` action](Installation.md#github-actions-setup-go).
 
 ### A `go` toolset that happens to be on my build agent
 

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -104,7 +104,7 @@ If you're using it, no action is needed.
 ### An Ubuntu `golang` package
 
 Ubuntu packages for the Microsoft build of Go are `msft-golang` on the [Linux Software Repository for Microsoft Products](https://learn.microsoft.com/en-us/linux/packages), also known as PMC (packages.microsoft.com).
-Install instructions [are in the Installation Guide(Installation.md#ubuntu).
+Install instructions [are in the Installation Guide](Installation.md#ubuntu).
 
 ### A OneBranch Azure Pipeline
 

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -104,7 +104,7 @@ If you're using it, no action is needed.
 ### An Ubuntu `golang` package
 
 Ubuntu packages for the Microsoft build of Go are `msft-golang` on the [Linux Software Repository for Microsoft Products](https://learn.microsoft.com/en-us/linux/packages), also known as PMC (packages.microsoft.com).
-Install instructions [are in the project README file](/README.md#ubuntu).
+Install instructions [are in the Installation Guide(Installation.md#ubuntu).
 
 ### A OneBranch Azure Pipeline
 

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -72,7 +72,7 @@ If your CI system has a built-in task or action that installs Go, it may support
 ### A `go` toolset that happens to be on my build agent
 
 Some build agents (VMs, containers, etc.) have `go` conveniently pre-installed, but it's the official distribution of Go rather than the Microsoft build.
-A universal migration is to use [the cross-platform `go-install.ps1` script](/README.md#the-go-installps1-script).
+A universal migration is to use [the cross-platform `go-install.ps1` script](Installation.md#the-go-installps1-script).
 However, we recommend looking at these options first:
 
 * Request that your agent provider includes the Microsoft build of Go.


### PR DESCRIPTION
Consolidates installation methods into a single markdown file with bullet links from the README.md and Migration Guide