### PR TITLE
Move fips140only.BackendApprovedHash to patch 0003

### DIFF
--- a/.github/workflows/patch-build.yml
+++ b/.github/workflows/patch-build.yml
@@ -53,8 +53,7 @@ jobs:
       - name: Build
         run: |
           set -x
-          # Don't build with the race detector. https://github.com/microsoft/go/issues/2204
-          pwsh eng/run.ps1 build -skipbuildrace
+          pwsh eng/run.ps1 build
           cd ${{ github.workspace }}/go/src
           ${{ github.workspace }}/go/bin/go mod vendor
           cd ${{ github.workspace }}/go/src/cmd

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -48,11 +48,12 @@ desired goexperiments and build tags.
  .../backend/internal/opensslsetup/stub.go     |   8 +
  src/crypto/internal/backend/nobackend.go      | 376 +++++++++++++++
  src/crypto/internal/backend/stub.s            |  10 +
+ .../internal/fips140only/fips140only.go       |  11 +-
  src/crypto/systemcrypto_nocgo_linux.go        |  18 +
  src/go/build/deps_test.go                     |  24 +-
  src/internal/buildcfg/exp.go                  |  47 ++
  src/runtime/runtime_boring.go                 |   5 +
- 43 files changed, 2754 insertions(+), 14 deletions(-)
+ 44 files changed, 2761 insertions(+), 17 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_darwin.go
  create mode 100644 src/crypto/internal/backend/backend_linux.go
@@ -3148,6 +3149,31 @@ index 00000000000000..5e4b436554d44d
 +// Having this assembly file keeps the go command
 +// from complaining about the missing body
 +// (because the implementation might be here).
+diff --git a/src/crypto/internal/fips140only/fips140only.go b/src/crypto/internal/fips140only/fips140only.go
+index a8d840b17022cc..2a17f7da2d4aaa 100644
+--- a/src/crypto/internal/fips140only/fips140only.go
++++ b/src/crypto/internal/fips140only/fips140only.go
+@@ -18,11 +18,18 @@ func Enforced() bool {
+ 	return fips140.Enforced()
+ }
+ 
++// BackendApprovedHash is set by a crypto backend during init to provide
++// backend-specific FIPS hash approval checking. If nil, only the standard
++// library FIPS hash types are recognized as approved.
++var BackendApprovedHash func(h hash.Hash) bool
++
+ func ApprovedHash(h hash.Hash) bool {
+ 	switch h.(type) {
+ 	case *sha256.Digest, *sha512.Digest, *sha3.Digest:
+ 		return true
+-	default:
+-		return false
+ 	}
++	if BackendApprovedHash != nil {
++		return BackendApprovedHash(h)
++	}
++	return false
+ }
 diff --git a/src/crypto/systemcrypto_nocgo_linux.go b/src/crypto/systemcrypto_nocgo_linux.go
 new file mode 100644
 index 00000000000000..7500bd3a86472b

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -49,7 +49,6 @@ Subject: [PATCH] Use crypto backends
  src/crypto/internal/cryptotest/hash.go        |   3 +-
  .../internal/cryptotest/implementations.go    |   2 +-
  src/crypto/internal/fips140hash/hash.go       |   3 +-
- .../internal/fips140only/fips140only.go       |  11 +-
  .../internal/fips140only/fips140only_test.go  |  45 ++--
  src/crypto/internal/fips140test/acvp_test.go  |   6 +
  src/crypto/internal/fips140test/cast_test.go  |   2 +
@@ -103,7 +102,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- 99 files changed, 1624 insertions(+), 246 deletions(-)
+ 98 files changed, 1617 insertions(+), 243 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -1758,31 +1757,6 @@ index 6d67ee8b3429a1..8f8d5937ea913c 100644
  
  // Unwrap returns h, or a crypto/internal/fips140 inner implementation of h.
  //
-diff --git a/src/crypto/internal/fips140only/fips140only.go b/src/crypto/internal/fips140only/fips140only.go
-index a8d840b17022cc..2a17f7da2d4aaa 100644
---- a/src/crypto/internal/fips140only/fips140only.go
-+++ b/src/crypto/internal/fips140only/fips140only.go
-@@ -18,11 +18,18 @@ func Enforced() bool {
- 	return fips140.Enforced()
- }
- 
-+// BackendApprovedHash is set by a crypto backend during init to provide
-+// backend-specific FIPS hash approval checking. If nil, only the standard
-+// library FIPS hash types are recognized as approved.
-+var BackendApprovedHash func(h hash.Hash) bool
-+
- func ApprovedHash(h hash.Hash) bool {
- 	switch h.(type) {
- 	case *sha256.Digest, *sha512.Digest, *sha3.Digest:
- 		return true
--	default:
--		return false
- 	}
-+	if BackendApprovedHash != nil {
-+		return BackendApprovedHash(h)
-+	}
-+	return false
- }
 diff --git a/src/crypto/internal/fips140only/fips140only_test.go b/src/crypto/internal/fips140only/fips140only_test.go
 index 96df536d56f345..91d2a792d90296 100644
 --- a/src/crypto/internal/fips140only/fips140only_test.go


### PR DESCRIPTION
fixes: https://github.com/microsoft/go/issues/2204

Patch 0003 references fips140only.BackendApprovedHash in backend_linux.go, backend_windows.go, and backend_darwin.go, but the BackendApprovedHash variable and the updated ApprovedHash function were only added to fips140only.go in patch 0004. This caused a build failure when building at the 0003 commit:

    # crypto/internal/backend
    crypto/internal/backend/backend_linux.go:44:14: undefined: fips140only.BackendApprovedHash

Move the fips140only.go hunk from patch 0004 into patch 0003 so the symbol exists when it is first used.