### PR TITLE
Drop obsolete retain-build placeholder

### DIFF
--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -301,10 +301,6 @@ stages:
                 targetPath: $(Build.SourcesDirectory)/eng/artifacts/RawTestOutput
                 artifactName: raw-test-output-${{ parameters.builder.id }}-retry-$(System.StageAttempt)-job-$(System.JobAttempt)
 
-          # - ${{ if eq(parameters.builder.config, 'buildandpack' ) }}:
-          #   - ${{ if ne(parameters.releaseVersion, 'nil') }}:
-          #     # Retain the build: https://github.com/microsoft/go-lab/issues/59
-
           - ${{ if eq(parameters.builder.os, 'linux') }}:
             # Files may be owned by root because builds don't set user ID. If this build is running on a
             # persistent machine, later builds may fail to clean up this build's directory as as


### PR DESCRIPTION
This pull request makes a minor change to the `eng/pipeline/stages/run-stage.yml` file by removing commented-out code related to retaining builds for the `buildandpack` configuration. This cleanup helps keep the pipeline YAML more readable and maintainable.

* Removed commented-out logic for retaining builds when using the `buildandpack` configuration and a non-nil `releaseVersion`.

- https://github.com/microsoft/go-infra/pull/480
- https://github.com/microsoft/go-lab/issues/59?reload=1?reload=1