### PR TITLE
Install stage 0 Go into repo instead of home directory

### DIFF
--- a/eng/pipeline/variables/pipeline.yml
+++ b/eng/pipeline/variables/pipeline.yml
@@ -24,3 +24,8 @@ variables:
   - name: MS_GOTOOLCHAIN_TELEMETRY_ENABLED
     value: '0'
 
+  # Download the exact stage 0 Go version in CI rather than using whatever is on PATH.
+  # See https://github.com/microsoft/go/issues/12
+  - name: MS_USE_CI_STAGE0
+    value: '1'
+

--- a/eng/run.ps1
+++ b/eng/run.ps1
@@ -17,10 +17,9 @@ To list all possible tools:
 
 Builds 'eng/_util/cmd/<tool>/<tool>.go' and runs it using the list of arguments.
 
-This command automatically installs a known version of the Microsoft build Go that
-will be used to build the tools. The known version of Go will also be used to build the
-Go source code, if it's built. Set environment variable "MS_USE_PATH_GO" to 1 to
-your own Go from PATH instead.
+This command uses Go from PATH by default. Set "MS_USE_CI_STAGE0" to 1 to instead
+download the exact Go version used in CI into the repository at
+'eng/artifacts/_goStage0/'. This is useful for reproducing CI-specific failures.
 
 Every tool accepts a '-h' argument to show tool usage help.
 #>
@@ -82,17 +81,19 @@ if (-not ($tool_source -is [System.IO.FileInfo])) {
 # Now that we have a single result, navigate upwards to see which module it's in.
 $tool_module = $tool_source.Directory.Parent.Parent.FullName
 
-# Download a consistent stage 0 version of Go unless opted out.
-if ($env:MS_USE_PATH_GO -eq "1") {
+# Set up a Go toolset. See https://github.com/microsoft/go/issues/12
+#  - Default: use Go from PATH.
+#  - "MS_USE_CI_STAGE0=1": download the exact CI stage 0 version (eng/artifacts/_goStage0/).
+if ($env:MS_USE_CI_STAGE0 -eq "1") {
+  Download-Stage0
+} else {
   try {
-    Write-Host "Using $(go version) from '$(go env GOROOT)'. Results may differ from CI environment."
+    Write-Host "Using $(go version) from '$(go env GOROOT)'. Results may differ from CI. Set MS_USE_CI_STAGE0=1 to download the CI version."
   } catch {
-    Write-Host "Error: 'go' is most likely not in PATH. To download the known version, set 'MS_USE_PATH_GO' to '0' or unset it, then try again."
+    Write-Host "Error: 'go' is not in PATH. Install Go or set MS_USE_CI_STAGE0=1 to download it automatically."
     Write-Host "Exception: $_"
     exit 1
   }
-} else {
-  Download-Stage0
 }
 
 $stage0_goroot = & go env GOROOT

--- a/eng/utilities.ps1
+++ b/eng/utilities.ps1
@@ -26,9 +26,14 @@ function Download-Stage0() {
   # specific version of Go. The downloaded copy of Go is called the "stage 0" version.
   $stage0_go_version = 'go1.25.0-1'
 
+  # Install stage 0 Go inside the repository (under "eng/artifacts/") to avoid modifying the user's
+  # home directory, and to make cleanup easy (included in "git clean -xdf"). The "_" prefix prevents
+  # Go's moddeps_test from traversing into this directory. See https://github.com/microsoft/go/issues/12
+  $stage0_install_dir = Join-Path $PSScriptRoot "artifacts" "_goStage0"
+
   # Source the install script so that we can use the PATH it assigns.
   $installScriptPath = Join-Path $PSScriptRoot "_util" "go-install.ps1"
-  . $installScriptPath -Version $stage0_go_version
+  . $installScriptPath -Version $stage0_go_version -InstallDir $stage0_install_dir
 }
 
 # Copied from https://github.com/dotnet/install-scripts/blob/49d5da7f7d313aa65d24fe95cc29767faef553fd/src/dotnet-install.ps1#L180-L197


### PR DESCRIPTION
Move the stage 0 Go toolset download location from the user's home directory (~/.local/share/microsoft-go/) into the repository at eng/artifacts/_goStage0/. This has several benefits:

- Building the repo no longer modifies state in the home directory.
- Cleanup is easy: the directory is removed by 'git clean -xdf' since eng/artifacts/ is already gitignored.
- The '_' prefix on the directory name prevents Go's moddeps_test from traversing into the stage 0 installation directory and failing.

The existing MS_USE_PATH_GO=1 opt-in to use a pre-installed Go from PATH continues to work as before.

Fixes 
- https://github.com/microsoft/go/issues/12