### PR TITLE
Add reusable line endings check workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Default: normalize text files to LF in the repo and on checkout.
+* text=auto eol=lf
+
 # On Windows, running "git apply" with CRLF patch files causes an error for binary files:
 # "git diff header lacks filename information when removing 1 leading pathname component".
 # To fix this, always check out patch files as LF.

--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -1,0 +1,16 @@
+name: Check Line Endings
+
+on:
+  push:
+    branches:
+      - "microsoft/*"
+  pull_request:
+    branches:
+      - "microsoft/*"
+
+permissions:
+  contents: read
+
+jobs:
+  check-line-endings:
+    uses: microsoft/go-infra/.github/workflows/check-line-endings.yml@main

--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   check-line-endings:
-    uses: microsoft/go-infra/.github/workflows/check-line-endings.yml@main
+    uses: microsoft/go-infra/.github/workflows/check-line-endings.yml@944d1d054c1265bf35b6632d42682217330907c4 # main


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to ensure consistent line endings in the codebase for all branches under the `microsoft/*` namespace.

CI/CD workflow improvements:

* Added a `.github/workflows/check-line-endings.yml` file that configures a workflow to check line endings using a reusable workflow from `microsoft/go-infra`. This workflow runs on both pushes and pull requests targeting `microsoft/*` branches.