### PR TITLE
Upload `msgo/systemcrypto` telemetry

### DIFF
--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -19,6 +19,7 @@ maintain this feature. For more information, see the test files.
  src/go/build/buildbackend_test.go             | 50 +++++++++++++
  .../build/testdata/backendtags_system/main.go |  3 +
  .../backendtags_system/systemcrypto.go        |  3 +
+ src/internal/buildcfg/cfg.go                  |  2 +
  src/internal/buildcfg/exp.go                  | 34 +++++++++
  src/internal/cfg/cfg.go                       |  1 +
  .../goexperiment/exp_cngcrypto_off.go         |  8 ++
@@ -30,7 +31,8 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_off.go      |  8 ++
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 +++++
- 19 files changed, 257 insertions(+), 1 deletion(-)
+ src/internal/platform/supported.go            | 12 +++
+ 21 files changed, 271 insertions(+), 1 deletion(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_system/main.go
@@ -274,8 +276,21 @@ index 00000000000000..eb8a026982259c
 +//go:build goexperiment.systemcrypto
 +
 +package main
+diff --git a/src/internal/buildcfg/cfg.go b/src/internal/buildcfg/cfg.go
+index 89fd74eb823162..6d266ff641d721 100644
+--- a/src/internal/buildcfg/cfg.go
++++ b/src/internal/buildcfg/cfg.go
+@@ -38,6 +38,8 @@ var (
+ 	Version   = version
+ )
+ 
++var SystemCryptoDisabled = os.Getenv("MS_GO_NOSYSTEMCRYPTO") == "1"
++
+ // Error is one of the errors found (if any) in the build configuration.
+ var Error error
+ 
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index c8506d41bb240f..f4d514baf8657e 100644
+index 82866cef66b5af..195e53de95eedd 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
 @@ -6,6 +6,7 @@ package buildcfg
@@ -290,7 +305,7 @@ index c8506d41bb240f..f4d514baf8657e 100644
  // default in the current toolchain. This is, in effect, the "control"
  // configuration and any variation from this is an experiment.
  var Experiment ExperimentFlags = func() ExperimentFlags {
-+	if os.Getenv("MS_GO_NOSYSTEMCRYPTO") == "1" {
++	if SystemCryptoDisabled {
 +		// If MS_GO_NOSYSTEMCRYPTO is set, ensure that nosystemcrypto is in GOEXPERIMENT.
 +		// We do it here because it is the earliest point where the toolchain tries to retrive
 +		// the GOEXPERIMENT value.
@@ -344,7 +359,7 @@ index c8506d41bb240f..f4d514baf8657e 100644
  			}
  			val := true
  			if strings.HasPrefix(f, "no") {
-@@ -149,6 +180,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -150,6 +181,9 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.RegabiArgs && !flags.RegabiWrappers {
  		return nil, fmt.Errorf("GOEXPERIMENT regabiargs requires regabiwrappers")
  	}
@@ -478,7 +493,7 @@ index 00000000000000..fcd4cb9da0d162
 +const SystemCrypto = true
 +const SystemCryptoInt = 1
 diff --git a/src/internal/goexperiment/flags.go b/src/internal/goexperiment/flags.go
-index 72f787bec7825a..baa40788e4bd34 100644
+index 683316b2135d52..b8ddbb1cb5b9ab 100644
 --- a/src/internal/goexperiment/flags.go
 +++ b/src/internal/goexperiment/flags.go
 @@ -60,6 +60,24 @@ type Flags struct {
@@ -506,3 +521,23 @@ index 72f787bec7825a..baa40788e4bd34 100644
  	// Regabi is split into several sub-experiments that can be
  	// enabled individually. Not all combinations work.
  	// The "regabi" GOEXPERIMENT is an alias for all "working"
+diff --git a/src/internal/platform/supported.go b/src/internal/platform/supported.go
+index 6cee00a7aebcdb..1182e37b86c0fc 100644
+--- a/src/internal/platform/supported.go
++++ b/src/internal/platform/supported.go
+@@ -281,3 +281,15 @@ func FirstClass(goos, goarch string) bool {
+ func Broken(goos, goarch string) bool {
+ 	return distInfo[OSArch{goos, goarch}].Broken
+ }
++
++// SystemCryptoSupported reports whether goos/goarch supports system crypto.
++func SystemCryptoSupported(goos, goarch string) bool {
++	switch goos {
++	case "linux", "darwin":
++		return true
++	case "windows":
++		return goarch == "amd64" || goarch == "arm64"
++	default:
++		return false
++	}
++}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -52,9 +52,9 @@ desired goexperiments and build tags.
  .../internal/fips140only/fips140only.go       |  11 +-
  src/crypto/systemcrypto_nocgo_linux.go        |  18 +
  src/go/build/deps_test.go                     |  24 +-
- src/internal/buildcfg/exp.go                  |  47 ++
+ src/internal/buildcfg/exp.go                  |  50 +-
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2863 insertions(+), 16 deletions(-)
+ 45 files changed, 2854 insertions(+), 28 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_darwin.go
  create mode 100644 src/crypto/internal/backend/backend_linux.go
@@ -146,10 +146,10 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index eacaa53b909632..63f3e2644a912f 100644
+index a0f8d8dd372088..6a1a5258b22dc8 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1396,6 +1396,80 @@ func toolenv() []string {
+@@ -1398,6 +1398,80 @@ func toolenv() []string {
  		// still have full paths for stack traces for compiler crashes and the like.
  		env = append(env, "GOFLAGS=-trimpath -ldflags=-w -gcflags=cmd/...=-dwarf=false")
  	}
@@ -230,7 +230,7 @@ index eacaa53b909632..63f3e2644a912f 100644
  	return env
  }
  
-@@ -1638,12 +1712,12 @@ func cmdbootstrap() {
+@@ -1640,12 +1714,12 @@ func cmdbootstrap() {
  		os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  		xprintf("Building packages and commands for target, %s/%s.\n", goos, goarch)
  	}
@@ -370,10 +370,10 @@ index a4edd854f1d35a..10ee92536b96cd 100644
  	// This will also update the BuildContext's tool tags to include the new
  	// experiment tags.
 diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
-index 91282ef9ace1c6..8f0deba2378f44 100644
+index 1d90061b065f5f..0d5d4fe0556564 100644
 --- a/src/cmd/go/internal/load/pkg.go
 +++ b/src/cmd/go/internal/load/pkg.go
-@@ -2415,6 +2415,9 @@ func (p *Package) setBuildInfo(ctx context.Context, f *modfetch.Fetcher, autoVCS
+@@ -2417,6 +2417,9 @@ func (p *Package) setBuildInfo(ctx context.Context, f *modfetch.Fetcher, autoVCS
  			buildmode = "archive"
  		}
  	}
@@ -674,7 +674,7 @@ index 2f46a6b44bffe1..69071289e2de81 100644
  
  ! go build -o $devnull cmd/buildid
 diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index 66c1619902e73e..d30198ae493442 100644
+index 07984396b7d44e..c7fbda270159f3 100644
 --- a/src/cmd/internal/testdir/testdir_test.go
 +++ b/src/cmd/internal/testdir/testdir_test.go
 @@ -118,6 +118,13 @@ func Test(t *testing.T) {
@@ -705,7 +705,7 @@ index 19ed197a20b57e..5e592c7c6697d7 100644
  		if !strings.Contains(buildVersion, "-") { // See go.dev/issue/75953.
  			sep = "-"
 diff --git a/src/cmd/link/link_test.go b/src/cmd/link/link_test.go
-index ac9a7a90b90155..7112047dcb5f39 100644
+index 941cee36a62a4b..4ccd22da3bcd0a 100644
 --- a/src/cmd/link/link_test.go
 +++ b/src/cmd/link/link_test.go
 @@ -12,6 +12,7 @@ import (
@@ -3307,7 +3307,7 @@ index 00000000000000..7500bd3a86472b
 +	`
 +}
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index e8eeb9455e4bb5..52c0785a87e5e8 100644
+index 03896fca65f120..465142153d1476 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -367,7 +367,7 @@ var depsRules = `
@@ -3319,7 +3319,7 @@ index e8eeb9455e4bb5..52c0785a87e5e8 100644
  	< internal/buildcfg;
  
  	# The vast majority of standard library packages should not be resorting to regexp.
-@@ -559,6 +559,10 @@ var depsRules = `
+@@ -552,6 +552,10 @@ var depsRules = `
  	< github.com/microsoft/go-crypto-winnative/internal/sysdll
  	< github.com/microsoft/go-crypto-winnative/internal/bcrypt;
  
@@ -3330,7 +3330,7 @@ index e8eeb9455e4bb5..52c0785a87e5e8 100644
  	FIPS, internal/godebug, embed
  	< crypto/internal/fips140only
  	< crypto
-@@ -579,6 +583,13 @@ var depsRules = `
+@@ -572,6 +576,13 @@ var depsRules = `
  	github.com/microsoft/go-crypto-winnative/internal/bcrypt
  	< github.com/microsoft/go-crypto-winnative/cng;
  
@@ -3344,7 +3344,7 @@ index e8eeb9455e4bb5..52c0785a87e5e8 100644
  	FIPS, internal/godebug, embed,
  	crypto/internal/boring/sig,
  	crypto/internal/boring/syso,
-@@ -617,8 +628,15 @@ var depsRules = `
+@@ -610,8 +621,15 @@ var depsRules = `
  	math/big, github.com/microsoft/go-crypto-darwin/xcrypto < github.com/microsoft/go-crypto-darwin/bbig;
  	math/big, github.com/microsoft/go-crypto-winnative/cng < github.com/microsoft/go-crypto-winnative/cng/bbig;
  
@@ -3363,7 +3363,7 @@ index e8eeb9455e4bb5..52c0785a87e5e8 100644
  	< crypto/rand
  	< crypto/ed25519 # depends on crypto/rand.Reader
 diff --git a/src/internal/buildcfg/exp.go b/src/internal/buildcfg/exp.go
-index d4121357526a84..c082274fcb6838 100644
+index 195e53de95eedd..c8b37f1e64955e 100644
 --- a/src/internal/buildcfg/exp.go
 +++ b/src/internal/buildcfg/exp.go
 @@ -8,9 +8,11 @@ import (
@@ -3378,7 +3378,35 @@ index d4121357526a84..c082274fcb6838 100644
  )
  
  // ExperimentFlags represents a set of GOEXPERIMENT flags relative to a baseline
-@@ -161,6 +163,16 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -81,17 +83,7 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+ 		regabiSupported = true
+ 	}
+ 
+-	// These are the goos/goarch combinations where systemcrypto is
+-	// enabled by default.
+-	var systemCryptoSupported bool
+-	switch goos {
+-	case "windows":
+-		systemCryptoSupported = goarch == "amd64" || goarch == "arm64"
+-	case "linux":
+-		systemCryptoSupported = true
+-	case "darwin":
+-		systemCryptoSupported = true
+-	}
++	systemCryptoSupported := goplatform.SystemCryptoSupported(goos, goarch)
+ 
+ 	// Older versions (anything before V16) of dsymutil don't handle
+ 	// the .debug_rnglists section in DWARF5. See
+@@ -111,7 +103,7 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+ 		RandomizedHeapBase64: true,
+ 		GreenTeaGC:           true,
+ 		GoroutineLeakProfile: true,
+-		SystemCrypto:         systemCryptoSupported,
++		SystemCrypto:         systemCryptoSupported, // if system crypto is supported, enable it by default
+ 	}
+ 	flags := &ExperimentFlags{
+ 		Flags:    baseline,
+@@ -160,6 +152,16 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  			if strings.HasPrefix(f, "no") {
  				f, val = f[2:], false
  			}
@@ -3395,29 +3423,18 @@ index d4121357526a84..c082274fcb6838 100644
  			set, ok := names[f]
  			if !ok {
  				return nil, fmt.Errorf("unknown GOEXPERIMENT %s", f)
-@@ -185,6 +197,21 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
+@@ -184,6 +186,10 @@ func ParseGOEXPERIMENT(goos, goarch, goexp string) (*ExperimentFlags, error) {
  	if flags.BoringCrypto {
  		return nil, fmt.Errorf("GOEXPERIMENT boringcrypto is not supported in the Microsoft build of Go")
  	}
-+	// Check systemcrypto platform support.
-+	if flags.SystemCrypto && goplatform.BuildModeSupported("gc", "default", goos, goarch) {
-+		var supported bool
-+		switch goos {
-+		case "linux":
-+			supported = true
-+		case "windows":
-+			supported = goarch == "amd64" || goarch == "arm64"
-+		case "darwin":
-+			supported = true
-+		}
-+		if !supported {
-+			return nil, fmt.Errorf("GOEXPERIMENT systemcrypto is not supported on %s/%s\n\tFor more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips", goos, goarch)
-+		}
++	if flags.SystemCrypto && !systemCryptoSupported && goplatform.BuildModeSupported("gc", "default", goos, goarch) {
++		// System crypto enabled but not supported.
++		return nil, fmt.Errorf("GOEXPERIMENT systemcrypto is not supported on %s/%s\n\tFor more information, visit https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips", goos, goarch)
 +	}
  	return flags, nil
  }
  
-@@ -194,6 +221,26 @@ func (exp *ExperimentFlags) String() string {
+@@ -193,6 +199,26 @@ func (exp *ExperimentFlags) String() string {
  	return strings.Join(expList(&exp.Flags, &exp.baseline, false), ",")
  }
  

--- a/patches/0009-Add-appinsights-telemetry.patch
+++ b/patches/0009-Add-appinsights-telemetry.patch
@@ -5,13 +5,14 @@ Subject: [PATCH] Add appinsights telemetry
 
 ---
  README.md                                     | 15 +++++
+ .../internal/telemetrystats/telemetrystats.go | 10 ++++
  src/cmd/go/main.go                            |  8 +++
  src/cmd/go/mstelemetry_test.go                | 56 +++++++++++++++++++
  src/cmd/go/script_test.go                     | 10 ++++
  src/cmd/go/scriptcmds_test.go                 | 22 ++++++++
  src/cmd/internal/telemetry/counter/counter.go | 54 +++++++++++++++++-
  .../telemetry/counter/counter_bootstrap.go    |  3 +
- 7 files changed, 167 insertions(+), 1 deletion(-)
+ 8 files changed, 177 insertions(+), 1 deletion(-)
  create mode 100644 src/cmd/go/mstelemetry_test.go
 
 diff --git a/README.md b/README.md
@@ -38,6 +39,34 @@ index 71c9d1dc299388..8cab5daec4da54 100644
 +our privacy statement. Your use of the software operates as your consent to
 +these practices.
 \ No newline at end of file
+diff --git a/src/cmd/go/internal/telemetrystats/telemetrystats.go b/src/cmd/go/internal/telemetrystats/telemetrystats.go
+index f975a759a1be55..f37857306d2f17 100644
+--- a/src/cmd/go/internal/telemetrystats/telemetrystats.go
++++ b/src/cmd/go/internal/telemetrystats/telemetrystats.go
+@@ -11,6 +11,8 @@ import (
+ 	"cmd/go/internal/cfg"
+ 	"cmd/go/internal/modload"
+ 	"cmd/internal/telemetry/counter"
++	"internal/buildcfg"
++	"internal/platform"
+ 	"strings"
+ )
+ 
+@@ -39,6 +41,14 @@ func incrementConfig() {
+ 		counter.Inc("go/cgo:disabled")
+ 	}
+ 
++	if platform.SystemCryptoSupported(cfg.Goos, cfg.Goarch) {
++		if buildcfg.SystemCryptoDisabled {
++			counter.Inc("msgo/systemcrypto:disabled")
++		} else {
++			counter.Inc("msgo/systemcrypto:enabled")
++		}
++	}
++
+ 	counter.Inc("go/platform/target/goos:" + cfg.Goos)
+ 	counter.Inc("go/platform/target/goarch:" + cfg.Goarch)
+ 	switch cfg.Goarch {
 diff --git a/src/cmd/go/main.go b/src/cmd/go/main.go
 index 8cdfd9196e4cb1..3f4a4d8f912969 100644
 --- a/src/cmd/go/main.go

--- a/patches/0013-Add-Microsoft-version-information.patch
+++ b/patches/0013-Add-Microsoft-version-information.patch
@@ -51,10 +51,10 @@ index 1736fd71017add..114079d8f99527 100644
  
  Go 1.25 added a new `decoratemappings` setting that controls whether the Go
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index ec10d9597b69fc..cd2b83cb6150b0 100644
+index 6a1a5258b22dc8..0d6b05a42920bb 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -454,6 +454,22 @@ func findgoversion() string {
+@@ -455,6 +455,22 @@ func findgoversion() string {
  	return version
  }
  
@@ -264,7 +264,7 @@ index 27d275644a4bd0..3c40024b4b7ab7 100644
  	}
  	if i := strings.Index(version, "-X:"); i >= 0 {
 diff --git a/src/cmd/go/internal/load/pkg.go b/src/cmd/go/internal/load/pkg.go
-index aaa3106e5a0e6e..3266f28252afea 100644
+index 0d5d4fe0556564..78cd9a2680b03f 100644
 --- a/src/cmd/go/internal/load/pkg.go
 +++ b/src/cmd/go/internal/load/pkg.go
 @@ -14,6 +14,7 @@ import (
@@ -275,7 +275,7 @@ index aaa3106e5a0e6e..3266f28252afea 100644
  	"internal/godebug"
  	"internal/platform"
  	"io/fs"
-@@ -2416,6 +2417,7 @@ func (p *Package) setBuildInfo(ctx context.Context, f *modfetch.Fetcher, autoVCS
+@@ -2420,6 +2421,7 @@ func (p *Package) setBuildInfo(ctx context.Context, f *modfetch.Fetcher, autoVCS
  	if cfg.Experiment.SystemCrypto {
  		appendSetting("microsoft_systemcrypto", "1")
  	}
@@ -396,16 +396,18 @@ index 5e592c7c6697d7..df70274e03b5df 100644
  		// dump symbol info on crash
  		defer func() { ctxt.loader.Dump() }()
 diff --git a/src/internal/buildcfg/cfg.go b/src/internal/buildcfg/cfg.go
-index 89fd74eb823162..f6d6a78531fc75 100644
+index 6d266ff641d721..d1ed759065e278 100644
 --- a/src/internal/buildcfg/cfg.go
 +++ b/src/internal/buildcfg/cfg.go
-@@ -35,9 +35,43 @@ var (
+@@ -35,11 +35,45 @@ var (
  	ToolTags  = toolTags()
  	GO_LDSO   = defaultGO_LDSO
  	GOFIPS140 = gofips140()
 -	Version   = version
 +	Version   = MSVersion
  )
+ 
+ var SystemCryptoDisabled = os.Getenv("MS_GO_NOSYSTEMCRYPTO") == "1"
  
 +var (
 +	UpstreamVersion = version
@@ -497,10 +499,10 @@ index a69f4aaede794d..f5c35867b78e26 100644
  
  // GOOS is the running program's operating system target:
 diff --git a/src/runtime/runtime1.go b/src/runtime/runtime1.go
-index 8da3682261bf9f..3b4531df8a5ec1 100644
+index 835aa8ecedb484..78c2673fbe3661 100644
 --- a/src/runtime/runtime1.go
 +++ b/src/runtime/runtime1.go
-@@ -365,6 +365,9 @@ var debug struct {
+@@ -361,6 +361,9 @@ var debug struct {
  	// tracebacklabels controls the inclusion of goroutine labels in the
  	// goroutine status header line.
  	tracebacklabels atomic.Int32
@@ -510,7 +512,7 @@ index 8da3682261bf9f..3b4531df8a5ec1 100644
  }
  
  var dbgvars = []*dbgVar{
-@@ -402,6 +405,7 @@ var dbgvars = []*dbgVar{
+@@ -398,6 +401,7 @@ var dbgvars = []*dbgVar{
  	{name: "tracebacklabels", atomic: &debug.tracebacklabels, def: 1},
  	{name: "tracefpunwindoff", value: &debug.tracefpunwindoff},
  	{name: "updatemaxprocs", value: &debug.updatemaxprocs, def: 1},


### PR DESCRIPTION
`GOEXPERIMENT=systemcrypto` will disappear in Go 1.27, so we won't be able to use it as a proxy to count systemcrypto usage in telemtry. Use a dedicated counter instead.

This implementation is a bit generic to accommodate future systemcrypto refactors.

For #2261