### PR TITLE
Test PR to exercise review: unrevendor backends

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -44,42 +44,43 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../github.com/golang-fips/openssl/v2/aes.go  |  157 ++
  .../golang-fips/openssl/v2/bbig/big.go        |   37 +
  .../github.com/golang-fips/openssl/v2/big.go  |   11 +
- .../openssl/v2/chacha20poly1305.go            |  151 +
- .../golang-fips/openssl/v2/cipher.go          |  662 +++++
+ .../openssl/v2/chacha20poly1305.go            |  149 +
+ .../golang-fips/openssl/v2/cipher.go          |  659 +++++
  .../golang-fips/openssl/v2/const.go           |   91 +
  .../golang-fips/openssl/v2/cshake.go          |  253 ++
  .../github.com/golang-fips/openssl/v2/des.go  |  112 +
- .../github.com/golang-fips/openssl/v2/dsa.go  |  305 ++
+ .../github.com/golang-fips/openssl/v2/dsa.go  |  308 +++
  .../github.com/golang-fips/openssl/v2/ec.go   |  136 +
- .../github.com/golang-fips/openssl/v2/ecdh.go |  340 +++
- .../golang-fips/openssl/v2/ecdsa.go           |  219 ++
+ .../github.com/golang-fips/openssl/v2/ecdh.go |  343 +++
+ .../golang-fips/openssl/v2/ecdsa.go           |  222 ++
  .../golang-fips/openssl/v2/ed25519.go         |  210 ++
  .../github.com/golang-fips/openssl/v2/evp.go  |  620 +++++
- .../github.com/golang-fips/openssl/v2/hash.go |  520 ++++
- .../github.com/golang-fips/openssl/v2/hkdf.go |  451 +++
- .../github.com/golang-fips/openssl/v2/hmac.go |  278 ++
+ .../github.com/golang-fips/openssl/v2/hash.go |  518 ++++
+ .../golang-fips/openssl/v2/hashclone.go       |   14 +
+ .../golang-fips/openssl/v2/hashclone_go125.go |    9 +
+ .../github.com/golang-fips/openssl/v2/hkdf.go |  455 ++++
+ .../github.com/golang-fips/openssl/v2/hmac.go |  282 ++
  .../openssl/v2/internal/fakecgo/abi_amd64.h   |   99 +
  .../openssl/v2/internal/fakecgo/abi_arm64.h   |   39 +
  .../openssl/v2/internal/fakecgo/abi_loong64.h |   60 +
  .../openssl/v2/internal/fakecgo/abi_ppc64x.h  |  195 ++
- .../openssl/v2/internal/fakecgo/abi_riscv64.h |   72 +
  .../openssl/v2/internal/fakecgo/asm_386.s     |   29 +
  .../openssl/v2/internal/fakecgo/asm_amd64.s   |   39 +
  .../openssl/v2/internal/fakecgo/asm_arm.s     |   52 +
  .../openssl/v2/internal/fakecgo/asm_arm64.s   |   36 +
  .../openssl/v2/internal/fakecgo/asm_loong64.s |   40 +
  .../openssl/v2/internal/fakecgo/asm_ppc64le.s |   82 +
- .../openssl/v2/internal/fakecgo/asm_riscv64.s |   37 +
+ .../openssl/v2/internal/fakecgo/asm_riscv64.s |   78 +
  .../openssl/v2/internal/fakecgo/asm_s390x.s   |   55 +
  .../openssl/v2/internal/fakecgo/callbacks.go  |   93 +
- .../openssl/v2/internal/fakecgo/fakecgo.go    |   14 +
+ .../openssl/v2/internal/fakecgo/fakecgo.go    |   29 +
  .../openssl/v2/internal/fakecgo/fakecgo.lock  |    3 +
  .../openssl/v2/internal/fakecgo/freebsd.go    |   27 +
  .../openssl/v2/internal/fakecgo/generate.go   |    3 +
  .../openssl/v2/internal/fakecgo/go_darwin.go  |   88 +
- .../openssl/v2/internal/fakecgo/go_freebsd.go |   79 +
+ .../openssl/v2/internal/fakecgo/go_freebsd.go |  100 +
  .../openssl/v2/internal/fakecgo/go_libinit.go |   72 +
- .../openssl/v2/internal/fakecgo/go_linux.go   |   79 +
+ .../openssl/v2/internal/fakecgo/go_linux.go   |  100 +
  .../openssl/v2/internal/fakecgo/go_setenv.go  |   18 +
  .../openssl/v2/internal/fakecgo/go_util.go    |   38 +
  .../openssl/v2/internal/fakecgo/iscgo.go      |   19 +
@@ -87,31 +88,31 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../v2/internal/fakecgo/libcgo_darwin.go      |   26 +
  .../v2/internal/fakecgo/libcgo_freebsd.go     |   20 +
  .../v2/internal/fakecgo/libcgo_linux.go       |   20 +
- .../openssl/v2/internal/fakecgo/linux.go      |  184 ++
+ .../openssl/v2/internal/fakecgo/linux.go      |   34 +
  .../openssl/v2/internal/fakecgo/setenv.go     |   19 +
- .../v2/internal/fakecgo/trampolines_386.s     |  121 +
+ .../v2/internal/fakecgo/trampolines_386.s     |  107 +
  .../v2/internal/fakecgo/trampolines_amd64.s   |  107 +
- .../v2/internal/fakecgo/trampolines_arm.s     |  122 +
- .../v2/internal/fakecgo/trampolines_arm64.s   |   81 +
- .../internal/fakecgo/trampolines_linux_386.s  |   78 +
- .../fakecgo/trampolines_linux_amd64.s         |   69 +
- .../internal/fakecgo/trampolines_linux_arm.s  |   69 +
- .../fakecgo/trampolines_linux_arm64.s         |   60 +
- .../fakecgo/trampolines_linux_loong64.s       |   60 +
- .../fakecgo/trampolines_linux_ppc64le.s       |   69 +
- .../fakecgo/trampolines_linux_riscv64.s       |   60 +
- .../fakecgo/trampolines_linux_s390x.s         |   53 +
- .../v2/internal/fakecgo/trampolines_loong64.s |   78 +
- .../v2/internal/fakecgo/trampolines_ppc64le.s |  128 +
- .../v2/internal/fakecgo/trampolines_riscv64.s |   76 +
- .../v2/internal/fakecgo/trampolines_s390x.s   |  154 ++
+ .../v2/internal/fakecgo/trampolines_arm.s     |   81 +
+ .../v2/internal/fakecgo/trampolines_arm64.s   |   84 +
+ .../v2/internal/fakecgo/trampolines_loong64.s |   88 +
+ .../v2/internal/fakecgo/trampolines_ppc64le.s |  227 ++
+ .../v2/internal/fakecgo/trampolines_riscv64.s |   72 +
+ .../v2/internal/fakecgo/trampolines_s390x.s   |  163 ++
  .../openssl/v2/internal/fakecgo/zsymbols.go   |  165 ++
  .../v2/internal/fakecgo/zsymbols_darwin.go    |   59 +
  .../v2/internal/fakecgo/zsymbols_freebsd.go   |   48 +
- .../v2/internal/fakecgo/zsymbols_linux.go     |  158 ++
+ .../v2/internal/fakecgo/zsymbols_linux.go     |  294 ++
  .../v2/internal/fakecgo/ztrampolines_darwin.s |   19 +
  .../internal/fakecgo/ztrampolines_freebsd.s   |   16 +
- .../v2/internal/fakecgo/ztrampolines_linux.s  |   46 +
+ .../v2/internal/fakecgo/ztrampolines_linux.s  |   16 +
+ .../internal/fakecgo/ztrampolines_linux_386.s |  110 +
+ .../fakecgo/ztrampolines_linux_amd64.s        |  102 +
+ .../internal/fakecgo/ztrampolines_linux_arm.s |   74 +
+ .../fakecgo/ztrampolines_linux_arm64.s        |   93 +
+ .../fakecgo/ztrampolines_linux_loong64.s      |   92 +
+ .../fakecgo/ztrampolines_linux_ppc64le.s      |  101 +
+ .../fakecgo/ztrampolines_linux_riscv64.s      |   92 +
+ .../fakecgo/ztrampolines_linux_s390x.s        |   90 +
  .../v2/internal/fakecgo/ztrampolines_stubs.s  |   55 +
  .../openssl/v2/internal/ossl/asm_386.s        |   98 +
  .../openssl/v2/internal/ossl/asm_amd64.s      |  120 +
@@ -135,14 +136,15 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../v2/internal/ossl/syscall_nocgo_unix.go    |   20 +
  .../v2/internal/ossl/syscall_nocgo_windows.go |   22 +
  .../openssl/v2/internal/ossl/zdl.s            |   55 +
- .../openssl/v2/internal/ossl/zdl_nocgo.go     |   58 +
- .../openssl/v2/internal/ossl/zossl.c          | 2054 ++++++++++++++
+ .../openssl/v2/internal/ossl/zdl_nocgo.go     |   45 +
+ .../openssl/v2/internal/ossl/zossl.c          | 2056 ++++++++++++++
  .../openssl/v2/internal/ossl/zossl.go         |   67 +
  .../openssl/v2/internal/ossl/zossl.h          |  363 +++
- .../openssl/v2/internal/ossl/zossl_cgo.go     | 1486 ++++++++++
- .../openssl/v2/internal/ossl/zossl_nocgo.go   | 2450 +++++++++++++++++
- .../golang-fips/openssl/v2/mlkem.go           |  365 +++
- .../golang-fips/openssl/v2/openssl.go         |  244 ++
+ .../openssl/v2/internal/ossl/zossl_cgo.go     | 1368 ++++++++++
+ .../v2/internal/ossl/zossl_cgo_go124.go       |   45 +
+ .../openssl/v2/internal/ossl/zossl_nocgo.go   | 2390 +++++++++++++++++
+ .../golang-fips/openssl/v2/mlkem.go           |  371 +++
+ .../golang-fips/openssl/v2/openssl.go         |  253 ++
  .../golang-fips/openssl/v2/openssl_cgo.go     |   16 +
  .../golang-fips/openssl/v2/openssl_nocgo.go   |   32 +
  .../golang-fips/openssl/v2/osslsetup/fips.go  |  165 ++
@@ -153,14 +155,14 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../openssl/v2/osslsetup/osslsetup.go         |   74 +
  .../openssl/v2/osslsetup/osslsetup_cgo.go     |   11 +
  .../openssl/v2/osslsetup/osslsetup_nocgo.go   |   21 +
- .../golang-fips/openssl/v2/params.go          |  180 ++
+ .../golang-fips/openssl/v2/params.go          |  184 ++
  .../golang-fips/openssl/v2/pbkdf2.go          |   54 +
  .../golang-fips/openssl/v2/provideropenssl.go |  239 ++
  .../openssl/v2/providersymcrypt.go            |  330 +++
  .../github.com/golang-fips/openssl/v2/rand.go |   21 +
  .../github.com/golang-fips/openssl/v2/rc4.go  |   68 +
- .../github.com/golang-fips/openssl/v2/rsa.go  |  711 +++++
- .../golang-fips/openssl/v2/tls1prf.go         |  156 ++
+ .../github.com/golang-fips/openssl/v2/rsa.go  |  714 +++++
+ .../golang-fips/openssl/v2/tls1prf.go         |  158 ++
  .../github.com/golang-fips/openssl/v2/zaes.go |   86 +
  .../microsoft/go-crypto-darwin/LICENSE        |   21 +
  .../microsoft/go-crypto-darwin/bbig/big.go    |   31 +
@@ -170,9 +172,10 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/commoncrypto/zcommoncrypto.c     |   47 +
  .../internal/commoncrypto/zcommoncrypto.go    |   50 +
  .../internal/commoncrypto/zcommoncrypto.h     |   69 +
- .../internal/commoncrypto/zcommoncrypto.s     |   76 +
- .../commoncrypto/zcommoncrypto_cgo.go         |   64 +
- .../commoncrypto/zcommoncrypto_nocgo.go       |  102 +
+ .../internal/commoncrypto/zcommoncrypto.s     |   74 +
+ .../commoncrypto/zcommoncrypto_cgo.go         |   60 +
+ .../commoncrypto/zcommoncrypto_go124.go       |   11 +
+ .../commoncrypto/zcommoncrypto_nocgo.go       |   89 +
  .../internal/cryptokit/CryptoKit_amd64.syso   |  Bin 0 -> 176512 bytes
  .../internal/cryptokit/CryptoKit_arm64.syso   |  Bin 0 -> 169880 bytes
  .../internal/cryptokit/cryptokit.go           |    8 +
@@ -181,9 +184,10 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/cryptokit/syscall_nocgo.go       |   15 +
  .../internal/cryptokit/zcryptokit.c           |  262 ++
  .../internal/cryptokit/zcryptokit.h           |   66 +
- .../internal/cryptokit/zcryptokit.s           |  334 +++
- .../internal/cryptokit/zcryptokit_cgo.go      |  320 +++
- .../internal/cryptokit/zcryptokit_nocgo.go    |  364 +++
+ .../internal/cryptokit/zcryptokit.s           |  332 +++
+ .../internal/cryptokit/zcryptokit_cgo.go      |  220 ++
+ .../cryptokit/zcryptokit_cgo_go124.go         |   78 +
+ .../internal/cryptokit/zcryptokit_nocgo.go    |  351 +++
  .../cryptokit/zcryptokit_swift_amd64.go       |  283 ++
  .../cryptokit/zcryptokit_swift_arm64.go       |  282 ++
  .../internal/fakecgo/abi_amd64.h              |   99 +
@@ -203,7 +207,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/fakecgo/libcgo_darwin.go         |   26 +
  .../internal/fakecgo/setenv.go                |   19 +
  .../internal/fakecgo/trampolines_amd64.s      |  107 +
- .../internal/fakecgo/trampolines_arm64.s      |   81 +
+ .../internal/fakecgo/trampolines_arm64.s      |   84 +
  .../internal/fakecgo/zsymbols.go              |  165 ++
  .../internal/fakecgo/zsymbols_darwin.go       |   59 +
  .../internal/fakecgo/ztrampolines_darwin.s    |   19 +
@@ -214,15 +218,21 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/security/zsecurity.c             |  127 +
  .../internal/security/zsecurity.go            |   21 +
  .../internal/security/zsecurity.h             |   98 +
- .../internal/security/zsecurity.s             |  172 ++
- .../internal/security/zsecurity_cgo.go        |  388 +++
- .../internal/security/zsecurity_nocgo.go      |  466 ++++
+ .../internal/security/zsecurity.s             |  170 ++
+ .../internal/security/zsecurity_cgo.go        |  368 +++
+ .../internal/security/zsecurity_cgo_go124.go  |   14 +
+ .../internal/security/zsecurity_go124.go      |   13 +
+ .../internal/security/zsecurity_nocgo.go      |  453 ++++
  .../internal/xsyscall/asm_amd64.s             |  120 +
  .../internal/xsyscall/asm_arm64.s             |   97 +
- .../internal/xsyscall/syscall_nocgo.go        |   72 +
- .../internal/xsyscall/syscall_nocgo_darwin.go |   10 +
+ .../go-crypto-darwin/internal/xsyscall/dl.h   |   15 +
+ .../internal/xsyscall/syscall_nocgo.go        |   88 +
+ .../internal/xsyscall/syscall_nocgo_darwin.go |   25 +
  .../internal/xsyscall/syscall_nocgo_others.go |   14 +
- .../microsoft/go-crypto-darwin/xcrypto/aes.go |  152 +
+ .../internal/xsyscall/xsyscall.go             |    6 +
+ .../go-crypto-darwin/internal/xsyscall/zdl.s  |   56 +
+ .../internal/xsyscall/zdl_nocgo.go            |   48 +
+ .../microsoft/go-crypto-darwin/xcrypto/aes.go |  152 ++
  .../microsoft/go-crypto-darwin/xcrypto/big.go |   16 +
  .../xcrypto/chacha20poly1305.go               |   88 +
  .../go-crypto-darwin/xcrypto/cipher.go        |  114 +
@@ -233,7 +243,9 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go-crypto-darwin/xcrypto/ed25519.go       |  124 +
  .../microsoft/go-crypto-darwin/xcrypto/evp.go |  339 +++
  .../microsoft/go-crypto-darwin/xcrypto/gcm.go |  218 ++
- .../go-crypto-darwin/xcrypto/hash.go          |  337 +++
+ .../go-crypto-darwin/xcrypto/hash.go          |  335 +++
+ .../go-crypto-darwin/xcrypto/hashclone.go     |   17 +
+ .../xcrypto/hashclone_go125.go                |   12 +
  .../go-crypto-darwin/xcrypto/hkdf.go          |  103 +
  .../go-crypto-darwin/xcrypto/hmac.go          |  119 +
  .../go-crypto-darwin/xcrypto/mlkem.go         |  261 ++
@@ -252,7 +264,9 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/dsa.go  |  465 ++++
  .../microsoft/go-crypto-winnative/cng/ecdh.go |  255 ++
  .../go-crypto-winnative/cng/ecdsa.go          |  169 ++
- .../microsoft/go-crypto-winnative/cng/hash.go |  344 +++
+ .../microsoft/go-crypto-winnative/cng/hash.go |  342 +++
+ .../go-crypto-winnative/cng/hashclone.go      |   18 +
+ .../cng/hashclone_go125.go                    |   13 +
  .../microsoft/go-crypto-winnative/cng/hkdf.go |  133 +
  .../microsoft/go-crypto-winnative/cng/hmac.go |   70 +
  .../microsoft/go-crypto-winnative/cng/keys.go |  220 ++
@@ -269,7 +283,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 261 files changed, 34032 insertions(+), 7 deletions(-)
+ 275 files changed, 34387 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -311,13 +325,14 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/evp.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/hash.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/hashclone.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/hashclone_go125.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/hmac.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_amd64.h
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_arm64.h
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_loong64.h
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_ppc64x.h
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_riscv64.h
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_386.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_amd64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_arm.s
@@ -348,14 +363,6 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_amd64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_386.s
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_amd64.s
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_arm.s
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_arm64.s
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_loong64.s
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_ppc64le.s
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_riscv64.s
- create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_s390x.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_loong64.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_ppc64le.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_riscv64.s
@@ -367,6 +374,14 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_darwin.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_freebsd.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_386.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_amd64.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_arm.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_arm64.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_loong64.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_ppc64le.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_riscv64.s
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_s390x.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_stubs.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_386.s
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/asm_amd64.s
@@ -395,6 +410,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.h
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo.go
+ create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo_go124.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_nocgo.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/mlkem.go
  create mode 100644 src/vendor/github.com/golang-fips/openssl/v2/openssl.go
@@ -427,6 +443,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto.h
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_cgo.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_go124.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_nocgo.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/CryptoKit_amd64.syso
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/CryptoKit_arm64.syso
@@ -438,6 +455,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit.h
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_cgo.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_cgo_go124.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_nocgo.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_swift_amd64.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_swift_arm64.go
@@ -471,12 +489,18 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity.h
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_cgo.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_cgo_go124.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_go124.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_nocgo.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_amd64.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/asm_arm64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/dl.h
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_darwin.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_others.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl_nocgo.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/aes.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/big.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/chacha20poly1305.go
@@ -489,6 +513,8 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/evp.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/gcm.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hash.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hashclone.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hashclone_go125.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hkdf.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hmac.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/mlkem.go
@@ -508,6 +534,8 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdh.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/ecdsa.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/hashclone.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/hashclone_go125.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/hmac.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/keys.go
@@ -2197,7 +2225,7 @@ index 00000000000000..ae4055d2d71303
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index d6c515017a7009..17efde8b19a412 100644
+index d6c515017a7009..348650059a4497 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2206,21 +2234,21 @@ index d6c515017a7009..17efde8b19a412 100644
  )
 +
 +require (
-+	github.com/golang-fips/openssl/v2 v2.0.4-0.20260317100950-3fc1e29e8efb
-+	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260317085126-9a7217034974
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20260307231751-f82d13314c5c
++	github.com/golang-fips/openssl/v2 v2.0.4-0.20260224093412-4123abe33e35
++	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260224094848-e322614384c3
++	github.com/microsoft/go-crypto-winnative v0.0.0-20260224091131-eabf5d4ea9cb
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 2223d2a7c231c1..0f168e2048a2e2 100644
+index 2223d2a7c231c1..55a77ae199a9af 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20260317100950-3fc1e29e8efb h1:FMUkmY3tU9zypzAzwdQvFg1sKM4kXcUKz+GkR/X6Im8=
-+github.com/golang-fips/openssl/v2 v2.0.4-0.20260317100950-3fc1e29e8efb/go.mod h1:E+yPtdllHdy5S8YLMfcIRcqjqQySyiexqxxaLK7+cQQ=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20260317085126-9a7217034974 h1:HdIFLjjkXB3AJ7cXjVynU+69l96flEVAlOwonfXVFqM=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20260317085126-9a7217034974/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260307231751-f82d13314c5c h1:kHYNsP4g/LehejM+7p42t1ZQWlV/HJBwwjCE7SwFBKo=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260307231751-f82d13314c5c/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20260224093412-4123abe33e35 h1:SCC2CxzMO45+PyZ4wVN/pUqjjH6BSznbMuSDmIBoV6w=
++github.com/golang-fips/openssl/v2 v2.0.4-0.20260224093412-4123abe33e35/go.mod h1:EtVnMfLGkB4pihGOH+tXEV0WlXxewWdT1n3GLJEHvpw=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20260224094848-e322614384c3 h1:yV7XVN+idaUMe3FrnP72MJt6swY7inyE/a5lusmVuuA=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20260224094848-e322614384c3/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260224091131-eabf5d4ea9cb h1:i7oTrN4NEokm433J/M8EfxiSm/W0feEPtLZ62YzePtQ=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260224091131-eabf5d4ea9cb/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
  golang.org/x/crypto v0.47.1-0.20260113154411-7d0074ccc6f1 h1:peTBrYsTa5Rr+jB2pbgd7X08cFAun6ME4So3jfEkYL4=
  golang.org/x/crypto v0.47.1-0.20260113154411-7d0074ccc6f1/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
  golang.org/x/net v0.49.1-0.20260122225915-f2078620ee33 h1:pNHjOZ0w6qb8R9EDmEsBXmV4o2YKLvtRiEk4q5gN5Hg=
@@ -2685,10 +2713,10 @@ index 00000000000000..6461f241f863fc
 +type BigInt []uint
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/chacha20poly1305.go b/src/vendor/github.com/golang-fips/openssl/v2/chacha20poly1305.go
 new file mode 100644
-index 00000000000000..789076408c515b
+index 00000000000000..29f9ecc6e2f1fa
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/chacha20poly1305.go
-@@ -0,0 +1,151 @@
+@@ -0,0 +1,149 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -2766,18 +2794,17 @@ index 00000000000000..789076408c515b
 +	}
 +	if len(additionalData) > 0 {
 +		var discard int32
-+		if _, err := ossl.EVP_EncryptUpdate(ctx, nil, &discard, additionalData); err != nil {
++		if _, err := ossl.EVP_EncryptUpdate(ctx, nil, &discard, base(additionalData), int32(len(additionalData))); err != nil {
 +			panic(err)
 +		}
 +	}
 +	var outl int32
 +	if len(plaintext) > 0 {
-+		if _, err := ossl.EVP_EncryptUpdate(ctx, out, &outl, plaintext); err != nil {
++		if _, err := ossl.EVP_EncryptUpdate(ctx, base(out), &outl, base(plaintext), int32(len(plaintext))); err != nil {
 +			panic(err)
 +		}
 +	}
-+	var discard int32
-+	if _, err := ossl.EVP_EncryptFinal_ex(ctx, out[outl:], &discard); err != nil {
++	if _, err := ossl.EVP_EncryptFinal_ex(ctx, base(out[outl:]), &outl); err != nil {
 +		panic(err)
 +	}
 +	tag := out[len(out)-chacha20Poly1305Overhead:]
@@ -2823,18 +2850,17 @@ index 00000000000000..789076408c515b
 +	}
 +	if len(additionalData) > 0 {
 +		var discard int32
-+		if _, err := ossl.EVP_DecryptUpdate(ctx, nil, &discard, additionalData); err != nil {
++		if _, err := ossl.EVP_DecryptUpdate(ctx, nil, &discard, base(additionalData), int32(len(additionalData))); err != nil {
 +			return nil, err
 +		}
 +	}
 +	var outl int32
 +	if len(ciphertext) > 0 {
-+		if _, err := ossl.EVP_DecryptUpdate(ctx, out, &outl, ciphertext); err != nil {
++		if _, err := ossl.EVP_DecryptUpdate(ctx, base(out), &outl, base(ciphertext), int32(len(ciphertext))); err != nil {
 +			return nil, err
 +		}
 +	}
-+	var discard int32
-+	if _, err := ossl.EVP_DecryptFinal_ex(ctx, out[outl:], &discard); err != nil {
++	if _, err := ossl.EVP_DecryptFinal_ex(ctx, base(out[outl:]), &outl); err != nil {
 +		return nil, errOpen
 +	}
 +	runtime.KeepAlive(c)
@@ -2842,10 +2868,10 @@ index 00000000000000..789076408c515b
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cipher.go b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
 new file mode 100644
-index 00000000000000..228b023453b3d3
+index 00000000000000..3bcd7538d95f05
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cipher.go
-@@ -0,0 +1,662 @@
+@@ -0,0 +1,659 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -3033,7 +3059,7 @@ index 00000000000000..228b023453b3d3
 +	defer ossl.EVP_CIPHER_CTX_free(enc_ctx)
 +
 +	var outl int32
-+	if _, err := ossl.EVP_EncryptUpdate(enc_ctx, dst[:c.blockSize], &outl, src[:c.blockSize]); err != nil {
++	if _, err := ossl.EVP_EncryptUpdate(enc_ctx, base(dst), &outl, base(src), int32(c.blockSize)); err != nil {
 +		return err
 +	}
 +	runtime.KeepAlive(c)
@@ -3063,7 +3089,7 @@ index 00000000000000..228b023453b3d3
 +	}
 +
 +	var outl int32
-+	ossl.EVP_DecryptUpdate(dec_ctx, dst[:c.blockSize], &outl, src[:c.blockSize])
++	ossl.EVP_DecryptUpdate(dec_ctx, base(dst), &outl, base(src), int32(c.blockSize))
 +	runtime.KeepAlive(c)
 +	return nil
 +}
@@ -3091,7 +3117,7 @@ index 00000000000000..228b023453b3d3
 +	}
 +	if len(src) > 0 {
 +		var outl int32
-+		if _, err := ossl.EVP_CipherUpdate(x.ctx, dst, &outl, src); err != nil {
++		if _, err := ossl.EVP_CipherUpdate(x.ctx, base(dst), &outl, base(src), int32(len(src))); err != nil {
 +			panic("crypto/cipher: " + err.Error())
 +		}
 +		runtime.KeepAlive(x)
@@ -3135,7 +3161,7 @@ index 00000000000000..228b023453b3d3
 +		return
 +	}
 +	var outl int32
-+	if _, err := ossl.EVP_EncryptUpdate(x.ctx, dst, &outl, src); err != nil {
++	if _, err := ossl.EVP_EncryptUpdate(x.ctx, base(dst), &outl, base(src), int32(len(src))); err != nil {
 +		panic("crypto/cipher: " + err.Error())
 +	}
 +	runtime.KeepAlive(x)
@@ -3315,17 +3341,16 @@ index 00000000000000..228b023453b3d3
 +		panic(err)
 +	}
 +	var outl, discard int32
-+	if _, err := ossl.EVP_EncryptUpdate(ctx, nil, &discard, sliceNeverNil(aad)); err != nil {
++	if _, err := ossl.EVP_EncryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), int32(len(aad))); err != nil {
 +		panic(err)
 +	}
-+	if _, err := ossl.EVP_EncryptUpdate(ctx, out, &outl, sliceNeverNil(plaintext)); err != nil {
++	if _, err := ossl.EVP_EncryptUpdate(ctx, base(out), &outl, baseNeverEmpty(plaintext), int32(len(plaintext))); err != nil {
 +		panic(err)
 +	}
 +	if len(plaintext) != int(outl) {
 +		panic("cipher: incorrect length returned from GCM EncryptUpdate")
 +	}
-+	discard = 0
-+	if _, err := ossl.EVP_EncryptFinal_ex(ctx, out[outl:], &discard); err != nil {
++	if _, err := ossl.EVP_EncryptFinal_ex(ctx, base(out[outl:]), &discard); err != nil {
 +		panic(err)
 +	}
 +	if _, err := ossl.EVP_CIPHER_CTX_ctrl(ctx, ossl.EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(base(out[outl:]))); err != nil {
@@ -3367,17 +3392,16 @@ index 00000000000000..228b023453b3d3
 +		panic(err)
 +	}
 +	var outl, discard int32
-+	if _, err := ossl.EVP_EncryptUpdate(ctx, nil, &discard, sliceNeverNil(aad)); err != nil {
++	if _, err := ossl.EVP_EncryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), int32(len(aad))); err != nil {
 +		panic(err)
 +	}
-+	if _, err := ossl.EVP_EncryptUpdate(ctx, out, &outl, sliceNeverNil(plaintext)); err != nil {
++	if _, err := ossl.EVP_EncryptUpdate(ctx, base(out), &outl, baseNeverEmpty(plaintext), int32(len(plaintext))); err != nil {
 +		panic(err)
 +	}
 +	if len(plaintext) != int(outl) {
 +		panic("cipher: incorrect length returned from GCM EncryptUpdate")
 +	}
-+	discard = 0
-+	if _, err := ossl.EVP_EncryptFinal_ex(ctx, out[outl:], &discard); err != nil {
++	if _, err := ossl.EVP_EncryptFinal_ex(ctx, base(out[outl:]), &discard); err != nil {
 +		panic(err)
 +	}
 +	if _, err := ossl.EVP_CIPHER_CTX_ctrl(ctx, ossl.EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(base(out[outl:]))); err != nil {
@@ -3432,17 +3456,16 @@ index 00000000000000..228b023453b3d3
 +		return nil, errOpen
 +	}
 +	var outl, discard int32
-+	if _, err := ossl.EVP_DecryptUpdate(ctx, nil, &discard, sliceNeverNil(aad)); err != nil {
++	if _, err := ossl.EVP_DecryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), int32(len(aad))); err != nil {
 +		return nil, errOpen
 +	}
-+	if _, err := ossl.EVP_DecryptUpdate(ctx, out, &outl, sliceNeverNil(ciphertext)); err != nil {
++	if _, err := ossl.EVP_DecryptUpdate(ctx, base(out), &outl, baseNeverEmpty(ciphertext), int32(len(ciphertext))); err != nil {
 +		return nil, errOpen
 +	}
 +	if len(ciphertext) != int(outl) {
 +		return nil, errOpen
 +	}
-+	discard = 0
-+	if _, err := ossl.EVP_DecryptFinal_ex(ctx, out[outl:], &discard); err != nil {
++	if _, err := ossl.EVP_DecryptFinal_ex(ctx, base(out[outl:]), &discard); err != nil {
 +		return nil, errOpen
 +	}
 +	runtime.KeepAlive(g)
@@ -3607,7 +3630,7 @@ index 00000000000000..e4f8f5b5d0c4a7
 +)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/cshake.go b/src/vendor/github.com/golang-fips/openssl/v2/cshake.go
 new file mode 100644
-index 00000000000000..c9fd5e5ad8d25c
+index 00000000000000..9ae41b4f5990b8
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/cshake.go
 @@ -0,0 +1,253 @@
@@ -3643,7 +3666,7 @@ index 00000000000000..c9fd5e5ad8d25c
 +	if _, err := ossl.EVP_DigestUpdate(ctx, data); err != nil {
 +		panic(err)
 +	}
-+	if _, err := ossl.EVP_DigestFinalXOF(ctx, out); err != nil {
++	if _, err := ossl.EVP_DigestFinalXOF(ctx, out, len(out)); err != nil {
 +		panic(err)
 +	}
 +}
@@ -3984,10 +4007,10 @@ index 00000000000000..772800a73e3389
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/dsa.go b/src/vendor/github.com/golang-fips/openssl/v2/dsa.go
 new file mode 100644
-index 00000000000000..63e2e63851fc7b
+index 00000000000000..24ba60258c3b23
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/dsa.go
-@@ -0,0 +1,305 @@
+@@ -0,0 +1,308 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -4236,7 +4259,10 @@ index 00000000000000..63e2e63851fc7b
 +func newDSA3(params DSAParameters, x, y BigInt) (ossl.EVP_PKEY_PTR, error) {
 +	checkMajorVersion(3)
 +
-+	bld := newParamBuilder()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return nil, err
++	}
 +	defer bld.finalize()
 +
 +	bld.addBigInt(_OSSL_PKEY_PARAM_FFC_P, params.P, false)
@@ -4295,7 +4321,7 @@ index 00000000000000..63e2e63851fc7b
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ec.go b/src/vendor/github.com/golang-fips/openssl/v2/ec.go
 new file mode 100644
-index 00000000000000..ea9587b5678add
+index 00000000000000..ad74a4b2038e59
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ec.go
 @@ -0,0 +1,136 @@
@@ -4387,13 +4413,13 @@ index 00000000000000..ea9587b5678add
 +// encodeEcPoint encodes pt.
 +func encodeEcPoint(group ossl.EC_GROUP_PTR, pt ossl.EC_POINT_PTR) ([]byte, error) {
 +	// Get encoded point size.
-+	n, err := ossl.EC_POINT_point2oct(group, pt, ossl.POINT_CONVERSION_UNCOMPRESSED, nil, nil)
++	n, err := ossl.EC_POINT_point2oct(group, pt, ossl.POINT_CONVERSION_UNCOMPRESSED, nil, 0, nil)
 +	if err != nil {
 +		return nil, err
 +	}
 +	// Encode point into bytes.
 +	bytes := make([]byte, n)
-+	if _, err = ossl.EC_POINT_point2oct(group, pt, ossl.POINT_CONVERSION_UNCOMPRESSED, bytes, nil); err != nil {
++	if _, err = ossl.EC_POINT_point2oct(group, pt, ossl.POINT_CONVERSION_UNCOMPRESSED, base(bytes), n, nil); err != nil {
 +		return nil, err
 +	}
 +	return bytes, nil
@@ -4416,7 +4442,7 @@ index 00000000000000..ea9587b5678add
 +
 +func extractPKEYRawPublic(pkey ossl.EVP_PKEY_PTR, pub []byte) error {
 +	keylen := len(pub)
-+	if _, err := ossl.EVP_PKEY_get_raw_public_key(pkey, pub, &keylen); err != nil {
++	if _, err := ossl.EVP_PKEY_get_raw_public_key(pkey, base(pub), &keylen); err != nil {
 +		return err
 +	}
 +	if keylen != len(pub) {
@@ -4427,7 +4453,7 @@ index 00000000000000..ea9587b5678add
 +
 +func extractPKEYRawPrivate(pkey ossl.EVP_PKEY_PTR, pub []byte) error {
 +	keylen := len(pub)
-+	if _, err := ossl.EVP_PKEY_get_raw_private_key(pkey, pub, &keylen); err != nil {
++	if _, err := ossl.EVP_PKEY_get_raw_private_key(pkey, base(pub), &keylen); err != nil {
 +		return err
 +	}
 +	if keylen != len(pub) {
@@ -4437,10 +4463,10 @@ index 00000000000000..ea9587b5678add
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ecdh.go b/src/vendor/github.com/golang-fips/openssl/v2/ecdh.go
 new file mode 100644
-index 00000000000000..65f669a6f77156
+index 00000000000000..303ce47cab30a5
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ecdh.go
-@@ -0,0 +1,340 @@
+@@ -0,0 +1,343 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -4574,9 +4600,9 @@ index 00000000000000..65f669a6f77156
 +func newECDHPkey(curve string, bytes []byte, isPrivate bool) (ossl.EVP_PKEY_PTR, error) {
 +	if curve == "X25519" {
 +		if isPrivate {
-+			return ossl.EVP_PKEY_new_raw_private_key(ossl.EVP_PKEY_X25519, nil, bytes)
++			return ossl.EVP_PKEY_new_raw_private_key(ossl.EVP_PKEY_X25519, nil, base(bytes), len(bytes))
 +		} else {
-+			return ossl.EVP_PKEY_new_raw_public_key(ossl.EVP_PKEY_X25519, nil, bytes)
++			return ossl.EVP_PKEY_new_raw_public_key(ossl.EVP_PKEY_X25519, nil, base(bytes), len(bytes))
 +		}
 +	}
 +	nid := curveNID(curve)
@@ -4604,7 +4630,7 @@ index 00000000000000..65f669a6f77156
 +	}()
 +	group := ossl.EC_KEY_get0_group(key)
 +	if isPrivate {
-+		priv, err := ossl.BN_bin2bn(bytes, nil)
++		priv, err := ossl.BN_bin2bn(base(bytes), int32(len(bytes)), nil)
 +		if err != nil {
 +			return nil, err
 +		}
@@ -4626,7 +4652,7 @@ index 00000000000000..65f669a6f77156
 +			return nil, err
 +		}
 +		defer ossl.EC_POINT_free(pub)
-+		if _, err := ossl.EC_POINT_oct2point(group, pub, bytes, nil); err != nil {
++		if _, err := ossl.EC_POINT_oct2point(group, pub, base(bytes), len(bytes), nil); err != nil {
 +			return nil, err
 +		}
 +		if _, err := ossl.EC_KEY_set_public_key(key, pub); err != nil {
@@ -4647,12 +4673,15 @@ index 00000000000000..65f669a6f77156
 +func newECDHPkey3(nid int32, bytes []byte, isPrivate bool) (ossl.EVP_PKEY_PTR, error) {
 +	checkMajorVersion(3)
 +
-+	bld := newParamBuilder()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return nil, err
++	}
 +	defer bld.finalize()
 +	bld.addUTF8String(_OSSL_PKEY_PARAM_GROUP_NAME, ossl.OBJ_nid2sn(nid), 0)
 +	var selection int32
 +	if isPrivate {
-+		priv, err := ossl.BN_bin2bn(bytes, nil)
++		priv, err := ossl.BN_bin2bn(base(bytes), int32(len(bytes)), nil)
 +		if err != nil {
 +			return nil, err
 +		}
@@ -4722,7 +4751,7 @@ index 00000000000000..65f669a6f77156
 +		return nil, err
 +	}
 +	out := make([]byte, keylen)
-+	if _, err := ossl.EVP_PKEY_derive(ctx, out, &keylen); err != nil {
++	if _, err := ossl.EVP_PKEY_derive(ctx, base(out), &keylen); err != nil {
 +		return nil, err
 +	}
 +	return out, nil
@@ -4743,7 +4772,7 @@ index 00000000000000..65f669a6f77156
 +	if curve == "X25519" {
 +		bytes = make([]byte, privateKeySizeX25519)
 +		keylen := len(bytes)
-+		if _, err := ossl.EVP_PKEY_get_raw_private_key(pkey, bytes, &keylen); err != nil {
++		if _, err := ossl.EVP_PKEY_get_raw_private_key(pkey, base(bytes), &keylen); err != nil {
 +			return nil, nil, err
 +		}
 +	} else {
@@ -4783,10 +4812,10 @@ index 00000000000000..65f669a6f77156
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go b/src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go
 new file mode 100644
-index 00000000000000..3157d02967aeb2
+index 00000000000000..d0c29b5b821f92
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ecdsa.go
-@@ -0,0 +1,219 @@
+@@ -0,0 +1,222 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -4988,7 +5017,10 @@ index 00000000000000..3157d02967aeb2
 +		return nil, err
 +	}
 +	// Construct the parameters.
-+	bld := newParamBuilder()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return nil, err
++	}
 +	defer bld.finalize()
 +	bld.addUTF8String(_OSSL_PKEY_PARAM_GROUP_NAME, ossl.OBJ_nid2sn(nid), 0)
 +	bld.addOctetString(_OSSL_PKEY_PARAM_PUB_KEY, pubBytes)
@@ -5008,7 +5040,7 @@ index 00000000000000..3157d02967aeb2
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go b/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
 new file mode 100644
-index 00000000000000..dc0060972d3e2a
+index 00000000000000..8377d7495e0731
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/ed25519.go
 @@ -0,0 +1,210 @@
@@ -5143,7 +5175,7 @@ index 00000000000000..dc0060972d3e2a
 +	if len(pub) != publicKeySizeEd25519 {
 +		panic("ed25519: bad public key length: " + strconv.Itoa(len(pub)))
 +	}
-+	pkey, err := ossl.EVP_PKEY_new_raw_public_key(ossl.EVP_PKEY_ED25519, nil, pub)
++	pkey, err := ossl.EVP_PKEY_new_raw_public_key(ossl.EVP_PKEY_ED25519, nil, base(pub), len(pub))
 +	if err != nil {
 +		return nil, err
 +	}
@@ -5159,7 +5191,7 @@ index 00000000000000..dc0060972d3e2a
 +	if len(seed) != seedSizeEd25519 {
 +		panic("ed25519: bad seed length: " + strconv.Itoa(len(seed)))
 +	}
-+	pkey, err := ossl.EVP_PKEY_new_raw_private_key(ossl.EVP_PKEY_ED25519, nil, seed)
++	pkey, err := ossl.EVP_PKEY_new_raw_private_key(ossl.EVP_PKEY_ED25519, nil, base(seed), len(seed))
 +	if err != nil {
 +		return nil, err
 +	}
@@ -5197,7 +5229,7 @@ index 00000000000000..dc0060972d3e2a
 +		return err
 +	}
 +	siglen := signatureSizeEd25519
-+	if _, err := ossl.EVP_DigestSign(ctx, sig, &siglen, message); err != nil {
++	if _, err := ossl.EVP_DigestSign(ctx, base(sig), &siglen, base(message), len(message)); err != nil {
 +		return err
 +	}
 +	if siglen != signatureSizeEd25519 {
@@ -5217,14 +5249,14 @@ index 00000000000000..dc0060972d3e2a
 +	if _, err := ossl.EVP_DigestVerifyInit(ctx, nil, nil, nil, pub._pkey); err != nil {
 +		return err
 +	}
-+	if _, err := ossl.EVP_DigestVerify(ctx, sig, message); err != nil {
++	if _, err := ossl.EVP_DigestVerify(ctx, base(sig), len(sig), base(message), len(message)); err != nil {
 +		return errors.New("ed25519: invalid signature")
 +	}
 +	return nil
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/evp.go b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 new file mode 100644
-index 00000000000000..5d7ddbbf02cfe1
+index 00000000000000..4c70cd75a1a553
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/evp.go
 @@ -0,0 +1,620 @@
@@ -5503,8 +5535,8 @@ index 00000000000000..5d7ddbbf02cfe1
 +
 +type withKeyFunc func(func(ossl.EVP_PKEY_PTR) error) error
 +type initFunc func(ossl.EVP_PKEY_CTX_PTR) error
-+type cryptFunc func(ossl.EVP_PKEY_CTX_PTR, []byte, *int, []byte) error
-+type verifyFunc func(ossl.EVP_PKEY_CTX_PTR, []byte, []byte) error
++type cryptFunc func(ossl.EVP_PKEY_CTX_PTR, *byte, *int, *byte, int) error
++type verifyFunc func(ossl.EVP_PKEY_CTX_PTR, *byte, int, *byte, int) error
 +
 +func setupEVP(withKey withKeyFunc, padding int32,
 +	h, mgfHash hash.Hash, label []byte, saltLen int32, ch crypto.Hash,
@@ -5620,7 +5652,7 @@ index 00000000000000..5d7ddbbf02cfe1
 +		copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
 +		var err error
 +		if major() == 3 {
-+			_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Slice(clabel, len(label)))
++			_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Pointer(clabel), int32(len(label)))
 +		} else {
 +			_, err = ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_OAEP_LABEL, int32(len(label)), unsafe.Pointer(clabel))
 +		}
@@ -5650,7 +5682,7 @@ index 00000000000000..5d7ddbbf02cfe1
 +	}
 +	outLen := int(pkeySize)
 +	out := make([]byte, pkeySize)
-+	if err := crypt(ctx, out, &outLen, in); err != nil {
++	if err := crypt(ctx, base(out), &outLen, base(in), len(in)); err != nil {
 +		return nil, err
 +	}
 +	// The size returned by EVP_PKEY_get_size() is only preliminary and not exact,
@@ -5668,7 +5700,7 @@ index 00000000000000..5d7ddbbf02cfe1
 +		return err
 +	}
 +	defer ossl.EVP_PKEY_CTX_free(ctx)
-+	return verify(ctx, sig, in)
++	return verify(ctx, base(sig), len(sig), base(in), len(in))
 +}
 +
 +func evpEncrypt(withKey withKeyFunc, padding int32, h, mgfHash hash.Hash, label, msg []byte) ([]byte, error) {
@@ -5676,8 +5708,8 @@ index 00000000000000..5d7ddbbf02cfe1
 +		_, err := ossl.EVP_PKEY_encrypt_init(ctx)
 +		return err
 +	}
-+	encrypt := func(ctx ossl.EVP_PKEY_CTX_PTR, out []byte, outLen *int, in []byte) error {
-+		if _, err := ossl.EVP_PKEY_encrypt(ctx, out, outLen, in); err != nil {
++	encrypt := func(ctx ossl.EVP_PKEY_CTX_PTR, out *byte, outLen *int, in *byte, inLen int) error {
++		if _, err := ossl.EVP_PKEY_encrypt(ctx, out, outLen, in, inLen); err != nil {
 +			return err
 +		}
 +		return nil
@@ -5690,8 +5722,8 @@ index 00000000000000..5d7ddbbf02cfe1
 +		_, err := ossl.EVP_PKEY_decrypt_init(ctx)
 +		return err
 +	}
-+	decrypt := func(ctx ossl.EVP_PKEY_CTX_PTR, out []byte, outLen *int, in []byte) error {
-+		_, err := ossl.EVP_PKEY_decrypt(ctx, out, outLen, in)
++	decrypt := func(ctx ossl.EVP_PKEY_CTX_PTR, out *byte, outLen *int, in *byte, inLen int) error {
++		_, err := ossl.EVP_PKEY_decrypt(ctx, out, outLen, in, inLen)
 +		return err
 +	}
 +	return cryptEVP(withKey, padding, h, mgfHash, label, 0, 0, decryptInit, decrypt, msg)
@@ -5702,8 +5734,8 @@ index 00000000000000..5d7ddbbf02cfe1
 +		_, err := ossl.EVP_PKEY_sign_init(ctx)
 +		return err
 +	}
-+	sign := func(ctx ossl.EVP_PKEY_CTX_PTR, out []byte, outLen *int, in []byte) error {
-+		_, err := ossl.EVP_PKEY_sign(ctx, out, outLen, in)
++	sign := func(ctx ossl.EVP_PKEY_CTX_PTR, out *byte, outLen *int, in *byte, inLen int) error {
++		_, err := ossl.EVP_PKEY_sign(ctx, out, outLen, in, inLen)
 +		return err
 +	}
 +	return cryptEVP(withKey, padding, nil, nil, nil, saltLen, h, signtInit, sign, hashed)
@@ -5714,8 +5746,8 @@ index 00000000000000..5d7ddbbf02cfe1
 +		_, err := ossl.EVP_PKEY_verify_init(ctx)
 +		return err
 +	}
-+	verify := func(ctx ossl.EVP_PKEY_CTX_PTR, sig []byte, in []byte) error {
-+		_, err := ossl.EVP_PKEY_verify(ctx, sig, in)
++	verify := func(ctx ossl.EVP_PKEY_CTX_PTR, out *byte, outLen int, in *byte, inLen int) error {
++		_, err := ossl.EVP_PKEY_verify(ctx, out, outLen, in, inLen)
 +		return err
 +	}
 +	return verifyEVP(withKey, padding, nil, nil, saltLen, h, verifyInit, verify, sig, hashed)
@@ -5750,7 +5782,7 @@ index 00000000000000..5d7ddbbf02cfe1
 +	}
 +	out = make([]byte, outLen)
 +	// Obtain the signature
-+	if _, err := ossl.EVP_DigestSignFinal(ctx, out, &outLen); err != nil {
++	if _, err := ossl.EVP_DigestSignFinal(ctx, base(out), &outLen); err != nil {
 +		return nil, err
 +	}
 +	return out[:outLen], nil
@@ -5777,7 +5809,7 @@ index 00000000000000..5d7ddbbf02cfe1
 +			return err
 +		}
 +	}
-+	if _, err := ossl.EVP_DigestVerifyFinal(ctx, sig); err != nil {
++	if _, err := ossl.EVP_DigestVerifyFinal(ctx, base(sig), len(sig)); err != nil {
 +		return err
 +	}
 +	return nil
@@ -5850,10 +5882,10 @@ index 00000000000000..5d7ddbbf02cfe1
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hash.go b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
 new file mode 100644
-index 00000000000000..d9c2c6c5f989e0
+index 00000000000000..a48a303bdc8147
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hash.go
-@@ -0,0 +1,520 @@
+@@ -0,0 +1,518 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -5888,8 +5920,6 @@ index 00000000000000..d9c2c6c5f989e0
 +
 +// maxHashSize is the size of SHA52 and SHA3_512, the largest hashes we support.
 +const maxHashSize = 64
-+
-+type HashCloner = hash.Cloner
 +
 +func hashOneShot(ch crypto.Hash, p []byte, sum []byte) bool {
 +	_, err := ossl.EVP_Digest(p, sum, nil, loadHash(ch, true).md, nil)
@@ -6374,12 +6404,47 @@ index 00000000000000..d9c2c6c5f989e0
 +	x := uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
 +	return b[4:], x
 +}
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hashclone.go b/src/vendor/github.com/golang-fips/openssl/v2/hashclone.go
+new file mode 100644
+index 00000000000000..423668c6acf239
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/hashclone.go
+@@ -0,0 +1,14 @@
++//go:build !go1.25 && !cmd_go_bootstrap
++
++package openssl
++
++import (
++	"hash"
++)
++
++// HashCloner is an interface that defines a Clone method.
++type HashCloner interface {
++	hash.Hash
++	// Clone returns a separate Hash instance with the same state as h.
++	Clone() (HashCloner, error)
++}
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hashclone_go125.go b/src/vendor/github.com/golang-fips/openssl/v2/hashclone_go125.go
+new file mode 100644
+index 00000000000000..f1f2364c7246d4
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/hashclone_go125.go
+@@ -0,0 +1,9 @@
++//go:build go1.25 && !cmd_go_bootstrap
++
++package openssl
++
++import (
++	"hash"
++)
++
++type HashCloner = hash.Cloner
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
 new file mode 100644
-index 00000000000000..610703a870c21a
+index 00000000000000..7e059d023ef00b
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hkdf.go
-@@ -0,0 +1,451 @@
+@@ -0,0 +1,455 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -6496,7 +6561,7 @@ index 00000000000000..610703a870c21a
 +	}
 +	c.buf = append(c.buf, make([]byte, needLen)...)
 +	outLen := prevLen + needLen
-+	if _, err := ossl.EVP_PKEY_derive(c.ctx, c.buf, &outLen); err != nil {
++	if _, err := ossl.EVP_PKEY_derive(c.ctx, base(c.buf), &outLen); err != nil {
 +		return 0, err
 +	}
 +	n := copy(p, c.buf[prevLen:outLen])
@@ -6547,7 +6612,7 @@ index 00000000000000..610703a870c21a
 +			return nil, err
 +		}
 +		out := make([]byte, keylen)
-+		if _, err := ossl.EVP_PKEY_derive(ctx, out, &keylen); err != nil {
++		if _, err := ossl.EVP_PKEY_derive(ctx, base(out), &keylen); err != nil {
 +			return nil, err
 +		}
 +		return out[:keylen], nil
@@ -6562,7 +6627,7 @@ index 00000000000000..610703a870c21a
 +			return nil, err
 +		}
 +		out := make([]byte, size)
-+		if _, err := ossl.EVP_KDF_derive(ctx, out, nil); err != nil {
++		if _, err := ossl.EVP_KDF_derive(ctx, base(out), len(out), nil); err != nil {
 +			return nil, err
 +		}
 +		return out, nil
@@ -6597,7 +6662,7 @@ index 00000000000000..610703a870c21a
 +			return out, nil
 +		}
 +		keylen := keyLength
-+		if _, err := ossl.EVP_PKEY_derive(ctx, out, &keylen); err != nil {
++		if _, err := ossl.EVP_PKEY_derive(ctx, base(out), &keylen); err != nil {
 +			return nil, err
 +		}
 +	case 3:
@@ -6612,7 +6677,7 @@ index 00000000000000..610703a870c21a
 +			// We can only exit after calling newHKDFCtx3 because we still need it to validate the parameters.
 +			return out, nil
 +		}
-+		if _, err := ossl.EVP_KDF_derive(ctx, out, nil); err != nil {
++		if _, err := ossl.EVP_KDF_derive(ctx, base(out), keyLength, nil); err != nil {
 +			return nil, err
 +		}
 +	default:
@@ -6640,7 +6705,7 @@ index 00000000000000..610703a870c21a
 +		return nil, err
 +	}
 +	defer ossl.EVP_KDF_CTX_free(ctx)
-+	if _, err := ossl.EVP_KDF_derive(ctx, out, nil); err != nil {
++	if _, err := ossl.EVP_KDF_derive(ctx, base(out), keyLength, nil); err != nil {
 +		return nil, err
 +	}
 +	return out, nil
@@ -6725,8 +6790,10 @@ index 00000000000000..610703a870c21a
 +		}
 +	}()
 +
-+	bld := newParamBuilder()
-+	defer bld.finalize()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return ctx, err
++	}
 +	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 +	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(ossl.EVP_KDF_HKDF_MODE_EXPAND_ONLY))
 +	bld.addOctetString(_OSSL_KDF_PARAM_PREFIX, []byte("tls13 "))
@@ -6779,8 +6846,10 @@ index 00000000000000..610703a870c21a
 +		}
 +	}()
 +
-+	bld := newParamBuilder()
-+	defer bld.finalize()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return ctx, err
++	}
 +	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 +	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(mode))
 +	if len(secret) > 0 {
@@ -6825,7 +6894,7 @@ index 00000000000000..610703a870c21a
 +	}
 +	c.buf = append(c.buf, make([]byte, needLen)...)
 +	outLen := prevLen + needLen
-+	if _, err := ossl.EVP_KDF_derive(c.ctx, c.buf[:outLen], nil); err != nil {
++	if _, err := ossl.EVP_KDF_derive(c.ctx, base(c.buf), outLen, nil); err != nil {
 +		return 0, err
 +	}
 +	n := copy(p, c.buf[prevLen:outLen])
@@ -6833,10 +6902,10 @@ index 00000000000000..610703a870c21a
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/hmac.go b/src/vendor/github.com/golang-fips/openssl/v2/hmac.go
 new file mode 100644
-index 00000000000000..fec80f30b1c94f
+index 00000000000000..14ffe51d6fefce
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/hmac.go
-@@ -0,0 +1,278 @@
+@@ -0,0 +1,282 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -6846,6 +6915,7 @@ index 00000000000000..fec80f30b1c94f
 +	"runtime"
 +	"slices"
 +	"sync"
++	"unsafe"
 +
 +	"github.com/golang-fips/openssl/v2/internal/ossl"
 +)
@@ -6919,7 +6989,7 @@ index 00000000000000..fec80f30b1c94f
 +	if err != nil {
 +		panic(err)
 +	}
-+	if _, err := ossl.HMAC_Init_ex(ctx, key, md, nil); err != nil {
++	if _, err := ossl.HMAC_Init_ex(ctx, unsafe.Pointer(&key[0]), int32(len(key)), md, nil); err != nil {
 +		panic(err)
 +	}
 +	return hmacCtx1{ctx}
@@ -6935,7 +7005,10 @@ index 00000000000000..fec80f30b1c94f
 +})
 +
 +func buildHMAC3Params(md ossl.EVP_MD_PTR) (ossl.OSSL_PARAM_PTR, error) {
-+	bld := newParamBuilder()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return nil, err
++	}
 +	defer bld.finalize()
 +	bld.addUTF8String(_OSSL_MAC_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 +	return bld.build()
@@ -6983,7 +7056,7 @@ index 00000000000000..fec80f30b1c94f
 +		panic(err)
 +	}
 +
-+	if _, err := ossl.EVP_MAC_init(ctx, key, params); err != nil {
++	if _, err := ossl.EVP_MAC_init(ctx, base(key), len(key), params); err != nil {
 +		ossl.EVP_MAC_CTX_free(ctx)
 +		panic(err)
 +	}
@@ -7003,11 +7076,11 @@ index 00000000000000..fec80f30b1c94f
 +func (h *opensslHMAC) Reset() {
 +	switch major() {
 +	case 1:
-+		if _, err := ossl.HMAC_Init_ex(h.ctx1.ctx, nil, nil, nil); err != nil {
++		if _, err := ossl.HMAC_Init_ex(h.ctx1.ctx, nil, 0, nil, nil); err != nil {
 +			panic(err)
 +		}
 +	case 3:
-+		if _, err := ossl.EVP_MAC_init(h.ctx3.ctx, h.ctx3.key, nil); err != nil {
++		if _, err := ossl.EVP_MAC_init(h.ctx3.ctx, base(h.ctx3.key), len(h.ctx3.key), nil); err != nil {
 +			panic(err)
 +		}
 +	default:
@@ -7030,9 +7103,9 @@ index 00000000000000..fec80f30b1c94f
 +	if len(p) > 0 {
 +		switch major() {
 +		case 1:
-+			ossl.HMAC_Update(h.ctx1.ctx, p)
++			ossl.HMAC_Update(h.ctx1.ctx, base(p), len(p))
 +		case 3:
-+			ossl.EVP_MAC_update(h.ctx3.ctx, p)
++			ossl.EVP_MAC_update(h.ctx3.ctx, base(p), len(p))
 +		default:
 +			panic(errUnsupportedVersion())
 +		}
@@ -7064,14 +7137,14 @@ index 00000000000000..fec80f30b1c94f
 +		if _, err := ossl.HMAC_CTX_copy(ctx2, h.ctx1.ctx); err != nil {
 +			panic(err)
 +		}
-+		ossl.HMAC_Final(ctx2, h.sum[:h.size], nil)
++		ossl.HMAC_Final(ctx2, base(h.sum[:h.size]), nil)
 +	case 3:
 +		ctx2, err := ossl.EVP_MAC_CTX_dup(h.ctx3.ctx)
 +		if err != nil {
 +			panic(err)
 +		}
 +		defer ossl.EVP_MAC_CTX_free(ctx2)
-+		ossl.EVP_MAC_final(ctx2, h.sum[:h.size], nil)
++		ossl.EVP_MAC_final(ctx2, base(h.sum[:h.size]), nil, len(h.sum))
 +	default:
 +		panic(errUnsupportedVersion())
 +	}
@@ -7532,84 +7605,6 @@ index 00000000000000..245a5266f6e9fa
 +	MOVD	R0, LR                                                \
 +	MOVD	8(R1), R0                                             \
 +	MOVW	R0, CR
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_riscv64.h b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_riscv64.h
-new file mode 100644
-index 00000000000000..b9322e0c53e2ac
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/abi_riscv64.h
-@@ -0,0 +1,72 @@
-+// Copyright 2026 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// Macros for transitioning from the host ABI to Go ABI0.
-+//
-+// These macros save and restore the callee-saved registers
-+// from the stack, but they don't adjust stack pointer, so
-+// the user should prepare stack space in advance.
-+// SAVE_GPR(offset) saves X8, X9, X18-X27 to the stack space
-+// of ((offset)+0*8)(X2) ~ ((offset)+11*8)(X2).
-+//
-+// SAVE_FPR(offset) saves F8, F9, F18-F27 to the stack space
-+// of ((offset)+0*8)(X2) ~ ((offset)+11*8)(X2).
-+//
-+// Note: g is X27
-+
-+#define SAVE_GPR(offset) \
-+	MOV X8, ((offset)+0*8)(X2)   \
-+	MOV X9, ((offset)+1*8)(X2)   \
-+	MOV X18, ((offset)+2*8)(X2)  \
-+	MOV X19, ((offset)+3*8)(X2)  \
-+	MOV X20, ((offset)+4*8)(X2)  \
-+	MOV X21, ((offset)+5*8)(X2)  \
-+	MOV X22, ((offset)+6*8)(X2)  \
-+	MOV X23, ((offset)+7*8)(X2)  \
-+	MOV X24, ((offset)+8*8)(X2)  \
-+	MOV X25, ((offset)+9*8)(X2)  \
-+	MOV X26, ((offset)+10*8)(X2) \
-+	MOV g, ((offset)+11*8)(X2)
-+
-+#define RESTORE_GPR(offset) \
-+	MOV ((offset)+0*8)(X2), X8   \
-+	MOV ((offset)+1*8)(X2), X9   \
-+	MOV ((offset)+2*8)(X2), X18  \
-+	MOV ((offset)+3*8)(X2), X19  \
-+	MOV ((offset)+4*8)(X2), X20  \
-+	MOV ((offset)+5*8)(X2), X21  \
-+	MOV ((offset)+6*8)(X2), X22  \
-+	MOV ((offset)+7*8)(X2), X23  \
-+	MOV ((offset)+8*8)(X2), X24  \
-+	MOV ((offset)+9*8)(X2), X25  \
-+	MOV ((offset)+10*8)(X2), X26 \
-+	MOV ((offset)+11*8)(X2), g
-+
-+#define SAVE_FPR(offset) \
-+	MOVD F8, ((offset)+0*8)(X2)   \
-+	MOVD F9, ((offset)+1*8)(X2)   \
-+	MOVD F18, ((offset)+2*8)(X2)  \
-+	MOVD F19, ((offset)+3*8)(X2)  \
-+	MOVD F20, ((offset)+4*8)(X2)  \
-+	MOVD F21, ((offset)+5*8)(X2)  \
-+	MOVD F22, ((offset)+6*8)(X2)  \
-+	MOVD F23, ((offset)+7*8)(X2)  \
-+	MOVD F24, ((offset)+8*8)(X2)  \
-+	MOVD F25, ((offset)+9*8)(X2)  \
-+	MOVD F26, ((offset)+10*8)(X2) \
-+	MOVD F27, ((offset)+11*8)(X2)
-+
-+#define RESTORE_FPR(offset) \
-+	MOVD ((offset)+0*8)(X2), F8   \
-+	MOVD ((offset)+1*8)(X2), F9   \
-+	MOVD ((offset)+2*8)(X2), F18  \
-+	MOVD ((offset)+3*8)(X2), F19  \
-+	MOVD ((offset)+4*8)(X2), F20  \
-+	MOVD ((offset)+5*8)(X2), F21  \
-+	MOVD ((offset)+6*8)(X2), F22  \
-+	MOVD ((offset)+7*8)(X2), F23  \
-+	MOVD ((offset)+8*8)(X2), F24  \
-+	MOVD ((offset)+9*8)(X2), F25  \
-+	MOVD ((offset)+10*8)(X2), F26 \
-+	MOVD ((offset)+11*8)(X2), F27
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_386.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_386.s
 new file mode 100644
 index 00000000000000..7475ec8a0b21fc
@@ -7926,16 +7921,15 @@ index 00000000000000..6d1938cd8d8bcd
 +	RET
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_riscv64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_riscv64.s
 new file mode 100644
-index 00000000000000..d34699e5a84d2a
+index 00000000000000..acf82c1b5ae501
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_riscv64.s
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,78 @@
 +// Copyright 2020 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +#include "textflag.h"
-+#include "abi_riscv64.h"
 +
 +// Called by C code generated by cmd/cgo.
 +// func crosscall2(fn, a unsafe.Pointer, n int32, ctxt uintptr)
@@ -7947,24 +7941,66 @@ index 00000000000000..d34699e5a84d2a
 + * registers. Note that at procedure entry the first argument is at
 + * 8(X2).
 + */
-+	ADD $(-8*29), X2
-+	MOV X10, (8*1)(X2) // fn unsafe.Pointer
-+	MOV X11, (8*2)(X2) // a unsafe.Pointer
-+	MOV X13, (8*3)(X2) // ctxt uintptr
-+
-+	SAVE_GPR((8*4))
-+	MOV X1, (8*16)(X2)
-+	SAVE_FPR((8*17))
++	ADD  $(-8*29), X2
++	MOV  X10, (8*1)(X2)  // fn unsafe.Pointer
++	MOV  X11, (8*2)(X2)  // a unsafe.Pointer
++	MOV  X13, (8*3)(X2)  // ctxt uintptr
++	MOV  X8, (8*4)(X2)
++	MOV  X9, (8*5)(X2)
++	MOV  X18, (8*6)(X2)
++	MOV  X19, (8*7)(X2)
++	MOV  X20, (8*8)(X2)
++	MOV  X21, (8*9)(X2)
++	MOV  X22, (8*10)(X2)
++	MOV  X23, (8*11)(X2)
++	MOV  X24, (8*12)(X2)
++	MOV  X25, (8*13)(X2)
++	MOV  X26, (8*14)(X2)
++	MOV  g, (8*15)(X2)
++	MOV  X1, (8*16)(X2)
++	MOVD F8, (8*17)(X2)
++	MOVD F9, (8*18)(X2)
++	MOVD F18, (8*19)(X2)
++	MOVD F19, (8*20)(X2)
++	MOVD F20, (8*21)(X2)
++	MOVD F21, (8*22)(X2)
++	MOVD F22, (8*23)(X2)
++	MOVD F23, (8*24)(X2)
++	MOVD F24, (8*25)(X2)
++	MOVD F25, (8*26)(X2)
++	MOVD F26, (8*27)(X2)
++	MOVD F27, (8*28)(X2)
 +
 +	// Initialize Go ABI environment
 +	CALL runtime·load_g(SB)
 +	CALL runtime·cgocallback(SB)
 +
-+	RESTORE_GPR((8*4))
-+	MOV (8*16)(X2), X1
-+	RESTORE_FPR((8*17))
-+
-+	ADD $(8*29), X2
++	MOV  (8*4)(X2), X8
++	MOV  (8*5)(X2), X9
++	MOV  (8*6)(X2), X18
++	MOV  (8*7)(X2), X19
++	MOV  (8*8)(X2), X20
++	MOV  (8*9)(X2), X21
++	MOV  (8*10)(X2), X22
++	MOV  (8*11)(X2), X23
++	MOV  (8*12)(X2), X24
++	MOV  (8*13)(X2), X25
++	MOV  (8*14)(X2), X26
++	MOV  (8*15)(X2), g
++	MOV  (8*16)(X2), X1
++	MOVD (8*17)(X2), F8
++	MOVD (8*18)(X2), F9
++	MOVD (8*19)(X2), F18
++	MOVD (8*20)(X2), F19
++	MOVD (8*21)(X2), F20
++	MOVD (8*22)(X2), F21
++	MOVD (8*23)(X2), F22
++	MOVD (8*24)(X2), F23
++	MOVD (8*25)(X2), F24
++	MOVD (8*26)(X2), F25
++	MOVD (8*27)(X2), F26
++	MOVD (8*28)(X2), F27
++	ADD  $(8*29), X2
 +
 +	RET
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_s390x.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/asm_s390x.s
@@ -8129,10 +8165,10 @@ index 00000000000000..f29e690cc15b3a
 +)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.go
 new file mode 100644
-index 00000000000000..58b95e1f4157f2
+index 00000000000000..0ff5482714439b
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.go
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,29 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2025 The Ebitengine Authors
 +
@@ -8140,21 +8176,36 @@ index 00000000000000..58b95e1f4157f2
 +
 +package fakecgo
 +
-+import _ "unsafe"
++import (
++	"unsafe"
++)
 +
 +// setg_trampoline calls setg with the G provided
 +func setg_trampoline(setg uintptr, G uintptr)
 +
 +// call5 takes fn the C function and 5 arguments and calls the function with those arguments
 +func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
++
++// argset matches runtime/cgocall.go:argset.
++type argset struct {
++	args   *uintptr
++	retval uintptr
++}
++
++//go:nosplit
++//go:norace
++func (a *argset) arg(i int) unsafe.Pointer {
++	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
++	return *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(a.args), uintptr(i)*unsafe.Sizeof(uintptr(0))))
++}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.lock b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.lock
 new file mode 100644
-index 00000000000000..9b0650d53777bd
+index 00000000000000..4e9bbeb5c4f3e3
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/fakecgo.lock
 @@ -0,0 +1,3 @@
 +{
-+  "commit_hash": "5110604b3385278be6887d0feead513a1bfe7a82"
++  "commit_hash": "585a4c527464bb6ef91b22aef08d55219c8fab09"
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/freebsd.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/freebsd.go
 new file mode 100644
@@ -8294,10 +8345,10 @@ index 00000000000000..d0868f0f790351
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_freebsd.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_freebsd.go
 new file mode 100644
-index 00000000000000..55ff71e2672086
+index 00000000000000..a3ba6bc8228757
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_freebsd.go
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,100 @@
 +// Copyright 2011 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -8367,15 +8418,36 @@ index 00000000000000..55ff71e2672086
 +//go:nosplit
 +func x_cgo_init(g *G, setg uintptr) {
 +	var size size_t
-+	var attr pthread_attr_t
++	var attr *pthread_attr_t
++
++	/* The memory sanitizer distributed with versions of clang
++	   before 3.8 has a bug: if you call mmap before malloc, mmap
++	   may return an address that is later overwritten by the msan
++	   library.  Avoid this problem by forcing a call to malloc
++	   here, before we ever call malloc.
++
++	   This is only required for the memory sanitizer, so it's
++	   unfortunate that we always run it.  It should be possible
++	   to remove this when we no longer care about versions of
++	   clang before 3.8.  The test for this is
++	   misc/cgo/testsanitizers.
++
++	   GCC works hard to eliminate a seemingly unnecessary call to
++	   malloc, so we actually use the memory we allocate.  */
 +
 +	setg_func = setg
-+	pthread_attr_init(&attr)
-+	pthread_attr_getstacksize(&attr, &size)
++	attr = (*pthread_attr_t)(malloc(unsafe.Sizeof(*attr)))
++	if attr == nil {
++		println("fakecgo: malloc failed")
++		abort()
++	}
++	pthread_attr_init(attr)
++	pthread_attr_getstacksize(attr, &size)
 +	// runtime/cgo uses __builtin_frame_address(0) instead of `uintptr(unsafe.Pointer(&size))`
 +	// but this should be OK since we are taking the address of the first variable in this function.
 +	g.stacklo = uintptr(unsafe.Pointer(&size)) - uintptr(size) + 4096
-+	pthread_attr_destroy(&attr)
++	pthread_attr_destroy(attr)
++	free(unsafe.Pointer(attr))
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_libinit.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_libinit.go
 new file mode 100644
@@ -8457,10 +8529,10 @@ index 00000000000000..e5a66f39d4f3f5
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_linux.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_linux.go
 new file mode 100644
-index 00000000000000..089d9fe489407b
+index 00000000000000..9f380c1b431807
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_linux.go
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,100 @@
 +// Copyright 2011 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -8530,15 +8602,36 @@ index 00000000000000..089d9fe489407b
 +//go:nosplit
 +func x_cgo_init(g *G, setg uintptr) {
 +	var size size_t
-+	var attr pthread_attr_t
++	var attr *pthread_attr_t
++
++	/* The memory sanitizer distributed with versions of clang
++	   before 3.8 has a bug: if you call mmap before malloc, mmap
++	   may return an address that is later overwritten by the msan
++	   library.  Avoid this problem by forcing a call to malloc
++	   here, before we ever call malloc.
++
++	   This is only required for the memory sanitizer, so it's
++	   unfortunate that we always run it.  It should be possible
++	   to remove this when we no longer care about versions of
++	   clang before 3.8.  The test for this is
++	   misc/cgo/testsanitizers.
++
++	   GCC works hard to eliminate a seemingly unnecessary call to
++	   malloc, so we actually use the memory we allocate.  */
 +
 +	setg_func = setg
-+	pthread_attr_init(&attr)
-+	pthread_attr_getstacksize(&attr, &size)
++	attr = (*pthread_attr_t)(malloc(unsafe.Sizeof(*attr)))
++	if attr == nil {
++		println("fakecgo: malloc failed")
++		abort()
++	}
++	pthread_attr_init(attr)
++	pthread_attr_getstacksize(attr, &size)
 +	// runtime/cgo uses __builtin_frame_address(0) instead of `uintptr(unsafe.Pointer(&size))`
 +	// but this should be OK since we are taking the address of the first variable in this function.
 +	g.stacklo = uintptr(unsafe.Pointer(&size)) - uintptr(size) + 4096
-+	pthread_attr_destroy(&attr)
++	pthread_attr_destroy(attr)
++	free(unsafe.Pointer(attr))
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_setenv.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/go_setenv.go
 new file mode 100644
@@ -8764,31 +8857,18 @@ index 00000000000000..b08a44a1001bc0
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/linux.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/linux.go
 new file mode 100644
-index 00000000000000..f98e272e42720e
+index 00000000000000..42c2b7d0b8176f
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/linux.go
-@@ -0,0 +1,184 @@
-+// Copyright 2016 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
+@@ -0,0 +1,34 @@
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
 +//go:build !cgo && linux
 +
 +package fakecgo
 +
 +import "unsafe"
-+
-+// argset matches runtime/cgocall.go:argset.
-+type argset struct {
-+	args   *uintptr
-+	retval uintptr
-+}
-+
-+//go:nosplit
-+//go:norace
-+func (a *argset) arg(i int) unsafe.Pointer {
-+	return *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(a.args), uintptr(i)*unsafe.Sizeof(uintptr(0))))
-+}
 +
 +//go:linkname _cgo_libc_setegid syscall.cgo_libc_setegid
 +//go:linkname _cgo_libc_seteuid syscall.cgo_libc_seteuid
@@ -8810,147 +8890,10 @@ index 00000000000000..f98e272e42720e
 +var _cgo_libc_setuid = &_cgo_purego_setuid_trampoline
 +var _cgo_libc_setgroups = &_cgo_purego_setgroups_trampoline
 +
-+//go:nosplit
-+//go:norace
 +func errno() int32 {
 +	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
 +	loc := __errno_location()
 +	return **(**int32)(unsafe.Pointer(&loc))
-+}
-+
-+//go:linkname _cgo_purego_setegid_trampoline _cgo_purego_setegid_trampoline
-+var _cgo_purego_setegid_trampoline byte
-+var x_cgo_purego_setegid_call = x_cgo_purego_setegid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setegid(c *argset) {
-+	ret := setegid(uint32(uintptr(c.arg(0))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_seteuid_trampoline _cgo_purego_seteuid_trampoline
-+var _cgo_purego_seteuid_trampoline byte
-+var x_cgo_purego_seteuid_call = x_cgo_purego_seteuid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_seteuid(c *argset) {
-+	ret := seteuid(uint32(uintptr(c.arg(0))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setgid_trampoline _cgo_purego_setgid_trampoline
-+var _cgo_purego_setgid_trampoline byte
-+var x_cgo_purego_setgid_call = x_cgo_purego_setgid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setgid(c *argset) {
-+	ret := setgid(uint32(uintptr(c.arg(0))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setregid_trampoline _cgo_purego_setregid_trampoline
-+var _cgo_purego_setregid_trampoline byte
-+var x_cgo_purego_setregid_call = x_cgo_purego_setregid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setregid(c *argset) {
-+	ret := setregid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setresgid_trampoline _cgo_purego_setresgid_trampoline
-+var _cgo_purego_setresgid_trampoline byte
-+var x_cgo_purego_setresgid_call = x_cgo_purego_setresgid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setresgid(c *argset) {
-+	ret := setresgid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))), uint32(uintptr(c.arg(2))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setresuid_trampoline _cgo_purego_setresuid_trampoline
-+var _cgo_purego_setresuid_trampoline byte
-+var x_cgo_purego_setresuid_call = x_cgo_purego_setresuid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setresuid(c *argset) {
-+	ret := setresuid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))), uint32(uintptr(c.arg(2))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setreuid_trampoline _cgo_purego_setreuid_trampoline
-+var _cgo_purego_setreuid_trampoline byte
-+var x_cgo_purego_setreuid_call = x_cgo_purego_setreuid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setreuid(c *argset) {
-+	ret := setreuid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setuid_trampoline _cgo_purego_setuid_trampoline
-+var _cgo_purego_setuid_trampoline byte
-+var x_cgo_purego_setuid_call = x_cgo_purego_setuid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setuid(c *argset) {
-+	ret := setuid(uint32(uintptr(c.arg(0))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setgroups_trampoline _cgo_purego_setgroups_trampoline
-+var _cgo_purego_setgroups_trampoline byte
-+var x_cgo_purego_setgroups_call = x_cgo_purego_setgroups
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setgroups(c *argset) {
-+	ret := setgroups(uint32(uintptr(c.arg(0))), (*uint32)(c.arg(1)))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/setenv.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/setenv.go
 new file mode 100644
@@ -8979,10 +8922,10 @@ index 00000000000000..f30af0e1515699
 +var _cgo_unsetenv = &x_cgo_unsetenv_trampoline
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_386.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_386.s
 new file mode 100644
-index 00000000000000..cf56a6c71575eb
+index 00000000000000..43277f854d34aa
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_386.s
-@@ -0,0 +1,121 @@
+@@ -0,0 +1,107 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
@@ -9065,29 +9008,15 @@ index 00000000000000..cf56a6c71575eb
 +	CALL BX
 +	RET
 +
-+TEXT threadentry_trampoline(SB), NOSPLIT, $24-4
-+	// Save callee-saved registers
-+	MOVL BP, 20(SP)
-+	MOVL BX, 16(SP)
-+	MOVL SI, 12(SP)
-+	MOVL DI, 8(SP)
-+
-+	// Move C argument (arg) to stack for Go function
-+	MOVL arg+0(FP), AX
-+	MOVL AX, 0(SP)
-+
++TEXT threadentry_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                 // first C arg
++	MOVL AX, 0(SP)                 // Go arg 1
 +	MOVL ·threadentry_call(SB), CX
 +	MOVL (CX), CX
 +	CALL CX
-+
-+	// Restore callee-saved registers
-+	MOVL 8(SP), DI
-+	MOVL 12(SP), SI
-+	MOVL 16(SP), BX
-+	MOVL 20(SP), BP
 +	RET
 +
-+TEXT ·call5(SB), NOSPLIT, $24-28
++TEXT ·call5(SB), NOSPLIT, $20-28
 +	MOVL fn+0(FP), AX
 +	MOVL a1+4(FP), BX
 +	MOVL a2+8(FP), CX
@@ -9219,10 +9148,10 @@ index 00000000000000..a4ca5ea98214fd
 +	RET
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm.s
 new file mode 100644
-index 00000000000000..c17925d60d6787
+index 00000000000000..9aa7eb0accb4c8
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm.s
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,81 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
@@ -9279,53 +9208,12 @@ index 00000000000000..c17925d60d6787
 +	BL   (R12)
 +	RET
 +
-+TEXT threadentry_trampoline(SB), NOSPLIT, $104-0
-+	// Save C callee-saved registers at C-to-Go boundary.
-+	// See crosscall2 in asm_arm.s.
-+	// ARM AAPCS callee-saved: R4-R11 (includes g=R10), D8-D15.
-+	// LR is saved/restored by the Go-managed frame prologue/epilogue.
-+	MOVW R0, 4(R13) // arg for threadentry_call
-+
-+	MOVW R4, 8(R13)
-+	MOVW R5, 12(R13)
-+	MOVW R6, 16(R13)
-+	MOVW R7, 20(R13)
-+	MOVW R8, 24(R13)
-+	MOVW R9, 28(R13)
-+	MOVW g, 32(R13)   // R10
-+	MOVW R11, 36(R13)
-+
-+	MOVD F8, 40(R13)
-+	MOVD F9, 48(R13)
-+	MOVD F10, 56(R13)
-+	MOVD F11, 64(R13)
-+	MOVD F12, 72(R13)
-+	MOVD F13, 80(R13)
-+	MOVD F14, 88(R13)
-+	MOVD F15, 96(R13)
-+
++TEXT threadentry_trampoline(SB), NOSPLIT, $8-0
++	// See crosscall2.
++	MOVW R0, 4(R13)
 +	MOVW ·threadentry_call(SB), R12
 +	MOVW (R12), R12
 +	CALL (R12)
-+
-+	MOVD 40(R13), F8
-+	MOVD 48(R13), F9
-+	MOVD 56(R13), F10
-+	MOVD 64(R13), F11
-+	MOVD 72(R13), F12
-+	MOVD 80(R13), F13
-+	MOVD 88(R13), F14
-+	MOVD 96(R13), F15
-+
-+	MOVW 8(R13), R4
-+	MOVW 12(R13), R5
-+	MOVW 16(R13), R6
-+	MOVW 20(R13), R7
-+	MOVW 24(R13), R8
-+	MOVW 28(R13), R9
-+	MOVW 32(R13), g
-+	MOVW 36(R13), R11
-+
 +	RET
 +
 +TEXT ·call5(SB), NOSPLIT, $8-28
@@ -9347,10 +9235,10 @@ index 00000000000000..c17925d60d6787
 +	RET
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s
 new file mode 100644
-index 00000000000000..1deb2747ad3245
+index 00000000000000..dceb1cac6e821c
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_arm64.s
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,84 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
@@ -9411,6 +9299,7 @@ index 00000000000000..1deb2747ad3245
 +
 +	SAVE_R19_TO_R28(8*4)
 +	SAVE_F8_TO_F15(8*14)
++	STP (R29, R30), (8*22)(RSP)
 +
 +	MOVD ·threadentry_call(SB), R9
 +	MOVD (R9), R9
@@ -9419,6 +9308,8 @@ index 00000000000000..1deb2747ad3245
 +
 +	RESTORE_R19_TO_R28(8*4)
 +	RESTORE_F8_TO_F15(8*14)
++	LDP (8*22)(RSP), (R29, R30)
++
 +	ADD $(8*24), RSP
 +	RET
 +
@@ -9432,578 +9323,12 @@ index 00000000000000..1deb2747ad3245
 +	CALL R9
 +	MOVD R0, ret+48(FP)
 +	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_386.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_386.s
-new file mode 100644
-index 00000000000000..eea96638fa9a9b
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_386.s
-@@ -0,0 +1,78 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
-+
-+//go:build !cgo && linux
-+
-+#include "textflag.h"
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX
-+	MOVL AX, 0(SP)
-+	MOVL ·x_cgo_purego_setegid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX
-+	MOVL AX, 0(SP)
-+	MOVL ·x_cgo_purego_seteuid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX
-+	MOVL AX, 0(SP)
-+	MOVL ·x_cgo_purego_setgid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX
-+	MOVL AX, 0(SP)
-+	MOVL ·x_cgo_purego_setregid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX
-+	MOVL AX, 0(SP)
-+	MOVL ·x_cgo_purego_setresgid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX
-+	MOVL AX, 0(SP)
-+	MOVL ·x_cgo_purego_setresuid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX
-+	MOVL AX, 0(SP)
-+	MOVL ·x_cgo_purego_setreuid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX
-+	MOVL AX, 0(SP)
-+	MOVL ·x_cgo_purego_setuid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX
-+	MOVL AX, 0(SP)
-+	MOVL ·x_cgo_purego_setgroups_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_amd64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_amd64.s
-new file mode 100644
-index 00000000000000..424ebc1e7cbb42
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_amd64.s
-@@ -0,0 +1,69 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
-+
-+//go:build !cgo && linux
-+
-+#include "textflag.h"
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setegid_call(SB), R11
-+	MOVQ (R11), R11
-+	CALL R11
-+	RET
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_seteuid_call(SB), R11
-+	MOVQ (R11), R11
-+	CALL R11
-+	RET
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setgid_call(SB), R11
-+	MOVQ (R11), R11
-+	CALL R11
-+	RET
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setregid_call(SB), R11
-+	MOVQ (R11), R11
-+	CALL R11
-+	RET
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setresgid_call(SB), R11
-+	MOVQ (R11), R11
-+	CALL R11
-+	RET
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setresuid_call(SB), R11
-+	MOVQ (R11), R11
-+	CALL R11
-+	RET
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setreuid_call(SB), R11
-+	MOVQ (R11), R11
-+	CALL R11
-+	RET
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setuid_call(SB), R11
-+	MOVQ (R11), R11
-+	CALL R11
-+	RET
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setgroups_call(SB), R11
-+	MOVQ (R11), R11
-+	CALL R11
-+	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_arm.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_arm.s
-new file mode 100644
-index 00000000000000..284fe5d0e3a87a
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_arm.s
-@@ -0,0 +1,69 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
-+
-+//go:build !cgo && linux
-+
-+#include "textflag.h"
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setegid_call(SB), R12
-+	MOVW (R12), R12
-+	CALL (R12)
-+	RET
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_seteuid_call(SB), R12
-+	MOVW (R12), R12
-+	CALL (R12)
-+	RET
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setgid_call(SB), R12
-+	MOVW (R12), R12
-+	CALL (R12)
-+	RET
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setregid_call(SB), R12
-+	MOVW (R12), R12
-+	CALL (R12)
-+	RET
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setresgid_call(SB), R12
-+	MOVW (R12), R12
-+	CALL (R12)
-+	RET
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setresuid_call(SB), R12
-+	MOVW (R12), R12
-+	CALL (R12)
-+	RET
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setreuid_call(SB), R12
-+	MOVW (R12), R12
-+	CALL (R12)
-+	RET
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setuid_call(SB), R12
-+	MOVW (R12), R12
-+	CALL (R12)
-+	RET
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setgroups_call(SB), R12
-+	MOVW (R12), R12
-+	CALL (R12)
-+	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_arm64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_arm64.s
-new file mode 100644
-index 00000000000000..771910817b7686
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_arm64.s
-@@ -0,0 +1,60 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
-+
-+//go:build !cgo && linux
-+
-+#include "textflag.h"
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_purego_setegid_call(SB), R9
-+	MOVD (R9), R9
-+	CALL R9
-+	RET
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_purego_seteuid_call(SB), R9
-+	MOVD (R9), R9
-+	CALL R9
-+	RET
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_purego_setgid_call(SB), R9
-+	MOVD (R9), R9
-+	CALL R9
-+	RET
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_purego_setregid_call(SB), R9
-+	MOVD (R9), R9
-+	CALL R9
-+	RET
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_purego_setresgid_call(SB), R9
-+	MOVD (R9), R9
-+	CALL R9
-+	RET
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_purego_setresuid_call(SB), R9
-+	MOVD (R9), R9
-+	CALL R9
-+	RET
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_purego_setreuid_call(SB), R9
-+	MOVD (R9), R9
-+	CALL R9
-+	RET
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_purego_setuid_call(SB), R9
-+	MOVD (R9), R9
-+	CALL R9
-+	RET
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0-0
-+	MOVD ·x_cgo_purego_setgroups_call(SB), R9
-+	MOVD (R9), R9
-+	CALL R9
-+	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_loong64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_loong64.s
-new file mode 100644
-index 00000000000000..ebcc1176c0a0a6
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_loong64.s
-@@ -0,0 +1,60 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
-+
-+//go:build !cgo && linux
-+
-+#include "textflag.h"
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8
-+	MOVV ·x_cgo_purego_setegid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8
-+	MOVV ·x_cgo_purego_seteuid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8
-+	MOVV ·x_cgo_purego_setgid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8
-+	MOVV ·x_cgo_purego_setregid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8
-+	MOVV ·x_cgo_purego_setresgid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8
-+	MOVV ·x_cgo_purego_setresuid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8
-+	MOVV ·x_cgo_purego_setreuid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8
-+	MOVV ·x_cgo_purego_setuid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8
-+	MOVV ·x_cgo_purego_setgroups_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_ppc64le.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_ppc64le.s
-new file mode 100644
-index 00000000000000..59a95a929fb5c2
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_ppc64le.s
-@@ -0,0 +1,69 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
-+
-+//go:build !cgo && linux
-+
-+#include "textflag.h"
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8-0
-+	MOVD ·x_cgo_purego_setegid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	CALL CTR
-+	RET
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8-0
-+	MOVD ·x_cgo_purego_seteuid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	CALL CTR
-+	RET
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8-0
-+	MOVD ·x_cgo_purego_setgid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	CALL CTR
-+	RET
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8-0
-+	MOVD ·x_cgo_purego_setregid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	CALL CTR
-+	RET
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8-0
-+	MOVD ·x_cgo_purego_setresgid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	CALL CTR
-+	RET
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8-0
-+	MOVD ·x_cgo_purego_setresuid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	CALL CTR
-+	RET
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8-0
-+	MOVD ·x_cgo_purego_setreuid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	CALL CTR
-+	RET
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8-0
-+	MOVD ·x_cgo_purego_setuid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	CALL CTR
-+	RET
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8-0
-+	MOVD ·x_cgo_purego_setgroups_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	CALL CTR
-+	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_riscv64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_riscv64.s
-new file mode 100644
-index 00000000000000..9e892dbd2daf71
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_riscv64.s
-@@ -0,0 +1,60 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
-+
-+//go:build !cgo && linux
-+
-+#include "textflag.h"
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8
-+	MOV  ·x_cgo_purego_setegid_call(SB), X5
-+	MOV  (X5), X5
-+	CALL X5
-+	RET
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8
-+	MOV  ·x_cgo_purego_seteuid_call(SB), X5
-+	MOV  (X5), X5
-+	CALL X5
-+	RET
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8
-+	MOV  ·x_cgo_purego_setgid_call(SB), X5
-+	MOV  (X5), X5
-+	CALL X5
-+	RET
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8
-+	MOV  ·x_cgo_purego_setregid_call(SB), X5
-+	MOV  (X5), X5
-+	CALL X5
-+	RET
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8
-+	MOV  ·x_cgo_purego_setresgid_call(SB), X5
-+	MOV  (X5), X5
-+	CALL X5
-+	RET
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8
-+	MOV  ·x_cgo_purego_setresuid_call(SB), X5
-+	MOV  (X5), X5
-+	CALL X5
-+	RET
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8
-+	MOV  ·x_cgo_purego_setreuid_call(SB), X5
-+	MOV  (X5), X5
-+	CALL X5
-+	RET
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8
-+	MOV  ·x_cgo_purego_setuid_call(SB), X5
-+	MOV  (X5), X5
-+	CALL X5
-+	RET
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8
-+	MOV  ·x_cgo_purego_setgroups_call(SB), X5
-+	MOV  (X5), X5
-+	CALL X5
-+	RET
-diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_s390x.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_s390x.s
-new file mode 100644
-index 00000000000000..ce4247c989f4c1
---- /dev/null
-+++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_linux_s390x.s
-@@ -0,0 +1,53 @@
-+// Code generated by 'go generate' with gen.go. DO NOT EDIT.
-+
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build go1.27 && !cgo
-+
-+#include "textflag.h"
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setegid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_seteuid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setgid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setregid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setresgid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setresuid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setreuid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setuid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setgroups_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_loong64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_loong64.s
 new file mode 100644
-index 00000000000000..b93b5da90a8333
+index 00000000000000..72c58f3f4fe01a
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_loong64.s
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,88 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2025 The Ebitengine Authors
 +
@@ -10017,24 +9342,29 @@ index 00000000000000..b93b5da90a8333
 +// R23 is used as temporary register.
 +
 +TEXT x_cgo_init_trampoline(SB), NOSPLIT, $16
++	MOVV R4, 8(R3)
++	MOVV R5, 16(R3)
 +	MOVV ·x_cgo_init_call(SB), R23
 +	MOVV (R23), R23
 +	CALL (R23)
 +	RET
 +
 +TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $8
++	MOVV R4, 8(R3)
 +	MOVV ·x_cgo_thread_start_call(SB), R23
 +	MOVV (R23), R23
 +	CALL (R23)
 +	RET
 +
 +TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $8
++	MOVV R4, 8(R3)
 +	MOVV ·x_cgo_setenv_call(SB), R23
 +	MOVV (R23), R23
 +	CALL (R23)
 +	RET
 +
 +TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $8
++	MOVV R4, 8(R3)
 +	MOVV ·x_cgo_unsetenv_call(SB), R23
 +	MOVV (R23), R23
 +	CALL (R23)
@@ -10055,14 +9385,16 @@ index 00000000000000..b93b5da90a8333
 +	CALL (R23)
 +	RET
 +
-+TEXT threadentry_trampoline(SB), NOSPLIT, $176
++TEXT threadentry_trampoline(SB), NOSPLIT, $0
 +	// See crosscall2.
++	ADDV $(-23*8), R3
 +	MOVV R4, (1*8)(R3) // fn unsafe.Pointer
 +	MOVV R5, (2*8)(R3) // a unsafe.Pointer
 +	MOVV R7, (3*8)(R3) // ctxt uintptr
 +
 +	SAVE_R22_TO_R31((4*8))
 +	SAVE_F24_TO_F31((14*8))
++	MOVV R1, (22*8)(R3)
 +
 +	MOVV ·threadentry_call(SB), R23
 +	MOVV (R23), R23
@@ -10070,6 +9402,9 @@ index 00000000000000..b93b5da90a8333
 +
 +	RESTORE_R22_TO_R31((4*8))
 +	RESTORE_F24_TO_F31((14*8))
++	MOVV (22*8)(R3), R1
++
++	ADDV $(23*8), R3
 +	RET
 +
 +TEXT ·call5(SB), NOSPLIT, $0-0
@@ -10084,10 +9419,10 @@ index 00000000000000..b93b5da90a8333
 +	RET
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_ppc64le.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_ppc64le.s
 new file mode 100644
-index 00000000000000..444529d8ae820b
+index 00000000000000..8a1434e60d756d
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_ppc64le.s
-@@ -0,0 +1,128 @@
+@@ -0,0 +1,227 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
@@ -10095,89 +9430,188 @@ index 00000000000000..444529d8ae820b
 +
 +#include "textflag.h"
 +#include "go_asm.h"
-+#include "abi_ppc64x.h"
 +
 +// These trampolines map the C ABI to Go ABI and call into the Go equivalent functions.
++//
++// PPC64LE ELFv2 ABI stack frame layout:
++//   0(R1)  = backchain (pointer to caller's frame)
++//   8(R1)  = CR save area
++//   16(R1) = LR save area
++//   24(R1) = reserved
++//   32(R1) = parameter save area (minimum 64 bytes for 8 args)
++//
++// Two patterns are used depending on call direction:
++//
++// C→Go trampolines: The C caller already provides a 32-byte linkage area.
++//   Save LR/CR into caller's frame at 16(R1)/8(R1) BEFORE allocating,
++//   then use MOVDU to allocate and set backchain atomically.
++//
++// Go→C trampolines: Go callers don't provide ELFv2 linkage area.
++//   Allocate frame first with MOVDU, then save LR/CR into OUR frame.
 +
-+TEXT x_cgo_init_trampoline(SB), NOSPLIT, $0-0
++TEXT x_cgo_init_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD LR, 16(R1)
++	MOVW CR, R0
++	MOVD R0, 8(R1)
++
++	MOVDU R1, -32(R1)
++
++	// R3, R4 already have the arguments
 +	MOVD ·x_cgo_init_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
++
++	ADD $32, R1
++
++	MOVD 16(R1), LR
++	MOVD 8(R1), R0
++	MOVW R0, CR
 +	RET
 +
-+TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $0-0
++TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD LR, 16(R1)
++	MOVW CR, R0
++	MOVD R0, 8(R1)
++
++	MOVDU R1, -32(R1)
++
 +	MOVD ·x_cgo_thread_start_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
++
++	ADD $32, R1
++
++	MOVD 16(R1), LR
++	MOVD 8(R1), R0
++	MOVW R0, CR
 +	RET
 +
-+TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $0-0
++// void (*_cgo_setenv)(char**)
++// C arg: R3 = pointer to env
++// This is C→Go: caller is C ABI.
++TEXT x_cgo_setenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD LR, 16(R1)
++	MOVW CR, R0
++	MOVD R0, 8(R1)
++
++	MOVDU R1, -32(R1)
++
 +	MOVD ·x_cgo_setenv_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
++
++	ADD $32, R1
++
++	MOVD 16(R1), LR
++	MOVD 8(R1), R0
++	MOVW R0, CR
 +	RET
 +
-+TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $0-0
++TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD LR, 16(R1)
++	MOVW CR, R0
++	MOVD R0, 8(R1)
++
++	MOVDU R1, -32(R1)
++
 +	MOVD ·x_cgo_unsetenv_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
++
++	ADD $32, R1
++
++	MOVD 16(R1), LR
++	MOVD 8(R1), R0
++	MOVW R0, CR
 +	RET
 +
-+TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0-0
-+	CALL ·x_cgo_notify_runtime_init_done(SB)
-+	RET
-+
-+TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0-0
-+	CALL ·x_cgo_bindm(SB)
-+	RET
-+
-+// func setg_trampoline(setg uintptr, g uintptr)
-+TEXT ·setg_trampoline(SB), NOSPLIT, $16-16
-+	MOVD R31, 8(R1) // save R31 (load_g clobbers it)
-+
-+	MOVD setg+0(FP), R12
-+	MOVD newg+8(FP), R3
-+
-+	MOVD R12, CTR
-+	CALL CTR
-+
-+	CALL runtime·load_g(SB)
-+
-+	MOVD 8(R1), R31
-+	XOR  R0, R0, R0
-+	RET
-+
-+TEXT threadentry_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	// Called from C (pthread_create). Must save all C callee-saved registers.
-+	// Uses NOFRAME for proper ELFv2 backchain via MOVDU.
-+	MOVD LR, R0
-+	MOVD R0, 16(R1)
++TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD LR, 16(R1)
 +	MOVW CR, R0
 +	MOVD R0, 8(R1)
 +
-+	MOVDU R1, -320(R1)
++	MOVDU R1, -32(R1)
 +
-+	SAVE_GPR(32)
-+	SAVE_FPR(32+SAVE_GPR_SIZE)
++	CALL ·x_cgo_notify_runtime_init_done(SB)
 +
-+	MOVD $0, R0
++	ADD $32, R1
++
++	MOVD 16(R1), LR
++	MOVD 8(R1), R0
++	MOVW R0, CR
++	RET
++
++TEXT x_cgo_bindm_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD LR, 16(R1)
++	MOVW CR, R0
++	MOVD R0, 8(R1)
++
++	MOVDU R1, -32(R1)
++
++	CALL ·x_cgo_bindm(SB)
++
++	ADD $32, R1
++
++	MOVD 16(R1), LR
++	MOVD 8(R1), R0
++	MOVW R0, CR
++	RET
++
++TEXT ·setg_trampoline(SB), NOSPLIT|NOFRAME, $0-16
++	// Save LR, CR, and R31 to non-volatile registers (C ABI preserves R14-R31)
++	MOVD LR, R20
++	MOVW CR, R21
++	MOVD R31, R22 // save R31 because load_g clobbers it
++
++	// Load arguments from Go stack
++	MOVD 32(R1), R12 // setg function pointer
++	MOVD 40(R1), R3  // g pointer → first C arg
++
++	// Allocate ELFv2 frame for the C callee (32 bytes minimum)
++	MOVDU R1, -32(R1)
++
++	// Call setg_gcc which stores g to TLS
++	MOVD R12, CTR
++	CALL CTR
++
++	// setg_gcc stored g to TLS but restored old g in R30.
++	// Call load_g to reload g from TLS into R30.
++	// Note: load_g clobbers R31
++	CALL runtime·load_g(SB)
++
++	// Deallocate frame
++	ADD $32, R1
++
++	// Clear R0 before returning to Go code.
++	// Go uses R0 as a constant 0 for things like "std r0,X(r1)" to zero stack locations.
++	// C/assembly functions may leave garbage in R0.
++	XOR R0, R0, R0
++
++	// Restore LR, CR, and R31 from non-volatile registers
++	MOVD R22, R31 // restore R31
++	MOVD R20, LR
++	MOVW R21, CR
++	RET
++
++TEXT threadentry_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD LR, 16(R1)
++	MOVW CR, R0
++	MOVD R0, 8(R1)
++
++	MOVDU R1, -32(R1)
 +
 +	MOVD ·threadentry_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
 +
-+	RESTORE_FPR(32+SAVE_GPR_SIZE)
-+	RESTORE_GPR(32)
++	ADD $32, R1
 +
-+	ADD $320, R1
-+
-+	MOVD 16(R1), R0
-+	MOVD R0, LR
++	MOVD 16(R1), LR
 +	MOVD 8(R1), R0
 +	MOVW R0, CR
 +	RET
@@ -10218,10 +9652,10 @@ index 00000000000000..444529d8ae820b
 +	RET
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_riscv64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_riscv64.s
 new file mode 100644
-index 00000000000000..b162fdde234629
+index 00000000000000..4154684b63ff51
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_riscv64.s
-@@ -0,0 +1,76 @@
+@@ -0,0 +1,72 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
@@ -10229,30 +9663,34 @@ index 00000000000000..b162fdde234629
 +
 +#include "textflag.h"
 +#include "go_asm.h"
-+#include "abi_riscv64.h"
 +
 +// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
 +// X5 is used as temporary register.
 +
 +TEXT x_cgo_init_trampoline(SB), NOSPLIT, $16
++	MOV  X10, 8(SP)
++	MOV  X11, 16(SP)
 +	MOV  ·x_cgo_init_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
 +	RET
 +
 +TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $8
++	MOV  X10, 8(SP)
 +	MOV  ·x_cgo_thread_start_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
 +	RET
 +
 +TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $8
++	MOV  X10, 8(SP)
 +	MOV  ·x_cgo_setenv_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
 +	RET
 +
 +TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $8
++	MOV  X10, 8(SP)
 +	MOV  ·x_cgo_unsetenv_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
@@ -10273,19 +9711,11 @@ index 00000000000000..b162fdde234629
 +	CALL X5
 +	RET
 +
-+TEXT threadentry_trampoline(SB), NOSPLIT, $200
-+	MOV X10, 8(SP)
-+
-+	SAVE_GPR(8*2)
-+	SAVE_FPR(8*14)
-+
++TEXT threadentry_trampoline(SB), NOSPLIT, $16
++	MOV  X10, 8(SP)
 +	MOV  ·threadentry_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
-+
-+	RESTORE_GPR(8*2)
-+	RESTORE_FPR(8*14)
-+
 +	RET
 +
 +TEXT ·call5(SB), NOSPLIT, $0-48
@@ -10300,10 +9730,10 @@ index 00000000000000..b162fdde234629
 +	RET
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_s390x.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_s390x.s
 new file mode 100644
-index 00000000000000..2b68d438e4ec1d
+index 00000000000000..49fec0cf2f1718
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/trampolines_s390x.s
-@@ -0,0 +1,154 @@
+@@ -0,0 +1,163 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
@@ -10312,31 +9742,35 @@ index 00000000000000..2b68d438e4ec1d
 +#include "textflag.h"
 +#include "go_asm.h"
 +
-+// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
-+// Note that C arguments are passed in R2-R6, which matches Go ABIInternal for the first five arguments.
-+// R1 is used as a temporary register.
++// S390X ELF ABI: args R2-R6, return R2, callee-save R6-R13/R15/F8-F15, R14=LR, R15=SP
++// CRITICAL: R0 as base register means "no base" (literal 0), not R0's value!
 +
++// x_cgo_init_trampoline must preserve R9 for Go runtime
 +TEXT x_cgo_init_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD R14, R0
 +	MOVD R15, R1
 +	SUB  $192, R15
-+	MOVD R1, 0(R15)    // backchain
-+	MOVD R14, 160(R15) // save R14
-+	MOVD R9, 168(R15)  // save R9 (Go runtime needs this preserved)
++	MOVD R1, 0(R15)   // backchain
++	MOVD R0, 160(R15) // save R14
++	MOVD R1, 168(R15) // save old R15
++	MOVD R9, 176(R15) // save R9 (Go runtime needs this preserved)
 +
 +	MOVD ·x_cgo_init_call(SB), R1
 +	MOVD (R1), R1
 +	BL   R1
 +
-+	MOVD 168(R15), R9
++	MOVD 176(R15), R9
 +	MOVD 160(R15), R14
-+	ADD  $192, R15
++	MOVD 168(R15), R15
 +	BR   R14
 +
++// Standard trampoline pattern: save R14/R15, call via pointer, restore
 +TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD R14, R0
 +	MOVD R15, R1
 +	SUB  $176, R15
-+	MOVD R1, 0(R15)    // backchain
-+	MOVD R14, 152(R15) // save R14
++	MOVD R1, 0(R15)
++	MOVD R0, 152(R15)
 +
 +	MOVD ·x_cgo_thread_start_call(SB), R1
 +	MOVD (R1), R1
@@ -10347,10 +9781,11 @@ index 00000000000000..2b68d438e4ec1d
 +	BR   R14
 +
 +TEXT x_cgo_setenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD R14, R0
 +	MOVD R15, R1
 +	SUB  $176, R15
-+	MOVD R1, 0(R15)    // backchain
-+	MOVD R14, 152(R15) // save R14
++	MOVD R1, 0(R15)
++	MOVD R0, 152(R15)
 +
 +	MOVD ·x_cgo_setenv_call(SB), R1
 +	MOVD (R1), R1
@@ -10361,10 +9796,11 @@ index 00000000000000..2b68d438e4ec1d
 +	BR   R14
 +
 +TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
++	MOVD R14, R0
 +	MOVD R15, R1
 +	SUB  $176, R15
-+	MOVD R1, 0(R15)    // backchain
-+	MOVD R14, 152(R15) // save R14
++	MOVD R1, 0(R15)
++	MOVD R0, 152(R15)
 +
 +	MOVD ·x_cgo_unsetenv_call(SB), R1
 +	MOVD (R1), R1
@@ -10384,7 +9820,7 @@ index 00000000000000..2b68d438e4ec1d
 +// setg_trampoline(setg uintptr, g uintptr) - called from Go
 +TEXT ·setg_trampoline(SB), NOSPLIT|NOFRAME, $0-16
 +	MOVD 8(R15), R1  // setg function pointer
-+	MOVD 16(R15), R2 // g pointer -> C arg
++	MOVD 16(R15), R2 // g pointer → C arg
 +
 +	MOVD R14, R0
 +	MOVD R15, R3
@@ -10399,11 +9835,13 @@ index 00000000000000..2b68d438e4ec1d
 +	ADD  $160, R15
 +	BR   R14
 +
++// threadentry_trampoline - called FROM C (pthread_create), arg in R2
 +TEXT threadentry_trampoline(SB), NOSPLIT|NOFRAME, $0-0
 +	STMG R6, R15, 48(R15) // C save area
 +	MOVD R15, R1
 +	SUB  $176, R15
 +	MOVD R1, 0(R15)       // backchain
++	MOVD R2, 8(R15)       // pthread arg → Go arg
 +
 +	MOVD ·threadentry_call(SB), R1
 +	MOVD (R1), R1
@@ -10413,6 +9851,7 @@ index 00000000000000..2b68d438e4ec1d
 +	LMG 48(R15), R6, R15
 +	RET
 +
++// call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr - Go calling C
 +TEXT ·call5(SB), NOSPLIT|NOFRAME, $0-56
 +	// Load Go args before modifying R15
 +	MOVD 8(R15), R1   // fn
@@ -10428,7 +9867,7 @@ index 00000000000000..2b68d438e4ec1d
 +	ADD  $-128, R15
 +
 +	// Set up C frame with backchain
-+	MOVD R0, 0(R15) // backchain -> original R15
++	MOVD R0, 0(R15) // backchain → original R15
 +	MOVD R0, R3     // R3 = original R15 (can't use R0 as base!)
 +	MOVD 0(R3), R7  // save 0(original R15)
 +	MOVD $0, 0(R3)  // terminate backchain
@@ -10750,10 +10189,10 @@ index 00000000000000..d69775596fddf3
 +var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_linux.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_linux.go
 new file mode 100644
-index 00000000000000..cbb120431ab6bb
+index 00000000000000..38ee622a366042
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/zsymbols_linux.go
-@@ -0,0 +1,158 @@
+@@ -0,0 +1,294 @@
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -10772,6 +10211,7 @@ index 00000000000000..cbb120431ab6bb
 +//go:cgo_import_dynamic purego_sigfillset sigfillset "libc.so.6"
 +//go:cgo_import_dynamic purego_nanosleep nanosleep "libc.so.6"
 +//go:cgo_import_dynamic purego_abort abort "libc.so.6"
++//go:cgo_import_dynamic purego_sigaltstack sigaltstack "libc.so.6"
 +//go:cgo_import_dynamic purego___errno_location __errno_location "libc.so.6"
 +//go:cgo_import_dynamic purego_setegid setegid "libc.so.6"
 +//go:cgo_import_dynamic purego_seteuid seteuid "libc.so.6"
@@ -10792,6 +10232,26 @@ index 00000000000000..cbb120431ab6bb
 +//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "libpthread.so.0"
++
++//go:nosplit
++//go:norace
++func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
++	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_attr_destroy(attr *pthread_attr_t) int32 {
++	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
++}
++
++//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
++var _pthread_attr_getstacksize uint8
++var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
++
++//go:linkname _pthread_attr_destroy _pthread_attr_destroy
++var _pthread_attr_destroy uint8
++var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
 +
 +//go:nosplit
 +//go:norace
@@ -10853,18 +10313,6 @@ index 00000000000000..cbb120431ab6bb
 +	return int32(call5(setgroupsABI0, uintptr(ngid), uintptr(unsafe.Pointer(gidset)), 0, 0, 0))
 +}
 +
-+//go:nosplit
-+//go:norace
-+func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
-+	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_attr_destroy(attr *pthread_attr_t) int32 {
-+	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
-+}
-+
 +//go:linkname ___errno_location ___errno_location
 +var ___errno_location uint8
 +var __errno_locationABI0 = uintptr(unsafe.Pointer(&___errno_location))
@@ -10905,13 +10353,140 @@ index 00000000000000..cbb120431ab6bb
 +var _setgroups uint8
 +var setgroupsABI0 = uintptr(unsafe.Pointer(&_setgroups))
 +
-+//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
-+var _pthread_attr_getstacksize uint8
-+var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
++//go:linkname _cgo_purego_setegid_trampoline _cgo_purego_setegid_trampoline
++var _cgo_purego_setegid_trampoline byte
++var x_cgo_purego_setegid_call = x_cgo_purego_setegid
 +
-+//go:linkname _pthread_attr_destroy _pthread_attr_destroy
-+var _pthread_attr_destroy uint8
-+var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
++//go:nosplit
++//go:norace
++func x_cgo_purego_setegid(c *argset) {
++	ret := setegid(uint32(uintptr(c.arg(0))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_seteuid_trampoline _cgo_purego_seteuid_trampoline
++var _cgo_purego_seteuid_trampoline byte
++var x_cgo_purego_seteuid_call = x_cgo_purego_seteuid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_seteuid(c *argset) {
++	ret := seteuid(uint32(uintptr(c.arg(0))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setgid_trampoline _cgo_purego_setgid_trampoline
++var _cgo_purego_setgid_trampoline byte
++var x_cgo_purego_setgid_call = x_cgo_purego_setgid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setgid(c *argset) {
++	ret := setgid(uint32(uintptr(c.arg(0))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setregid_trampoline _cgo_purego_setregid_trampoline
++var _cgo_purego_setregid_trampoline byte
++var x_cgo_purego_setregid_call = x_cgo_purego_setregid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setregid(c *argset) {
++	ret := setregid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setresgid_trampoline _cgo_purego_setresgid_trampoline
++var _cgo_purego_setresgid_trampoline byte
++var x_cgo_purego_setresgid_call = x_cgo_purego_setresgid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setresgid(c *argset) {
++	ret := setresgid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))), uint32(uintptr(c.arg(2))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setresuid_trampoline _cgo_purego_setresuid_trampoline
++var _cgo_purego_setresuid_trampoline byte
++var x_cgo_purego_setresuid_call = x_cgo_purego_setresuid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setresuid(c *argset) {
++	ret := setresuid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))), uint32(uintptr(c.arg(2))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setreuid_trampoline _cgo_purego_setreuid_trampoline
++var _cgo_purego_setreuid_trampoline byte
++var x_cgo_purego_setreuid_call = x_cgo_purego_setreuid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setreuid(c *argset) {
++	ret := setreuid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setuid_trampoline _cgo_purego_setuid_trampoline
++var _cgo_purego_setuid_trampoline byte
++var x_cgo_purego_setuid_call = x_cgo_purego_setuid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setuid(c *argset) {
++	ret := setuid(uint32(uintptr(c.arg(0))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setgroups_trampoline _cgo_purego_setgroups_trampoline
++var _cgo_purego_setgroups_trampoline byte
++var x_cgo_purego_setgroups_call = x_cgo_purego_setgroups
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setgroups(c *argset) {
++	ret := setgroups(uint32(uintptr(c.arg(0))), (*uint32)(c.arg(1)))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_darwin.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_darwin.s
 new file mode 100644
 index 00000000000000..35ef7ac11cb955
@@ -10961,10 +10536,10 @@ index 00000000000000..da07005c0bc988
 +	JMP purego_pthread_attr_destroy(SB)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux.s
 new file mode 100644
-index 00000000000000..ba2cb38918d538
+index 00000000000000..da07005c0bc988
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux.s
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,16 @@
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -10976,41 +10551,813 @@ index 00000000000000..ba2cb38918d538
 +
 +// these stubs are here because it is not possible to go:linkname directly the C functions
 +
-+TEXT ___errno_location(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego___errno_location(SB)
-+
-+TEXT _setegid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setegid(SB)
-+
-+TEXT _seteuid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_seteuid(SB)
-+
-+TEXT _setgid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setgid(SB)
-+
-+TEXT _setregid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setregid(SB)
-+
-+TEXT _setresgid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setresgid(SB)
-+
-+TEXT _setresuid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setresuid(SB)
-+
-+TEXT _setreuid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setreuid(SB)
-+
-+TEXT _setuid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setuid(SB)
-+
-+TEXT _setgroups(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setgroups(SB)
-+
 +TEXT _pthread_attr_getstacksize(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_attr_getstacksize(SB)
 +
 +TEXT _pthread_attr_destroy(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_attr_destroy(SB)
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_386.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_386.s
+new file mode 100644
+index 00000000000000..2903c5bdb7e54c
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_386.s
+@@ -0,0 +1,110 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++#include "textflag.h"
++
++TEXT ___errno_location(SB), NOSPLIT, $0-0
++	JMP purego___errno_location(SB)
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                          // first C arg
++	MOVL AX, 0(SP)                          // Go arg 1
++	MOVL ·x_cgo_purego_setegid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _setegid(SB), NOSPLIT, $0-0
++	JMP purego_setegid(SB)
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                          // first C arg
++	MOVL AX, 0(SP)                          // Go arg 1
++	MOVL ·x_cgo_purego_seteuid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _seteuid(SB), NOSPLIT, $0-0
++	JMP purego_seteuid(SB)
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                         // first C arg
++	MOVL AX, 0(SP)                         // Go arg 1
++	MOVL ·x_cgo_purego_setgid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _setgid(SB), NOSPLIT, $0-0
++	JMP purego_setgid(SB)
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                           // first C arg
++	MOVL AX, 0(SP)                           // Go arg 1
++	MOVL ·x_cgo_purego_setregid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _setregid(SB), NOSPLIT, $0-0
++	JMP purego_setregid(SB)
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                            // first C arg
++	MOVL AX, 0(SP)                            // Go arg 1
++	MOVL ·x_cgo_purego_setresgid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _setresgid(SB), NOSPLIT, $0-0
++	JMP purego_setresgid(SB)
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                            // first C arg
++	MOVL AX, 0(SP)                            // Go arg 1
++	MOVL ·x_cgo_purego_setresuid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _setresuid(SB), NOSPLIT, $0-0
++	JMP purego_setresuid(SB)
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                           // first C arg
++	MOVL AX, 0(SP)                           // Go arg 1
++	MOVL ·x_cgo_purego_setreuid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _setreuid(SB), NOSPLIT, $0-0
++	JMP purego_setreuid(SB)
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                         // first C arg
++	MOVL AX, 0(SP)                         // Go arg 1
++	MOVL ·x_cgo_purego_setuid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _setuid(SB), NOSPLIT, $0-0
++	JMP purego_setuid(SB)
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX                            // first C arg
++	MOVL AX, 0(SP)                            // Go arg 1
++	MOVL ·x_cgo_purego_setgroups_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _setgroups(SB), NOSPLIT, $0-0
++	JMP purego_setgroups(SB)
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_amd64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_amd64.s
+new file mode 100644
+index 00000000000000..776a6f3ad9533b
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_amd64.s
+@@ -0,0 +1,102 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++#include "textflag.h"
++
++TEXT ___errno_location(SB), NOSPLIT, $0-0
++	JMP purego___errno_location(SB)
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setegid_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT _setegid(SB), NOSPLIT, $0-0
++	JMP purego_setegid(SB)
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_seteuid_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT _seteuid(SB), NOSPLIT, $0-0
++	JMP purego_seteuid(SB)
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setgid_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT _setgid(SB), NOSPLIT, $0-0
++	JMP purego_setgid(SB)
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setregid_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT _setregid(SB), NOSPLIT, $0-0
++	JMP purego_setregid(SB)
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setresgid_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT _setresgid(SB), NOSPLIT, $0-0
++	JMP purego_setresgid(SB)
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setresuid_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT _setresuid(SB), NOSPLIT, $0-0
++	JMP purego_setresuid(SB)
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setreuid_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT _setreuid(SB), NOSPLIT, $0-0
++	JMP purego_setreuid(SB)
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setuid_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT _setuid(SB), NOSPLIT, $0-0
++	JMP purego_setuid(SB)
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setgroups_call(SB), DX
++	MOVQ (DX), CX
++	CALL CX
++	RET
++
++TEXT _setgroups(SB), NOSPLIT, $0-0
++	JMP purego_setgroups(SB)
++
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_arm.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_arm.s
+new file mode 100644
+index 00000000000000..09401d72019bde
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_arm.s
+@@ -0,0 +1,74 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++#include "textflag.h"
++
++TEXT ___errno_location(SB), NOSPLIT, $0-0
++	JMP purego___errno_location(SB)
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $4-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setegid_call(SB), R12
++	MOVW (R12), R2
++	CALL (R2)
++	RET
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $4-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_seteuid_call(SB), R12
++	MOVW (R12), R2
++	CALL (R2)
++	RET
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $4-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setgid_call(SB), R12
++	MOVW (R12), R2
++	CALL (R2)
++	RET
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $4-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setregid_call(SB), R12
++	MOVW (R12), R2
++	CALL (R2)
++	RET
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $4-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setresgid_call(SB), R12
++	MOVW (R12), R2
++	CALL (R2)
++	RET
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $4-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setresuid_call(SB), R12
++	MOVW (R12), R2
++	CALL (R2)
++	RET
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $4-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setreuid_call(SB), R12
++	MOVW (R12), R2
++	CALL (R2)
++	RET
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $4-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setuid_call(SB), R12
++	MOVW (R12), R2
++	CALL (R2)
++	RET
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $4-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setgroups_call(SB), R12
++	MOVW (R12), R2
++	CALL (R2)
++	RET
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_arm64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_arm64.s
+new file mode 100644
+index 00000000000000..0b25425c004d38
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_arm64.s
+@@ -0,0 +1,93 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++#include "textflag.h"
++
++TEXT ___errno_location(SB), NOSPLIT, $0-0
++	JMP purego___errno_location(SB)
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
++	MOVD ·x_cgo_purego_setegid_call(SB), R26
++	MOVD (R26), R2
++	CALL R2
++	RET
++
++TEXT _setegid(SB), NOSPLIT, $0-0
++	JMP purego_setegid(SB)
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
++	MOVD ·x_cgo_purego_seteuid_call(SB), R26
++	MOVD (R26), R2
++	CALL R2
++	RET
++
++TEXT _seteuid(SB), NOSPLIT, $0-0
++	JMP purego_seteuid(SB)
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
++	MOVD ·x_cgo_purego_setgid_call(SB), R26
++	MOVD (R26), R2
++	CALL R2
++	RET
++
++TEXT _setgid(SB), NOSPLIT, $0-0
++	JMP purego_setgid(SB)
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
++	MOVD ·x_cgo_purego_setregid_call(SB), R26
++	MOVD (R26), R2
++	CALL R2
++	RET
++
++TEXT _setregid(SB), NOSPLIT, $0-0
++	JMP purego_setregid(SB)
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
++	MOVD ·x_cgo_purego_setresgid_call(SB), R26
++	MOVD (R26), R2
++	CALL R2
++	RET
++
++TEXT _setresgid(SB), NOSPLIT, $0-0
++	JMP purego_setresgid(SB)
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
++	MOVD ·x_cgo_purego_setresuid_call(SB), R26
++	MOVD (R26), R2
++	CALL R2
++	RET
++
++TEXT _setresuid(SB), NOSPLIT, $0-0
++	JMP purego_setresuid(SB)
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
++	MOVD ·x_cgo_purego_setreuid_call(SB), R26
++	MOVD (R26), R2
++	CALL R2
++	RET
++
++TEXT _setreuid(SB), NOSPLIT, $0-0
++	JMP purego_setreuid(SB)
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
++	MOVD ·x_cgo_purego_setuid_call(SB), R26
++	MOVD (R26), R2
++	CALL R2
++	RET
++
++TEXT _setuid(SB), NOSPLIT, $0-0
++	JMP purego_setuid(SB)
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
++	MOVD ·x_cgo_purego_setgroups_call(SB), R26
++	MOVD (R26), R2
++	CALL R2
++	RET
++
++TEXT _setgroups(SB), NOSPLIT, $0-0
++	JMP purego_setgroups(SB)
++
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_loong64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_loong64.s
+new file mode 100644
+index 00000000000000..3c8a0d64e659fa
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_loong64.s
+@@ -0,0 +1,92 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++#include "textflag.h"
++
++TEXT ___errno_location(SB), NOSPLIT, $0-0
++	JMP purego___errno_location(SB)
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
++	MOVV ·x_cgo_purego_setegid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _setegid(SB), NOSPLIT, $0-0
++	JMP purego_setegid(SB)
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
++	MOVV ·x_cgo_purego_seteuid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _seteuid(SB), NOSPLIT, $0-0
++	JMP purego_seteuid(SB)
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
++	MOVV ·x_cgo_purego_setgid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _setgid(SB), NOSPLIT, $0-0
++	JMP purego_setgid(SB)
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
++	MOVV ·x_cgo_purego_setregid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _setregid(SB), NOSPLIT, $0-0
++	JMP purego_setregid(SB)
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
++	MOVV ·x_cgo_purego_setresgid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _setresgid(SB), NOSPLIT, $0-0
++	JMP purego_setresgid(SB)
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
++	MOVV ·x_cgo_purego_setresuid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _setresuid(SB), NOSPLIT, $0-0
++	JMP purego_setresuid(SB)
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
++	MOVV ·x_cgo_purego_setreuid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _setreuid(SB), NOSPLIT, $0-0
++	JMP purego_setreuid(SB)
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
++	MOVV ·x_cgo_purego_setuid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _setuid(SB), NOSPLIT, $0-0
++	JMP purego_setuid(SB)
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
++	MOVV ·x_cgo_purego_setgroups_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _setgroups(SB), NOSPLIT, $0-0
++	JMP purego_setgroups(SB)
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_ppc64le.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_ppc64le.s
+new file mode 100644
+index 00000000000000..70c51e674587ef
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_ppc64le.s
+@@ -0,0 +1,101 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++#include "textflag.h"
++
++TEXT ___errno_location(SB), NOSPLIT, $0-0
++	BR purego___errno_location(SB)
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
++	MOVD R3, R3
++	MOVD ·x_cgo_purego_setegid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	BR   (CTR)
++
++TEXT _setegid(SB), NOSPLIT, $0-0
++	BR purego_setegid(SB)
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
++	MOVD R3, R3
++	MOVD ·x_cgo_purego_seteuid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	BR   (CTR)
++
++TEXT _seteuid(SB), NOSPLIT, $0-0
++	BR purego_seteuid(SB)
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
++	MOVD R3, R3
++	MOVD ·x_cgo_purego_setgid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	BR   (CTR)
++
++TEXT _setgid(SB), NOSPLIT, $0-0
++	BR purego_setgid(SB)
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
++	MOVD R3, R3
++	MOVD ·x_cgo_purego_setregid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	BR   (CTR)
++
++TEXT _setregid(SB), NOSPLIT, $0-0
++	BR purego_setregid(SB)
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
++	MOVD R3, R3
++	MOVD ·x_cgo_purego_setresgid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	BR   (CTR)
++
++TEXT _setresgid(SB), NOSPLIT, $0-0
++	BR purego_setresgid(SB)
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
++	MOVD R3, R3
++	MOVD ·x_cgo_purego_setresuid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	BR   (CTR)
++
++TEXT _setresuid(SB), NOSPLIT, $0-0
++	BR purego_setresuid(SB)
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
++	MOVD R3, R3
++	MOVD ·x_cgo_purego_setreuid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	BR   (CTR)
++
++TEXT _setreuid(SB), NOSPLIT, $0-0
++	BR purego_setreuid(SB)
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
++	MOVD R3, R3
++	MOVD ·x_cgo_purego_setuid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	BR   (CTR)
++
++TEXT _setuid(SB), NOSPLIT, $0-0
++	BR purego_setuid(SB)
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
++	MOVD R3, R3
++	MOVD ·x_cgo_purego_setgroups_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	BR   (CTR)
++
++TEXT _setgroups(SB), NOSPLIT, $0-0
++	BR purego_setgroups(SB)
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_riscv64.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_riscv64.s
+new file mode 100644
+index 00000000000000..30dbb92f51fbb8
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_riscv64.s
+@@ -0,0 +1,92 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build !cgo
++
++#include "textflag.h"
++
++TEXT ___errno_location(SB), NOSPLIT, $0-0
++	JMP purego___errno_location(SB)
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
++	MOV  ·x_cgo_purego_setegid_call(SB), T0
++	MOV  (T0), T1
++	CALL T1
++	RET
++
++TEXT _setegid(SB), NOSPLIT, $0-0
++	JMP purego_setegid(SB)
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
++	MOV  ·x_cgo_purego_seteuid_call(SB), T0
++	MOV  (T0), T1
++	CALL T1
++	RET
++
++TEXT _seteuid(SB), NOSPLIT, $0-0
++	JMP purego_seteuid(SB)
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
++	MOV  ·x_cgo_purego_setgid_call(SB), T0
++	MOV  (T0), T1
++	CALL T1
++	RET
++
++TEXT _setgid(SB), NOSPLIT, $0-0
++	JMP purego_setgid(SB)
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
++	MOV  ·x_cgo_purego_setregid_call(SB), T0
++	MOV  (T0), T1
++	CALL T1
++	RET
++
++TEXT _setregid(SB), NOSPLIT, $0-0
++	JMP purego_setregid(SB)
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
++	MOV  ·x_cgo_purego_setresgid_call(SB), T0
++	MOV  (T0), T1
++	CALL T1
++	RET
++
++TEXT _setresgid(SB), NOSPLIT, $0-0
++	JMP purego_setresgid(SB)
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
++	MOV  ·x_cgo_purego_setresuid_call(SB), T0
++	MOV  (T0), T1
++	CALL T1
++	RET
++
++TEXT _setresuid(SB), NOSPLIT, $0-0
++	JMP purego_setresuid(SB)
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
++	MOV  ·x_cgo_purego_setreuid_call(SB), T0
++	MOV  (T0), T1
++	CALL T1
++	RET
++
++TEXT _setreuid(SB), NOSPLIT, $0-0
++	JMP purego_setreuid(SB)
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
++	MOV  ·x_cgo_purego_setuid_call(SB), T0
++	MOV  (T0), T1
++	CALL T1
++	RET
++
++TEXT _setuid(SB), NOSPLIT, $0-0
++	JMP purego_setuid(SB)
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
++	MOV  ·x_cgo_purego_setgroups_call(SB), T0
++	MOV  (T0), T1
++	CALL T1
++	RET
++
++TEXT _setgroups(SB), NOSPLIT, $0-0
++	JMP purego_setgroups(SB)
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_s390x.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_s390x.s
+new file mode 100644
+index 00000000000000..edc21761ddd8ad
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_linux_s390x.s
+@@ -0,0 +1,90 @@
++// Code generated by 'go generate' with gen.go. DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build go1.27 && !cgo
++
++#include "textflag.h"
++
++TEXT ___errno_location(SB), NOSPLIT, $0-0
++	JMP purego___errno_location(SB)
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	// R2 already has the argument from C caller
++	MOVD ·x_cgo_purego_setegid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _setegid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setegid(SB)
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_seteuid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _seteuid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_seteuid(SB)
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setgid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _setgid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setgid(SB)
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	// R2, R3 have arguments from C caller
++	MOVD ·x_cgo_purego_setregid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _setregid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setregid(SB)
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	// R2, R3, R4 have arguments from C caller
++	MOVD ·x_cgo_purego_setresgid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _setresgid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setresgid(SB)
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	// R2, R3, R4 have arguments from C caller
++	MOVD ·x_cgo_purego_setresuid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _setresuid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setresuid(SB)
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	// R2, R3 have arguments from C caller
++	MOVD ·x_cgo_purego_setreuid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _setreuid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setreuid(SB)
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setuid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _setuid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setuid(SB)
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT|NOFRAME, $0
++	// R2, R3 have arguments from C caller
++	MOVD ·x_cgo_purego_setgroups_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _setgroups(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setgroups(SB)
++
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_stubs.s b/src/vendor/github.com/golang-fips/openssl/v2/internal/fakecgo/ztrampolines_stubs.s
 new file mode 100644
 index 00000000000000..067583d68517a9
@@ -12202,7 +12549,7 @@ index 00000000000000..9d38464e9fb964
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/shims.h b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/shims.h
 new file mode 100644
-index 00000000000000..ef675266fc2f0d
+index 00000000000000..d926c6adf17dda
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/shims.h
 @@ -0,0 +1,434 @@
@@ -12358,12 +12705,12 @@ index 00000000000000..ef675266fc2f0d
 +// BIO API
 +const _BIO_METHOD_PTR BIO_s_mem(void) __attribute__((tag(""),tag("init_3"),noerror));
 +_BIO_PTR BIO_new(const _BIO_METHOD_PTR type) __attribute__((tag(""),tag("init_3")));
-+int BIO_free(_BIO_PTR a) __attribute__((tag(""),tag("init_3"),noerror,noescape,nocallback));
++int BIO_free(_BIO_PTR a) __attribute__((tag(""),tag("init_3"),noerror));
 +long BIO_ctrl(_BIO_PTR bp, int cmd, long larg, void *parg) __attribute__((tag(""),tag("init_3"),noerror,noescape,nocallback));
 +
 +// ERR API
 +unsigned long ERR_peek_error(void) __attribute__((noerror));
-+void ERR_print_errors(_BIO_PTR bp) __attribute__((tag(""),tag("init_3"),noescape,nocallback));
++void ERR_print_errors(_BIO_PTR bp) __attribute__((tag(""),tag("init_3")));
 +
 +// OPENSSL API
 +const char *OpenSSL_version(int type) __attribute__((noerror));
@@ -12392,7 +12739,7 @@ index 00000000000000..ef675266fc2f0d
 +const char *OSSL_PROVIDER_get0_name(const _OSSL_PROVIDER_PTR prov) __attribute__((tag("3"),noerror));
 +
 +// RAND API
-+int RAND_bytes(unsigned char *arg0, int arg1) __attribute__((noescape,nocallback,slice("arg0","arg1")));
++int RAND_bytes(unsigned char *arg0, int arg1) __attribute__((noescape,nocallback));
 +
 +// EVP_MD API
 +_EVP_MD_PTR EVP_MD_fetch(_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties) __attribute__((tag("3"),tag("init_3")));
@@ -12426,28 +12773,28 @@ index 00000000000000..ef675266fc2f0d
 +const _OSSL_PARAM_PTR EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
 +int EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR ctx, _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
 +int EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
-+int EVP_Digest(const void *data, size_t count, unsigned char *md, unsigned int *size, const _EVP_MD_PTR type, _ENGINE_PTR impl) __attribute__((noescape,nocallback,slice("data","count"),slice("md","size")));
++int EVP_Digest(const void *data, size_t count, unsigned char *md, unsigned int *size, const _EVP_MD_PTR type, _ENGINE_PTR impl) __attribute__((noescape,nocallback,slice("data","count"),slice("md")));
 +int EVP_DigestInit_ex(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type, _ENGINE_PTR impl);
 +int EVP_DigestInit(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type);
 +int EVP_DigestUpdate(_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt) __attribute__((noescape,nocallback,slice("d","cnt")));
-+int EVP_DigestFinal_ex(_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s) __attribute__((noescape,nocallback,slice("md","s")));
-+int EVP_DigestFinalXOF(_EVP_MD_CTX_PTR ctx, unsigned char *md, size_t mdlen) __attribute__((tag("33"),noescape,nocallback,slice("md","mdlen")));
-+int EVP_DigestSqueeze(_EVP_MD_CTX_PTR ctx, unsigned char *out, size_t outlen) __attribute__((tag("33"),noescape,nocallback,slice("out","outlen")));
-+int EVP_DigestSign(_EVP_MD_CTX_PTR ctx, unsigned char *sigret, size_t *siglen, const unsigned char *tbs, size_t tbslen) __attribute__((tag("111"),noescape,nocallback,slice("sigret","siglen"),slice("tbs","tbslen")));
++int EVP_DigestFinal_ex(_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s) __attribute__((noescape,nocallback,slice(md)));
++int EVP_DigestFinalXOF(_EVP_MD_CTX_PTR ctx, unsigned char *md, size_t len) __attribute__((tag("33"),noescape,nocallback,slice(md)));
++int EVP_DigestSqueeze(_EVP_MD_CTX_PTR ctx, unsigned char *out, size_t len) __attribute__((tag("33"),noescape,nocallback,slice("out","len")));
++int EVP_DigestSign(_EVP_MD_CTX_PTR ctx, unsigned char *sigret, size_t *siglen, const unsigned char *tbs, size_t tbslen) __attribute__((tag("111"),noescape,nocallback));
 +int EVP_DigestSignInit(_EVP_MD_CTX_PTR ctx, _EVP_PKEY_CTX_PTR *pctx, const _EVP_MD_PTR type, _ENGINE_PTR e, _EVP_PKEY_PTR pkey);
-+int EVP_DigestSignFinal(_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen) __attribute__((slice("sig","siglen")));
++int EVP_DigestSignFinal(_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen);
 +int EVP_DigestVerifyInit(_EVP_MD_CTX_PTR ctx, _EVP_PKEY_CTX_PTR *pctx, const _EVP_MD_PTR type, _ENGINE_PTR e, _EVP_PKEY_PTR pkey);
-+int EVP_DigestVerifyFinal(_EVP_MD_CTX_PTR ctx, const unsigned char *sig, size_t siglen) __attribute__((slice("sig","siglen")));
-+int EVP_DigestVerify(_EVP_MD_CTX_PTR ctx, const unsigned char *sigret, size_t siglen, const unsigned char *tbs, size_t tbslen) __attribute__((tag("111"),slice("sigret","siglen"),slice("tbs","tbslen")));
++int EVP_DigestVerifyFinal(_EVP_MD_CTX_PTR ctx, const unsigned char *sig, size_t siglen);
++int EVP_DigestVerify(_EVP_MD_CTX_PTR ctx, const unsigned char *sigret, size_t siglen, const unsigned char *tbs, size_t tbslen) __attribute__((tag("111")));
 +
 +// HMAC API
-+int HMAC_Init_ex(_HMAC_CTX_PTR arg0, const void *arg1, int arg2, const _EVP_MD_PTR arg3, _ENGINE_PTR arg4) __attribute__((tag("legacy_1"),noescape,nocallback,slice("arg1","arg2")));
-+int HMAC_Update(_HMAC_CTX_PTR arg0, const unsigned char *arg1, size_t arg2) __attribute__((tag("legacy_1"),noescape,nocallback,slice("arg1","arg2")));
-+int HMAC_Final(_HMAC_CTX_PTR arg0, unsigned char *arg1, unsigned int *arg2) __attribute__((tag("legacy_1"),noescape,nocallback,slice("arg1","arg2")));
++int HMAC_Init_ex(_HMAC_CTX_PTR arg0, const void *arg1, int arg2, const _EVP_MD_PTR arg3, _ENGINE_PTR arg4) __attribute__((tag("legacy_1")));
++int HMAC_Update(_HMAC_CTX_PTR arg0, const unsigned char *arg1, size_t arg2) __attribute__((tag("legacy_1")));
++int HMAC_Final(_HMAC_CTX_PTR arg0, unsigned char *arg1, unsigned int *arg2) __attribute__((tag("legacy_1")));
 +
 +_HMAC_CTX_PTR HMAC_CTX_new(void) __attribute__((tag("legacy_1")));
-+int HMAC_CTX_copy(_HMAC_CTX_PTR dest, _HMAC_CTX_PTR src) __attribute__((tag("legacy_1"),noescape,nocallback));
-+void HMAC_CTX_free(_HMAC_CTX_PTR arg0) __attribute__((tag("legacy_1"),noescape,nocallback));
++int HMAC_CTX_copy(_HMAC_CTX_PTR dest, _HMAC_CTX_PTR src) __attribute__((tag("legacy_1")));
++void HMAC_CTX_free(_HMAC_CTX_PTR arg0) __attribute__((tag("legacy_1")));
 +
 +// EVP_CIPHER API
 +_EVP_CIPHER_PTR EVP_CIPHER_fetch(_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties) __attribute__((tag("3")));
@@ -12478,18 +12825,18 @@ index 00000000000000..ef675266fc2f0d
 +void EVP_CIPHER_CTX_free(_EVP_CIPHER_CTX_PTR arg0);
 +int EVP_CIPHER_CTX_ctrl(_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr);
 +int EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv, int enc);
-+int EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback,slice("out","outl"),slice("in","inl")));
++int EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));
 +int EVP_EncryptInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv);
-+int EVP_EncryptUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback,slice("out","outl"),slice("in","inl")));
-+int EVP_EncryptFinal_ex(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl) __attribute__((noescape,nocallback,slice("out","outl")));
++int EVP_EncryptUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));
++int EVP_EncryptFinal_ex(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl) __attribute__((noescape,nocallback));
 +int EVP_DecryptInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv);
-+int EVP_DecryptUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback,slice("out","outl"),slice("in","inl")));
-+int EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR ctx, unsigned char *outm, int *outl) __attribute__((noescape,nocallback,slice("outm","outl")));
++int EVP_DecryptUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));
++int EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR ctx, unsigned char *outm, int *outl) __attribute__((noescape,nocallback));
 +
 +// EVP_PKEY API
 +_EVP_PKEY_PTR EVP_PKEY_new(void);
-+_EVP_PKEY_PTR EVP_PKEY_new_raw_private_key(int type, _ENGINE_PTR e, const unsigned char *key, size_t keylen) __attribute__((tag("111"),slice("key","keylen")));
-+_EVP_PKEY_PTR EVP_PKEY_new_raw_public_key(int type, _ENGINE_PTR e, const unsigned char *key, size_t keylen) __attribute__((tag("111"),slice("key","keylen")));
++_EVP_PKEY_PTR EVP_PKEY_new_raw_private_key(int type, _ENGINE_PTR e, const unsigned char *key, size_t keylen) __attribute__((tag("111")));
++_EVP_PKEY_PTR EVP_PKEY_new_raw_public_key(int type, _ENGINE_PTR e, const unsigned char *key, size_t keylen) __attribute__((tag("111")));
 +int EVP_PKEY_get_size(const _EVP_PKEY_PTR pkey) __attribute__((tag("3"),tag("legacy_1","EVP_PKEY_size")));
 +int EVP_PKEY_get_bits(const _EVP_PKEY_PTR pkey) __attribute__((tag("3"),tag("legacy_1","EVP_PKEY_bits"))); 
 +void EVP_PKEY_free(_EVP_PKEY_PTR arg0);
@@ -12497,40 +12844,40 @@ index 00000000000000..ef675266fc2f0d
 +int EVP_PKEY_assign(_EVP_PKEY_PTR pkey, int type, void *key) __attribute__((tag("legacy_1")));
 +_EC_KEY_PTR EVP_PKEY_get0_EC_KEY(_EVP_PKEY_PTR pkey) __attribute__((tag("legacy_1")));
 +_DSA_PTR EVP_PKEY_get0_DSA(_EVP_PKEY_PTR pkey) __attribute__((tag("legacy_1")));
-+int EVP_PKEY_set1_encoded_public_key(_EVP_PKEY_PTR pkey, const unsigned char *pub, size_t publen) __attribute__((tag("3"),slice("pub","publen")));
++int EVP_PKEY_set1_encoded_public_key(_EVP_PKEY_PTR pkey, const unsigned char *pub, size_t publen) __attribute__((tag("3")));
 +size_t EVP_PKEY_get1_encoded_public_key(_EVP_PKEY_PTR pkey, unsigned char **ppub) __attribute__((tag("3")));
-+int EVP_PKEY_get_bn_param(const _EVP_PKEY_PTR pkey, const char *key_name, _BIGNUM_PTR *bn) __attribute__((tag("3"),noescape,nocallback));
-+int EVP_PKEY_get_octet_string_param(const _EVP_PKEY_PTR pkey, const char *key_name, unsigned char *buf, size_t buf_len, size_t *out_len) __attribute__((tag("3"),slice("buf","buf_len")));
++int EVP_PKEY_get_bn_param(const _EVP_PKEY_PTR pkey, const char *key_name, _BIGNUM_PTR *bn) __attribute__((tag("3")));
++int EVP_PKEY_get_octet_string_param(const _EVP_PKEY_PTR pkey, const char *key_name, unsigned char *buf, size_t buf_len, size_t *out_len) __attribute__((tag("3")));
 +int EVP_PKEY_up_ref(_EVP_PKEY_PTR key);
 +int EVP_PKEY_set1_EC_KEY(_EVP_PKEY_PTR pkey, _EC_KEY_PTR key) __attribute__((tag("legacy_1")));
-+int EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR ctx, void *label, int labellen) __attribute__((tag("3"),slice("label","labellen")));
-+int EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR pkey, unsigned char *pub, size_t *publen) __attribute__((tag("111"),noescape,nocallback,slice("pub","publen")));
-+int EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR pkey, unsigned char *priv, size_t *privlen) __attribute__((tag("111"),noescape,nocallback,slice("priv","privlen")));
++int EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR ctx, void *label, int len) __attribute__((tag("3")));
++int EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR pkey, unsigned char *pub, size_t *len) __attribute__((tag("111"),noescape,nocallback));
++int EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR pkey, unsigned char *priv, size_t *len) __attribute__((tag("111"),noescape,nocallback));
 +int EVP_PKEY_fromdata_init(_EVP_PKEY_CTX_PTR ctx) __attribute__((tag("3")));
 +int EVP_PKEY_fromdata(_EVP_PKEY_CTX_PTR ctx, _EVP_PKEY_PTR *pkey, int selection, _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 +int EVP_PKEY_paramgen_init(_EVP_PKEY_CTX_PTR ctx);
 +int EVP_PKEY_paramgen(_EVP_PKEY_CTX_PTR ctx, _EVP_PKEY_PTR *ppkey);
 +int EVP_PKEY_keygen_init(_EVP_PKEY_CTX_PTR ctx);
-+int EVP_PKEY_keygen(_EVP_PKEY_CTX_PTR ctx, _EVP_PKEY_PTR *ppkey) __attribute__((noescape,nocallback));
-+int EVP_PKEY_decrypt(_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4) __attribute__((slice("arg1","arg2"),slice("arg3","arg4")));
-+int EVP_PKEY_encrypt(_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4) __attribute__((slice("arg1","arg2"),slice("arg3","arg4")));
++int EVP_PKEY_keygen(_EVP_PKEY_CTX_PTR ctx, _EVP_PKEY_PTR *ppkey);
++int EVP_PKEY_decrypt(_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4);
++int EVP_PKEY_encrypt(_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4);
 +int EVP_PKEY_decrypt_init(_EVP_PKEY_CTX_PTR arg0);
 +int EVP_PKEY_encrypt_init(_EVP_PKEY_CTX_PTR arg0);
 +int EVP_PKEY_sign_init(_EVP_PKEY_CTX_PTR arg0);
 +int EVP_PKEY_verify_init(_EVP_PKEY_CTX_PTR arg0);
-+int EVP_PKEY_sign(_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4) __attribute__((slice("arg1","arg2"),slice("arg3","arg4")));
-+int EVP_PKEY_verify(_EVP_PKEY_CTX_PTR ctx, const unsigned char *sig, size_t siglen, const unsigned char *tbs, size_t tbslen) __attribute__((slice("sig","siglen"),slice("tbs","tbslen")));
++int EVP_PKEY_sign(_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4);
++int EVP_PKEY_verify(_EVP_PKEY_CTX_PTR ctx, const unsigned char *sig, size_t siglen, const unsigned char *tbs, size_t tbslen);
 +int EVP_PKEY_derive_init(_EVP_PKEY_CTX_PTR ctx);
 +int EVP_PKEY_derive_set_peer(_EVP_PKEY_CTX_PTR ctx, _EVP_PKEY_PTR peer);
-+int EVP_PKEY_derive(_EVP_PKEY_CTX_PTR ctx, unsigned char *key, size_t *keylen) __attribute__((noescape,nocallback,slice("key","keylen")));
++int EVP_PKEY_derive(_EVP_PKEY_CTX_PTR ctx, unsigned char *key, size_t *keylen) __attribute__((noescape,nocallback));
 +int EVP_PKEY_public_check_quick(_EVP_PKEY_CTX_PTR ctx) __attribute__((tag("3")));
 +int EVP_PKEY_private_check(_EVP_PKEY_CTX_PTR ctx) __attribute__((tag("3")));
 +_EVP_PKEY_PTR EVP_PKEY_Q_keygen(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type, ...) __attribute__((tag("3")));
-+_EVP_PKEY_PTR EVP_PKEY_Q_keygen_RSA(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type, size_t arg1) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen"),noescape,nocallback));
-+_EVP_PKEY_PTR EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type, const char *arg1) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen"),noescape,nocallback));
-+_EVP_PKEY_PTR EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen"),noescape,nocallback));
-+_EVP_PKEY_PTR EVP_PKEY_Q_keygen_X25519(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen"),noescape,nocallback));
-+_EVP_PKEY_PTR EVP_PKEY_Q_keygen_MLKEM(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen"),noescape,nocallback));
++_EVP_PKEY_PTR EVP_PKEY_Q_keygen_RSA(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type, size_t arg1) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen")));
++_EVP_PKEY_PTR EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type, const char *arg1) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen")));
++_EVP_PKEY_PTR EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen")));
++_EVP_PKEY_PTR EVP_PKEY_Q_keygen_X25519(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen")));
++_EVP_PKEY_PTR EVP_PKEY_Q_keygen_MLKEM(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen")));
 +
 +_EVP_PKEY_CTX_PTR EVP_PKEY_CTX_new(_EVP_PKEY_PTR arg0, _ENGINE_PTR arg1);
 +_EVP_PKEY_CTX_PTR EVP_PKEY_CTX_new_id(int id, _ENGINE_PTR e);
@@ -12539,9 +12886,9 @@ index 00000000000000..ef675266fc2f0d
 +int EVP_PKEY_CTX_ctrl(_EVP_PKEY_CTX_PTR ctx, int keytype, int optype, int cmd, int p1, void *p2);
 +int EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR arg0, int arg1) __attribute__((tag("3")));
 +int EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR arg0, const _EVP_MD_PTR arg1) __attribute__((tag("3")));
-+int EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2) __attribute__((tag("3"),slice("arg1","arg2")));
-+int EVP_PKEY_CTX_set1_hkdf_key(_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2) __attribute__((tag("3"),slice("arg1","arg2")));
-+int EVP_PKEY_CTX_add1_hkdf_info(_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2) __attribute__((tag("3"),slice("arg1","arg2")));
++int EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2) __attribute__((tag("3")));
++int EVP_PKEY_CTX_set1_hkdf_key(_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2) __attribute__((tag("3")));
++int EVP_PKEY_CTX_add1_hkdf_info(_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2) __attribute__((tag("3")));
 +
 +// RSA API
 +_RSA_PTR RSA_new(void) __attribute__((tag("legacy_1")));
@@ -12559,10 +12906,10 @@ index 00000000000000..ef675266fc2f0d
 +void BN_clear(_BIGNUM_PTR arg0);
 +void BN_clear_free(_BIGNUM_PTR arg0);
 +int BN_num_bits(const _BIGNUM_PTR arg0) __attribute__((noerror));
-+_BIGNUM_PTR BN_bin2bn(const unsigned char *arg0, int arg1, _BIGNUM_PTR arg2) __attribute__((slice("arg0","arg1")));
-+_BIGNUM_PTR BN_lebin2bn(const unsigned char *s, int slen, _BIGNUM_PTR ret) __attribute__((slice("s","slen")));
-+int BN_bn2lebinpad(const _BIGNUM_PTR a, unsigned char *to, int tolen) __attribute__((errcond("== -1"),slice("to","tolen")));
-+int BN_bn2binpad(const _BIGNUM_PTR a, unsigned char *to, int tolen) __attribute__((errcond("== -1"),slice("to","tolen")));
++_BIGNUM_PTR BN_bin2bn(const unsigned char *arg0, int arg1, _BIGNUM_PTR arg2);
++_BIGNUM_PTR BN_lebin2bn(const unsigned char *s, int len, _BIGNUM_PTR ret);
++int BN_bn2lebinpad(const _BIGNUM_PTR a, unsigned char *to, int tolen) __attribute__((errcond("== -1")));
++int BN_bn2binpad(const _BIGNUM_PTR a, unsigned char *to, int tolen) __attribute__((errcond("== -1")));
 +
 +// EC API
 +int EC_KEY_set_public_key_affine_coordinates(_EC_KEY_PTR key, _BIGNUM_PTR x, _BIGNUM_PTR y) __attribute__((tag("legacy_1")));
@@ -12579,8 +12926,8 @@ index 00000000000000..ef675266fc2f0d
 +int EC_POINT_mul(const _EC_GROUP_PTR group, _EC_POINT_PTR r, const _BIGNUM_PTR n, const _EC_POINT_PTR q, const _BIGNUM_PTR m, _BN_CTX_PTR ctx);
 +int EC_POINT_get_affine_coordinates_GFp(const _EC_GROUP_PTR arg0, const _EC_POINT_PTR arg1, _BIGNUM_PTR arg2, _BIGNUM_PTR arg3, _BN_CTX_PTR arg4) __attribute__((tag("legacy_1")));
 +int EC_POINT_set_affine_coordinates(const _EC_GROUP_PTR arg0, _EC_POINT_PTR arg1, const _BIGNUM_PTR arg2, const _BIGNUM_PTR arg3, _BN_CTX_PTR arg4)  __attribute__((tag("3")));
-+size_t EC_POINT_point2oct(const _EC_GROUP_PTR group, const _EC_POINT_PTR p, point_conversion_form_t form, unsigned char *buf, size_t buflen, _BN_CTX_PTR ctx) __attribute__((slice("buf","buflen")));
-+int EC_POINT_oct2point(const _EC_GROUP_PTR group, _EC_POINT_PTR p, const unsigned char *buf, size_t buflen, _BN_CTX_PTR ctx) __attribute__((slice("buf","buflen")));
++size_t EC_POINT_point2oct(const _EC_GROUP_PTR group, const _EC_POINT_PTR p, point_conversion_form_t form, unsigned char *buf, size_t len, _BN_CTX_PTR ctx);
++int EC_POINT_oct2point(const _EC_GROUP_PTR group, _EC_POINT_PTR p, const unsigned char *buf, size_t len, _BN_CTX_PTR ctx);
 +_EC_GROUP_PTR EC_GROUP_new_by_curve_name(int nid);
 +void EC_GROUP_free(_EC_GROUP_PTR group);
 +
@@ -12588,20 +12935,20 @@ index 00000000000000..ef675266fc2f0d
 +_EVP_MAC_PTR EVP_MAC_fetch(_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties) __attribute__((tag("3")));
 +_EVP_MAC_CTX_PTR EVP_MAC_CTX_new(_EVP_MAC_PTR arg0) __attribute__((tag("3")));
 +int EVP_MAC_CTX_set_params(_EVP_MAC_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
-+void EVP_MAC_CTX_free(_EVP_MAC_CTX_PTR arg0) __attribute__((tag("3"),noescape,nocallback));
++void EVP_MAC_CTX_free(_EVP_MAC_CTX_PTR arg0) __attribute__((tag("3")));
 +_EVP_MAC_CTX_PTR EVP_MAC_CTX_dup(const _EVP_MAC_CTX_PTR arg0) __attribute__((tag("3")));
-+int EVP_MAC_init(_EVP_MAC_CTX_PTR ctx, const unsigned char *key, size_t keylen, const _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback,slice("key","keylen")));
-+int EVP_MAC_update(_EVP_MAC_CTX_PTR ctx, const unsigned char *data, size_t datalen) __attribute__((tag("3"),noescape,nocallback,slice("data","datalen")));
-+int EVP_MAC_final(_EVP_MAC_CTX_PTR ctx, unsigned char *out, size_t *outl, size_t outsize) __attribute__((tag("3"),noescape,nocallback,slice("out","outsize")));
++int EVP_MAC_init(_EVP_MAC_CTX_PTR ctx, const unsigned char *key, size_t keylen, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
++int EVP_MAC_update(_EVP_MAC_CTX_PTR ctx, const unsigned char *data, size_t datalen) __attribute__((tag("3")));
++int EVP_MAC_final(_EVP_MAC_CTX_PTR ctx, unsigned char *out, size_t *outl, size_t outsize) __attribute__((tag("3")));
 +
 +// OSSL_PARAM API
 +void OSSL_PARAM_free(_OSSL_PARAM_PTR p) __attribute__((tag("3")));
 +const _OSSL_PARAM_PTR OSSL_PARAM_locate_const(const _OSSL_PARAM_PTR p, const char *key) __attribute__((tag("3")));
-+_OSSL_PARAM_BLD_PTR OSSL_PARAM_BLD_new(void) __attribute__((tag("3"),noerror));
++_OSSL_PARAM_BLD_PTR OSSL_PARAM_BLD_new(void) __attribute__((tag("3")));
 +void OSSL_PARAM_BLD_free(_OSSL_PARAM_BLD_PTR bld) __attribute__((tag("3")));
 +_OSSL_PARAM_PTR OSSL_PARAM_BLD_to_param(_OSSL_PARAM_BLD_PTR bld) __attribute__((tag("3")));
-+int OSSL_PARAM_BLD_push_utf8_string(_OSSL_PARAM_BLD_PTR bld, const char *key, const char *buf, size_t bsize) __attribute__((tag("3"),slice("buf","bsize")));
-+int OSSL_PARAM_BLD_push_octet_string(_OSSL_PARAM_BLD_PTR bld, const char *key, const void *buf, size_t bsize) __attribute__((tag("3"),slice("buf","bsize")));
++int OSSL_PARAM_BLD_push_utf8_string(_OSSL_PARAM_BLD_PTR bld, const char *key, const char *buf, size_t bsize) __attribute__((tag("3")));
++int OSSL_PARAM_BLD_push_octet_string(_OSSL_PARAM_BLD_PTR bld, const char *key, const void *buf, size_t bsize) __attribute__((tag("3")));
 +int OSSL_PARAM_BLD_push_BN(_OSSL_PARAM_BLD_PTR bld, const char *key, const _BIGNUM_PTR bn) __attribute__((tag("3")));
 +int OSSL_PARAM_BLD_push_int32(_OSSL_PARAM_BLD_PTR bld, const char *key, int32_t num) __attribute__((tag("3")));
 +
@@ -12625,8 +12972,8 @@ index 00000000000000..ef675266fc2f0d
 +int EVP_KDF_CTX_set_params(_EVP_KDF_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 +void EVP_KDF_CTX_free(_EVP_KDF_CTX_PTR ctx) __attribute__((tag("3")));
 +size_t EVP_KDF_CTX_get_kdf_size(_EVP_KDF_CTX_PTR ctx) __attribute__((tag("3")));
-+int EVP_KDF_derive(_EVP_KDF_CTX_PTR ctx, unsigned char *key, size_t keylen, const _OSSL_PARAM_PTR params) __attribute__((tag("3"),slice("key","keylen")));
-+int PKCS5_PBKDF2_HMAC(const char *pass, int passlen, const unsigned char *salt, int saltlen, int iter, const _EVP_MD_PTR digest, int keylen, unsigned char *out) __attribute__((slice("pass","passlen"),slice("salt","saltlen"),slice("out","keylen")));
++int EVP_KDF_derive(_EVP_KDF_CTX_PTR ctx, unsigned char *key, size_t keylen, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
++int PKCS5_PBKDF2_HMAC(const char *pass, int passlen, const unsigned char *salt, int saltlen, int iter, const _EVP_MD_PTR digest, int keylen, unsigned char *out);
 +
 +// OBJ API
 +const char *OBJ_nid2sn(int n) __attribute__((noerror));
@@ -12880,10 +13227,10 @@ index 00000000000000..068a94d4c83ae1
 +
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zdl_nocgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zdl_nocgo.go
 new file mode 100644
-index 00000000000000..0a087c1514bd8b
+index 00000000000000..e4d870cecde36c
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zdl_nocgo.go
-@@ -0,0 +1,58 @@
+@@ -0,0 +1,45 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +//go:build !cgo && unix
@@ -12896,19 +13243,6 @@ index 00000000000000..0a087c1514bd8b
 +)
 +
 +var _ = runtime.GOOS
-+
-+var _mkcgoAlwaysFalseDl bool
-+var _mkcgoEscapeSinkDl unsafe.Pointer
-+
-+// mkcgoEscapePtrDl forces p to escape to the heap.
-+// This implementation is also used in the standard library:
-+// https://github.com/golang/go/blob/f71432d223eeb2139b460957817400750fd13655/src/internal/abi/escape.go#L24-L33
-+func mkcgoEscapePtrDl(p unsafe.Pointer) unsafe.Pointer {
-+	if _mkcgoAlwaysFalseDl {
-+		_mkcgoEscapeSinkDl = p
-+	}
-+	return p
-+}
 +
 +//go:cgo_import_dynamic _mkcgo_dlclose dlclose ""
 +//go:cgo_import_dynamic _mkcgo_dlerror dlerror ""
@@ -12932,22 +13266,22 @@ index 00000000000000..0a087c1514bd8b
 +var _mkcgo_dlopen_trampoline_addr uintptr
 +
 +func Dlopen(path *byte, flags int32) unsafe.Pointer {
-+	r0, _ := syscallN(0, _mkcgo_dlopen_trampoline_addr, uintptr(mkcgoEscapePtrDl(unsafe.Pointer(path))), uintptr(flags))
++	r0, _ := syscallN(0, _mkcgo_dlopen_trampoline_addr, uintptr(unsafe.Pointer(path)), uintptr(flags))
 +	return unsafe.Pointer(r0)
 +}
 +
 +var _mkcgo_dlsym_trampoline_addr uintptr
 +
 +func Dlsym(handle unsafe.Pointer, symbol *byte) unsafe.Pointer {
-+	r0, _ := syscallN(0, _mkcgo_dlsym_trampoline_addr, uintptr(handle), uintptr(mkcgoEscapePtrDl(unsafe.Pointer(symbol))))
++	r0, _ := syscallN(0, _mkcgo_dlsym_trampoline_addr, uintptr(handle), uintptr(unsafe.Pointer(symbol)))
 +	return unsafe.Pointer(r0)
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.c b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.c
 new file mode 100644
-index 00000000000000..c284c017339d4a
+index 00000000000000..832ecd8558ffef
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.c
-@@ -0,0 +1,2054 @@
+@@ -0,0 +1,2056 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +#include <stddef.h>
@@ -13072,7 +13406,7 @@ index 00000000000000..c284c017339d4a
 +_EVP_PKEY_CTX_PTR (*_g_EVP_PKEY_CTX_new)(_EVP_PKEY_PTR, _ENGINE_PTR);
 +_EVP_PKEY_CTX_PTR (*_g_EVP_PKEY_CTX_new_from_pkey)(_OSSL_LIB_CTX_PTR, _EVP_PKEY_PTR, const char*);
 +_EVP_PKEY_CTX_PTR (*_g_EVP_PKEY_CTX_new_id)(int, _ENGINE_PTR);
-+int (*_g_EVP_PKEY_CTX_set0_rsa_oaep_label)(_EVP_PKEY_CTX_PTR, unsigned char*, int);
++int (*_g_EVP_PKEY_CTX_set0_rsa_oaep_label)(_EVP_PKEY_CTX_PTR, void*, int);
 +int (*_g_EVP_PKEY_CTX_set1_hkdf_key)(_EVP_PKEY_CTX_PTR, const unsigned char*, int);
 +int (*_g_EVP_PKEY_CTX_set1_hkdf_salt)(_EVP_PKEY_CTX_PTR, const unsigned char*, int);
 +int (*_g_EVP_PKEY_CTX_set_hkdf_md)(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR);
@@ -13162,7 +13496,7 @@ index 00000000000000..c284c017339d4a
 +void (*_g_HMAC_CTX_free)(_HMAC_CTX_PTR);
 +_HMAC_CTX_PTR (*_g_HMAC_CTX_new)(void);
 +int (*_g_HMAC_Final)(_HMAC_CTX_PTR, unsigned char*, unsigned int*);
-+int (*_g_HMAC_Init_ex)(_HMAC_CTX_PTR, const unsigned char*, int, const _EVP_MD_PTR, _ENGINE_PTR);
++int (*_g_HMAC_Init_ex)(_HMAC_CTX_PTR, const void*, int, const _EVP_MD_PTR, _ENGINE_PTR);
 +int (*_g_HMAC_Update)(_HMAC_CTX_PTR, const unsigned char*, size_t);
 +const char* (*_g_OBJ_nid2sn)(int);
 +void (*_g_OPENSSL_init)(void);
@@ -13174,7 +13508,7 @@ index 00000000000000..c284c017339d4a
 +_OSSL_PARAM_BLD_PTR (*_g_OSSL_PARAM_BLD_new)(void);
 +int (*_g_OSSL_PARAM_BLD_push_BN)(_OSSL_PARAM_BLD_PTR, const char*, const _BIGNUM_PTR);
 +int (*_g_OSSL_PARAM_BLD_push_int32)(_OSSL_PARAM_BLD_PTR, const char*, int32_t);
-+int (*_g_OSSL_PARAM_BLD_push_octet_string)(_OSSL_PARAM_BLD_PTR, const char*, const unsigned char*, size_t);
++int (*_g_OSSL_PARAM_BLD_push_octet_string)(_OSSL_PARAM_BLD_PTR, const char*, const void*, size_t);
 +int (*_g_OSSL_PARAM_BLD_push_utf8_string)(_OSSL_PARAM_BLD_PTR, const char*, const char*, size_t);
 +_OSSL_PARAM_PTR (*_g_OSSL_PARAM_BLD_to_param)(_OSSL_PARAM_BLD_PTR);
 +void (*_g_OSSL_PARAM_free)(_OSSL_PARAM_PTR);
@@ -14334,7 +14668,7 @@ index 00000000000000..c284c017339d4a
 +	return _ret;
 +}
 +
-+int _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, int _arg2, uintptr_t *_err_state) {
++int _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR _arg0, void* _arg1, int _arg2, uintptr_t *_err_state) {
 +	int _ret = _g_EVP_PKEY_CTX_set0_rsa_oaep_label(_arg0, _arg1, _arg2);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -14826,7 +15160,7 @@ index 00000000000000..c284c017339d4a
 +	return _ret;
 +}
 +
-+int _mkcgo_HMAC_Init_ex(_HMAC_CTX_PTR _arg0, const unsigned char* _arg1, int _arg2, const _EVP_MD_PTR _arg3, _ENGINE_PTR _arg4, uintptr_t *_err_state) {
++int _mkcgo_HMAC_Init_ex(_HMAC_CTX_PTR _arg0, const void* _arg1, int _arg2, const _EVP_MD_PTR _arg3, _ENGINE_PTR _arg4, uintptr_t *_err_state) {
 +	int _ret = _g_HMAC_Init_ex(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -14880,8 +15214,10 @@ index 00000000000000..c284c017339d4a
 +	_g_OSSL_PARAM_BLD_free(_arg0);
 +}
 +
-+_OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(void) {
-+	return _g_OSSL_PARAM_BLD_new();
++_OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(uintptr_t *_err_state) {
++	_OSSL_PARAM_BLD_PTR _ret = _g_OSSL_PARAM_BLD_new();
++	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
++	return _ret;
 +}
 +
 +int _mkcgo_OSSL_PARAM_BLD_push_BN(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const _BIGNUM_PTR _arg2, uintptr_t *_err_state) {
@@ -14896,7 +15232,7 @@ index 00000000000000..c284c017339d4a
 +	return _ret;
 +}
 +
-+int _mkcgo_OSSL_PARAM_BLD_push_octet_string(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const unsigned char* _arg2, size_t _arg3, uintptr_t *_err_state) {
++int _mkcgo_OSSL_PARAM_BLD_push_octet_string(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const void* _arg2, size_t _arg3, uintptr_t *_err_state) {
 +	int _ret = _g_OSSL_PARAM_BLD_push_octet_string(_arg0, _arg1, _arg2, _arg3);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
@@ -15077,7 +15413,7 @@ index 00000000000000..39b0a728fdd700
 +)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.h b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.h
 new file mode 100644
-index 00000000000000..c65571c283503c
+index 00000000000000..e7513f3e402401
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl.h
 @@ -0,0 +1,363 @@
@@ -15316,7 +15652,7 @@ index 00000000000000..c65571c283503c
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new(_EVP_PKEY_PTR, _ENGINE_PTR, uintptr_t *);
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_from_pkey(_OSSL_LIB_CTX_PTR, _EVP_PKEY_PTR, const char*, uintptr_t *);
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_id(int, _ENGINE_PTR, uintptr_t *);
-+int _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR, unsigned char*, int, uintptr_t *);
++int _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR, void*, int, uintptr_t *);
 +int _mkcgo_EVP_PKEY_CTX_set1_hkdf_key(_EVP_PKEY_CTX_PTR, const unsigned char*, int, uintptr_t *);
 +int _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR, const unsigned char*, int, uintptr_t *);
 +int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR, uintptr_t *);
@@ -15410,7 +15746,7 @@ index 00000000000000..c65571c283503c
 +void _mkcgo_HMAC_CTX_free(_HMAC_CTX_PTR);
 +_HMAC_CTX_PTR _mkcgo_HMAC_CTX_new(uintptr_t *);
 +int _mkcgo_HMAC_Final(_HMAC_CTX_PTR, unsigned char*, unsigned int*, uintptr_t *);
-+int _mkcgo_HMAC_Init_ex(_HMAC_CTX_PTR, const unsigned char*, int, const _EVP_MD_PTR, _ENGINE_PTR, uintptr_t *);
++int _mkcgo_HMAC_Init_ex(_HMAC_CTX_PTR, const void*, int, const _EVP_MD_PTR, _ENGINE_PTR, uintptr_t *);
 +int _mkcgo_HMAC_Update(_HMAC_CTX_PTR, const unsigned char*, size_t, uintptr_t *);
 +const char* _mkcgo_OBJ_nid2sn(int);
 +void _mkcgo_OPENSSL_init(void);
@@ -15419,10 +15755,10 @@ index 00000000000000..c65571c283503c
 +unsigned int _mkcgo_OPENSSL_version_minor(void);
 +unsigned int _mkcgo_OPENSSL_version_patch(void);
 +void _mkcgo_OSSL_PARAM_BLD_free(_OSSL_PARAM_BLD_PTR);
-+_OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(void);
++_OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(uintptr_t *);
 +int _mkcgo_OSSL_PARAM_BLD_push_BN(_OSSL_PARAM_BLD_PTR, const char*, const _BIGNUM_PTR, uintptr_t *);
 +int _mkcgo_OSSL_PARAM_BLD_push_int32(_OSSL_PARAM_BLD_PTR, const char*, int32_t, uintptr_t *);
-+int _mkcgo_OSSL_PARAM_BLD_push_octet_string(_OSSL_PARAM_BLD_PTR, const char*, const unsigned char*, size_t, uintptr_t *);
++int _mkcgo_OSSL_PARAM_BLD_push_octet_string(_OSSL_PARAM_BLD_PTR, const char*, const void*, size_t, uintptr_t *);
 +int _mkcgo_OSSL_PARAM_BLD_push_utf8_string(_OSSL_PARAM_BLD_PTR, const char*, const char*, size_t, uintptr_t *);
 +_OSSL_PARAM_PTR _mkcgo_OSSL_PARAM_BLD_to_param(_OSSL_PARAM_BLD_PTR, uintptr_t *);
 +void _mkcgo_OSSL_PARAM_free(_OSSL_PARAM_PTR);
@@ -15446,10 +15782,10 @@ index 00000000000000..c65571c283503c
 +#endif // MKCGO_H
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo.go
 new file mode 100644
-index 00000000000000..7e7063d31539c8
+index 00000000000000..059562f35df7b3
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo.go
-@@ -0,0 +1,1486 @@
+@@ -0,0 +1,1368 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +package ossl
@@ -15459,78 +15795,6 @@ index 00000000000000..7e7063d31539c8
 +#cgo unix LDFLAGS: -ldl
 +
 +#include "zossl.h"
-+#cgo noescape _mkcgo_BIO_ctrl
-+#cgo nocallback _mkcgo_BIO_ctrl
-+#cgo noescape _mkcgo_BIO_free
-+#cgo nocallback _mkcgo_BIO_free
-+#cgo noescape _mkcgo_ERR_print_errors
-+#cgo nocallback _mkcgo_ERR_print_errors
-+#cgo noescape _mkcgo_EVP_CipherUpdate
-+#cgo nocallback _mkcgo_EVP_CipherUpdate
-+#cgo noescape _mkcgo_EVP_DecryptFinal_ex
-+#cgo nocallback _mkcgo_EVP_DecryptFinal_ex
-+#cgo noescape _mkcgo_EVP_DecryptUpdate
-+#cgo nocallback _mkcgo_EVP_DecryptUpdate
-+#cgo noescape _mkcgo_EVP_Digest
-+#cgo nocallback _mkcgo_EVP_Digest
-+#cgo noescape _mkcgo_EVP_DigestFinalXOF
-+#cgo nocallback _mkcgo_EVP_DigestFinalXOF
-+#cgo noescape _mkcgo_EVP_DigestFinal_ex
-+#cgo nocallback _mkcgo_EVP_DigestFinal_ex
-+#cgo noescape _mkcgo_EVP_DigestSign
-+#cgo nocallback _mkcgo_EVP_DigestSign
-+#cgo noescape _mkcgo_EVP_DigestSqueeze
-+#cgo nocallback _mkcgo_EVP_DigestSqueeze
-+#cgo noescape _mkcgo_EVP_DigestUpdate
-+#cgo nocallback _mkcgo_EVP_DigestUpdate
-+#cgo noescape _mkcgo_EVP_EncryptFinal_ex
-+#cgo nocallback _mkcgo_EVP_EncryptFinal_ex
-+#cgo noescape _mkcgo_EVP_EncryptUpdate
-+#cgo nocallback _mkcgo_EVP_EncryptUpdate
-+#cgo noescape _mkcgo_EVP_MAC_CTX_free
-+#cgo nocallback _mkcgo_EVP_MAC_CTX_free
-+#cgo noescape _mkcgo_EVP_MAC_final
-+#cgo nocallback _mkcgo_EVP_MAC_final
-+#cgo noescape _mkcgo_EVP_MAC_init
-+#cgo nocallback _mkcgo_EVP_MAC_init
-+#cgo noescape _mkcgo_EVP_MAC_update
-+#cgo nocallback _mkcgo_EVP_MAC_update
-+#cgo noescape _mkcgo_EVP_MD_CTX_get_params
-+#cgo nocallback _mkcgo_EVP_MD_CTX_get_params
-+#cgo noescape _mkcgo_EVP_MD_CTX_set_params
-+#cgo nocallback _mkcgo_EVP_MD_CTX_set_params
-+#cgo noescape _mkcgo_EVP_PKEY_Q_keygen_EC
-+#cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_EC
-+#cgo noescape _mkcgo_EVP_PKEY_Q_keygen_ED25519
-+#cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_ED25519
-+#cgo noescape _mkcgo_EVP_PKEY_Q_keygen_MLKEM
-+#cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_MLKEM
-+#cgo noescape _mkcgo_EVP_PKEY_Q_keygen_RSA
-+#cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_RSA
-+#cgo noescape _mkcgo_EVP_PKEY_Q_keygen_X25519
-+#cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_X25519
-+#cgo noescape _mkcgo_EVP_PKEY_derive
-+#cgo nocallback _mkcgo_EVP_PKEY_derive
-+#cgo noescape _mkcgo_EVP_PKEY_get_bn_param
-+#cgo nocallback _mkcgo_EVP_PKEY_get_bn_param
-+#cgo noescape _mkcgo_EVP_PKEY_get_raw_private_key
-+#cgo nocallback _mkcgo_EVP_PKEY_get_raw_private_key
-+#cgo noescape _mkcgo_EVP_PKEY_get_raw_public_key
-+#cgo nocallback _mkcgo_EVP_PKEY_get_raw_public_key
-+#cgo noescape _mkcgo_EVP_PKEY_keygen
-+#cgo nocallback _mkcgo_EVP_PKEY_keygen
-+#cgo noescape _mkcgo_HMAC_CTX_copy
-+#cgo nocallback _mkcgo_HMAC_CTX_copy
-+#cgo noescape _mkcgo_HMAC_CTX_free
-+#cgo nocallback _mkcgo_HMAC_CTX_free
-+#cgo noescape _mkcgo_HMAC_Final
-+#cgo nocallback _mkcgo_HMAC_Final
-+#cgo noescape _mkcgo_HMAC_Init_ex
-+#cgo nocallback _mkcgo_HMAC_Init_ex
-+#cgo noescape _mkcgo_HMAC_Update
-+#cgo nocallback _mkcgo_HMAC_Update
-+#cgo noescape _mkcgo_RAND_bytes
-+#cgo nocallback _mkcgo_RAND_bytes
 +*/
 +import "C"
 +import "unsafe"
@@ -15653,21 +15917,21 @@ index 00000000000000..7e7063d31539c8
 +	return C._mkcgo_BIO_s_mem()
 +}
 +
-+func BN_bin2bn(arg0 []byte, arg2 BIGNUM_PTR) (BIGNUM_PTR, error) {
++func BN_bin2bn(arg0 *byte, arg1 int32, arg2 BIGNUM_PTR) (BIGNUM_PTR, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_BN_bin2bn((*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg0))), C.int(len(arg0)), arg2, mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_BN_bin2bn((*C.uchar)(unsafe.Pointer(arg0)), C.int(arg1), arg2, mkcgoNoEscape(&_err))
 +	return _ret, newMkcgoErr("BN_bin2bn", uintptr(_err))
 +}
 +
-+func BN_bn2binpad(a BIGNUM_PTR, to []byte) (int32, error) {
++func BN_bn2binpad(a BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_BN_bn2binpad(a, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(to))), C.int(len(to)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_BN_bn2binpad(a, (*C.uchar)(unsafe.Pointer(to)), C.int(tolen), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("BN_bn2binpad", uintptr(_err))
 +}
 +
-+func BN_bn2lebinpad(a BIGNUM_PTR, to []byte) (int32, error) {
++func BN_bn2lebinpad(a BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_BN_bn2lebinpad(a, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(to))), C.int(len(to)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_BN_bn2lebinpad(a, (*C.uchar)(unsafe.Pointer(to)), C.int(tolen), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("BN_bn2lebinpad", uintptr(_err))
 +}
 +
@@ -15683,9 +15947,9 @@ index 00000000000000..7e7063d31539c8
 +	C._mkcgo_BN_free(arg0)
 +}
 +
-+func BN_lebin2bn(s []byte, ret BIGNUM_PTR) (BIGNUM_PTR, error) {
++func BN_lebin2bn(s *byte, len int32, ret BIGNUM_PTR) (BIGNUM_PTR, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_BN_lebin2bn((*C.uchar)(unsafe.Pointer(unsafe.SliceData(s))), C.int(len(s)), ret, mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_BN_lebin2bn((*C.uchar)(unsafe.Pointer(s)), C.int(len), ret, mkcgoNoEscape(&_err))
 +	return _ret, newMkcgoErr("BN_lebin2bn", uintptr(_err))
 +}
 +
@@ -15823,15 +16087,15 @@ index 00000000000000..7e7063d31539c8
 +	return _ret, newMkcgoErr("EC_POINT_new", uintptr(_err))
 +}
 +
-+func EC_POINT_oct2point(group EC_GROUP_PTR, p EC_POINT_PTR, buf []byte, ctx BN_CTX_PTR) (int32, error) {
++func EC_POINT_oct2point(group EC_GROUP_PTR, p EC_POINT_PTR, buf *byte, len int, ctx BN_CTX_PTR) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EC_POINT_oct2point(group, p, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(buf))), C.size_t(len(buf)), ctx, mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EC_POINT_oct2point(group, p, (*C.uchar)(unsafe.Pointer(buf)), C.size_t(len), ctx, mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EC_POINT_oct2point", uintptr(_err))
 +}
 +
-+func EC_POINT_point2oct(group EC_GROUP_PTR, p EC_POINT_PTR, form Point_conversion_form_t, buf []byte, ctx BN_CTX_PTR) (int, error) {
++func EC_POINT_point2oct(group EC_GROUP_PTR, p EC_POINT_PTR, form Point_conversion_form_t, buf *byte, len int, ctx BN_CTX_PTR) (int, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EC_POINT_point2oct(group, p, form, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(buf))), C.size_t(len(buf)), ctx, mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EC_POINT_point2oct(group, p, form, (*C.uchar)(unsafe.Pointer(buf)), C.size_t(len), ctx, mkcgoNoEscape(&_err))
 +	return int(_ret), newMkcgoErr("EC_POINT_point2oct", uintptr(_err))
 +}
 +
@@ -15897,21 +16161,15 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex", uintptr(_err))
 +}
 +
-+func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32, in []byte) (int32, error) {
-+	if outl != nil && int(*outl) > len(out) {
-+		panic("EVP_CipherUpdate: *outl exceeds len(out)")
-+	}
++func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_CipherUpdate(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(out))), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(in))), C.int(len(in)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_CipherUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_CipherUpdate", uintptr(_err))
 +}
 +
-+func EVP_DecryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, outm []byte, outl *int32) (int32, error) {
-+	if outl != nil && int(*outl) > len(outm) {
-+		panic("EVP_DecryptFinal_ex: *outl exceeds len(outm)")
-+	}
++func EVP_DecryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, outm *byte, outl *int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_DecryptFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(outm))), (*C.int)(unsafe.Pointer(outl)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_DecryptFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(outm)), (*C.int)(unsafe.Pointer(outl)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_DecryptFinal_ex", uintptr(_err))
 +}
 +
@@ -15921,34 +16179,25 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_DecryptInit_ex", uintptr(_err))
 +}
 +
-+func EVP_DecryptUpdate(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32, in []byte) (int32, error) {
-+	if outl != nil && int(*outl) > len(out) {
-+		panic("EVP_DecryptUpdate: *outl exceeds len(out)")
-+	}
++func EVP_DecryptUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_DecryptUpdate(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(out))), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(in))), C.int(len(in)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_DecryptUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_DecryptUpdate", uintptr(_err))
 +}
 +
 +func EVP_Digest(data []byte, md []byte, size *uint32, __type EVP_MD_PTR, impl ENGINE_PTR) (int32, error) {
-+	if size != nil && int(*size) > len(md) {
-+		panic("EVP_Digest: *size exceeds len(md)")
-+	}
 +	var _err C.uintptr_t
 +	_ret := C._mkcgo_EVP_Digest((*C.uchar)(unsafe.Pointer(unsafe.SliceData(data))), C.size_t(len(data)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(md))), (*C.uint)(unsafe.Pointer(size)), __type, impl, mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_Digest", uintptr(_err))
 +}
 +
-+func EVP_DigestFinalXOF(ctx EVP_MD_CTX_PTR, md []byte) (int32, error) {
++func EVP_DigestFinalXOF(ctx EVP_MD_CTX_PTR, md []byte, len int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_DigestFinalXOF(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(md))), C.size_t(len(md)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_DigestFinalXOF(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(md))), C.size_t(len), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_DigestFinalXOF", uintptr(_err))
 +}
 +
 +func EVP_DigestFinal_ex(ctx EVP_MD_CTX_PTR, md []byte, s *uint32) (int32, error) {
-+	if s != nil && int(*s) > len(md) {
-+		panic("EVP_DigestFinal_ex: *s exceeds len(md)")
-+	}
 +	var _err C.uintptr_t
 +	_ret := C._mkcgo_EVP_DigestFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(md))), (*C.uint)(unsafe.Pointer(s)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_DigestFinal_ex", uintptr(_err))
@@ -15966,21 +16215,15 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_DigestInit_ex", uintptr(_err))
 +}
 +
-+func EVP_DigestSign(ctx EVP_MD_CTX_PTR, sigret []byte, siglen *int, tbs []byte) (int32, error) {
-+	if siglen != nil && int(*siglen) > len(sigret) {
-+		panic("EVP_DigestSign: *siglen exceeds len(sigret)")
-+	}
++func EVP_DigestSign(ctx EVP_MD_CTX_PTR, sigret *byte, siglen *int, tbs *byte, tbslen int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_DigestSign(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(sigret))), (*C.size_t)(unsafe.Pointer(siglen)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(tbs))), C.size_t(len(tbs)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_DigestSign(ctx, (*C.uchar)(unsafe.Pointer(sigret)), (*C.size_t)(unsafe.Pointer(siglen)), (*C.uchar)(unsafe.Pointer(tbs)), C.size_t(tbslen), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_DigestSign", uintptr(_err))
 +}
 +
-+func EVP_DigestSignFinal(ctx EVP_MD_CTX_PTR, sig []byte, siglen *int) (int32, error) {
-+	if siglen != nil && int(*siglen) > len(sig) {
-+		panic("EVP_DigestSignFinal: *siglen exceeds len(sig)")
-+	}
++func EVP_DigestSignFinal(ctx EVP_MD_CTX_PTR, sig *byte, siglen *int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_DigestSignFinal(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(sig))), (*C.size_t)(unsafe.Pointer(siglen)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_DigestSignFinal(ctx, (*C.uchar)(unsafe.Pointer(sig)), (*C.size_t)(unsafe.Pointer(siglen)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_DigestSignFinal", uintptr(_err))
 +}
 +
@@ -16002,15 +16245,15 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_DigestUpdate", uintptr(_err))
 +}
 +
-+func EVP_DigestVerify(ctx EVP_MD_CTX_PTR, sigret []byte, tbs []byte) (int32, error) {
++func EVP_DigestVerify(ctx EVP_MD_CTX_PTR, sigret *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_DigestVerify(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(sigret))), C.size_t(len(sigret)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(tbs))), C.size_t(len(tbs)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_DigestVerify(ctx, (*C.uchar)(unsafe.Pointer(sigret)), C.size_t(siglen), (*C.uchar)(unsafe.Pointer(tbs)), C.size_t(tbslen), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_DigestVerify", uintptr(_err))
 +}
 +
-+func EVP_DigestVerifyFinal(ctx EVP_MD_CTX_PTR, sig []byte) (int32, error) {
++func EVP_DigestVerifyFinal(ctx EVP_MD_CTX_PTR, sig *byte, siglen int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_DigestVerifyFinal(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(sig))), C.size_t(len(sig)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_DigestVerifyFinal(ctx, (*C.uchar)(unsafe.Pointer(sig)), C.size_t(siglen), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_DigestVerifyFinal", uintptr(_err))
 +}
 +
@@ -16020,12 +16263,9 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_DigestVerifyInit", uintptr(_err))
 +}
 +
-+func EVP_EncryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32) (int32, error) {
-+	if outl != nil && int(*outl) > len(out) {
-+		panic("EVP_EncryptFinal_ex: *outl exceeds len(out)")
-+	}
++func EVP_EncryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_EncryptFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(out))), (*C.int)(unsafe.Pointer(outl)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_EncryptFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_EncryptFinal_ex", uintptr(_err))
 +}
 +
@@ -16035,12 +16275,9 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_EncryptInit_ex", uintptr(_err))
 +}
 +
-+func EVP_EncryptUpdate(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32, in []byte) (int32, error) {
-+	if outl != nil && int(*outl) > len(out) {
-+		panic("EVP_EncryptUpdate: *outl exceeds len(out)")
-+	}
++func EVP_EncryptUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_EncryptUpdate(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(out))), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(in))), C.int(len(in)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_EncryptUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_EncryptUpdate", uintptr(_err))
 +}
 +
@@ -16066,9 +16303,9 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_KDF_CTX_set_params", uintptr(_err))
 +}
 +
-+func EVP_KDF_derive(ctx EVP_KDF_CTX_PTR, key []byte, params OSSL_PARAM_PTR) (int32, error) {
++func EVP_KDF_derive(ctx EVP_KDF_CTX_PTR, key *byte, keylen int, params OSSL_PARAM_PTR) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_KDF_derive(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(key))), C.size_t(len(key)), params, mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_KDF_derive(ctx, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen), params, mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_KDF_derive", uintptr(_err))
 +}
 +
@@ -16120,21 +16357,21 @@ index 00000000000000..7e7063d31539c8
 +	return _ret, newMkcgoErr("EVP_MAC_fetch", uintptr(_err))
 +}
 +
-+func EVP_MAC_final(ctx EVP_MAC_CTX_PTR, out []byte, outl *int) (int32, error) {
++func EVP_MAC_final(ctx EVP_MAC_CTX_PTR, out *byte, outl *int, outsize int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_MAC_final(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(out))), (*C.size_t)(unsafe.Pointer(outl)), C.size_t(len(out)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_MAC_final(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.size_t)(unsafe.Pointer(outl)), C.size_t(outsize), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_MAC_final", uintptr(_err))
 +}
 +
-+func EVP_MAC_init(ctx EVP_MAC_CTX_PTR, key []byte, params OSSL_PARAM_PTR) (int32, error) {
++func EVP_MAC_init(ctx EVP_MAC_CTX_PTR, key *byte, keylen int, params OSSL_PARAM_PTR) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_MAC_init(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(key))), C.size_t(len(key)), params, mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_MAC_init(ctx, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen), params, mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_MAC_init", uintptr(_err))
 +}
 +
-+func EVP_MAC_update(ctx EVP_MAC_CTX_PTR, data []byte) (int32, error) {
++func EVP_MAC_update(ctx EVP_MAC_CTX_PTR, data *byte, datalen int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_MAC_update(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(data))), C.size_t(len(data)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_MAC_update(ctx, (*C.uchar)(unsafe.Pointer(data)), C.size_t(datalen), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_MAC_update", uintptr(_err))
 +}
 +
@@ -16214,9 +16451,9 @@ index 00000000000000..7e7063d31539c8
 +	return int32(C._mkcgo_EVP_MD_get_type(md))
 +}
 +
-+func EVP_PKEY_CTX_add1_hkdf_info(arg0 EVP_PKEY_CTX_PTR, arg1 []byte) (int32, error) {
++func EVP_PKEY_CTX_add1_hkdf_info(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_CTX_add1_hkdf_info(arg0, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg1))), C.int(len(arg1)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_CTX_add1_hkdf_info(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.int(arg2), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_add1_hkdf_info", uintptr(_err))
 +}
 +
@@ -16248,21 +16485,21 @@ index 00000000000000..7e7063d31539c8
 +	return _ret, newMkcgoErr("EVP_PKEY_CTX_new_id", uintptr(_err))
 +}
 +
-+func EVP_PKEY_CTX_set0_rsa_oaep_label(ctx EVP_PKEY_CTX_PTR, label []byte) (int32, error) {
++func EVP_PKEY_CTX_set0_rsa_oaep_label(ctx EVP_PKEY_CTX_PTR, label unsafe.Pointer, len int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(label))), C.int(len(label)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label, C.int(len), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set0_rsa_oaep_label", uintptr(_err))
 +}
 +
-+func EVP_PKEY_CTX_set1_hkdf_key(arg0 EVP_PKEY_CTX_PTR, arg1 []byte) (int32, error) {
++func EVP_PKEY_CTX_set1_hkdf_key(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_CTX_set1_hkdf_key(arg0, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg1))), C.int(len(arg1)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_CTX_set1_hkdf_key(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.int(arg2), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set1_hkdf_key", uintptr(_err))
 +}
 +
-+func EVP_PKEY_CTX_set1_hkdf_salt(arg0 EVP_PKEY_CTX_PTR, arg1 []byte) (int32, error) {
++func EVP_PKEY_CTX_set1_hkdf_salt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(arg0, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg1))), C.int(len(arg1)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.int(arg2), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set1_hkdf_salt", uintptr(_err))
 +}
 +
@@ -16326,12 +16563,9 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_decapsulate_init", uintptr(_err))
 +}
 +
-+func EVP_PKEY_decrypt(arg0 EVP_PKEY_CTX_PTR, arg1 []byte, arg2 *int, arg3 []byte) (int32, error) {
-+	if arg2 != nil && int(*arg2) > len(arg1) {
-+		panic("EVP_PKEY_decrypt: *arg2 exceeds len(arg1)")
-+	}
++func EVP_PKEY_decrypt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_decrypt(arg0, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg1))), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg3))), C.size_t(len(arg3)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_decrypt(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(arg3)), C.size_t(arg4), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_decrypt", uintptr(_err))
 +}
 +
@@ -16341,12 +16575,9 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_decrypt_init", uintptr(_err))
 +}
 +
-+func EVP_PKEY_derive(ctx EVP_PKEY_CTX_PTR, key []byte, keylen *int) (int32, error) {
-+	if keylen != nil && int(*keylen) > len(key) {
-+		panic("EVP_PKEY_derive: *keylen exceeds len(key)")
-+	}
++func EVP_PKEY_derive(ctx EVP_PKEY_CTX_PTR, key *byte, keylen *int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_derive(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(key))), (*C.size_t)(unsafe.Pointer(keylen)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_derive(ctx, (*C.uchar)(unsafe.Pointer(key)), (*C.size_t)(unsafe.Pointer(keylen)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_derive", uintptr(_err))
 +}
 +
@@ -16374,12 +16605,9 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_encapsulate_init", uintptr(_err))
 +}
 +
-+func EVP_PKEY_encrypt(arg0 EVP_PKEY_CTX_PTR, arg1 []byte, arg2 *int, arg3 []byte) (int32, error) {
-+	if arg2 != nil && int(*arg2) > len(arg1) {
-+		panic("EVP_PKEY_encrypt: *arg2 exceeds len(arg1)")
-+	}
++func EVP_PKEY_encrypt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_encrypt(arg0, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg1))), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg3))), C.size_t(len(arg3)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_encrypt(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(arg3)), C.size_t(arg4), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_encrypt", uintptr(_err))
 +}
 +
@@ -16441,27 +16669,21 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_get_bn_param", uintptr(_err))
 +}
 +
-+func EVP_PKEY_get_octet_string_param(pkey EVP_PKEY_PTR, key_name *byte, buf []byte, out_len *int) (int32, error) {
++func EVP_PKEY_get_octet_string_param(pkey EVP_PKEY_PTR, key_name *byte, buf *byte, buf_len int, out_len *int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_get_octet_string_param(pkey, (*C.char)(unsafe.Pointer(key_name)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(buf))), C.size_t(len(buf)), (*C.size_t)(unsafe.Pointer(out_len)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_get_octet_string_param(pkey, (*C.char)(unsafe.Pointer(key_name)), (*C.uchar)(unsafe.Pointer(buf)), C.size_t(buf_len), (*C.size_t)(unsafe.Pointer(out_len)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_get_octet_string_param", uintptr(_err))
 +}
 +
-+func EVP_PKEY_get_raw_private_key(pkey EVP_PKEY_PTR, priv []byte, privlen *int) (int32, error) {
-+	if privlen != nil && int(*privlen) > len(priv) {
-+		panic("EVP_PKEY_get_raw_private_key: *privlen exceeds len(priv)")
-+	}
++func EVP_PKEY_get_raw_private_key(pkey EVP_PKEY_PTR, priv *byte, len *int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_get_raw_private_key(pkey, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(priv))), (*C.size_t)(unsafe.Pointer(privlen)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_get_raw_private_key(pkey, (*C.uchar)(unsafe.Pointer(priv)), (*C.size_t)(unsafe.Pointer(len)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_get_raw_private_key", uintptr(_err))
 +}
 +
-+func EVP_PKEY_get_raw_public_key(pkey EVP_PKEY_PTR, pub []byte, publen *int) (int32, error) {
-+	if publen != nil && int(*publen) > len(pub) {
-+		panic("EVP_PKEY_get_raw_public_key: *publen exceeds len(pub)")
-+	}
++func EVP_PKEY_get_raw_public_key(pkey EVP_PKEY_PTR, pub *byte, len *int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_get_raw_public_key(pkey, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(pub))), (*C.size_t)(unsafe.Pointer(publen)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_get_raw_public_key(pkey, (*C.uchar)(unsafe.Pointer(pub)), (*C.size_t)(unsafe.Pointer(len)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_get_raw_public_key", uintptr(_err))
 +}
 +
@@ -16489,15 +16711,15 @@ index 00000000000000..7e7063d31539c8
 +	return _ret, newMkcgoErr("EVP_PKEY_new", uintptr(_err))
 +}
 +
-+func EVP_PKEY_new_raw_private_key(__type int32, e ENGINE_PTR, key []byte) (EVP_PKEY_PTR, error) {
++func EVP_PKEY_new_raw_private_key(__type int32, e ENGINE_PTR, key *byte, keylen int) (EVP_PKEY_PTR, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_new_raw_private_key(C.int(__type), e, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(key))), C.size_t(len(key)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_new_raw_private_key(C.int(__type), e, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen), mkcgoNoEscape(&_err))
 +	return _ret, newMkcgoErr("EVP_PKEY_new_raw_private_key", uintptr(_err))
 +}
 +
-+func EVP_PKEY_new_raw_public_key(__type int32, e ENGINE_PTR, key []byte) (EVP_PKEY_PTR, error) {
++func EVP_PKEY_new_raw_public_key(__type int32, e ENGINE_PTR, key *byte, keylen int) (EVP_PKEY_PTR, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_new_raw_public_key(C.int(__type), e, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(key))), C.size_t(len(key)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_new_raw_public_key(C.int(__type), e, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen), mkcgoNoEscape(&_err))
 +	return _ret, newMkcgoErr("EVP_PKEY_new_raw_public_key", uintptr(_err))
 +}
 +
@@ -16531,18 +16753,15 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_set1_EC_KEY", uintptr(_err))
 +}
 +
-+func EVP_PKEY_set1_encoded_public_key(pkey EVP_PKEY_PTR, pub []byte) (int32, error) {
++func EVP_PKEY_set1_encoded_public_key(pkey EVP_PKEY_PTR, pub *byte, publen int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_set1_encoded_public_key(pkey, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(pub))), C.size_t(len(pub)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_set1_encoded_public_key(pkey, (*C.uchar)(unsafe.Pointer(pub)), C.size_t(publen), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_set1_encoded_public_key", uintptr(_err))
 +}
 +
-+func EVP_PKEY_sign(arg0 EVP_PKEY_CTX_PTR, arg1 []byte, arg2 *int, arg3 []byte) (int32, error) {
-+	if arg2 != nil && int(*arg2) > len(arg1) {
-+		panic("EVP_PKEY_sign: *arg2 exceeds len(arg1)")
-+	}
++func EVP_PKEY_sign(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_sign(arg0, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg1))), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg3))), C.size_t(len(arg3)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_sign(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(arg3)), C.size_t(arg4), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_sign", uintptr(_err))
 +}
 +
@@ -16558,9 +16777,9 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_up_ref", uintptr(_err))
 +}
 +
-+func EVP_PKEY_verify(ctx EVP_PKEY_CTX_PTR, sig []byte, tbs []byte) (int32, error) {
++func EVP_PKEY_verify(ctx EVP_PKEY_CTX_PTR, sig *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_EVP_PKEY_verify(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(sig))), C.size_t(len(sig)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(tbs))), C.size_t(len(tbs)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_EVP_PKEY_verify(ctx, (*C.uchar)(unsafe.Pointer(sig)), C.size_t(siglen), (*C.uchar)(unsafe.Pointer(tbs)), C.size_t(tbslen), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_verify", uintptr(_err))
 +}
 +
@@ -16752,24 +16971,21 @@ index 00000000000000..7e7063d31539c8
 +	return _ret, newMkcgoErr("HMAC_CTX_new", uintptr(_err))
 +}
 +
-+func HMAC_Final(arg0 HMAC_CTX_PTR, arg1 []byte, arg2 *uint32) (int32, error) {
-+	if arg2 != nil && int(*arg2) > len(arg1) {
-+		panic("HMAC_Final: *arg2 exceeds len(arg1)")
-+	}
++func HMAC_Final(arg0 HMAC_CTX_PTR, arg1 *byte, arg2 *uint32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_HMAC_Final(arg0, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg1))), (*C.uint)(unsafe.Pointer(arg2)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_HMAC_Final(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.uint)(unsafe.Pointer(arg2)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("HMAC_Final", uintptr(_err))
 +}
 +
-+func HMAC_Init_ex(arg0 HMAC_CTX_PTR, arg1 []byte, arg3 EVP_MD_PTR, arg4 ENGINE_PTR) (int32, error) {
++func HMAC_Init_ex(arg0 HMAC_CTX_PTR, arg1 unsafe.Pointer, arg2 int32, arg3 EVP_MD_PTR, arg4 ENGINE_PTR) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_HMAC_Init_ex(arg0, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg1))), C.int(len(arg1)), arg3, arg4, mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_HMAC_Init_ex(arg0, arg1, C.int(arg2), arg3, arg4, mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("HMAC_Init_ex", uintptr(_err))
 +}
 +
-+func HMAC_Update(arg0 HMAC_CTX_PTR, arg1 []byte) (int32, error) {
++func HMAC_Update(arg0 HMAC_CTX_PTR, arg1 *byte, arg2 int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_HMAC_Update(arg0, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg1))), C.size_t(len(arg1)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_HMAC_Update(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.size_t(arg2), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("HMAC_Update", uintptr(_err))
 +}
 +
@@ -16815,8 +17031,10 @@ index 00000000000000..7e7063d31539c8
 +	C._mkcgo_OSSL_PARAM_BLD_free(bld)
 +}
 +
-+func OSSL_PARAM_BLD_new() OSSL_PARAM_BLD_PTR {
-+	return C._mkcgo_OSSL_PARAM_BLD_new()
++func OSSL_PARAM_BLD_new() (OSSL_PARAM_BLD_PTR, error) {
++	var _err C.uintptr_t
++	_ret := C._mkcgo_OSSL_PARAM_BLD_new(mkcgoNoEscape(&_err))
++	return _ret, newMkcgoErr("OSSL_PARAM_BLD_new", uintptr(_err))
 +}
 +
 +func OSSL_PARAM_BLD_push_BN(bld OSSL_PARAM_BLD_PTR, key *byte, bn BIGNUM_PTR) (int32, error) {
@@ -16831,15 +17049,15 @@ index 00000000000000..7e7063d31539c8
 +	return int32(_ret), newMkcgoErr("OSSL_PARAM_BLD_push_int32", uintptr(_err))
 +}
 +
-+func OSSL_PARAM_BLD_push_octet_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf []byte) (int32, error) {
++func OSSL_PARAM_BLD_push_octet_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf unsafe.Pointer, bsize int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_OSSL_PARAM_BLD_push_octet_string(bld, (*C.char)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(buf))), C.size_t(len(buf)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_OSSL_PARAM_BLD_push_octet_string(bld, (*C.char)(unsafe.Pointer(key)), buf, C.size_t(bsize), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("OSSL_PARAM_BLD_push_octet_string", uintptr(_err))
 +}
 +
-+func OSSL_PARAM_BLD_push_utf8_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf []byte) (int32, error) {
++func OSSL_PARAM_BLD_push_utf8_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf *byte, bsize int) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_OSSL_PARAM_BLD_push_utf8_string(bld, (*C.char)(unsafe.Pointer(key)), (*C.char)(unsafe.Pointer(unsafe.SliceData(buf))), C.size_t(len(buf)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_OSSL_PARAM_BLD_push_utf8_string(bld, (*C.char)(unsafe.Pointer(key)), (*C.char)(unsafe.Pointer(buf)), C.size_t(bsize), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("OSSL_PARAM_BLD_push_utf8_string", uintptr(_err))
 +}
 +
@@ -16885,15 +17103,15 @@ index 00000000000000..7e7063d31539c8
 +	return uint64(C._mkcgo_OpenSSL_version_num())
 +}
 +
-+func PKCS5_PBKDF2_HMAC(pass []byte, salt []byte, iter int32, digest EVP_MD_PTR, out []byte) (int32, error) {
++func PKCS5_PBKDF2_HMAC(pass *byte, passlen int32, salt *byte, saltlen int32, iter int32, digest EVP_MD_PTR, keylen int32, out *byte) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_PKCS5_PBKDF2_HMAC((*C.char)(unsafe.Pointer(unsafe.SliceData(pass))), C.int(len(pass)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(salt))), C.int(len(salt)), C.int(iter), digest, C.int(len(out)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(out))), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_PKCS5_PBKDF2_HMAC((*C.char)(unsafe.Pointer(pass)), C.int(passlen), (*C.uchar)(unsafe.Pointer(salt)), C.int(saltlen), C.int(iter), digest, C.int(keylen), (*C.uchar)(unsafe.Pointer(out)), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("PKCS5_PBKDF2_HMAC", uintptr(_err))
 +}
 +
-+func RAND_bytes(arg0 []byte) (int32, error) {
++func RAND_bytes(arg0 *byte, arg1 int32) (int32, error) {
 +	var _err C.uintptr_t
-+	_ret := C._mkcgo_RAND_bytes((*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg0))), C.int(len(arg0)), mkcgoNoEscape(&_err))
++	_ret := C._mkcgo_RAND_bytes((*C.uchar)(unsafe.Pointer(arg0)), C.int(arg1), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("RAND_bytes", uintptr(_err))
 +}
 +
@@ -16936,12 +17154,63 @@ index 00000000000000..7e7063d31539c8
 +	_ret := C._mkcgo_RSA_set0_key(r, n, e, d, mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("RSA_set0_key", uintptr(_err))
 +}
+diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo_go124.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo_go124.go
+new file mode 100644
+index 00000000000000..677ef1d157a670
+--- /dev/null
++++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_cgo_go124.go
+@@ -0,0 +1,45 @@
++// Code generated by mkcgo. DO NOT EDIT.
++
++//go:build go1.24 && !cmd_go_bootstrap
++
++package ossl
++
++/*
++#cgo noescape _mkcgo_BIO_ctrl
++#cgo nocallback _mkcgo_BIO_ctrl
++#cgo noescape _mkcgo_EVP_CipherUpdate
++#cgo nocallback _mkcgo_EVP_CipherUpdate
++#cgo noescape _mkcgo_EVP_DecryptFinal_ex
++#cgo nocallback _mkcgo_EVP_DecryptFinal_ex
++#cgo noescape _mkcgo_EVP_DecryptUpdate
++#cgo nocallback _mkcgo_EVP_DecryptUpdate
++#cgo noescape _mkcgo_EVP_Digest
++#cgo nocallback _mkcgo_EVP_Digest
++#cgo noescape _mkcgo_EVP_DigestFinalXOF
++#cgo nocallback _mkcgo_EVP_DigestFinalXOF
++#cgo noescape _mkcgo_EVP_DigestFinal_ex
++#cgo nocallback _mkcgo_EVP_DigestFinal_ex
++#cgo noescape _mkcgo_EVP_DigestSign
++#cgo nocallback _mkcgo_EVP_DigestSign
++#cgo noescape _mkcgo_EVP_DigestSqueeze
++#cgo nocallback _mkcgo_EVP_DigestSqueeze
++#cgo noescape _mkcgo_EVP_DigestUpdate
++#cgo nocallback _mkcgo_EVP_DigestUpdate
++#cgo noescape _mkcgo_EVP_EncryptFinal_ex
++#cgo nocallback _mkcgo_EVP_EncryptFinal_ex
++#cgo noescape _mkcgo_EVP_EncryptUpdate
++#cgo nocallback _mkcgo_EVP_EncryptUpdate
++#cgo noescape _mkcgo_EVP_MD_CTX_get_params
++#cgo nocallback _mkcgo_EVP_MD_CTX_get_params
++#cgo noescape _mkcgo_EVP_MD_CTX_set_params
++#cgo nocallback _mkcgo_EVP_MD_CTX_set_params
++#cgo noescape _mkcgo_EVP_PKEY_derive
++#cgo nocallback _mkcgo_EVP_PKEY_derive
++#cgo noescape _mkcgo_EVP_PKEY_get_raw_private_key
++#cgo nocallback _mkcgo_EVP_PKEY_get_raw_private_key
++#cgo noescape _mkcgo_EVP_PKEY_get_raw_public_key
++#cgo nocallback _mkcgo_EVP_PKEY_get_raw_public_key
++#cgo noescape _mkcgo_RAND_bytes
++#cgo nocallback _mkcgo_RAND_bytes
++*/
++import "C"
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_nocgo.go b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_nocgo.go
 new file mode 100644
-index 00000000000000..1f3ab498325710
+index 00000000000000..56b1f871c7fcbf
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/internal/ossl/zossl_nocgo.go
-@@ -0,0 +1,2450 @@
+@@ -0,0 +1,2390 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +//go:build !cgo
@@ -16954,19 +17223,6 @@ index 00000000000000..1f3ab498325710
 +)
 +
 +var _ = runtime.GOOS
-+
-+var _mkcgoAlwaysFalseOssl bool
-+var _mkcgoEscapeSinkOssl unsafe.Pointer
-+
-+// mkcgoEscapePtrOssl forces p to escape to the heap.
-+// This implementation is also used in the standard library:
-+// https://github.com/golang/go/blob/f71432d223eeb2139b460957817400750fd13655/src/internal/abi/escape.go#L24-L33
-+func mkcgoEscapePtrOssl(p unsafe.Pointer) unsafe.Pointer {
-+	if _mkcgoAlwaysFalseOssl {
-+		_mkcgoEscapeSinkOssl = p
-+	}
-+	return p
-+}
 +
 +type OPENSSL_INIT_SETTINGS_PTR unsafe.Pointer
 +type OSSL_LIB_CTX_PTR unsafe.Pointer
@@ -17029,25 +17285,25 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_BN_bin2bn uintptr
 +
-+func BN_bin2bn(arg0 []byte, arg2 BIGNUM_PTR) (BIGNUM_PTR, error) {
++func BN_bin2bn(arg0 *byte, arg1 int32, arg2 BIGNUM_PTR) (BIGNUM_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_BN_bin2bn, uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg0)))), uintptr(len(arg0)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_BN_bin2bn, uintptr(unsafe.Pointer(arg0)), uintptr(arg1), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 +	return BIGNUM_PTR(r0), newMkcgoErr("BN_bin2bn", _err)
 +}
 +
 +var _mkcgo_BN_bn2binpad uintptr
 +
-+func BN_bn2binpad(a BIGNUM_PTR, to []byte) (int32, error) {
++func BN_bn2binpad(a BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(2, _mkcgo_BN_bn2binpad, uintptr(a), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(to)))), uintptr(len(to)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(2, _mkcgo_BN_bn2binpad, uintptr(a), uintptr(unsafe.Pointer(to)), uintptr(tolen), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("BN_bn2binpad", _err)
 +}
 +
 +var _mkcgo_BN_bn2lebinpad uintptr
 +
-+func BN_bn2lebinpad(a BIGNUM_PTR, to []byte) (int32, error) {
++func BN_bn2lebinpad(a BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(2, _mkcgo_BN_bn2lebinpad, uintptr(a), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(to)))), uintptr(len(to)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(2, _mkcgo_BN_bn2lebinpad, uintptr(a), uintptr(unsafe.Pointer(to)), uintptr(tolen), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("BN_bn2lebinpad", _err)
 +}
 +
@@ -17071,9 +17327,9 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_BN_lebin2bn uintptr
 +
-+func BN_lebin2bn(s []byte, ret BIGNUM_PTR) (BIGNUM_PTR, error) {
++func BN_lebin2bn(s *byte, len int32, ret BIGNUM_PTR) (BIGNUM_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_BN_lebin2bn, uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(s)))), uintptr(len(s)), uintptr(ret), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_BN_lebin2bn, uintptr(unsafe.Pointer(s)), uintptr(len), uintptr(ret), uintptr(unsafe.Pointer(&_err)))
 +	return BIGNUM_PTR(r0), newMkcgoErr("BN_lebin2bn", _err)
 +}
 +
@@ -17095,14 +17351,14 @@ index 00000000000000..1f3ab498325710
 +var _mkcgo_CRYPTO_free uintptr
 +
 +func CRYPTO_free(str unsafe.Pointer, file *byte, line int32) {
-+	syscallN(0, _mkcgo_CRYPTO_free, uintptr(str), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(file))), uintptr(line))
++	syscallN(0, _mkcgo_CRYPTO_free, uintptr(str), uintptr(unsafe.Pointer(file)), uintptr(line))
 +}
 +
 +var _mkcgo_CRYPTO_malloc uintptr
 +
 +func CRYPTO_malloc(num int, file *byte, line int32) (unsafe.Pointer, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_CRYPTO_malloc, uintptr(num), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(file))), uintptr(line), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_CRYPTO_malloc, uintptr(num), uintptr(unsafe.Pointer(file)), uintptr(line), uintptr(unsafe.Pointer(&_err)))
 +	return unsafe.Pointer(r0), newMkcgoErr("CRYPTO_malloc", _err)
 +}
 +
@@ -17123,13 +17379,13 @@ index 00000000000000..1f3ab498325710
 +var _mkcgo_DSA_get0_key uintptr
 +
 +func DSA_get0_key(d DSA_PTR, pub_key *BIGNUM_PTR, priv_key *BIGNUM_PTR) {
-+	syscallN(0, _mkcgo_DSA_get0_key, uintptr(d), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(pub_key))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(priv_key))))
++	syscallN(0, _mkcgo_DSA_get0_key, uintptr(d), uintptr(unsafe.Pointer(pub_key)), uintptr(unsafe.Pointer(priv_key)))
 +}
 +
 +var _mkcgo_DSA_get0_pqg uintptr
 +
 +func DSA_get0_pqg(d DSA_PTR, p *BIGNUM_PTR, q *BIGNUM_PTR, g *BIGNUM_PTR) {
-+	syscallN(0, _mkcgo_DSA_get0_pqg, uintptr(d), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(p))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(q))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(g))))
++	syscallN(0, _mkcgo_DSA_get0_pqg, uintptr(d), uintptr(unsafe.Pointer(p)), uintptr(unsafe.Pointer(q)), uintptr(unsafe.Pointer(g)))
 +}
 +
 +var _mkcgo_DSA_new uintptr
@@ -17269,17 +17525,17 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EC_POINT_oct2point uintptr
 +
-+func EC_POINT_oct2point(group EC_GROUP_PTR, p EC_POINT_PTR, buf []byte, ctx BN_CTX_PTR) (int32, error) {
++func EC_POINT_oct2point(group EC_GROUP_PTR, p EC_POINT_PTR, buf *byte, len int, ctx BN_CTX_PTR) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EC_POINT_oct2point, uintptr(group), uintptr(p), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(buf)))), uintptr(len(buf)), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EC_POINT_oct2point, uintptr(group), uintptr(p), uintptr(unsafe.Pointer(buf)), uintptr(len), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EC_POINT_oct2point", _err)
 +}
 +
 +var _mkcgo_EC_POINT_point2oct uintptr
 +
-+func EC_POINT_point2oct(group EC_GROUP_PTR, p EC_POINT_PTR, form Point_conversion_form_t, buf []byte, ctx BN_CTX_PTR) (int, error) {
++func EC_POINT_point2oct(group EC_GROUP_PTR, p EC_POINT_PTR, form Point_conversion_form_t, buf *byte, len int, ctx BN_CTX_PTR) (int, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(4, _mkcgo_EC_POINT_point2oct, uintptr(group), uintptr(p), uintptr(form), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(buf)))), uintptr(len(buf)), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(4, _mkcgo_EC_POINT_point2oct, uintptr(group), uintptr(p), uintptr(form), uintptr(unsafe.Pointer(buf)), uintptr(len), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
 +	return int(r0), newMkcgoErr("EC_POINT_point2oct", _err)
 +}
 +
@@ -17346,7 +17602,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_CIPHER_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_CIPHER_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_EVP_CIPHER_fetch, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(algorithm))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_EVP_CIPHER_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_CIPHER_PTR(r0), newMkcgoErr("EVP_CIPHER_fetch", _err)
 +}
 +
@@ -17368,29 +17624,23 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_CipherInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGINE_PTR, key *byte, iv *byte, enc int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_CipherInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(iv))), uintptr(enc), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_CipherInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(enc), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_CipherInit_ex", _err)
 +}
 +
 +var _mkcgo_EVP_CipherUpdate uintptr
 +
-+func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32, in []byte) (int32, error) {
-+	if outl != nil && int(*outl) > len(out) {
-+		panic("EVP_CipherUpdate: *outl exceeds len(out)")
-+	}
++func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_CipherUpdate, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(out))), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(unsafe.SliceData(in))), uintptr(len(in)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_CipherUpdate, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(in)), uintptr(inl), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_CipherUpdate", _err)
 +}
 +
 +var _mkcgo_EVP_DecryptFinal_ex uintptr
 +
-+func EVP_DecryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, outm []byte, outl *int32) (int32, error) {
-+	if outl != nil && int(*outl) > len(outm) {
-+		panic("EVP_DecryptFinal_ex: *outl exceeds len(outm)")
-+	}
++func EVP_DecryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, outm *byte, outl *int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DecryptFinal_ex, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(outm))), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DecryptFinal_ex, uintptr(ctx), uintptr(unsafe.Pointer(outm)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DecryptFinal_ex", _err)
 +}
 +
@@ -17398,27 +17648,21 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_DecryptInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGINE_PTR, key *byte, iv *byte) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DecryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(iv))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DecryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DecryptInit_ex", _err)
 +}
 +
 +var _mkcgo_EVP_DecryptUpdate uintptr
 +
-+func EVP_DecryptUpdate(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32, in []byte) (int32, error) {
-+	if outl != nil && int(*outl) > len(out) {
-+		panic("EVP_DecryptUpdate: *outl exceeds len(out)")
-+	}
++func EVP_DecryptUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DecryptUpdate, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(out))), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(unsafe.SliceData(in))), uintptr(len(in)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DecryptUpdate, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(in)), uintptr(inl), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DecryptUpdate", _err)
 +}
 +
 +var _mkcgo_EVP_Digest uintptr
 +
 +func EVP_Digest(data []byte, md []byte, size *uint32, __type EVP_MD_PTR, impl ENGINE_PTR) (int32, error) {
-+	if size != nil && int(*size) > len(md) {
-+		panic("EVP_Digest: *size exceeds len(md)")
-+	}
 +	var _err uintptr
 +	r0, _ := syscallN(3, _mkcgo_EVP_Digest, uintptr(unsafe.Pointer(unsafe.SliceData(data))), uintptr(len(data)), uintptr(unsafe.Pointer(unsafe.SliceData(md))), uintptr(unsafe.Pointer(size)), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_Digest", _err)
@@ -17426,18 +17670,15 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_DigestFinalXOF uintptr
 +
-+func EVP_DigestFinalXOF(ctx EVP_MD_CTX_PTR, md []byte) (int32, error) {
++func EVP_DigestFinalXOF(ctx EVP_MD_CTX_PTR, md []byte, len int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DigestFinalXOF, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(md))), uintptr(len(md)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DigestFinalXOF, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(md))), uintptr(len), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DigestFinalXOF", _err)
 +}
 +
 +var _mkcgo_EVP_DigestFinal_ex uintptr
 +
 +func EVP_DigestFinal_ex(ctx EVP_MD_CTX_PTR, md []byte, s *uint32) (int32, error) {
-+	if s != nil && int(*s) > len(md) {
-+		panic("EVP_DigestFinal_ex: *s exceeds len(md)")
-+	}
 +	var _err uintptr
 +	r0, _ := syscallN(3, _mkcgo_EVP_DigestFinal_ex, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(md))), uintptr(unsafe.Pointer(s)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DigestFinal_ex", _err)
@@ -17461,23 +17702,17 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_DigestSign uintptr
 +
-+func EVP_DigestSign(ctx EVP_MD_CTX_PTR, sigret []byte, siglen *int, tbs []byte) (int32, error) {
-+	if siglen != nil && int(*siglen) > len(sigret) {
-+		panic("EVP_DigestSign: *siglen exceeds len(sigret)")
-+	}
++func EVP_DigestSign(ctx EVP_MD_CTX_PTR, sigret *byte, siglen *int, tbs *byte, tbslen int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DigestSign, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(sigret))), uintptr(unsafe.Pointer(siglen)), uintptr(unsafe.Pointer(unsafe.SliceData(tbs))), uintptr(len(tbs)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DigestSign, uintptr(ctx), uintptr(unsafe.Pointer(sigret)), uintptr(unsafe.Pointer(siglen)), uintptr(unsafe.Pointer(tbs)), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DigestSign", _err)
 +}
 +
 +var _mkcgo_EVP_DigestSignFinal uintptr
 +
-+func EVP_DigestSignFinal(ctx EVP_MD_CTX_PTR, sig []byte, siglen *int) (int32, error) {
-+	if siglen != nil && int(*siglen) > len(sig) {
-+		panic("EVP_DigestSignFinal: *siglen exceeds len(sig)")
-+	}
++func EVP_DigestSignFinal(ctx EVP_MD_CTX_PTR, sig *byte, siglen *int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignFinal, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(sig)))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(siglen))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignFinal, uintptr(ctx), uintptr(unsafe.Pointer(sig)), uintptr(unsafe.Pointer(siglen)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DigestSignFinal", _err)
 +}
 +
@@ -17485,7 +17720,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_DigestSignInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_MD_PTR, e ENGINE_PTR, pkey EVP_PKEY_PTR) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignInit, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(pctx))), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignInit, uintptr(ctx), uintptr(unsafe.Pointer(pctx)), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DigestSignInit", _err)
 +}
 +
@@ -17507,17 +17742,17 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_DigestVerify uintptr
 +
-+func EVP_DigestVerify(ctx EVP_MD_CTX_PTR, sigret []byte, tbs []byte) (int32, error) {
++func EVP_DigestVerify(ctx EVP_MD_CTX_PTR, sigret *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerify, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(sigret)))), uintptr(len(sigret)), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(tbs)))), uintptr(len(tbs)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerify, uintptr(ctx), uintptr(unsafe.Pointer(sigret)), uintptr(siglen), uintptr(unsafe.Pointer(tbs)), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DigestVerify", _err)
 +}
 +
 +var _mkcgo_EVP_DigestVerifyFinal uintptr
 +
-+func EVP_DigestVerifyFinal(ctx EVP_MD_CTX_PTR, sig []byte) (int32, error) {
++func EVP_DigestVerifyFinal(ctx EVP_MD_CTX_PTR, sig *byte, siglen int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyFinal, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(sig)))), uintptr(len(sig)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyFinal, uintptr(ctx), uintptr(unsafe.Pointer(sig)), uintptr(siglen), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DigestVerifyFinal", _err)
 +}
 +
@@ -17525,18 +17760,15 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_DigestVerifyInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_MD_PTR, e ENGINE_PTR, pkey EVP_PKEY_PTR) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyInit, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(pctx))), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyInit, uintptr(ctx), uintptr(unsafe.Pointer(pctx)), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_DigestVerifyInit", _err)
 +}
 +
 +var _mkcgo_EVP_EncryptFinal_ex uintptr
 +
-+func EVP_EncryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32) (int32, error) {
-+	if outl != nil && int(*outl) > len(out) {
-+		panic("EVP_EncryptFinal_ex: *outl exceeds len(out)")
-+	}
++func EVP_EncryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_EncryptFinal_ex, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(out))), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_EncryptFinal_ex, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_EncryptFinal_ex", _err)
 +}
 +
@@ -17544,18 +17776,15 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_EncryptInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGINE_PTR, key *byte, iv *byte) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_EncryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(iv))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_EncryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_EncryptInit_ex", _err)
 +}
 +
 +var _mkcgo_EVP_EncryptUpdate uintptr
 +
-+func EVP_EncryptUpdate(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32, in []byte) (int32, error) {
-+	if outl != nil && int(*outl) > len(out) {
-+		panic("EVP_EncryptUpdate: *outl exceeds len(out)")
-+	}
++func EVP_EncryptUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_EncryptUpdate, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(out))), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(unsafe.SliceData(in))), uintptr(len(in)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_EncryptUpdate, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(in)), uintptr(inl), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_EncryptUpdate", _err)
 +}
 +
@@ -17591,9 +17820,9 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_KDF_derive uintptr
 +
-+func EVP_KDF_derive(ctx EVP_KDF_CTX_PTR, key []byte, params OSSL_PARAM_PTR) (int32, error) {
++func EVP_KDF_derive(ctx EVP_KDF_CTX_PTR, key *byte, keylen int, params OSSL_PARAM_PTR) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_KDF_derive, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(key)))), uintptr(len(key)), uintptr(params), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_KDF_derive, uintptr(ctx), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(params), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_KDF_derive", _err)
 +}
 +
@@ -17601,7 +17830,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_KDF_fetch(libctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_KDF_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_EVP_KDF_fetch, uintptr(libctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(algorithm))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_EVP_KDF_fetch, uintptr(libctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_KDF_PTR(r0), newMkcgoErr("EVP_KDF_fetch", _err)
 +}
 +
@@ -17615,7 +17844,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_KEYMGMT_fetch(libctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_KEYMGMT_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_EVP_KEYMGMT_fetch, uintptr(libctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(algorithm))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_EVP_KEYMGMT_fetch, uintptr(libctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_KEYMGMT_PTR(r0), newMkcgoErr("EVP_KEYMGMT_fetch", _err)
 +}
 +
@@ -17659,31 +17888,31 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_MAC_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_MAC_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_EVP_MAC_fetch, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(algorithm))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_EVP_MAC_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_MAC_PTR(r0), newMkcgoErr("EVP_MAC_fetch", _err)
 +}
 +
 +var _mkcgo_EVP_MAC_final uintptr
 +
-+func EVP_MAC_final(ctx EVP_MAC_CTX_PTR, out []byte, outl *int) (int32, error) {
++func EVP_MAC_final(ctx EVP_MAC_CTX_PTR, out *byte, outl *int, outsize int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_MAC_final, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(out))), uintptr(unsafe.Pointer(outl)), uintptr(len(out)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_MAC_final, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(outsize), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_MAC_final", _err)
 +}
 +
 +var _mkcgo_EVP_MAC_init uintptr
 +
-+func EVP_MAC_init(ctx EVP_MAC_CTX_PTR, key []byte, params OSSL_PARAM_PTR) (int32, error) {
++func EVP_MAC_init(ctx EVP_MAC_CTX_PTR, key *byte, keylen int, params OSSL_PARAM_PTR) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_MAC_init, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(key))), uintptr(len(key)), uintptr(params), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_MAC_init, uintptr(ctx), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(params), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_MAC_init", _err)
 +}
 +
 +var _mkcgo_EVP_MAC_update uintptr
 +
-+func EVP_MAC_update(ctx EVP_MAC_CTX_PTR, data []byte) (int32, error) {
++func EVP_MAC_update(ctx EVP_MAC_CTX_PTR, data *byte, datalen int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_MAC_update, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(data))), uintptr(len(data)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_MAC_update, uintptr(ctx), uintptr(unsafe.Pointer(data)), uintptr(datalen), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_MAC_update", _err)
 +}
 +
@@ -17753,7 +17982,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_MD_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_MD_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_EVP_MD_fetch, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(algorithm))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_EVP_MD_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_MD_PTR(r0), newMkcgoErr("EVP_MD_fetch", _err)
 +}
 +
@@ -17800,9 +18029,9 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_PKEY_CTX_add1_hkdf_info uintptr
 +
-+func EVP_PKEY_CTX_add1_hkdf_info(arg0 EVP_PKEY_CTX_PTR, arg1 []byte) (int32, error) {
++func EVP_PKEY_CTX_add1_hkdf_info(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_add1_hkdf_info, uintptr(arg0), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg1)))), uintptr(len(arg1)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_add1_hkdf_info, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_add1_hkdf_info", _err)
 +}
 +
@@ -17832,7 +18061,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_PKEY_CTX_new_from_pkey(libctx OSSL_LIB_CTX_PTR, pkey EVP_PKEY_PTR, propquery *byte) (EVP_PKEY_CTX_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_CTX_new_from_pkey, uintptr(libctx), uintptr(pkey), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(propquery))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_CTX_new_from_pkey, uintptr(libctx), uintptr(pkey), uintptr(unsafe.Pointer(propquery)), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_PKEY_CTX_PTR(r0), newMkcgoErr("EVP_PKEY_CTX_new_from_pkey", _err)
 +}
 +
@@ -17846,25 +18075,25 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label uintptr
 +
-+func EVP_PKEY_CTX_set0_rsa_oaep_label(ctx EVP_PKEY_CTX_PTR, label []byte) (int32, error) {
++func EVP_PKEY_CTX_set0_rsa_oaep_label(ctx EVP_PKEY_CTX_PTR, label unsafe.Pointer, len int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(label)))), uintptr(len(label)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label, uintptr(ctx), uintptr(label), uintptr(len), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set0_rsa_oaep_label", _err)
 +}
 +
 +var _mkcgo_EVP_PKEY_CTX_set1_hkdf_key uintptr
 +
-+func EVP_PKEY_CTX_set1_hkdf_key(arg0 EVP_PKEY_CTX_PTR, arg1 []byte) (int32, error) {
++func EVP_PKEY_CTX_set1_hkdf_key(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_key, uintptr(arg0), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg1)))), uintptr(len(arg1)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_key, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set1_hkdf_key", _err)
 +}
 +
 +var _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt uintptr
 +
-+func EVP_PKEY_CTX_set1_hkdf_salt(arg0 EVP_PKEY_CTX_PTR, arg1 []byte) (int32, error) {
++func EVP_PKEY_CTX_set1_hkdf_salt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt, uintptr(arg0), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg1)))), uintptr(len(arg1)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set1_hkdf_salt", _err)
 +}
 +
@@ -17938,7 +18167,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_PKEY_decapsulate(ctx EVP_PKEY_CTX_PTR, genkey *byte, genkeylen *int, wrappedkey *byte, wrappedkeylen int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decapsulate, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(genkey))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(genkeylen))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(wrappedkey))), uintptr(wrappedkeylen), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decapsulate, uintptr(ctx), uintptr(unsafe.Pointer(genkey)), uintptr(unsafe.Pointer(genkeylen)), uintptr(unsafe.Pointer(wrappedkey)), uintptr(wrappedkeylen), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_decapsulate", _err)
 +}
 +
@@ -17952,12 +18181,9 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_PKEY_decrypt uintptr
 +
-+func EVP_PKEY_decrypt(arg0 EVP_PKEY_CTX_PTR, arg1 []byte, arg2 *int, arg3 []byte) (int32, error) {
-+	if arg2 != nil && int(*arg2) > len(arg1) {
-+		panic("EVP_PKEY_decrypt: *arg2 exceeds len(arg1)")
-+	}
++func EVP_PKEY_decrypt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decrypt, uintptr(arg0), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg1)))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(arg2))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg3)))), uintptr(len(arg3)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decrypt, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(arg3)), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_decrypt", _err)
 +}
 +
@@ -17971,12 +18197,9 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_PKEY_derive uintptr
 +
-+func EVP_PKEY_derive(ctx EVP_PKEY_CTX_PTR, key []byte, keylen *int) (int32, error) {
-+	if keylen != nil && int(*keylen) > len(key) {
-+		panic("EVP_PKEY_derive: *keylen exceeds len(key)")
-+	}
++func EVP_PKEY_derive(ctx EVP_PKEY_CTX_PTR, key *byte, keylen *int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_derive, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(key))), uintptr(unsafe.Pointer(keylen)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_derive, uintptr(ctx), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(keylen)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_derive", _err)
 +}
 +
@@ -18000,7 +18223,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_PKEY_encapsulate(ctx EVP_PKEY_CTX_PTR, wrappedkey *byte, wrappedkeylen *int, genkey *byte, genkeylen *int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encapsulate, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(wrappedkey))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(wrappedkeylen))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(genkey))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(genkeylen))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encapsulate, uintptr(ctx), uintptr(unsafe.Pointer(wrappedkey)), uintptr(unsafe.Pointer(wrappedkeylen)), uintptr(unsafe.Pointer(genkey)), uintptr(unsafe.Pointer(genkeylen)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_encapsulate", _err)
 +}
 +
@@ -18014,12 +18237,9 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_PKEY_encrypt uintptr
 +
-+func EVP_PKEY_encrypt(arg0 EVP_PKEY_CTX_PTR, arg1 []byte, arg2 *int, arg3 []byte) (int32, error) {
-+	if arg2 != nil && int(*arg2) > len(arg1) {
-+		panic("EVP_PKEY_encrypt: *arg2 exceeds len(arg1)")
-+	}
++func EVP_PKEY_encrypt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encrypt, uintptr(arg0), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg1)))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(arg2))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg3)))), uintptr(len(arg3)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encrypt, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(arg3)), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_encrypt", _err)
 +}
 +
@@ -18041,7 +18261,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_PKEY_fromdata(ctx EVP_PKEY_CTX_PTR, pkey *EVP_PKEY_PTR, selection int32, params OSSL_PARAM_PTR) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_fromdata, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(pkey))), uintptr(selection), uintptr(params), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_fromdata, uintptr(ctx), uintptr(unsafe.Pointer(pkey)), uintptr(selection), uintptr(params), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_fromdata", _err)
 +}
 +
@@ -18081,7 +18301,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_PKEY_get1_encoded_public_key(pkey EVP_PKEY_PTR, ppub **byte) (int, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(4, _mkcgo_EVP_PKEY_get1_encoded_public_key, uintptr(pkey), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(ppub))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(4, _mkcgo_EVP_PKEY_get1_encoded_public_key, uintptr(pkey), uintptr(unsafe.Pointer(ppub)), uintptr(unsafe.Pointer(&_err)))
 +	return int(r0), newMkcgoErr("EVP_PKEY_get1_encoded_public_key", _err)
 +}
 +
@@ -18103,31 +18323,25 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_PKEY_get_octet_string_param uintptr
 +
-+func EVP_PKEY_get_octet_string_param(pkey EVP_PKEY_PTR, key_name *byte, buf []byte, out_len *int) (int32, error) {
++func EVP_PKEY_get_octet_string_param(pkey EVP_PKEY_PTR, key_name *byte, buf *byte, buf_len int, out_len *int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_octet_string_param, uintptr(pkey), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key_name))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(buf)))), uintptr(len(buf)), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(out_len))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_octet_string_param, uintptr(pkey), uintptr(unsafe.Pointer(key_name)), uintptr(unsafe.Pointer(buf)), uintptr(buf_len), uintptr(unsafe.Pointer(out_len)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_get_octet_string_param", _err)
 +}
 +
 +var _mkcgo_EVP_PKEY_get_raw_private_key uintptr
 +
-+func EVP_PKEY_get_raw_private_key(pkey EVP_PKEY_PTR, priv []byte, privlen *int) (int32, error) {
-+	if privlen != nil && int(*privlen) > len(priv) {
-+		panic("EVP_PKEY_get_raw_private_key: *privlen exceeds len(priv)")
-+	}
++func EVP_PKEY_get_raw_private_key(pkey EVP_PKEY_PTR, priv *byte, len *int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_raw_private_key, uintptr(pkey), uintptr(unsafe.Pointer(unsafe.SliceData(priv))), uintptr(unsafe.Pointer(privlen)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_raw_private_key, uintptr(pkey), uintptr(unsafe.Pointer(priv)), uintptr(unsafe.Pointer(len)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_get_raw_private_key", _err)
 +}
 +
 +var _mkcgo_EVP_PKEY_get_raw_public_key uintptr
 +
-+func EVP_PKEY_get_raw_public_key(pkey EVP_PKEY_PTR, pub []byte, publen *int) (int32, error) {
-+	if publen != nil && int(*publen) > len(pub) {
-+		panic("EVP_PKEY_get_raw_public_key: *publen exceeds len(pub)")
-+	}
++func EVP_PKEY_get_raw_public_key(pkey EVP_PKEY_PTR, pub *byte, len *int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_raw_public_key, uintptr(pkey), uintptr(unsafe.Pointer(unsafe.SliceData(pub))), uintptr(unsafe.Pointer(publen)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_raw_public_key, uintptr(pkey), uintptr(unsafe.Pointer(pub)), uintptr(unsafe.Pointer(len)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_get_raw_public_key", _err)
 +}
 +
@@ -18165,17 +18379,17 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_PKEY_new_raw_private_key uintptr
 +
-+func EVP_PKEY_new_raw_private_key(__type int32, e ENGINE_PTR, key []byte) (EVP_PKEY_PTR, error) {
++func EVP_PKEY_new_raw_private_key(__type int32, e ENGINE_PTR, key *byte, keylen int) (EVP_PKEY_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_private_key, uintptr(__type), uintptr(e), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(key)))), uintptr(len(key)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_private_key, uintptr(__type), uintptr(e), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_new_raw_private_key", _err)
 +}
 +
 +var _mkcgo_EVP_PKEY_new_raw_public_key uintptr
 +
-+func EVP_PKEY_new_raw_public_key(__type int32, e ENGINE_PTR, key []byte) (EVP_PKEY_PTR, error) {
++func EVP_PKEY_new_raw_public_key(__type int32, e ENGINE_PTR, key *byte, keylen int) (EVP_PKEY_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_public_key, uintptr(__type), uintptr(e), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(key)))), uintptr(len(key)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_public_key, uintptr(__type), uintptr(e), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_new_raw_public_key", _err)
 +}
 +
@@ -18183,7 +18397,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_PKEY_paramgen(ctx EVP_PKEY_CTX_PTR, ppkey *EVP_PKEY_PTR) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_paramgen, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(ppkey))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_paramgen, uintptr(ctx), uintptr(unsafe.Pointer(ppkey)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_paramgen", _err)
 +}
 +
@@ -18221,20 +18435,17 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_PKEY_set1_encoded_public_key uintptr
 +
-+func EVP_PKEY_set1_encoded_public_key(pkey EVP_PKEY_PTR, pub []byte) (int32, error) {
++func EVP_PKEY_set1_encoded_public_key(pkey EVP_PKEY_PTR, pub *byte, publen int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_set1_encoded_public_key, uintptr(pkey), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(pub)))), uintptr(len(pub)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_set1_encoded_public_key, uintptr(pkey), uintptr(unsafe.Pointer(pub)), uintptr(publen), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_set1_encoded_public_key", _err)
 +}
 +
 +var _mkcgo_EVP_PKEY_sign uintptr
 +
-+func EVP_PKEY_sign(arg0 EVP_PKEY_CTX_PTR, arg1 []byte, arg2 *int, arg3 []byte) (int32, error) {
-+	if arg2 != nil && int(*arg2) > len(arg1) {
-+		panic("EVP_PKEY_sign: *arg2 exceeds len(arg1)")
-+	}
++func EVP_PKEY_sign(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_sign, uintptr(arg0), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg1)))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(arg2))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(arg3)))), uintptr(len(arg3)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_sign, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(arg3)), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_sign", _err)
 +}
 +
@@ -18256,9 +18467,9 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_EVP_PKEY_verify uintptr
 +
-+func EVP_PKEY_verify(ctx EVP_PKEY_CTX_PTR, sig []byte, tbs []byte) (int32, error) {
++func EVP_PKEY_verify(ctx EVP_PKEY_CTX_PTR, sig *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_verify, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(sig)))), uintptr(len(sig)), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(tbs)))), uintptr(len(tbs)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_verify, uintptr(ctx), uintptr(unsafe.Pointer(sig)), uintptr(siglen), uintptr(unsafe.Pointer(tbs)), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_verify", _err)
 +}
 +
@@ -18274,7 +18485,7 @@ index 00000000000000..1f3ab498325710
 +
 +func EVP_SIGNATURE_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_SIGNATURE_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_EVP_SIGNATURE_fetch, uintptr(ctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(algorithm))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_EVP_SIGNATURE_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_SIGNATURE_PTR(r0), newMkcgoErr("EVP_SIGNATURE_fetch", _err)
 +}
 +
@@ -18573,28 +18784,25 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_HMAC_Final uintptr
 +
-+func HMAC_Final(arg0 HMAC_CTX_PTR, arg1 []byte, arg2 *uint32) (int32, error) {
-+	if arg2 != nil && int(*arg2) > len(arg1) {
-+		panic("HMAC_Final: *arg2 exceeds len(arg1)")
-+	}
++func HMAC_Final(arg0 HMAC_CTX_PTR, arg1 *byte, arg2 *uint32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_HMAC_Final, uintptr(arg0), uintptr(unsafe.Pointer(unsafe.SliceData(arg1))), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_HMAC_Final, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("HMAC_Final", _err)
 +}
 +
 +var _mkcgo_HMAC_Init_ex uintptr
 +
-+func HMAC_Init_ex(arg0 HMAC_CTX_PTR, arg1 []byte, arg3 EVP_MD_PTR, arg4 ENGINE_PTR) (int32, error) {
++func HMAC_Init_ex(arg0 HMAC_CTX_PTR, arg1 unsafe.Pointer, arg2 int32, arg3 EVP_MD_PTR, arg4 ENGINE_PTR) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_HMAC_Init_ex, uintptr(arg0), uintptr(unsafe.Pointer(unsafe.SliceData(arg1))), uintptr(len(arg1)), uintptr(arg3), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_HMAC_Init_ex, uintptr(arg0), uintptr(arg1), uintptr(arg2), uintptr(arg3), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("HMAC_Init_ex", _err)
 +}
 +
 +var _mkcgo_HMAC_Update uintptr
 +
-+func HMAC_Update(arg0 HMAC_CTX_PTR, arg1 []byte) (int32, error) {
++func HMAC_Update(arg0 HMAC_CTX_PTR, arg1 *byte, arg2 int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_HMAC_Update, uintptr(arg0), uintptr(unsafe.Pointer(unsafe.SliceData(arg1))), uintptr(len(arg1)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_HMAC_Update, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("HMAC_Update", _err)
 +}
 +
@@ -18660,16 +18868,17 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_OSSL_PARAM_BLD_new uintptr
 +
-+func OSSL_PARAM_BLD_new() OSSL_PARAM_BLD_PTR {
-+	r0, _ := syscallN(0, _mkcgo_OSSL_PARAM_BLD_new)
-+	return OSSL_PARAM_BLD_PTR(r0)
++func OSSL_PARAM_BLD_new() (OSSL_PARAM_BLD_PTR, error) {
++	var _err uintptr
++	r0, _ := syscallN(1, _mkcgo_OSSL_PARAM_BLD_new, uintptr(unsafe.Pointer(&_err)))
++	return OSSL_PARAM_BLD_PTR(r0), newMkcgoErr("OSSL_PARAM_BLD_new", _err)
 +}
 +
 +var _mkcgo_OSSL_PARAM_BLD_push_BN uintptr
 +
 +func OSSL_PARAM_BLD_push_BN(bld OSSL_PARAM_BLD_PTR, key *byte, bn BIGNUM_PTR) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_BN, uintptr(bld), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key))), uintptr(bn), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_BN, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(bn), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_BN", _err)
 +}
 +
@@ -18677,23 +18886,23 @@ index 00000000000000..1f3ab498325710
 +
 +func OSSL_PARAM_BLD_push_int32(bld OSSL_PARAM_BLD_PTR, key *byte, num int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_int32, uintptr(bld), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key))), uintptr(num), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_int32, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(num), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_int32", _err)
 +}
 +
 +var _mkcgo_OSSL_PARAM_BLD_push_octet_string uintptr
 +
-+func OSSL_PARAM_BLD_push_octet_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf []byte) (int32, error) {
++func OSSL_PARAM_BLD_push_octet_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf unsafe.Pointer, bsize int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_octet_string, uintptr(bld), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(buf)))), uintptr(len(buf)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_octet_string, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(buf), uintptr(bsize), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_octet_string", _err)
 +}
 +
 +var _mkcgo_OSSL_PARAM_BLD_push_utf8_string uintptr
 +
-+func OSSL_PARAM_BLD_push_utf8_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf []byte) (int32, error) {
++func OSSL_PARAM_BLD_push_utf8_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf *byte, bsize int) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_utf8_string, uintptr(bld), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(buf)))), uintptr(len(buf)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_utf8_string, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(buf)), uintptr(bsize), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_utf8_string", _err)
 +}
 +
@@ -18715,14 +18924,14 @@ index 00000000000000..1f3ab498325710
 +
 +func OSSL_PARAM_locate_const(p OSSL_PARAM_PTR, key *byte) (OSSL_PARAM_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_OSSL_PARAM_locate_const, uintptr(p), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_OSSL_PARAM_locate_const, uintptr(p), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(&_err)))
 +	return OSSL_PARAM_PTR(r0), newMkcgoErr("OSSL_PARAM_locate_const", _err)
 +}
 +
 +var _mkcgo_OSSL_PROVIDER_available uintptr
 +
 +func OSSL_PROVIDER_available(libctx OSSL_LIB_CTX_PTR, name *byte) int32 {
-+	r0, _ := syscallN(0, _mkcgo_OSSL_PROVIDER_available, uintptr(libctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(name))))
++	r0, _ := syscallN(0, _mkcgo_OSSL_PROVIDER_available, uintptr(libctx), uintptr(unsafe.Pointer(name)))
 +	return int32(r0)
 +}
 +
@@ -18737,7 +18946,7 @@ index 00000000000000..1f3ab498325710
 +
 +func OSSL_PROVIDER_try_load(libctx OSSL_LIB_CTX_PTR, name *byte, retain_fallbacks int32) (OSSL_PROVIDER_PTR, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(1, _mkcgo_OSSL_PROVIDER_try_load, uintptr(libctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(name))), uintptr(retain_fallbacks), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(1, _mkcgo_OSSL_PROVIDER_try_load, uintptr(libctx), uintptr(unsafe.Pointer(name)), uintptr(retain_fallbacks), uintptr(unsafe.Pointer(&_err)))
 +	return OSSL_PROVIDER_PTR(r0), newMkcgoErr("OSSL_PROVIDER_try_load", _err)
 +}
 +
@@ -18761,17 +18970,17 @@ index 00000000000000..1f3ab498325710
 +
 +var _mkcgo_PKCS5_PBKDF2_HMAC uintptr
 +
-+func PKCS5_PBKDF2_HMAC(pass []byte, salt []byte, iter int32, digest EVP_MD_PTR, out []byte) (int32, error) {
++func PKCS5_PBKDF2_HMAC(pass *byte, passlen int32, salt *byte, saltlen int32, iter int32, digest EVP_MD_PTR, keylen int32, out *byte) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_PKCS5_PBKDF2_HMAC, uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(pass)))), uintptr(len(pass)), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(salt)))), uintptr(len(salt)), uintptr(iter), uintptr(digest), uintptr(len(out)), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(unsafe.SliceData(out)))), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_PKCS5_PBKDF2_HMAC, uintptr(unsafe.Pointer(pass)), uintptr(passlen), uintptr(unsafe.Pointer(salt)), uintptr(saltlen), uintptr(iter), uintptr(digest), uintptr(keylen), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("PKCS5_PBKDF2_HMAC", _err)
 +}
 +
 +var _mkcgo_RAND_bytes uintptr
 +
-+func RAND_bytes(arg0 []byte) (int32, error) {
++func RAND_bytes(arg0 *byte, arg1 int32) (int32, error) {
 +	var _err uintptr
-+	r0, _ := syscallN(3, _mkcgo_RAND_bytes, uintptr(unsafe.Pointer(unsafe.SliceData(arg0))), uintptr(len(arg0)), uintptr(unsafe.Pointer(&_err)))
++	r0, _ := syscallN(3, _mkcgo_RAND_bytes, uintptr(unsafe.Pointer(arg0)), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("RAND_bytes", _err)
 +}
 +
@@ -18784,19 +18993,19 @@ index 00000000000000..1f3ab498325710
 +var _mkcgo_RSA_get0_crt_params uintptr
 +
 +func RSA_get0_crt_params(r RSA_PTR, dmp1 *BIGNUM_PTR, dmq1 *BIGNUM_PTR, iqmp *BIGNUM_PTR) {
-+	syscallN(0, _mkcgo_RSA_get0_crt_params, uintptr(r), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(dmp1))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(dmq1))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(iqmp))))
++	syscallN(0, _mkcgo_RSA_get0_crt_params, uintptr(r), uintptr(unsafe.Pointer(dmp1)), uintptr(unsafe.Pointer(dmq1)), uintptr(unsafe.Pointer(iqmp)))
 +}
 +
 +var _mkcgo_RSA_get0_factors uintptr
 +
 +func RSA_get0_factors(rsa RSA_PTR, p *BIGNUM_PTR, q *BIGNUM_PTR) {
-+	syscallN(0, _mkcgo_RSA_get0_factors, uintptr(rsa), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(p))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(q))))
++	syscallN(0, _mkcgo_RSA_get0_factors, uintptr(rsa), uintptr(unsafe.Pointer(p)), uintptr(unsafe.Pointer(q)))
 +}
 +
 +var _mkcgo_RSA_get0_key uintptr
 +
 +func RSA_get0_key(rsa RSA_PTR, n *BIGNUM_PTR, e *BIGNUM_PTR, d *BIGNUM_PTR) {
-+	syscallN(0, _mkcgo_RSA_get0_key, uintptr(rsa), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(n))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(e))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(d))))
++	syscallN(0, _mkcgo_RSA_get0_key, uintptr(rsa), uintptr(unsafe.Pointer(n)), uintptr(unsafe.Pointer(e)), uintptr(unsafe.Pointer(d)))
 +}
 +
 +var _mkcgo_RSA_new uintptr
@@ -19394,10 +19603,10 @@ index 00000000000000..1f3ab498325710
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/mlkem.go b/src/vendor/github.com/golang-fips/openssl/v2/mlkem.go
 new file mode 100644
-index 00000000000000..17444fbf258584
+index 00000000000000..38ed8f5d69d946
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/mlkem.go
-@@ -0,0 +1,365 @@
+@@ -0,0 +1,371 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -19698,7 +19907,7 @@ index 00000000000000..17444fbf258584
 +	}
 +	defer ossl.EVP_PKEY_free(pkey)
 +
-+	_, err = ossl.EVP_PKEY_get_octet_string_param(pkey, _OSSL_PKEY_PARAM_ML_KEM_SEED.ptr(), seed, nil)
++	_, err = ossl.EVP_PKEY_get_octet_string_param(pkey, _OSSL_PKEY_PARAM_ML_KEM_SEED.ptr(), base(seed), seedSizeMLKEM, nil)
 +	return err
 +}
 +
@@ -19708,7 +19917,10 @@ index 00000000000000..17444fbf258584
 +		return nil, errors.New("mlkem: invalid seed size")
 +	}
 +
-+	bld := newParamBuilder()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return nil, err
++	}
 +	defer bld.finalize()
 +
 +	bld.addOctetString(_OSSL_PKEY_PARAM_ML_KEM_SEED, seed)
@@ -19724,7 +19936,10 @@ index 00000000000000..17444fbf258584
 +
 +// createMLKEMPublicKey creates an ML-KEM public key from encoded bytes.
 +func createMLKEMPublicKey(id int32, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, error) {
-+	bld := newParamBuilder()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return nil, err
++	}
 +	defer bld.finalize()
 +
 +	bld.addOctetString(_OSSL_PKEY_PARAM_PUB_KEY, pubKeyBytes)
@@ -19765,10 +19980,10 @@ index 00000000000000..17444fbf258584
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/openssl.go b/src/vendor/github.com/golang-fips/openssl/v2/openssl.go
 new file mode 100644
-index 00000000000000..43fd4a209ab821
+index 00000000000000..30ed1f38392629
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/openssl.go
-@@ -0,0 +1,244 @@
+@@ -0,0 +1,253 @@
 +//go:build !cmd_go_bootstrap
 +
 +// Package openssl provides access to OpenSSL cryptographic functions.
@@ -19888,12 +20103,21 @@ index 00000000000000..43fd4a209ab821
 +	return osslsetup.SetFIPS(enable)
 +}
 +
-+// sliceNeverNil returns b if non-nil, and a non-nil zero-length slice otherwise.
-+func sliceNeverNil(b []byte) []byte {
-+	if b == nil {
-+		return []byte{}
++var zero byte
++
++// baseNeverEmpty returns the address of the underlying array in b.
++// If b has zero length, it returns a pointer to a zero byte.
++func baseNeverEmpty(b []byte) *byte {
++	if len(b) == 0 {
++		return &zero
 +	}
-+	return b
++	return unsafe.SliceData(b)
++}
++
++// pbase returns the address of the underlying array in b,
++// being careful not to panic when b has zero length.
++func pbase(b []byte) unsafe.Pointer {
++	return unsafe.Pointer(base(b))
 +}
 +
 +// base returns the address of the underlying array in b,
@@ -19969,7 +20193,7 @@ index 00000000000000..43fd4a209ab821
 +	}
 +	// Limbs are always ordered in LSB first, so we can safely apply
 +	// BN_lebin2bn regardless of host endianness.
-+	bn, err := ossl.BN_lebin2bn(unsafe.Slice(wbase(x), len(x)*wordBytes), nil)
++	bn, err := ossl.BN_lebin2bn(wbase(x), int32(len(x)*wordBytes), nil)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -19984,7 +20208,7 @@ index 00000000000000..43fd4a209ab821
 +	// Limbs are always ordered in LSB first, so we can safely apply
 +	// BN_bn2lebinpad regardless of host endianness.
 +	x := make(BigInt, ossl.BN_num_bits(bn))
-+	if _, err := ossl.BN_bn2lebinpad(bn, unsafe.Slice(wbase(x), len(x)*wordBytes)); err != nil {
++	if _, err := ossl.BN_bn2lebinpad(bn, wbase(x), int32(len(x)*wordBytes)); err != nil {
 +		panic(err)
 +	}
 +	if isBigEndian() {
@@ -19997,7 +20221,7 @@ index 00000000000000..43fd4a209ab821
 +// it at to, padding with zeroes if necessary. If len(to) is not large enough to
 +// hold the result, an error is returned.
 +func bnToBinPad(bn ossl.BIGNUM_PTR, to []byte) error {
-+	_, err := ossl.BN_bn2binpad(bn, to)
++	_, err := ossl.BN_bn2binpad(bn, base(to), int32(len(to)))
 +	return err
 +}
 +
@@ -20653,17 +20877,16 @@ index 00000000000000..fd1cad5692a0bc
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/params.go b/src/vendor/github.com/golang-fips/openssl/v2/params.go
 new file mode 100644
-index 00000000000000..aae278e743a73a
+index 00000000000000..3bdc8037c0c9af
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/params.go
-@@ -0,0 +1,180 @@
+@@ -0,0 +1,184 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
 +
 +import (
 +	"runtime"
-+	"unsafe"
 +
 +	"github.com/golang-fips/openssl/v2/internal/ossl"
 +)
@@ -20695,14 +20918,17 @@ index 00000000000000..aae278e743a73a
 +}
 +
 +// newParamBuilder creates a new paramBuilder.
-+// [paramBuilder.finalize] must be called to free the builder.
-+func newParamBuilder() *paramBuilder {
-+	bld := ossl.OSSL_PARAM_BLD_new()
-+	if bld == nil {
-+		// If this happens it indicates an issue allocating memory.
-+		panic("openssl: failed to create OSSL_PARAM_BLD")
++func newParamBuilder() (*paramBuilder, error) {
++	bld, err := ossl.OSSL_PARAM_BLD_new()
++	if err != nil {
++		return nil, err
 +	}
-+	return &paramBuilder{bld: bld}
++	pb := &paramBuilder{
++		bld:      bld,
++		bnToFree: make([]bnParam, 0, 8), // the maximum known number of BIGNUMs to free are 8 for RSA
++	}
++	runtime.SetFinalizer(pb, (*paramBuilder).finalize)
++	return pb, nil
 +}
 +
 +// finalize frees the builder.
@@ -20759,10 +20985,7 @@ index 00000000000000..aae278e743a73a
 +		return
 +	}
 +	// OSSL_PARAM_BLD_push_utf8_string calculates the size if it is zero.
-+	if size == 0 {
-+		size = cStringLen(value)
-+	}
-+	if _, err := ossl.OSSL_PARAM_BLD_push_utf8_string(b.bld, name.ptr(), unsafe.Slice(value, size)); err != nil {
++	if _, err := ossl.OSSL_PARAM_BLD_push_utf8_string(b.bld, name.ptr(), value, size); err != nil {
 +		b.err = addParamError{name.str(), err}
 +	}
 +}
@@ -20776,19 +20999,8 @@ index 00000000000000..aae278e743a73a
 +	if len(value) != 0 {
 +		b.pinner.Pin(&value[0])
 +	}
-+	if _, err := ossl.OSSL_PARAM_BLD_push_octet_string(b.bld, name.ptr(), value); err != nil {
++	if _, err := ossl.OSSL_PARAM_BLD_push_octet_string(b.bld, name.ptr(), pbase(value), len(value)); err != nil {
 +		b.err = addParamError{name.str(), err}
-+	}
-+}
-+
-+func cStringLen(ptr *byte) int {
-+	if ptr == nil {
-+		return 0
-+	}
-+	for n := 0; ; n++ {
-+		if *(*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + uintptr(n))) == 0 {
-+			return n
-+		}
 +	}
 +}
 +
@@ -20812,6 +21024,27 @@ index 00000000000000..aae278e743a73a
 +	}
 +}
 +
++// addBin adds a byte slice to the builder.
++// The slice is converted to a BIGNUM using BN_bin2bn and freed when the builder is finalized.
++// If private is true, the BIGNUM will be cleared with BN_clear_free,
++// otherwise it will be freed with BN_free.
++func (b *paramBuilder) addBin(name cString, value []byte, private bool) {
++	if !b.check() {
++		return
++	}
++	if len(value) == 0 {
++		// Nothing to do.
++		return
++	}
++	bn, err := ossl.BN_bin2bn(base(value), int32(len(value)), nil)
++	if err != nil {
++		b.err = err
++		return
++	}
++	b.bnToFree = append(b.bnToFree, bnParam{bn, private})
++	b.addBN(name, bn)
++}
++
 +// addBigInt adds a BigInt to the builder.
 +// The BigInt is converted using bigToBN to a BIGNUM that is freed when the builder is finalized.
 +// If private is true, the BIGNUM will be cleared with BN_clear_free,
@@ -20829,17 +21062,12 @@ index 00000000000000..aae278e743a73a
 +		b.err = err
 +		return
 +	}
-+	if b.bnToFree == nil {
-+		// Preallocate the slice to avoid growing it later, which would cause allocations and copies.
-+		// The maximum known number of BIGNUMs to free are 8 for RSA, so we use that as the capacity.
-+		b.bnToFree = make([]bnParam, 0, 8)
-+	}
 +	b.bnToFree = append(b.bnToFree, bnParam{bn, private})
 +	b.addBN(name, bn)
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/pbkdf2.go b/src/vendor/github.com/golang-fips/openssl/v2/pbkdf2.go
 new file mode 100644
-index 00000000000000..5f87281d8746a3
+index 00000000000000..c12c0119e99767
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/pbkdf2.go
 @@ -0,0 +1,54 @@
@@ -20891,7 +21119,7 @@ index 00000000000000..5f87281d8746a3
 +		return nil, errors.New("unsupported hash function")
 +	}
 +	out := make([]byte, keyLen)
-+	_, err = ossl.PKCS5_PBKDF2_HMAC(password, salt, int32(iter), md, out)
++	_, err = ossl.PKCS5_PBKDF2_HMAC(base(password), int32(len(password)), base(salt), int32(len(salt)), int32(iter), md, int32(keyLen), base(out))
 +	if err != nil {
 +		return nil, err
 +	}
@@ -21480,7 +21708,7 @@ index 00000000000000..bdba34f1378e9c
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rand.go b/src/vendor/github.com/golang-fips/openssl/v2/rand.go
 new file mode 100644
-index 00000000000000..963c3ad733dcf0
+index 00000000000000..bcc58f2e42ec86
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/rand.go
 @@ -0,0 +1,21 @@
@@ -21498,7 +21726,7 @@ index 00000000000000..963c3ad733dcf0
 +	}
 +	// Note: RAND_bytes should never fail; the return value exists only for historical reasons.
 +	// We check it even so.
-+	if _, err := ossl.RAND_bytes(b); err != nil {
++	if _, err := ossl.RAND_bytes(base(b), int32(len(b))); err != nil {
 +		return 0, err
 +	}
 +	return len(b), nil
@@ -21507,7 +21735,7 @@ index 00000000000000..963c3ad733dcf0
 +const RandReader = randReader(0)
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rc4.go b/src/vendor/github.com/golang-fips/openssl/v2/rc4.go
 new file mode 100644
-index 00000000000000..28e846829f29ea
+index 00000000000000..25fa08d0152e81
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/rc4.go
 @@ -0,0 +1,68 @@
@@ -21571,7 +21799,7 @@ index 00000000000000..28e846829f29ea
 +	// which is what crypto/rc4 does.
 +	_ = dst[len(src)-1]
 +	var outLen int32
-+	if _, err := ossl.EVP_EncryptUpdate(c.ctx, dst, &outLen, src); err != nil {
++	if _, err := ossl.EVP_EncryptUpdate(c.ctx, base(dst), &outLen, base(src), int32(len(src))); err != nil {
 +		panic("crypto/rc4: " + err.Error())
 +	}
 +	if int(outLen) != len(src) {
@@ -21581,10 +21809,10 @@ index 00000000000000..28e846829f29ea
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/rsa.go b/src/vendor/github.com/golang-fips/openssl/v2/rsa.go
 new file mode 100644
-index 00000000000000..2aa773d9592e06
+index 00000000000000..935a3962b9d00f
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/rsa.go
-@@ -0,0 +1,711 @@
+@@ -0,0 +1,714 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -21911,7 +22139,10 @@ index 00000000000000..2aa773d9592e06
 +}
 +
 +func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (ossl.EVP_PKEY_PTR, error) {
-+	bld := newParamBuilder()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return nil, err
++	}
 +	defer bld.finalize()
 +
 +	bld.addBigInt(_OSSL_PKEY_PARAM_RSA_N, n, false)
@@ -21968,7 +22199,7 @@ index 00000000000000..2aa773d9592e06
 +	// So we need to try to encrypt something to be sure.
 +	in := []byte("test")
 +	var outLen int
-+	if _, err := ossl.EVP_PKEY_encrypt(ctx, nil, &outLen, in); err != nil {
++	if _, err := ossl.EVP_PKEY_encrypt(ctx, nil, &outLen, &in[0], len(in)); err != nil {
 +		return false
 +	}
 +	return true
@@ -22006,7 +22237,7 @@ index 00000000000000..2aa773d9592e06
 +	}
 +	in := make([]byte, size, maxHashSize)
 +	var outLen int
-+	if _, err := ossl.EVP_PKEY_sign(ctx, nil, &outLen, in); err != nil {
++	if _, err := ossl.EVP_PKEY_sign(ctx, nil, &outLen, &in[0], len(in)); err != nil {
 +		return false
 +	}
 +	return true
@@ -22045,7 +22276,7 @@ index 00000000000000..2aa773d9592e06
 +	// So we need to try to sign something to be sure.
 +	in := make([]byte, ch.Size(), maxHashSize)
 +	var outLen int
-+	if _, err := ossl.EVP_PKEY_sign(ctx, nil, &outLen, in); err != nil {
++	if _, err := ossl.EVP_PKEY_sign(ctx, nil, &outLen, &in[0], len(in)); err != nil {
 +		return false
 +	}
 +	return true
@@ -22102,7 +22333,7 @@ index 00000000000000..2aa773d9592e06
 +	// So we need to try to encrypt something to be sure.
 +	in := []byte("test")
 +	var outLen int
-+	if _, err := ossl.EVP_PKEY_encrypt(ctx, nil, &outLen, in); err != nil {
++	if _, err := ossl.EVP_PKEY_encrypt(ctx, nil, &outLen, &in[0], len(in)); err != nil {
 +		return false
 +	}
 +	return true
@@ -22271,7 +22502,7 @@ index 00000000000000..2aa773d9592e06
 +
 +	// Convert []byte to BigInt using BN_bin2bn and bnToBig
 +	bytesToBigInt := func(b []byte) BigInt {
-+		bn, err := ossl.BN_bin2bn(b, nil)
++		bn, err := ossl.BN_bin2bn(base(b), int32(len(b)), nil)
 +		if err != nil {
 +			panic(err)
 +		}
@@ -22298,10 +22529,10 @@ index 00000000000000..2aa773d9592e06
 +})
 diff --git a/src/vendor/github.com/golang-fips/openssl/v2/tls1prf.go b/src/vendor/github.com/golang-fips/openssl/v2/tls1prf.go
 new file mode 100644
-index 00000000000000..38fea6de0c33c4
+index 00000000000000..57930900c2bfa8
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/v2/tls1prf.go
-@@ -0,0 +1,156 @@
+@@ -0,0 +1,158 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -22401,7 +22632,7 @@ index 00000000000000..38fea6de0c33c4
 +		return err
 +	}
 +	outLen := len(result)
-+	if _, err := ossl.EVP_PKEY_derive(ctx, result, &outLen); err != nil {
++	if _, err := ossl.EVP_PKEY_derive(ctx, base(result), &outLen); err != nil {
 +		return err
 +	}
 +	// The Go standard library expects TLS1PRF to return the requested number of bytes,
@@ -22441,8 +22672,10 @@ index 00000000000000..38fea6de0c33c4
 +	}
 +	defer ossl.EVP_KDF_CTX_free(ctx)
 +
-+	bld := newParamBuilder()
-+	defer bld.finalize()
++	bld, err := newParamBuilder()
++	if err != nil {
++		return err
++	}
 +	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 +	bld.addOctetString(_OSSL_KDF_PARAM_SECRET, secret)
 +	bld.addOctetString(_OSSL_KDF_PARAM_SEED, label)
@@ -22453,7 +22686,7 @@ index 00000000000000..38fea6de0c33c4
 +	}
 +	defer ossl.OSSL_PARAM_free(params)
 +
-+	if _, err := ossl.EVP_KDF_derive(ctx, result, params); err != nil {
++	if _, err := ossl.EVP_KDF_derive(ctx, base(result), len(result), params); err != nil {
 +		return err
 +	}
 +	return nil
@@ -22631,7 +22864,7 @@ index 00000000000000..e1b9ee1d005406
 +//go:generate go run ../../cmd/mkcgo -out zcommoncrypto.go -nocgo -package commoncrypto --noerrors shims.h
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/shims.h b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/shims.h
 new file mode 100644
-index 00000000000000..de1f9bc059aa43
+index 00000000000000..b186cf8723ed20
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/shims.h
 @@ -0,0 +1,72 @@
@@ -22700,9 +22933,9 @@ index 00000000000000..de1f9bc059aa43
 +
 +CCCryptorStatus CCCryptorCreate(CCOperation op, CCAlgorithm alg, CCOptions options, const void *key, size_t keyLength, const void *iv, CCCryptorRef *cryptorRef) __attribute__((framework(System, B), slice(key, keyLength), slice(iv)));
 +CCCryptorStatus CCCryptorRelease(CCCryptorRef cryptorRef) __attribute__((framework(System, B)));
-+CCCryptorStatus CCCryptorUpdate(CCCryptorRef cryptorRef, const void *dataIn, size_t dataInLength, void *dataOut, size_t dataOutAvailable, size_t *dataOutMoved) __attribute__((noescape, nocallback, framework(System, B), slice(dataIn, dataInLength), slice(dataOut, dataOutAvailable)));
++CCCryptorStatus CCCryptorUpdate(CCCryptorRef cryptorRef, const void *dataIn, size_t dataInLength, void *dataOut, size_t dataOutAvailable, size_t *dataOutMoved) __attribute__((framework(System, B), slice(dataIn, dataInLength), slice(dataOut, dataOutAvailable)));
 +CCCryptorStatus CCKeyDerivationPBKDF(CCPBKDFAlgorithm algorithm, const char *password, size_t passwordLen, const uint8_t *salt, size_t saltLen, CCPseudoRandomAlgorithm prf, unsigned rounds, uint8_t *derivedKey, size_t derivedKeyLen) __attribute__((framework(System, B), slice(password, passwordLen), slice(salt, saltLen), slice(derivedKey, derivedKeyLen)));
-+CCCryptorStatus CCCrypt(CCOperation op, CCAlgorithm alg, CCOptions options, const void *key, size_t keyLength, const void *iv, const void *dataIn, size_t dataInLength, void *dataOut, size_t dataOutAvailable, size_t *dataOutMoved) __attribute__((noescape, nocallback, framework(System, B), slice(key, keyLength), slice(iv), slice(dataIn, dataInLength), slice(dataOut, dataOutAvailable)));
++CCCryptorStatus CCCrypt(CCOperation op, CCAlgorithm alg, CCOptions options, const void *key, size_t keyLength, const void *iv, const void *dataIn, size_t dataInLength, void *dataOut, size_t dataOutAvailable, size_t *dataOutMoved) __attribute__((framework(System, B), slice(key, keyLength), slice(iv), slice(dataIn, dataInLength), slice(dataOut, dataOutAvailable)));
 +CCCryptorStatus CCCryptorCreateWithMode(CCOperation op, CCMode mode, CCAlgorithm alg, CCPadding padding, const void *iv, const void *key, size_t keyLength, const void *tweak, size_t tweakLength, int numRounds, CCModeOptions options, CCCryptorRef *cryptorRef) __attribute__((framework(System, B), slice(iv), slice(key, keyLength), slice(tweak, tweakLength)));
 +CCCryptorStatus CCCryptorReset(CCCryptorRef cryptorRef, const void *iv) __attribute__((framework(System, B), slice(iv)));
 +
@@ -22914,10 +23147,10 @@ index 00000000000000..016e73758ac4e0
 +#endif // MKCGO_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto.s
 new file mode 100644
-index 00000000000000..a722bc56d9dab4
+index 00000000000000..968a0d0fccd10f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto.s
-@@ -0,0 +1,76 @@
+@@ -0,0 +1,74 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -22935,10 +23168,8 @@ index 00000000000000..a722bc56d9dab4
 +#ifndef GOARCH_mips64le
 +#ifndef GOARCH_ppc64
 +#ifndef GOARCH_ppc64le
-+#ifndef GOARCH_s390x
 +#ifndef GOARCH_sparc64
 +#define _GOPTRSIZE 4
-+#endif
 +#endif
 +#endif
 +#endif
@@ -22996,10 +23227,10 @@ index 00000000000000..a722bc56d9dab4
 +
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_cgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_cgo.go
 new file mode 100644
-index 00000000000000..a774ad9a32ae86
+index 00000000000000..f569456a1e6010
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_cgo.go
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,60 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -23012,10 +23243,6 @@ index 00000000000000..a774ad9a32ae86
 +#cgo darwin LDFLAGS: -framework System
 +
 +#include "zcommoncrypto.h"
-+#cgo noescape _mkcgo_CCCrypt
-+#cgo nocallback _mkcgo_CCCrypt
-+#cgo noescape _mkcgo_CCCryptorUpdate
-+#cgo nocallback _mkcgo_CCCryptorUpdate
 +*/
 +import "C"
 +import "unsafe"
@@ -23064,12 +23291,29 @@ index 00000000000000..a774ad9a32ae86
 +func CCKeyDerivationPBKDF(algorithm CCPBKDFAlgorithm, password []byte, salt []uint8, prf CCPseudoRandomAlgorithm, rounds uint32, derivedKey []uint8) CCCryptorStatus {
 +	return C._mkcgo_CCKeyDerivationPBKDF(algorithm, (*C.char)(unsafe.Pointer(unsafe.SliceData(password))), C.size_t(len(password)), (*C.uint8_t)(unsafe.Pointer(unsafe.SliceData(salt))), C.size_t(len(salt)), prf, C.uint(rounds), (*C.uint8_t)(unsafe.Pointer(unsafe.SliceData(derivedKey))), C.size_t(len(derivedKey)))
 +}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_go124.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_go124.go
+new file mode 100644
+index 00000000000000..c4cb78b4888fa5
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_go124.go
+@@ -0,0 +1,11 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++// Code generated by mkcgo. DO NOT EDIT.
++
++//go:build go1.24 && !cmd_go_bootstrap
++
++package commoncrypto
++
++/*
++ */
++import "C"
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_nocgo.go
 new file mode 100644
-index 00000000000000..b17312278da948
+index 00000000000000..9de8feb80b0276
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/commoncrypto/zcommoncrypto_nocgo.go
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,89 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -23085,19 +23329,6 @@ index 00000000000000..b17312278da948
 +)
 +
 +var _ = runtime.GOOS
-+
-+var _mkcgoAlwaysFalseCommoncrypto bool
-+var _mkcgoEscapeSinkCommoncrypto unsafe.Pointer
-+
-+// mkcgoEscapePtrCommoncrypto forces p to escape to the heap.
-+// This implementation is also used in the standard library:
-+// https://github.com/golang/go/blob/f71432d223eeb2139b460957817400750fd13655/src/internal/abi/escape.go#L24-L33
-+func mkcgoEscapePtrCommoncrypto(p unsafe.Pointer) unsafe.Pointer {
-+	if _mkcgoAlwaysFalseCommoncrypto {
-+		_mkcgoEscapeSinkCommoncrypto = p
-+	}
-+	return p
-+}
 +
 +type CCCryptorRef unsafe.Pointer
 +type CCModeOptions = uint32
@@ -23129,7 +23360,7 @@ index 00000000000000..b17312278da948
 +var _mkcgo_CCCryptorCreate_trampoline_addr uintptr
 +
 +func CCCryptorCreate(op CCOperation, alg CCAlgorithm, options CCOptions, key []byte, iv []byte, cryptorRef *CCCryptorRef) CCCryptorStatus {
-+	r0, _ := syscallN(0, _mkcgo_CCCryptorCreate_trampoline_addr, uintptr(op), uintptr(alg), uintptr(options), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(unsafe.SliceData(key)))), uintptr(len(key)), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(unsafe.SliceData(iv)))), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(cryptorRef))))
++	r0, _ := syscallN(0, _mkcgo_CCCryptorCreate_trampoline_addr, uintptr(op), uintptr(alg), uintptr(options), uintptr(unsafe.Pointer(unsafe.SliceData(key))), uintptr(len(key)), uintptr(unsafe.Pointer(unsafe.SliceData(iv))), uintptr(unsafe.Pointer(cryptorRef)))
 +	return CCCryptorStatus(r0)
 +}
 +
@@ -23140,7 +23371,7 @@ index 00000000000000..b17312278da948
 +	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 +		r0, _ = syscallN(0, _mkcgo_CCCryptorCreateWithMode_trampoline_addr, uintptr(op), uintptr(mode), uintptr(alg), uintptr(padding), uintptr(unsafe.Pointer(unsafe.SliceData(iv))), uintptr(unsafe.Pointer(unsafe.SliceData(key))), uintptr(len(key)), uintptr(unsafe.Pointer(unsafe.SliceData(tweak))), uintptr(len(tweak)), uintptr(numRounds)<<32|uintptr(options), uintptr(unsafe.Pointer(cryptorRef)))
 +	} else {
-+		r0, _ = syscallN(0, _mkcgo_CCCryptorCreateWithMode_trampoline_addr, uintptr(op), uintptr(mode), uintptr(alg), uintptr(padding), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(unsafe.SliceData(iv)))), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(unsafe.SliceData(key)))), uintptr(len(key)), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(unsafe.SliceData(tweak)))), uintptr(len(tweak)), uintptr(numRounds), uintptr(options), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(cryptorRef))))
++		r0, _ = syscallN(0, _mkcgo_CCCryptorCreateWithMode_trampoline_addr, uintptr(op), uintptr(mode), uintptr(alg), uintptr(padding), uintptr(unsafe.Pointer(unsafe.SliceData(iv))), uintptr(unsafe.Pointer(unsafe.SliceData(key))), uintptr(len(key)), uintptr(unsafe.Pointer(unsafe.SliceData(tweak))), uintptr(len(tweak)), uintptr(numRounds), uintptr(options), uintptr(unsafe.Pointer(cryptorRef)))
 +	}
 +	return CCCryptorStatus(r0)
 +}
@@ -23155,7 +23386,7 @@ index 00000000000000..b17312278da948
 +var _mkcgo_CCCryptorReset_trampoline_addr uintptr
 +
 +func CCCryptorReset(cryptorRef CCCryptorRef, iv []byte) CCCryptorStatus {
-+	r0, _ := syscallN(0, _mkcgo_CCCryptorReset_trampoline_addr, uintptr(cryptorRef), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(unsafe.SliceData(iv)))))
++	r0, _ := syscallN(0, _mkcgo_CCCryptorReset_trampoline_addr, uintptr(cryptorRef), uintptr(unsafe.Pointer(unsafe.SliceData(iv))))
 +	return CCCryptorStatus(r0)
 +}
 +
@@ -23169,7 +23400,7 @@ index 00000000000000..b17312278da948
 +var _mkcgo_CCKeyDerivationPBKDF_trampoline_addr uintptr
 +
 +func CCKeyDerivationPBKDF(algorithm CCPBKDFAlgorithm, password []byte, salt []uint8, prf CCPseudoRandomAlgorithm, rounds uint32, derivedKey []uint8) CCCryptorStatus {
-+	r0, _ := syscallN(0, _mkcgo_CCKeyDerivationPBKDF_trampoline_addr, uintptr(algorithm), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(unsafe.SliceData(password)))), uintptr(len(password)), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(unsafe.SliceData(salt)))), uintptr(len(salt)), uintptr(prf), uintptr(rounds), uintptr(mkcgoEscapePtrCommoncrypto(unsafe.Pointer(unsafe.SliceData(derivedKey)))), uintptr(len(derivedKey)))
++	r0, _ := syscallN(0, _mkcgo_CCKeyDerivationPBKDF_trampoline_addr, uintptr(algorithm), uintptr(unsafe.Pointer(unsafe.SliceData(password))), uintptr(len(password)), uintptr(unsafe.Pointer(unsafe.SliceData(salt))), uintptr(len(salt)), uintptr(prf), uintptr(rounds), uintptr(unsafe.Pointer(unsafe.SliceData(derivedKey))), uintptr(len(derivedKey)))
 +	return CCCryptorStatus(r0)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/CryptoKit_amd64.syso b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/CryptoKit_amd64.syso
@@ -25239,7 +25470,7 @@ index 00000000000000..e134697ed96de7
 +import "C"
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/shims.h b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/shims.h
 new file mode 100644
-index 00000000000000..d9ad79d513f910
+index 00000000000000..81a303d5e49a5a
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/shims.h
 @@ -0,0 +1,84 @@
@@ -25259,52 +25490,52 @@ index 00000000000000..d9ad79d513f910
 +#include <stdint.h>
 +
 +// AES GCM encryption and decryption
-+int64_t go_encryptAESGCM(const uint8_t *key, size_t keyLength, const uint8_t *data, size_t dataLength, const uint8_t *nonce, size_t nonceLength, const uint8_t *aad, size_t aadLength, uint8_t *cipherText, size_t cipherTextLength, uint8_t *tag) __attribute__((noescape, nocallback, static, slice(key, keyLength), slice(data, dataLength), slice(nonce, nonceLength), slice(aad, aadLength), slice(cipherText, cipherTextLength), slice(tag)));
-+int64_t go_decryptAESGCM(const uint8_t *key, size_t keyLength, const uint8_t *data, size_t dataLength, const uint8_t *nonce, size_t nonceLength, const uint8_t *aad, size_t aadLength, const uint8_t *tag, size_t tagLength, uint8_t *out, size_t *outLength) __attribute__((noescape, nocallback, static, slice(key, keyLength), slice(data, dataLength), slice(nonce, nonceLength), slice(aad, aadLength), slice(tag, tagLength), slice(out)));
++int64_t go_encryptAESGCM(const uint8_t *key, size_t keyLength, const uint8_t *data, size_t dataLength, const uint8_t *nonce, size_t nonceLength, const uint8_t *aad, size_t aadLength, uint8_t *cipherText, size_t cipherTextLength, uint8_t *tag) __attribute__((static, slice(key, keyLength), slice(data, dataLength), slice(nonce, nonceLength), slice(aad, aadLength), slice(cipherText, cipherTextLength), slice(tag)));
++int64_t go_decryptAESGCM(const uint8_t *key, size_t keyLength, const uint8_t *data, size_t dataLength, const uint8_t *nonce, size_t nonceLength, const uint8_t *aad, size_t aadLength, const uint8_t *tag, size_t tagLength, uint8_t *out, size_t *outLength) __attribute__((static, slice(key, keyLength), slice(data, dataLength), slice(nonce, nonceLength), slice(aad, aadLength), slice(tag, tagLength), slice(out)));
 +
 +// ChaChaPoly encryption and decryption
-+int64_t go_encryptChaChaPoly(const uint8_t *key, size_t keyLength, const uint8_t *data, size_t dataLength, const uint8_t *nonce, size_t nonceLength, const uint8_t *aad, size_t aadLength, uint8_t *cipherText, size_t cipherTextLength, uint8_t *tag) __attribute__((noescape, nocallback, static, slice(key, keyLength), slice(data, dataLength), slice(nonce, nonceLength), slice(aad, aadLength), slice(cipherText, cipherTextLength), slice(tag)));
-+int64_t go_decryptChaChaPoly(const uint8_t *key, size_t keyLength, const uint8_t *data, size_t dataLength, const uint8_t *nonce, size_t nonceLength, const uint8_t *aad, size_t aadLength, const uint8_t *tag, size_t tagLength, uint8_t *out, size_t *outLength) __attribute__((noescape, nocallback, static, slice(key, keyLength), slice(data, dataLength), slice(nonce, nonceLength), slice(aad, aadLength), slice(tag, tagLength), slice(out)));
++int64_t go_encryptChaChaPoly(const uint8_t *key, size_t keyLength, const uint8_t *data, size_t dataLength, const uint8_t *nonce, size_t nonceLength, const uint8_t *aad, size_t aadLength, uint8_t *cipherText, size_t cipherTextLength, uint8_t *tag) __attribute__((static, slice(key, keyLength), slice(data, dataLength), slice(nonce, nonceLength), slice(aad, aadLength), slice(cipherText, cipherTextLength), slice(tag)));
++int64_t go_decryptChaChaPoly(const uint8_t *key, size_t keyLength, const uint8_t *data, size_t dataLength, const uint8_t *nonce, size_t nonceLength, const uint8_t *aad, size_t aadLength, const uint8_t *tag, size_t tagLength, uint8_t *out, size_t *outLength) __attribute__((static, slice(key, keyLength), slice(data, dataLength), slice(nonce, nonceLength), slice(aad, aadLength), slice(tag, tagLength), slice(out)));
 +
 +// Generates an Ed25519 keypair.
 +// The private key is 64 bytes (first 32 bytes are the seed, next 32 bytes are the public key). The public key is 32 bytes.
-+void go_generateKeyEd25519(uint8_t *key) __attribute__((noescape, nocallback, static, slice(key)));
-+int64_t go_newPrivateKeyEd25519FromSeed(uint8_t *key, const uint8_t *seed) __attribute__((noescape, nocallback, static, slice(key), slice(seed)));
-+int64_t go_newPublicKeyEd25519(uint8_t *key, const uint8_t *pub) __attribute__((noescape, nocallback, static, slice(key), slice(pub)));
-+int64_t go_signEd25519(const uint8_t *privateKey, const uint8_t *message, size_t messageLength, uint8_t *sigBuffer) __attribute__((noescape, nocallback, static, slice(privateKey), slice(message, messageLength), slice(sigBuffer)));
-+int64_t go_verifyEd25519(const uint8_t *publicKey, const uint8_t *message, size_t messageLength, const uint8_t *sig) __attribute__((noescape, nocallback, static, slice(publicKey), slice(message, messageLength), slice(sig)));
++void go_generateKeyEd25519(uint8_t *key) __attribute__((static, slice(key)));
++int64_t go_newPrivateKeyEd25519FromSeed(uint8_t *key, const uint8_t *seed) __attribute__((static, slice(key), slice(seed)));
++int64_t go_newPublicKeyEd25519(uint8_t *key, const uint8_t *pub) __attribute__((static, slice(key), slice(pub)));
++int64_t go_signEd25519(const uint8_t *privateKey, const uint8_t *message, size_t messageLength, uint8_t *sigBuffer) __attribute__((static, slice(privateKey), slice(message, messageLength), slice(sigBuffer)));
++int64_t go_verifyEd25519(const uint8_t *publicKey, const uint8_t *message, size_t messageLength, const uint8_t *sig) __attribute__((static, slice(publicKey), slice(message, messageLength), slice(sig)));
 +
 +// HKDF key derivation
-+int64_t go_extractHKDF(int32_t hashFunction, const uint8_t *secret, size_t secretLength, const uint8_t *salt, size_t saltLength, uint8_t *prk, size_t prkLength) __attribute__((noescape, nocallback, static, slice(secret, secretLength), slice(salt, saltLength), slice(prk, prkLength)));
-+int64_t go_expandHKDF(int32_t hashFunction, const uint8_t *prk, size_t prkLength, const uint8_t *info, size_t infoLength, uint8_t *okm, size_t okmLength) __attribute__((noescape, nocallback, static, slice(prk, prkLength), slice(info, infoLength), slice(okm, okmLength)));
++int64_t go_extractHKDF(int32_t hashFunction, const uint8_t *secret, size_t secretLength, const uint8_t *salt, size_t saltLength, uint8_t *prk, size_t prkLength) __attribute__((static, slice(secret, secretLength), slice(salt, saltLength), slice(prk, prkLength)));
++int64_t go_expandHKDF(int32_t hashFunction, const uint8_t *prk, size_t prkLength, const uint8_t *info, size_t infoLength, uint8_t *okm, size_t okmLength) __attribute__((static, slice(prk, prkLength), slice(info, infoLength), slice(okm, okmLength)));
 +
-+void *go_initHMAC(int32_t hashFunction, const uint8_t *key, int64_t keyLength) __attribute__((noescape, nocallback, static, slice(key, keyLength)));
-+void go_freeHMAC(int32_t hashFunction, void *ptr) __attribute__((noescape, nocallback, static));
++void *go_initHMAC(int32_t hashFunction, const uint8_t *key, int64_t keyLength) __attribute__((nocallback, static, slice(key, keyLength)));
++void go_freeHMAC(int32_t hashFunction, void *ptr) __attribute__((nocallback, static));
 +void go_updateHMAC(int32_t hashFunction, void *ptr, const uint8_t *data, int64_t length) __attribute__((noescape, nocallback, static, slice(data, length)));
 +void go_finalizeHMAC(int32_t hashFunction, void *ptr, uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(outputPointer)));
-+void *go_copyHMAC(int32_t hashAlgorithm, void *ptr) __attribute__((noescape, nocallback, static));
++void *go_copyHMAC(int32_t hashAlgorithm, void *ptr) __attribute__((static));
 +
 +void go_MD5(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(inputPointer, inputLength), slice(outputPointer)));
 +void go_SHA1(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(inputPointer, inputLength), slice(outputPointer)));
 +void go_SHA256(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(inputPointer, inputLength), slice(outputPointer)));
 +void go_SHA384(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(inputPointer, inputLength), slice(outputPointer)));
 +void go_SHA512(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(inputPointer, inputLength), slice(outputPointer)));
-+int64_t go_supportsSHA3() __attribute__((noescape, nocallback, static));
++int64_t go_supportsSHA3() __attribute__((nocallback, static));
 +void go_SHA3_256(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(inputPointer, inputLength), slice(outputPointer)));
 +void go_SHA3_384(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(inputPointer, inputLength), slice(outputPointer)));
 +void go_SHA3_512(const uint8_t *inputPointer, size_t inputLength, const uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(inputPointer, inputLength), slice(outputPointer)));
 +
-+void *go_hashNew(int32_t hashAlgorithm) __attribute__((noescape, nocallback, static));
++void *go_hashNew(int32_t hashAlgorithm) __attribute__((nocallback, static));
 +void go_hashWrite(int32_t hashAlgorithm, void *ptr, const uint8_t *data, int64_t length) __attribute__((noescape, nocallback, static, slice(data, length)));
 +void go_hashSum(int32_t hashAlgorithm, void *ptr, uint8_t *outputPointer) __attribute__((noescape, nocallback, static, slice(outputPointer)));
-+void go_hashReset(int32_t hashAlgorithm, void *ptr) __attribute__((noescape, nocallback, static));
-+int64_t go_hashSize(int32_t hashAlgorithm) __attribute__((noescape, nocallback, static));
-+int64_t go_hashBlockSize(int32_t hashAlgorithm) __attribute__((noescape, nocallback, static));
-+void *go_hashCopy(int32_t hashAlgorithm, void *ptr) __attribute__((noescape, nocallback, static));
-+void go_hashFree(int32_t hashAlgorithm, void *ptr) __attribute__((noescape, nocallback, static));
++void go_hashReset(int32_t hashAlgorithm, void *ptr) __attribute__((nocallback, static));
++int64_t go_hashSize(int32_t hashAlgorithm) __attribute__((nocallback, static));
++int64_t go_hashBlockSize(int32_t hashAlgorithm) __attribute__((nocallback, static));
++void *go_hashCopy(int32_t hashAlgorithm, void *ptr) __attribute__((nocallback, static));
++void go_hashFree(int32_t hashAlgorithm, void *ptr) __attribute__((nocallback, static));
 +
 +// ML-KEM (Post-quantum key encapsulation mechanism)
-+int64_t go_supportsMLKEM() __attribute__((noescape, nocallback, static));
++int64_t go_supportsMLKEM() __attribute__((nocallback, static));
 +int64_t go_generateKeyMLKEM768(uint8_t *seed, int64_t seedLen) __attribute__((noescape, nocallback, static, slice(seed, seedLen)));
 +int64_t go_generateKeyMLKEM1024(uint8_t *seed, int64_t seedLen) __attribute__((noescape, nocallback, static, slice(seed, seedLen)));
 +int64_t go_deriveEncapsulationKeyMLKEM768(const uint8_t *seed, int64_t seedLen, uint8_t *encapKey, int64_t encapKeyLen) __attribute__((noescape, nocallback, static, slice(seed, seedLen), slice(encapKey, encapKeyLen)));
@@ -25690,10 +25921,10 @@ index 00000000000000..d738d7278076ec
 +#endif // MKCGO_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit.s
 new file mode 100644
-index 00000000000000..85d38bd6d881c3
+index 00000000000000..4f1714d6126e3d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit.s
-@@ -0,0 +1,334 @@
+@@ -0,0 +1,332 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -25711,10 +25942,8 @@ index 00000000000000..85d38bd6d881c3
 +#ifndef GOARCH_mips64le
 +#ifndef GOARCH_ppc64
 +#ifndef GOARCH_ppc64le
-+#ifndef GOARCH_s390x
 +#ifndef GOARCH_sparc64
 +#define _GOPTRSIZE 4
-+#endif
 +#endif
 +#endif
 +#endif
@@ -26030,10 +26259,10 @@ index 00000000000000..85d38bd6d881c3
 +
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_cgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_cgo.go
 new file mode 100644
-index 00000000000000..a5612fded9b225
+index 00000000000000..366dcf4c7b43dd
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_cgo.go
-@@ -0,0 +1,320 @@
+@@ -0,0 +1,220 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -26045,106 +26274,6 @@ index 00000000000000..a5612fded9b225
 +#cgo CFLAGS: -Wno-attributes
 +
 +#include "zcryptokit.h"
-+#cgo noescape _mkcgo_go_MD5
-+#cgo nocallback _mkcgo_go_MD5
-+#cgo noescape _mkcgo_go_SHA1
-+#cgo nocallback _mkcgo_go_SHA1
-+#cgo noescape _mkcgo_go_SHA256
-+#cgo nocallback _mkcgo_go_SHA256
-+#cgo noescape _mkcgo_go_SHA384
-+#cgo nocallback _mkcgo_go_SHA384
-+#cgo noescape _mkcgo_go_SHA3_256
-+#cgo nocallback _mkcgo_go_SHA3_256
-+#cgo noescape _mkcgo_go_SHA3_384
-+#cgo nocallback _mkcgo_go_SHA3_384
-+#cgo noescape _mkcgo_go_SHA3_512
-+#cgo nocallback _mkcgo_go_SHA3_512
-+#cgo noescape _mkcgo_go_SHA512
-+#cgo nocallback _mkcgo_go_SHA512
-+#cgo noescape _mkcgo_go_copyHMAC
-+#cgo nocallback _mkcgo_go_copyHMAC
-+#cgo noescape _mkcgo_go_decapsulateMLKEM1024
-+#cgo nocallback _mkcgo_go_decapsulateMLKEM1024
-+#cgo noescape _mkcgo_go_decapsulateMLKEM768
-+#cgo nocallback _mkcgo_go_decapsulateMLKEM768
-+#cgo noescape _mkcgo_go_decryptAESGCM
-+#cgo nocallback _mkcgo_go_decryptAESGCM
-+#cgo noescape _mkcgo_go_decryptChaChaPoly
-+#cgo nocallback _mkcgo_go_decryptChaChaPoly
-+#cgo noescape _mkcgo_go_deriveEncapsulationKeyMLKEM1024
-+#cgo nocallback _mkcgo_go_deriveEncapsulationKeyMLKEM1024
-+#cgo noescape _mkcgo_go_deriveEncapsulationKeyMLKEM768
-+#cgo nocallback _mkcgo_go_deriveEncapsulationKeyMLKEM768
-+#cgo noescape _mkcgo_go_ecdhSharedSecret
-+#cgo nocallback _mkcgo_go_ecdhSharedSecret
-+#cgo noescape _mkcgo_go_ecdsaSign
-+#cgo nocallback _mkcgo_go_ecdsaSign
-+#cgo noescape _mkcgo_go_ecdsaVerify
-+#cgo nocallback _mkcgo_go_ecdsaVerify
-+#cgo noescape _mkcgo_go_encapsulateMLKEM1024
-+#cgo nocallback _mkcgo_go_encapsulateMLKEM1024
-+#cgo noescape _mkcgo_go_encapsulateMLKEM768
-+#cgo nocallback _mkcgo_go_encapsulateMLKEM768
-+#cgo noescape _mkcgo_go_encryptAESGCM
-+#cgo nocallback _mkcgo_go_encryptAESGCM
-+#cgo noescape _mkcgo_go_encryptChaChaPoly
-+#cgo nocallback _mkcgo_go_encryptChaChaPoly
-+#cgo noescape _mkcgo_go_expandHKDF
-+#cgo nocallback _mkcgo_go_expandHKDF
-+#cgo noescape _mkcgo_go_extractHKDF
-+#cgo nocallback _mkcgo_go_extractHKDF
-+#cgo noescape _mkcgo_go_finalizeHMAC
-+#cgo nocallback _mkcgo_go_finalizeHMAC
-+#cgo noescape _mkcgo_go_freeHMAC
-+#cgo nocallback _mkcgo_go_freeHMAC
-+#cgo noescape _mkcgo_go_generateKeyECDH
-+#cgo nocallback _mkcgo_go_generateKeyECDH
-+#cgo noescape _mkcgo_go_generateKeyECDSA
-+#cgo nocallback _mkcgo_go_generateKeyECDSA
-+#cgo noescape _mkcgo_go_generateKeyEd25519
-+#cgo nocallback _mkcgo_go_generateKeyEd25519
-+#cgo noescape _mkcgo_go_generateKeyMLKEM1024
-+#cgo nocallback _mkcgo_go_generateKeyMLKEM1024
-+#cgo noescape _mkcgo_go_generateKeyMLKEM768
-+#cgo nocallback _mkcgo_go_generateKeyMLKEM768
-+#cgo noescape _mkcgo_go_hashBlockSize
-+#cgo nocallback _mkcgo_go_hashBlockSize
-+#cgo noescape _mkcgo_go_hashCopy
-+#cgo nocallback _mkcgo_go_hashCopy
-+#cgo noescape _mkcgo_go_hashFree
-+#cgo nocallback _mkcgo_go_hashFree
-+#cgo noescape _mkcgo_go_hashNew
-+#cgo nocallback _mkcgo_go_hashNew
-+#cgo noescape _mkcgo_go_hashReset
-+#cgo nocallback _mkcgo_go_hashReset
-+#cgo noescape _mkcgo_go_hashSize
-+#cgo nocallback _mkcgo_go_hashSize
-+#cgo noescape _mkcgo_go_hashSum
-+#cgo nocallback _mkcgo_go_hashSum
-+#cgo noescape _mkcgo_go_hashWrite
-+#cgo nocallback _mkcgo_go_hashWrite
-+#cgo noescape _mkcgo_go_initHMAC
-+#cgo nocallback _mkcgo_go_initHMAC
-+#cgo noescape _mkcgo_go_newPrivateKeyEd25519FromSeed
-+#cgo nocallback _mkcgo_go_newPrivateKeyEd25519FromSeed
-+#cgo noescape _mkcgo_go_newPublicKeyEd25519
-+#cgo nocallback _mkcgo_go_newPublicKeyEd25519
-+#cgo noescape _mkcgo_go_publicKeyFromPrivateECDH
-+#cgo nocallback _mkcgo_go_publicKeyFromPrivateECDH
-+#cgo noescape _mkcgo_go_signEd25519
-+#cgo nocallback _mkcgo_go_signEd25519
-+#cgo noescape _mkcgo_go_supportsMLKEM
-+#cgo nocallback _mkcgo_go_supportsMLKEM
-+#cgo noescape _mkcgo_go_supportsSHA3
-+#cgo nocallback _mkcgo_go_supportsSHA3
-+#cgo noescape _mkcgo_go_updateHMAC
-+#cgo nocallback _mkcgo_go_updateHMAC
-+#cgo noescape _mkcgo_go_validatePrivateKeyECDH
-+#cgo nocallback _mkcgo_go_validatePrivateKeyECDH
-+#cgo noescape _mkcgo_go_validatePublicKeyECDH
-+#cgo nocallback _mkcgo_go_validatePublicKeyECDH
-+#cgo noescape _mkcgo_go_verifyEd25519
-+#cgo nocallback _mkcgo_go_verifyEd25519
 +*/
 +import "C"
 +import "unsafe"
@@ -26354,12 +26483,96 @@ index 00000000000000..a5612fded9b225
 +func VerifyEd25519(publicKey []uint8, message []uint8, sig []uint8) int64 {
 +	return int64(C._mkcgo_go_verifyEd25519((*C.uint8_t)(unsafe.Pointer(unsafe.SliceData(publicKey))), (*C.uint8_t)(unsafe.Pointer(unsafe.SliceData(message))), C.size_t(len(message)), (*C.uint8_t)(unsafe.Pointer(unsafe.SliceData(sig)))))
 +}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_cgo_go124.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_cgo_go124.go
+new file mode 100644
+index 00000000000000..ca1fa1d6f9347e
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_cgo_go124.go
+@@ -0,0 +1,78 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++// Code generated by mkcgo. DO NOT EDIT.
++
++//go:build go1.24 && !cmd_go_bootstrap
++
++package cryptokit
++
++/*
++#cgo noescape _mkcgo_go_MD5
++#cgo nocallback _mkcgo_go_MD5
++#cgo noescape _mkcgo_go_SHA1
++#cgo nocallback _mkcgo_go_SHA1
++#cgo noescape _mkcgo_go_SHA256
++#cgo nocallback _mkcgo_go_SHA256
++#cgo noescape _mkcgo_go_SHA384
++#cgo nocallback _mkcgo_go_SHA384
++#cgo noescape _mkcgo_go_SHA3_256
++#cgo nocallback _mkcgo_go_SHA3_256
++#cgo noescape _mkcgo_go_SHA3_384
++#cgo nocallback _mkcgo_go_SHA3_384
++#cgo noescape _mkcgo_go_SHA3_512
++#cgo nocallback _mkcgo_go_SHA3_512
++#cgo noescape _mkcgo_go_SHA512
++#cgo nocallback _mkcgo_go_SHA512
++#cgo noescape _mkcgo_go_decapsulateMLKEM1024
++#cgo nocallback _mkcgo_go_decapsulateMLKEM1024
++#cgo noescape _mkcgo_go_decapsulateMLKEM768
++#cgo nocallback _mkcgo_go_decapsulateMLKEM768
++#cgo noescape _mkcgo_go_deriveEncapsulationKeyMLKEM1024
++#cgo nocallback _mkcgo_go_deriveEncapsulationKeyMLKEM1024
++#cgo noescape _mkcgo_go_deriveEncapsulationKeyMLKEM768
++#cgo nocallback _mkcgo_go_deriveEncapsulationKeyMLKEM768
++#cgo noescape _mkcgo_go_ecdhSharedSecret
++#cgo nocallback _mkcgo_go_ecdhSharedSecret
++#cgo noescape _mkcgo_go_ecdsaSign
++#cgo nocallback _mkcgo_go_ecdsaSign
++#cgo noescape _mkcgo_go_ecdsaVerify
++#cgo nocallback _mkcgo_go_ecdsaVerify
++#cgo noescape _mkcgo_go_encapsulateMLKEM1024
++#cgo nocallback _mkcgo_go_encapsulateMLKEM1024
++#cgo noescape _mkcgo_go_encapsulateMLKEM768
++#cgo nocallback _mkcgo_go_encapsulateMLKEM768
++#cgo noescape _mkcgo_go_finalizeHMAC
++#cgo nocallback _mkcgo_go_finalizeHMAC
++#cgo nocallback _mkcgo_go_freeHMAC
++#cgo noescape _mkcgo_go_generateKeyECDH
++#cgo nocallback _mkcgo_go_generateKeyECDH
++#cgo noescape _mkcgo_go_generateKeyECDSA
++#cgo nocallback _mkcgo_go_generateKeyECDSA
++#cgo noescape _mkcgo_go_generateKeyMLKEM1024
++#cgo nocallback _mkcgo_go_generateKeyMLKEM1024
++#cgo noescape _mkcgo_go_generateKeyMLKEM768
++#cgo nocallback _mkcgo_go_generateKeyMLKEM768
++#cgo nocallback _mkcgo_go_hashBlockSize
++#cgo nocallback _mkcgo_go_hashCopy
++#cgo nocallback _mkcgo_go_hashFree
++#cgo nocallback _mkcgo_go_hashNew
++#cgo nocallback _mkcgo_go_hashReset
++#cgo nocallback _mkcgo_go_hashSize
++#cgo noescape _mkcgo_go_hashSum
++#cgo nocallback _mkcgo_go_hashSum
++#cgo noescape _mkcgo_go_hashWrite
++#cgo nocallback _mkcgo_go_hashWrite
++#cgo nocallback _mkcgo_go_initHMAC
++#cgo noescape _mkcgo_go_publicKeyFromPrivateECDH
++#cgo nocallback _mkcgo_go_publicKeyFromPrivateECDH
++#cgo nocallback _mkcgo_go_supportsMLKEM
++#cgo nocallback _mkcgo_go_supportsSHA3
++#cgo noescape _mkcgo_go_updateHMAC
++#cgo nocallback _mkcgo_go_updateHMAC
++#cgo noescape _mkcgo_go_validatePrivateKeyECDH
++#cgo nocallback _mkcgo_go_validatePrivateKeyECDH
++#cgo noescape _mkcgo_go_validatePublicKeyECDH
++#cgo nocallback _mkcgo_go_validatePublicKeyECDH
++*/
++import "C"
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_nocgo.go
 new file mode 100644
-index 00000000000000..64315a13705101
+index 00000000000000..c3716b4124efcd
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/cryptokit/zcryptokit_nocgo.go
-@@ -0,0 +1,364 @@
+@@ -0,0 +1,351 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -26375,19 +26588,6 @@ index 00000000000000..64315a13705101
 +)
 +
 +var _ = runtime.GOOS
-+
-+var _mkcgoAlwaysFalseCryptokit bool
-+var _mkcgoEscapeSinkCryptokit unsafe.Pointer
-+
-+// mkcgoEscapePtrCryptokit forces p to escape to the heap.
-+// This implementation is also used in the standard library:
-+// https://github.com/golang/go/blob/f71432d223eeb2139b460957817400750fd13655/src/internal/abi/escape.go#L24-L33
-+func mkcgoEscapePtrCryptokit(p unsafe.Pointer) unsafe.Pointer {
-+	if _mkcgoAlwaysFalseCryptokit {
-+		_mkcgoEscapeSinkCryptokit = p
-+	}
-+	return p
-+}
 +
 +//go:linkname go_MD5 go_MD5
 +//go:linkname go_SHA1 go_SHA1
@@ -27659,12 +27859,12 @@ index 00000000000000..b631396bd2ffe7
 +func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/fakecgo.lock b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/fakecgo.lock
 new file mode 100644
-index 00000000000000..9b0650d53777bd
+index 00000000000000..57250706a043f1
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/fakecgo.lock
 @@ -0,0 +1,3 @@
 +{
-+  "commit_hash": "5110604b3385278be6887d0feead513a1bfe7a82"
++  "commit_hash": "49bede11a66085d4400e4a257e4c77c9604c791a"
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/generate.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/generate.go
 new file mode 100644
@@ -28160,10 +28360,10 @@ index 00000000000000..098f56ce5e6b77
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s
 new file mode 100644
-index 00000000000000..970f3fd9a1ef0d
+index 00000000000000..2864fc192a0331
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/fakecgo/trampolines_arm64.s
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,84 @@
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
@@ -28224,6 +28424,7 @@ index 00000000000000..970f3fd9a1ef0d
 +
 +	SAVE_R19_TO_R28(8*4)
 +	SAVE_F8_TO_F15(8*14)
++	STP (R29, R30), (8*22)(RSP)
 +
 +	MOVD ·threadentry_call(SB), R9
 +	MOVD (R9), R9
@@ -28232,6 +28433,8 @@ index 00000000000000..970f3fd9a1ef0d
 +
 +	RESTORE_R19_TO_R28(8*4)
 +	RESTORE_F8_TO_F15(8*14)
++	LDP (8*22)(RSP), (R29, R30)
++
 +	ADD $(8*24), RSP
 +	RET
 +
@@ -28584,7 +28787,7 @@ index 00000000000000..74ee18d383784e
 +//go:generate go run ../../cmd/mkcgo -out zsecurity.go -nocgo -package security --noerrors shims.h
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/shims.h b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/shims.h
 new file mode 100644
-index 00000000000000..2f29d1d916958f
+index 00000000000000..e1ba0ec484288f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/shims.h
 @@ -0,0 +1,107 @@
@@ -28671,20 +28874,20 @@ index 00000000000000..2f29d1d916958f
 +
 +int SecRandomCopyBytes(SecRandomRef rnd, size_t count, void *bytes) __attribute__((framework(Security, A), noescape, nocallback, slice(bytes, count)));
 +SecKeyRef SecKeyCopyPublicKey(SecKeyRef key) __attribute__((framework(Security, A)));
-+SecKeyRef SecKeyCreateWithData(CFDataRef keyData, CFDictionaryRef attributes, CFErrorRef *error) __attribute__((noescape, nocallback, framework(Security, A)));
-+SecKeyRef SecKeyCreateRandomKey(CFDictionaryRef parameters, CFErrorRef *error) __attribute__((noescape, nocallback, framework(Security, A)));
-+CFDataRef SecKeyCopyExternalRepresentation(SecKeyRef key, CFErrorRef *error) __attribute__((noescape, nocallback, framework(Security, A)));
-+CFDataRef SecKeyCreateDecryptedData(SecKeyRef key, SecKeyAlgorithm algorithm, CFDataRef ciphertext, CFErrorRef *error) __attribute__((noescape, nocallback, framework(Security, A)));
-+CFDataRef SecKeyCreateEncryptedData(SecKeyRef key, SecKeyAlgorithm algorithm, CFDataRef plaintext, CFErrorRef *error) __attribute__((noescape, nocallback, framework(Security, A)));
-+CFDataRef SecKeyCreateSignature(SecKeyRef key, SecKeyAlgorithm algorithm, CFDataRef data, CFErrorRef *error) __attribute__((noescape, nocallback, framework(Security, A)));
-+Boolean SecKeyVerifySignature(SecKeyRef key, SecKeyAlgorithm algorithm, CFDataRef signedData, CFDataRef signature, CFErrorRef *error) __attribute__((noescape, nocallback, framework(Security, A)));
++SecKeyRef SecKeyCreateWithData(CFDataRef keyData, CFDictionaryRef attributes, CFErrorRef *error) __attribute__((framework(Security, A)));
++SecKeyRef SecKeyCreateRandomKey(CFDictionaryRef parameters, CFErrorRef *error) __attribute__((framework(Security, A)));
++CFDataRef SecKeyCopyExternalRepresentation(SecKeyRef key, CFErrorRef *error) __attribute__((framework(Security, A)));
++CFDataRef SecKeyCreateDecryptedData(SecKeyRef key, SecKeyAlgorithm algorithm, CFDataRef ciphertext, CFErrorRef *error) __attribute__((framework(Security, A)));
++CFDataRef SecKeyCreateEncryptedData(SecKeyRef key, SecKeyAlgorithm algorithm, CFDataRef plaintext, CFErrorRef *error) __attribute__((framework(Security, A)));
++CFDataRef SecKeyCreateSignature(SecKeyRef key, SecKeyAlgorithm algorithm, CFDataRef data, CFErrorRef *error) __attribute__((framework(Security, A)));
++Boolean SecKeyVerifySignature(SecKeyRef key, SecKeyAlgorithm algorithm, CFDataRef signedData, CFDataRef signature, CFErrorRef *error) __attribute__((framework(Security, A)));
 +Boolean SecKeyIsAlgorithmSupported(SecKeyRef key, SecKeyOperationType operation, SecKeyAlgorithm algorithm) __attribute__((framework(Security, A)));
 +size_t SecKeyGetBlockSize(SecKeyRef key) __attribute__((framework(Security, A)));
 +
-+CFDataRef CFDataCreate(CFAllocatorRef allocator, const uint8_t *bytes, CFIndex length) __attribute__((noescape, nocallback, framework(CoreFoundation, A), slice(bytes, length)));
++CFDataRef CFDataCreate(CFAllocatorRef allocator, const uint8_t *bytes, CFIndex length) __attribute__((framework(CoreFoundation, A), slice(bytes, length)));
 +CFDictionaryRef CFDictionaryCreate(CFAllocatorRef allocator, const void **keys, const void **values, CFIndex numValues, const CFDictionaryKeyCallBacks *keyCallBacks, const CFDictionaryValueCallBacks *valueCallBacks) __attribute__((framework(CoreFoundation, A)));
 +CFMutableDictionaryRef CFDictionaryCreateMutable(CFAllocatorRef allocator, CFIndex capacity, const CFDictionaryKeyCallBacks *keyCallBacks, const CFDictionaryValueCallBacks *valueCallBacks) __attribute__((framework(CoreFoundation, A)));
-+CFNumberRef CFNumberCreate(CFAllocatorRef allocator, CFNumberType theType, const void *valuePtr) __attribute__((noescape, nocallback, framework(CoreFoundation, A)));
++CFNumberRef CFNumberCreate(CFAllocatorRef allocator, CFNumberType theType, const void *valuePtr) __attribute__((framework(CoreFoundation, A)));
 +CFIndex CFDataGetLength(CFDataRef data) __attribute__((framework(CoreFoundation, A)));
 +const uint8_t *CFDataGetBytePtr(CFDataRef data) __attribute__((framework(CoreFoundation, A)));
 +void CFRelease(CFTypeRef cf) __attribute__((framework(CoreFoundation, A)));
@@ -28982,10 +29185,10 @@ index 00000000000000..6b0cd286f82d58
 +#endif // MKCGO_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity.s
 new file mode 100644
-index 00000000000000..5b021a6afed14b
+index 00000000000000..ff317532f1ef02
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity.s
-@@ -0,0 +1,172 @@
+@@ -0,0 +1,170 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -29003,10 +29206,8 @@ index 00000000000000..5b021a6afed14b
 +#ifndef GOARCH_mips64le
 +#ifndef GOARCH_ppc64
 +#ifndef GOARCH_ppc64le
-+#ifndef GOARCH_s390x
 +#ifndef GOARCH_sparc64
 +#define _GOPTRSIZE 4
-+#endif
 +#endif
 +#endif
 +#endif
@@ -29160,10 +29361,10 @@ index 00000000000000..5b021a6afed14b
 +
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_cgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_cgo.go
 new file mode 100644
-index 00000000000000..c17b764ee90662
+index 00000000000000..20bd49b26f21f7
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_cgo.go
-@@ -0,0 +1,388 @@
+@@ -0,0 +1,368 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -29177,26 +29378,6 @@ index 00000000000000..c17b764ee90662
 +#cgo darwin LDFLAGS: -framework Security
 +
 +#include "zsecurity.h"
-+#cgo noescape _mkcgo_CFDataCreate
-+#cgo nocallback _mkcgo_CFDataCreate
-+#cgo noescape _mkcgo_CFNumberCreate
-+#cgo nocallback _mkcgo_CFNumberCreate
-+#cgo noescape _mkcgo_SecKeyCopyExternalRepresentation
-+#cgo nocallback _mkcgo_SecKeyCopyExternalRepresentation
-+#cgo noescape _mkcgo_SecKeyCreateDecryptedData
-+#cgo nocallback _mkcgo_SecKeyCreateDecryptedData
-+#cgo noescape _mkcgo_SecKeyCreateEncryptedData
-+#cgo nocallback _mkcgo_SecKeyCreateEncryptedData
-+#cgo noescape _mkcgo_SecKeyCreateRandomKey
-+#cgo nocallback _mkcgo_SecKeyCreateRandomKey
-+#cgo noescape _mkcgo_SecKeyCreateSignature
-+#cgo nocallback _mkcgo_SecKeyCreateSignature
-+#cgo noescape _mkcgo_SecKeyCreateWithData
-+#cgo nocallback _mkcgo_SecKeyCreateWithData
-+#cgo noescape _mkcgo_SecKeyVerifySignature
-+#cgo nocallback _mkcgo_SecKeyVerifySignature
-+#cgo noescape _mkcgo_SecRandomCopyBytes
-+#cgo nocallback _mkcgo_SecRandomCopyBytes
 +*/
 +import "C"
 +import "unsafe"
@@ -29552,12 +29733,51 @@ index 00000000000000..c17b764ee90662
 +func SecRandomCopyBytes(rnd SecRandomRef, bytes []byte) int32 {
 +	return int32(C._mkcgo_SecRandomCopyBytes(rnd, C.size_t(len(bytes)), (*C.uchar)(unsafe.Pointer(unsafe.SliceData(bytes)))))
 +}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_cgo_go124.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_cgo_go124.go
+new file mode 100644
+index 00000000000000..52f1736a94347c
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_cgo_go124.go
+@@ -0,0 +1,14 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++// Code generated by mkcgo. DO NOT EDIT.
++
++//go:build go1.24 && !cmd_go_bootstrap
++
++package security
++
++/*
++#cgo noescape _mkcgo_SecRandomCopyBytes
++#cgo nocallback _mkcgo_SecRandomCopyBytes
++*/
++import "C"
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_go124.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_go124.go
+new file mode 100644
+index 00000000000000..3001e7040e80f1
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_go124.go
+@@ -0,0 +1,13 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++// Code generated by mkcgo. DO NOT EDIT.
++
++//go:build go1.24 && !cmd_go_bootstrap
++
++package security
++
++/*
++#cgo noescape _mkcgo_SecRandomCopyBytes
++#cgo nocallback _mkcgo_SecRandomCopyBytes
++*/
++import "C"
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_nocgo.go
 new file mode 100644
-index 00000000000000..08bafd9a64d7c4
+index 00000000000000..b10738f5d6ec26
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/security/zsecurity_nocgo.go
-@@ -0,0 +1,466 @@
+@@ -0,0 +1,453 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -29573,19 +29793,6 @@ index 00000000000000..08bafd9a64d7c4
 +)
 +
 +var _ = runtime.GOOS
-+
-+var _mkcgoAlwaysFalseSecurity bool
-+var _mkcgoEscapeSinkSecurity unsafe.Pointer
-+
-+// mkcgoEscapePtrSecurity forces p to escape to the heap.
-+// This implementation is also used in the standard library:
-+// https://github.com/golang/go/blob/f71432d223eeb2139b460957817400750fd13655/src/internal/abi/escape.go#L24-L33
-+func mkcgoEscapePtrSecurity(p unsafe.Pointer) unsafe.Pointer {
-+	if _mkcgoAlwaysFalseSecurity {
-+		_mkcgoEscapeSinkSecurity = p
-+	}
-+	return p
-+}
 +
 +type Boolean = byte
 +type SecRandomRef unsafe.Pointer
@@ -29890,14 +30097,14 @@ index 00000000000000..08bafd9a64d7c4
 +var _mkcgo_CFDictionaryCreate_trampoline_addr uintptr
 +
 +func CFDictionaryCreate(allocator CFAllocatorRef, keys *unsafe.Pointer, values *unsafe.Pointer, numValues CFIndex, keyCallBacks *CFDictionaryKeyCallBacks, valueCallBacks *CFDictionaryValueCallBacks) CFDictionaryRef {
-+	r0, _ := syscallN(0, _mkcgo_CFDictionaryCreate_trampoline_addr, uintptr(allocator), uintptr(mkcgoEscapePtrSecurity(unsafe.Pointer(keys))), uintptr(mkcgoEscapePtrSecurity(unsafe.Pointer(values))), uintptr(numValues), uintptr(mkcgoEscapePtrSecurity(unsafe.Pointer(keyCallBacks))), uintptr(mkcgoEscapePtrSecurity(unsafe.Pointer(valueCallBacks))))
++	r0, _ := syscallN(0, _mkcgo_CFDictionaryCreate_trampoline_addr, uintptr(allocator), uintptr(unsafe.Pointer(keys)), uintptr(unsafe.Pointer(values)), uintptr(numValues), uintptr(unsafe.Pointer(keyCallBacks)), uintptr(unsafe.Pointer(valueCallBacks)))
 +	return CFDictionaryRef(r0)
 +}
 +
 +var _mkcgo_CFDictionaryCreateMutable_trampoline_addr uintptr
 +
 +func CFDictionaryCreateMutable(allocator CFAllocatorRef, capacity CFIndex, keyCallBacks *CFDictionaryKeyCallBacks, valueCallBacks *CFDictionaryValueCallBacks) CFMutableDictionaryRef {
-+	r0, _ := syscallN(0, _mkcgo_CFDictionaryCreateMutable_trampoline_addr, uintptr(allocator), uintptr(capacity), uintptr(mkcgoEscapePtrSecurity(unsafe.Pointer(keyCallBacks))), uintptr(mkcgoEscapePtrSecurity(unsafe.Pointer(valueCallBacks))))
++	r0, _ := syscallN(0, _mkcgo_CFDictionaryCreateMutable_trampoline_addr, uintptr(allocator), uintptr(capacity), uintptr(unsafe.Pointer(keyCallBacks)), uintptr(unsafe.Pointer(valueCallBacks)))
 +	return CFMutableDictionaryRef(r0)
 +}
 +
@@ -30253,12 +30460,33 @@ index 00000000000000..261a7e4cb90d56
 +	MOVD R1, libcCallInfo_r2(R3) // save r2
 +
 +	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/dl.h b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/dl.h
+new file mode 100644
+index 00000000000000..9a24f0b6c13b1b
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/dl.h
+@@ -0,0 +1,15 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++// This header file is used by the mkcgo tool to generate cgo and Go bindings for the
++// C APIs. Run "go generate ." to regenerate the bindings.
++
++#ifndef _GO_DL_SHIMS_H // only include this header once
++#define _GO_DL_SHIMS_H
++
++void *dlopen(const char *path, int flags);
++int dlclose(void *handle);
++void *dlsym(void *handle, const char *symbol);
++char *dlerror(void);
++
++#endif // _GO_DL_SHIMS_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go
 new file mode 100644
-index 00000000000000..a9ad56e22fa2ac
+index 00000000000000..20f2ae5d853877
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo.go
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,88 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -30331,12 +30559,28 @@ index 00000000000000..a9ad56e22fa2ac
 +func syscallN(errType uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
 +	return SyscallN(errType, fn, args...)
 +}
++
++// syscallNRaw performs a syscall with the given function and arguments,
++// without any error checking nor switching to the system stack.
++//
++//go:nosplit
++func syscallNRaw(fn uintptr, args ...uintptr) uintptr {
++	libcArgs := libcCallInfo{
++		fn: fn,
++		n:  uintptr(len(args)),
++	}
++	if libcArgs.n != 0 {
++		libcArgs.args = uintptr(noescape(unsafe.Pointer(&args[0])))
++	}
++	syscallNAsm(&libcArgs)
++	return libcArgs.r1
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_darwin.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_darwin.go
 new file mode 100644
-index 00000000000000..2d4d32fca87fdb
+index 00000000000000..c7e683e6790a27
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_darwin.go
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,25 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -30345,8 +30589,23 @@ index 00000000000000..2d4d32fca87fdb
 +package xsyscall
 +
 +import (
++	"unsafe"
++
 +	_ "github.com/microsoft/go-crypto-darwin/internal/fakecgo"
 +)
++
++//go:cgo_import_dynamic _ _ "/usr/lib/libSystem.B.dylib"
++
++func dlsym(handle unsafe.Pointer, symbol string, optional bool) uintptr {
++	r0 := Dlsym(handle, unsafe.StringData(symbol))
++	if r0 == nil {
++		if !optional {
++			panic("cannot get required symbol " + symbol)
++		}
++		return 0
++	}
++	return uintptr(r0)
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_others.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/syscall_nocgo_others.go
 new file mode 100644
 index 00000000000000..28dba16a23340e
@@ -30366,6 +30625,134 @@ index 00000000000000..28dba16a23340e
 +//go:nosplit
 +func SyscallN(errType uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
 +	panic("SyscallN is not supported on this architecture")
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go
+new file mode 100644
+index 00000000000000..458053d55e4541
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/xsyscall.go
+@@ -0,0 +1,6 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++package xsyscall
++
++//go:generate go run ../../cmd/mkcgo -out zdl.go -nocgo -mode dynamic -noerrors -package xsyscall -tags "darwin" dl.h
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl.s b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl.s
+new file mode 100644
+index 00000000000000..cf4762ce141355
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl.s
+@@ -0,0 +1,56 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++// Code generated by mkcgo. DO NOT EDIT.
++
++//go:build !cgo && darwin
++
++#include "textflag.h"
++
++#ifndef GOARCH_amd64
++#ifndef GOARCH_arm64
++#ifndef GOARCH_riscv64
++#ifndef GOARCH_loong64
++#ifndef GOARCH_mips64
++#ifndef GOARCH_mips64le
++#ifndef GOARCH_ppc64
++#ifndef GOARCH_ppc64le
++#ifndef GOARCH_sparc64
++#define _GOPTRSIZE 4
++#endif
++#endif
++#endif
++#endif
++#endif
++#endif
++#endif
++#endif
++#endif
++
++#ifndef _GOPTRSIZE
++#define _GOPTRSIZE 8
++#endif
++TEXT _mkcgo_dlclose_trampoline<>(SB), NOSPLIT, $0-0
++	JMP _mkcgo_dlclose(SB)
++
++GLOBL ·_mkcgo_dlclose_trampoline_addr(SB), RODATA, $_GOPTRSIZE
++DATA ·_mkcgo_dlclose_trampoline_addr(SB)/_GOPTRSIZE, $_mkcgo_dlclose_trampoline<>(SB)
++
++TEXT _mkcgo_dlerror_trampoline<>(SB), NOSPLIT, $0-0
++	JMP _mkcgo_dlerror(SB)
++
++GLOBL ·_mkcgo_dlerror_trampoline_addr(SB), RODATA, $_GOPTRSIZE
++DATA ·_mkcgo_dlerror_trampoline_addr(SB)/_GOPTRSIZE, $_mkcgo_dlerror_trampoline<>(SB)
++
++TEXT _mkcgo_dlopen_trampoline<>(SB), NOSPLIT, $0-0
++	JMP _mkcgo_dlopen(SB)
++
++GLOBL ·_mkcgo_dlopen_trampoline_addr(SB), RODATA, $_GOPTRSIZE
++DATA ·_mkcgo_dlopen_trampoline_addr(SB)/_GOPTRSIZE, $_mkcgo_dlopen_trampoline<>(SB)
++
++TEXT _mkcgo_dlsym_trampoline<>(SB), NOSPLIT, $0-0
++	JMP _mkcgo_dlsym(SB)
++
++GLOBL ·_mkcgo_dlsym_trampoline_addr(SB), RODATA, $_GOPTRSIZE
++DATA ·_mkcgo_dlsym_trampoline_addr(SB)/_GOPTRSIZE, $_mkcgo_dlsym_trampoline<>(SB)
++
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl_nocgo.go
+new file mode 100644
+index 00000000000000..a30d07b27ed848
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/internal/xsyscall/zdl_nocgo.go
+@@ -0,0 +1,48 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++// Code generated by mkcgo. DO NOT EDIT.
++
++//go:build !cgo && darwin
++
++package xsyscall
++
++import (
++	"runtime"
++	"unsafe"
++)
++
++var _ = runtime.GOOS
++
++//go:cgo_import_dynamic _mkcgo_dlclose dlclose ""
++//go:cgo_import_dynamic _mkcgo_dlerror dlerror ""
++//go:cgo_import_dynamic _mkcgo_dlopen dlopen ""
++//go:cgo_import_dynamic _mkcgo_dlsym dlsym ""
++
++var _mkcgo_dlclose_trampoline_addr uintptr
++
++func Dlclose(handle unsafe.Pointer) int32 {
++	r0, _ := syscallN(0, _mkcgo_dlclose_trampoline_addr, uintptr(handle))
++	return int32(r0)
++}
++
++var _mkcgo_dlerror_trampoline_addr uintptr
++
++func Dlerror() *byte {
++	r0, _ := syscallN(0, _mkcgo_dlerror_trampoline_addr)
++	return (*byte)(unsafe.Pointer(r0))
++}
++
++var _mkcgo_dlopen_trampoline_addr uintptr
++
++func Dlopen(path *byte, flags int32) unsafe.Pointer {
++	r0, _ := syscallN(0, _mkcgo_dlopen_trampoline_addr, uintptr(unsafe.Pointer(path)), uintptr(flags))
++	return unsafe.Pointer(r0)
++}
++
++var _mkcgo_dlsym_trampoline_addr uintptr
++
++func Dlsym(handle unsafe.Pointer, symbol *byte) unsafe.Pointer {
++	r0, _ := syscallN(0, _mkcgo_dlsym_trampoline_addr, uintptr(handle), uintptr(unsafe.Pointer(symbol)))
++	return unsafe.Pointer(r0)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/aes.go b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/aes.go
 new file mode 100644
@@ -31936,10 +32323,10 @@ index 00000000000000..82a961d974f129
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hash.go b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hash.go
 new file mode 100644
-index 00000000000000..016827afea2eee
+index 00000000000000..f44e192ecbe548
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hash.go
-@@ -0,0 +1,337 @@
+@@ -0,0 +1,335 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -31975,8 +32362,6 @@ index 00000000000000..016827afea2eee
 +	size      int
 +	blockSize int
 +}
-+
-+type HashCloner = hash.Cloner
 +
 +var cacheHash sync.Map // map[crypto.Hash]*hashAlgorithm
 +
@@ -32277,6 +32662,47 @@ index 00000000000000..016827afea2eee
 +func NewSHA3_512() *Hash {
 +	return newHash(crypto.SHA3_512)
 +}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hashclone.go b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hashclone.go
+new file mode 100644
+index 00000000000000..1e3c96d429ff33
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hashclone.go
+@@ -0,0 +1,17 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build !go1.25 && darwin
++
++package xcrypto
++
++import (
++	"hash"
++)
++
++// HashCloner is an interface that defines a Clone method.
++type HashCloner interface {
++	hash.Hash
++	// Clone returns a separate Hash instance with the same state as h.
++	Clone() (HashCloner, error)
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hashclone_go125.go b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hashclone_go125.go
+new file mode 100644
+index 00000000000000..a4b0c717ef5e38
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hashclone_go125.go
+@@ -0,0 +1,12 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build go1.25 && darwin
++
++package xcrypto
++
++import (
++	"hash"
++)
++
++type HashCloner = hash.Cloner
 diff --git a/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-darwin/xcrypto/hkdf.go
 new file mode 100644
 index 00000000000000..f6183de583d9ac
@@ -35078,10 +35504,10 @@ index 00000000000000..586e9ae2ebb0c9
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
 new file mode 100644
-index 00000000000000..13c39fea4f64fb
+index 00000000000000..d1d018ccbffa8c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hash.go
-@@ -0,0 +1,344 @@
+@@ -0,0 +1,342 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -35103,8 +35529,6 @@ index 00000000000000..13c39fea4f64fb
 +
 +// maxHashSize is the size of SHA512 and SHA3_512, the largest hashes we support.
 +const maxHashSize = 64
-+
-+type HashCloner = hash.Cloner
 +
 +// SupportsHash returns true if a hash.Hash implementation is supported for h.
 +func SupportsHash(h crypto.Hash) bool {
@@ -35426,6 +35850,49 @@ index 00000000000000..13c39fea4f64fb
 +		panic(err)
 +	}
 +}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hashclone.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hashclone.go
+new file mode 100644
+index 00000000000000..2340cb2f0127f9
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hashclone.go
+@@ -0,0 +1,18 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build !go1.25 && windows
++// +build !go1.25,windows
++
++package cng
++
++import (
++	"hash"
++)
++
++// HashCloner is an interface that defines a Clone method.
++type HashCloner interface {
++	hash.Hash
++	// Clone returns a separate Hash instance with the same state as h.
++	Clone() (HashCloner, error)
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hashclone_go125.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hashclone_go125.go
+new file mode 100644
+index 00000000000000..f86a9e9bfd47a9
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hashclone_go125.go
+@@ -0,0 +1,13 @@
++// Copyright (c) Microsoft Corporation.
++// Licensed under the MIT License.
++
++//go:build go1.25 && windows
++// +build go1.25,windows
++
++package cng
++
++import (
++	"hash"
++)
++
++type HashCloner = hash.Cloner
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
 new file mode 100644
 index 00000000000000..aa48b084d708da
@@ -38188,19 +38655,19 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 48967bc9ee3bd2..203fcbdad089ae 100644
+index 48967bc9ee3bd2..b4491a043c1f3f 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
-+# github.com/golang-fips/openssl/v2 v2.0.4-0.20260317100950-3fc1e29e8efb
-+## explicit; go 1.25
++# github.com/golang-fips/openssl/v2 v2.0.4-0.20260224093412-4123abe33e35
++## explicit; go 1.24
 +github.com/golang-fips/openssl/v2
 +github.com/golang-fips/openssl/v2/bbig
 +github.com/golang-fips/openssl/v2/internal/fakecgo
 +github.com/golang-fips/openssl/v2/internal/ossl
 +github.com/golang-fips/openssl/v2/osslsetup
-+# github.com/microsoft/go-crypto-darwin v0.0.3-0.20260317085126-9a7217034974
-+## explicit; go 1.25
++# github.com/microsoft/go-crypto-darwin v0.0.3-0.20260224094848-e322614384c3
++## explicit; go 1.24
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/commoncrypto
 +github.com/microsoft/go-crypto-darwin/internal/cryptokit
@@ -38208,8 +38675,8 @@ index 48967bc9ee3bd2..203fcbdad089ae 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20260307231751-f82d13314c5c
-+## explicit; go 1.25
++# github.com/microsoft/go-crypto-winnative v0.0.0-20260224091131-eabf5d4ea9cb
++## explicit; go 1.24
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig
 +github.com/microsoft/go-crypto-winnative/internal/bcrypt


### PR DESCRIPTION
* To simulate a vendor patch change, reverts microsoft/go#2192

It seems like Copilot review has changed to expose the session. This might help figure out what is going wrong with the reviewer when it sees a vendor patch change. Try it out.