### PR TITLE
Add msgo/module/hash telemetry counter

### DIFF
--- a/eng/doc/Telemetry.md
+++ b/eng/doc/Telemetry.md
@@ -24,7 +24,7 @@ The counters and properties collected are defined in the [telemetry upload confi
 
 | Property | Description |
 |---|---|
-| `msgo/module/hash` | A SHA-256 hash of the Go module path from the nearest `go.mod` file. This is a one-way hash — the original module path cannot be recovered from it. Only sent when a `go.mod` file is found in the current directory or a parent directory. |
+| `msgo/module/hash` | A SHA-256 hash of the Go module path from the nearest `go.mod` file. Only sent when a `go.mod` file is found in the current directory or a parent directory. |
 
 ### Subcommand
 
@@ -61,7 +61,7 @@ The counters and properties collected are defined in the [telemetry upload confi
 
 - No source code or file contents.
 - No file paths from the local file system.
-- No module names or paths — only a one-way SHA-256 hash of the module path is collected.
+- No textual module names or paths (a one-way SHA-256 hash of the module path is collected).
 - No environment variable values (only the presence of specific CI-related variables is checked).
 - No network or authentication information.
 - No personally identifiable information (PII).

--- a/eng/doc/Telemetry.md
+++ b/eng/doc/Telemetry.md
@@ -8,17 +8,23 @@ For the blog post announcing this feature, see [Microsoft Go Telemetry](https://
 
 ## What is collected
 
-All telemetry data consists of **counters** — simple event names that are incremented.
+Telemetry data consists of **counters** (simple event names that are incremented) and **properties** (key-value custom dimensions attached to a counter event).
 No source code, file paths, module contents, or personally identifiable information is collected.
 Each telemetry session is assigned a random session ID that cannot be linked back to a user.
 
-The counters collected are defined in the [telemetry upload configuration](/go/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json) and are listed below.
+The counters and properties collected are defined in the [telemetry upload configuration](https://github.com/microsoft/go-infra/blob/main/telemetry/config/config.json) and are listed below.
 
 ### Invocation counter
 
 | Counter | Description |
 |---|---|
 | `go/invocations` | Incremented once per `go` command invocation. |
+
+#### Properties on `go/invocations`
+
+| Property | Description |
+|---|---|
+| `msgo/module/hash` | A SHA-256 hash of the Go module path from the nearest `go.mod` file. This is a one-way hash — the original module path cannot be recovered from it. Only sent when a `go.mod` file is found in the current directory or a parent directory. |
 
 ### Subcommand
 
@@ -55,6 +61,7 @@ The counters collected are defined in the [telemetry upload configuration](/go/s
 
 - No source code or file contents.
 - No file paths from the local file system.
+- No module names or paths — only a one-way SHA-256 hash of the module path is collected.
 - No environment variable values (only the presence of specific CI-related variables is checked).
 - No network or authentication information.
 - No personally identifiable information (PII).

--- a/eng/doc/Telemetry.md
+++ b/eng/doc/Telemetry.md
@@ -24,7 +24,7 @@ The counters and properties collected are defined in the [telemetry upload confi
 
 | Property | Description |
 |---|---|
-| `msgo/module/hash` | A SHA-256 hash of the Go module path from the nearest `go.mod` file. Only sent when a `go.mod` file is found in the current directory or a parent directory. |
+| `msgo/module/hash` | A SHA-256 hash of the Go module path from the nearest `go.mod` file, found using [`modload.FindGoMod`](https://pkg.go.dev/cmd/go/internal/modload#FindGoMod). Only sent when a `go.mod` file is found. |
 
 ### Subcommand
 

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -16,10 +16,10 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-infra/telemetry/ci.go        |   97 +
  .../go-infra/telemetry/config/LICENSE         |   21 +
  .../go-infra/telemetry/config/config.go       |   11 +
- .../go-infra/telemetry/config/config.json     |   79 +
- .../go-infra/telemetry/counter/counter.go     |   63 +
+ .../go-infra/telemetry/config/config.json     |   77 +
+ .../go-infra/telemetry/counter/counter.go     |   71 +
  .../telemetry/internal/appinsights/README.md  |   12 +
- .../telemetry/internal/appinsights/client.go  |  192 ++
+ .../telemetry/internal/appinsights/client.go  |  200 ++
  .../internal/appinsights/inmemorychannel.go   |  349 +++
  .../internal/contracts/contexttagkeys.go      |   50 +
  .../internal/contracts/envelope.go            |  123 +
@@ -28,10 +28,10 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../telemetry/internal/appinsights/package.go |   13 +
  .../internal/appinsights/telemetrycontext.go  |   44 +
  .../internal/appinsights/transmitter.go       |  172 ++
- .../telemetry/internal/config/config.go       |   78 +
+ .../telemetry/internal/config/config.go       |   80 +
  .../telemetry/internal/telemetry/proginfo.go  |   46 +
  .../telemetry/internal/telemetry/telemetry.go |   32 +
- .../microsoft/go-infra/telemetry/telemetry.go |  144 +
+ .../microsoft/go-infra/telemetry/telemetry.go |  168 ++
  src/cmd/vendor/modules.txt                    |   11 +
  src/crypto/internal/backend/deps_ignore.go    |   22 +
  src/go.mod                                    |    6 +
@@ -271,7 +271,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 263 files changed, 35719 insertions(+), 7 deletions(-)
+ 263 files changed, 35759 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -529,30 +529,30 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 
 diff --git a/src/cmd/go.mod b/src/cmd/go.mod
-index 29b78693abd787..ffcaa3d7848408 100644
+index 29b78693abd787..8f3e096d276223 100644
 --- a/src/cmd/go.mod
 +++ b/src/cmd/go.mod
 @@ -4,6 +4,8 @@ go 1.27
  
  require (
  	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83
-+	github.com/microsoft/go-infra/telemetry v0.0.0-20260522114235-13e33af6063a
-+	github.com/microsoft/go-infra/telemetry/config v0.0.0-20260522114235-13e33af6063a
++	github.com/microsoft/go-infra/telemetry v0.0.0-20260526160655-aa04f117b3ce
++	github.com/microsoft/go-infra/telemetry/config v0.0.0-20260526160655-aa04f117b3ce
  	golang.org/x/arch v0.27.1-0.20260521044007-9c1a596a2c97
  	golang.org/x/build v0.0.0-20260122183339-3ba88df37c64
  	golang.org/x/mod v0.36.1-0.20260513122029-343ee60345a1
 diff --git a/src/cmd/go.sum b/src/cmd/go.sum
-index 929e1c34dcbec1..68262698d63570 100644
+index 929e1c34dcbec1..e5b03ca050f661 100644
 --- a/src/cmd/go.sum
 +++ b/src/cmd/go.sum
 @@ -4,6 +4,10 @@ github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/v
  github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
  github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b h1:ogbOPx86mIhFy764gGkqnkFC8m5PJA7sPzlk9ppLVQA=
  github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
-+github.com/microsoft/go-infra/telemetry v0.0.0-20260522114235-13e33af6063a h1:1yIH/VJLOUUWw2yVBEqAqDsakqIsx1TyjHv3rQuVv2A=
-+github.com/microsoft/go-infra/telemetry v0.0.0-20260522114235-13e33af6063a/go.mod h1:LxxLUDlqi1gwmGrnh1slAFqnEhZnKjn37MABZ6xJs44=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20260522114235-13e33af6063a h1:F/bJDa61Hj7ISaUMyErZ9m0GIgHSaLMrhf2f1Pja9Io=
-+github.com/microsoft/go-infra/telemetry/config v0.0.0-20260522114235-13e33af6063a/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
++github.com/microsoft/go-infra/telemetry v0.0.0-20260526160655-aa04f117b3ce h1:mIjWtu9i00ZMtAmGy0gJYvW3P6bqnGt1s1J8aG87UuQ=
++github.com/microsoft/go-infra/telemetry v0.0.0-20260526160655-aa04f117b3ce/go.mod h1:LxxLUDlqi1gwmGrnh1slAFqnEhZnKjn37MABZ6xJs44=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20260526160655-aa04f117b3ce h1:+9hsuF75XR8yABS2Oo9yevxvqxxS5+58qPH5rwJW4CM=
++github.com/microsoft/go-infra/telemetry/config v0.0.0-20260526160655-aa04f117b3ce/go.mod h1:t6u8QcO4tExYT4+NEB0XqR0ObiUvLe0D8ZpxFobGuA8=
  github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
  github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
  golang.org/x/arch v0.27.1-0.20260521044007-9c1a596a2c97 h1:OEbDVxixMxnrAI3whhcFkCb0rPrEHwxeSSUMdN0V414=
@@ -770,10 +770,10 @@ index 00000000000000..044268a046a54d
 +var Config []byte
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
 new file mode 100644
-index 00000000000000..89ce84ff435575
+index 00000000000000..e2ba3596943583
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/config/config.json
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,77 @@
 +{
 +	"GOOS": [
 +		"aix",
@@ -826,7 +826,8 @@ index 00000000000000..89ce84ff435575
 +			"Name": "cmd/go",
 +			"Counters": [
 +				{
-+					"Name": "go/invocations"
++					"Name": "go/invocations",
++					"Properties": ["msgo/module/hash"]
 +				},
 +				{
 +					"Name": "go/goexperiment:{ms_tls_config_schannel,systemcrypto,nosystemcrypto,opensslcrypto,cngcrypto,darwincrypto,ms_nocgo_opensslcrypto}"
@@ -845,9 +846,6 @@ index 00000000000000..89ce84ff435575
 +				},
 +				{
 +					"Name": "msgo/systemcrypto:{enabled,disabled}"
-+				},
-+				{
-+					"Name": "msgo/module:*"
 +				}
 +			]
 +		}
@@ -856,10 +854,10 @@ index 00000000000000..89ce84ff435575
 \ No newline at end of file
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/counter/counter.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/counter/counter.go
 new file mode 100644
-index 00000000000000..542b9c780b5f1b
+index 00000000000000..808caafd45e383
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/counter/counter.go
-@@ -0,0 +1,63 @@
+@@ -0,0 +1,71 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -890,6 +888,14 @@ index 00000000000000..542b9c780b5f1b
 +// New returns a counter with the given name.
 +func New(name string) *Counter {
 +	return telemetry.Client.NewEvent(name, nil)
++}
++
++// NewWithProperties returns a counter with the given name and custom properties.
++// Properties are sent as custom dimensions in Application Insights, allowing
++// high-cardinality values (such as hashes) to be sent as values rather than
++// as part of the counter name.
++func NewWithProperties(name string, properties map[string]string) *Counter {
++	return telemetry.Client.NewEvent(name, properties)
 +}
 +
 +// CountFlags creates a counter for every flag that is set
@@ -943,10 +949,10 @@ index 00000000000000..2e96890f60b871
 +- Improve testing.
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/client.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/client.go
 new file mode 100644
-index 00000000000000..c3dd88924fdcfa
+index 00000000000000..b54a026b0fe540
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/appinsights/client.go
-@@ -0,0 +1,192 @@
+@@ -0,0 +1,200 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -1001,6 +1007,11 @@ index 00000000000000..c3dd88924fdcfa
 +	// Function to filter out telemetry items by name before they are sent.
 +	// If nil, all telemetry items are sent.
 +	UploadFilter func(name string) bool
++
++	// Function to filter property keys for a given event name.
++	// Returns a new map containing only the allowed keys.
++	// If nil, all properties are sent.
++	PropertyFilter func(name string, properties map[string]string) map[string]string
 +
 +	channel *inMemoryChannel
 +	context *telemetryContext
@@ -1102,6 +1113,9 @@ index 00000000000000..c3dd88924fdcfa
 +func (c *Client) track(data contracts.EventData, n int64) {
 +	if n == 0 || (c.UploadFilter != nil && !c.UploadFilter(data.Name)) {
 +		return
++	}
++	if c.PropertyFilter != nil && data.Properties != nil {
++		data.Properties = c.PropertyFilter(data.Name, data.Properties)
 +	}
 +	if !c.init() {
 +		// Stop or Close consumed initOnce before init could run.
@@ -2005,10 +2019,10 @@ index 00000000000000..0299c87c81cb41
 +}
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/config/config.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/config/config.go
 new file mode 100644
-index 00000000000000..1cb6c22a7bcd72
+index 00000000000000..e0070ab70977e5
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/internal/config/config.go
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,80 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2029,16 +2043,18 @@ index 00000000000000..1cb6c22a7bcd72
 +
 +// A ProgramConfig contains the configuration for a single program.
 +type ProgramConfig struct {
-+	// the counter names may have to be
-+	// repeated for each program. (e.g., if the counters are in a package
-+	// that is used in more than one program.)
++	// The counter and property names may have to be repeated for each
++	// program (e.g., if they are defined in a package used by more than
++	// one program).
 +	Name     string
 +	Counters []CounterConfig `json:",omitempty"`
 +}
 +
 +// A CounterConfig contains the configuration for a single counter.
++// Counters may optionally declare associated property event names.
 +type CounterConfig struct {
-+	Name string // The "collapsed" counter: <chart>:{<bucket1>,<bucket2>,...}
++	Name       string   // The "collapsed" counter: <chart>:{<bucket1>,<bucket2>,...}
++	Properties []string `json:",omitempty"` // Associated property event names
 +}
 +
 +func ReadConfig(file string) (*UploadConfig, error) {
@@ -2179,10 +2195,10 @@ index 00000000000000..02d112edb8ad3e
 +}
 diff --git a/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/telemetry.go b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/telemetry.go
 new file mode 100644
-index 00000000000000..e50deaa4189b18
+index 00000000000000..016de9bdd95956
 --- /dev/null
 +++ b/src/cmd/vendor/github.com/microsoft/go-infra/telemetry/telemetry.go
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,168 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -2239,8 +2255,9 @@ index 00000000000000..e50deaa4189b18
 +	Logger *slog.Logger
 +}
 +
-+var countersToUpload map[string]struct{}
++var eventsToUpload map[string]struct{}
 +var wildcardPrefixes []string
++var allowedProperties map[string]map[string]struct{}
 +
 +// Start initializes telemetry using the specified configuration.
 +func Start(cfg Config) {
@@ -2276,7 +2293,8 @@ index 00000000000000..e50deaa4189b18
 +	if progIdx == -1 {
 +		return // Program not configured for telemetry
 +	}
-+	countersToUpload = make(map[string]struct{})
++	eventsToUpload = make(map[string]struct{})
++	allowedProperties = make(map[string]map[string]struct{})
 +	wildcardPrefixes = nil
 +	for _, c := range uploadConfig.Programs[progIdx].Counters {
 +		if c.Name == "" {
@@ -2288,7 +2306,14 @@ index 00000000000000..e50deaa4189b18
 +					wildcardPrefixes = append(wildcardPrefixes, prefix)
 +				}
 +			} else {
-+				countersToUpload[e] = struct{}{}
++				eventsToUpload[e] = struct{}{}
++				if len(c.Properties) > 0 {
++					keys := make(map[string]struct{}, len(c.Properties))
++					for _, p := range c.Properties {
++						keys[p] = struct{}{}
++					}
++					allowedProperties[e] = keys
++				}
 +			}
 +		}
 +	}
@@ -2302,8 +2327,9 @@ index 00000000000000..e50deaa4189b18
 +			"ai.application.ver": ver,
 +			"ai.cloud.role":      prog,
 +		},
-+		UploadFilter: uploadFilter,
-+		Logger:       cfg.Logger,
++		UploadFilter:   uploadFilter,
++		PropertyFilter: propertyFilter,
++		Logger:         cfg.Logger,
 +	})
 +}
 +
@@ -2317,7 +2343,7 @@ index 00000000000000..e50deaa4189b18
 +}
 +
 +func uploadFilter(name string) bool {
-+	if _, ok := countersToUpload[name]; ok {
++	if _, ok := eventsToUpload[name]; ok {
 +		return true
 +	}
 +	for _, prefix := range wildcardPrefixes {
@@ -2327,15 +2353,29 @@ index 00000000000000..e50deaa4189b18
 +	}
 +	return false
 +}
++
++func propertyFilter(name string, properties map[string]string) map[string]string {
++	keys, ok := allowedProperties[name]
++	if !ok {
++		return nil
++	}
++	filtered := make(map[string]string, len(keys))
++	for k, v := range properties {
++		if _, ok := keys[k]; ok {
++			filtered[k] = v
++		}
++	}
++	return filtered
++}
 diff --git a/src/cmd/vendor/modules.txt b/src/cmd/vendor/modules.txt
-index f3ed9c985e7bf5..67e1651ba7e3c5 100644
+index f3ed9c985e7bf5..f11ce5085c79ca 100644
 --- a/src/cmd/vendor/modules.txt
 +++ b/src/cmd/vendor/modules.txt
 @@ -16,6 +16,17 @@ github.com/google/pprof/third_party/svgpan
  # github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b
  ## explicit; go 1.13
  github.com/ianlancetaylor/demangle
-+# github.com/microsoft/go-infra/telemetry v0.0.0-20260522114235-13e33af6063a
++# github.com/microsoft/go-infra/telemetry v0.0.0-20260526160655-aa04f117b3ce
 +## explicit; go 1.25
 +github.com/microsoft/go-infra/telemetry
 +github.com/microsoft/go-infra/telemetry/counter
@@ -2343,7 +2383,7 @@ index f3ed9c985e7bf5..67e1651ba7e3c5 100644
 +github.com/microsoft/go-infra/telemetry/internal/appinsights/internal/contracts
 +github.com/microsoft/go-infra/telemetry/internal/config
 +github.com/microsoft/go-infra/telemetry/internal/telemetry
-+# github.com/microsoft/go-infra/telemetry/config v0.0.0-20260522114235-13e33af6063a
++# github.com/microsoft/go-infra/telemetry/config v0.0.0-20260526160655-aa04f117b3ce
 +## explicit; go 1.24
 +github.com/microsoft/go-infra/telemetry/config
  # golang.org/x/arch v0.27.1-0.20260521044007-9c1a596a2c97

--- a/patches/0009-Add-appinsights-telemetry.patch
+++ b/patches/0009-Add-appinsights-telemetry.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Add appinsights telemetry
 
 ---
  README.md                                     | 15 +++++
- .../internal/telemetrystats/telemetrystats.go | 17 ++++++
+ .../internal/telemetrystats/telemetrystats.go | 31 ++++++++++
  src/cmd/go/main.go                            |  8 +++
- src/cmd/go/mstelemetry_test.go                | 56 +++++++++++++++++++
- src/cmd/go/script_test.go                     | 10 ++++
- src/cmd/go/scriptcmds_test.go                 | 22 ++++++++
- src/cmd/internal/telemetry/counter/counter.go | 54 +++++++++++++++++-
- .../telemetry/counter/counter_bootstrap.go    |  3 +
- 8 files changed, 184 insertions(+), 1 deletion(-)
+ src/cmd/go/mstelemetry_test.go                | 56 +++++++++++++++++
+ src/cmd/go/script_test.go                     | 10 +++
+ src/cmd/go/scriptcmds_test.go                 | 22 +++++++
+ src/cmd/internal/telemetry/counter/counter.go | 61 ++++++++++++++++++-
+ .../telemetry/counter/counter_bootstrap.go    | 10 ++-
+ 8 files changed, 209 insertions(+), 4 deletions(-)
  create mode 100644 src/cmd/go/mstelemetry_test.go
 
 diff --git a/README.md b/README.md
@@ -40,15 +40,20 @@ index 71c9d1dc299388..8cab5daec4da54 100644
 +these practices.
 \ No newline at end of file
 diff --git a/src/cmd/go/internal/telemetrystats/telemetrystats.go b/src/cmd/go/internal/telemetrystats/telemetrystats.go
-index c6e58935bb0ee2..0cd7d3582c9ee6 100644
+index c6e58935bb0ee2..5244f2e039ce98 100644
 --- a/src/cmd/go/internal/telemetrystats/telemetrystats.go
 +++ b/src/cmd/go/internal/telemetrystats/telemetrystats.go
-@@ -11,7 +11,12 @@ import (
+@@ -9,9 +9,17 @@ package telemetrystats
+ import (
+ 	"cmd/go/internal/base"
  	"cmd/go/internal/cfg"
++	"cmd/go/internal/gover"
  	"cmd/go/internal/modload"
  	"cmd/internal/telemetry/counter"
++	"crypto/sha256"
 +	"internal/buildcfg"
 +	"internal/platform"
++	"math/big"
 +	"os"
  	"strings"
 +
@@ -56,7 +61,7 @@ index c6e58935bb0ee2..0cd7d3582c9ee6 100644
  )
  
  func Increment() {
-@@ -39,6 +44,18 @@ func incrementConfig() {
+@@ -39,6 +47,29 @@ func incrementConfig() {
  		counter.Inc("go/cgo:disabled")
  	}
  
@@ -69,6 +74,17 @@ index c6e58935bb0ee2..0cd7d3582c9ee6 100644
 +			counter.Inc("msgo/systemcrypto:disabled")
 +		} else {
 +			counter.Inc("msgo/systemcrypto:enabled")
++		}
++	}
++
++	// Send a SHA-256 hash of the module path as a property on go/invocations.
++	if gomod := modload.FindGoMod(base.Cwd()); gomod != "" {
++		if data, err := os.ReadFile(gomod); err == nil {
++			if mod := gover.GoModLookup(data, "module"); mod != "" {
++				h := sha256.Sum256([]byte(mod))
++				hash := new(big.Int).SetBytes(h[:]).String()
++				counter.IncWithProperties("go/invocations", map[string]string{"msgo/module/hash": hash})
++			}
 +		}
 +	}
 +
@@ -232,7 +248,7 @@ index 8195e830caa31b..882aeecfa562b9 100644
  	})
  }
 diff --git a/src/cmd/internal/telemetry/counter/counter.go b/src/cmd/internal/telemetry/counter/counter.go
-index 5cef0b0041551a..8c2bae0e613c92 100644
+index 5cef0b0041551a..a81daf56c9e991 100644
 --- a/src/cmd/internal/telemetry/counter/counter.go
 +++ b/src/cmd/internal/telemetry/counter/counter.go
 @@ -7,10 +7,24 @@
@@ -260,7 +276,7 @@ index 5cef0b0041551a..8c2bae0e613c92 100644
  )
  
  var openCalled bool
-@@ -24,9 +38,44 @@ func Open() {
+@@ -24,9 +38,51 @@ func Open() {
  	counter.OpenDir(os.Getenv("TEST_TELEMETRY_DIR"))
  }
  
@@ -302,10 +318,17 @@ index 5cef0b0041551a..8c2bae0e613c92 100644
  func Inc(name string) {
  	counter.Inc(name)
 +	mscounter.Inc(name)
++}
++
++// IncWithProperties increments the counter with the given name and custom properties.
++// Properties are sent as custom dimensions in Application Insights.
++func IncWithProperties(name string, properties map[string]string) {
++	counter.Inc(name)
++	mscounter.NewWithProperties(name, properties).Inc()
  }
  
  // New returns a counter with the given name.
-@@ -44,6 +93,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
+@@ -44,6 +100,7 @@ func NewStack(name string, depth int) *counter.StackCounter {
  // the concatenation of prefix and the flag name.
  func CountFlags(prefix string, flagSet flag.FlagSet) {
  	counter.CountFlags(prefix, flagSet)
@@ -313,7 +336,7 @@ index 5cef0b0041551a..8c2bae0e613c92 100644
  }
  
  // CountFlagValue creates a counter for the flag value
-@@ -56,7 +106,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
+@@ -56,7 +113,9 @@ func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {
  	// TODO(matloob): Add this to x/telemetry?
  	flagSet.Visit(func(f *flag.Flag) {
  		if f.Name == flagName {
@@ -325,10 +348,20 @@ index 5cef0b0041551a..8c2bae0e613c92 100644
  	})
  }
 diff --git a/src/cmd/internal/telemetry/counter/counter_bootstrap.go b/src/cmd/internal/telemetry/counter/counter_bootstrap.go
-index 00808294053c23..e19970cf926e16 100644
+index 00808294053c23..0780b24792c795 100644
 --- a/src/cmd/internal/telemetry/counter/counter_bootstrap.go
 +++ b/src/cmd/internal/telemetry/counter/counter_bootstrap.go
-@@ -18,3 +18,6 @@ func New(name string) dummyCounter                                        { retu
+@@ -12,9 +12,13 @@ type dummyCounter struct{}
+ 
+ func (dc dummyCounter) Inc() {}
+ 
+-func Open()                                                               {}
+-func Inc(name string)                                                     {}
+-func New(name string) dummyCounter                                        { return dummyCounter{} }
++func Open()                                                                          {}
++func Inc(name string)                                                                {}
++func IncWithProperties(name string, properties map[string]string)                    {}
++func New(name string) dummyCounter                                                   { return dummyCounter{} }
  func NewStack(name string, depth int) dummyCounter                        { return dummyCounter{} }
  func CountFlags(name string, flagSet flag.FlagSet)                        {}
  func CountFlagValue(prefix string, flagSet flag.FlagSet, flagName string) {}

--- a/patches/0009-Add-appinsights-telemetry.patch
+++ b/patches/0009-Add-appinsights-telemetry.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Add appinsights telemetry
 
 ---
  README.md                                     | 15 +++++
- .../internal/telemetrystats/telemetrystats.go | 31 ++++++++++
- src/cmd/go/main.go                            |  8 +++
+ .../internal/telemetrystats/telemetrystats.go | 17 ++++++
+ src/cmd/go/main.go                            | 28 ++++++++-
  src/cmd/go/mstelemetry_test.go                | 56 +++++++++++++++++
  src/cmd/go/script_test.go                     | 10 +++
  src/cmd/go/scriptcmds_test.go                 | 22 +++++++
  src/cmd/internal/telemetry/counter/counter.go | 61 ++++++++++++++++++-
  .../telemetry/counter/counter_bootstrap.go    | 10 ++-
- 8 files changed, 209 insertions(+), 4 deletions(-)
+ 8 files changed, 214 insertions(+), 5 deletions(-)
  create mode 100644 src/cmd/go/mstelemetry_test.go
 
 diff --git a/README.md b/README.md
@@ -40,20 +40,15 @@ index 71c9d1dc299388..8cab5daec4da54 100644
 +these practices.
 \ No newline at end of file
 diff --git a/src/cmd/go/internal/telemetrystats/telemetrystats.go b/src/cmd/go/internal/telemetrystats/telemetrystats.go
-index c6e58935bb0ee2..5244f2e039ce98 100644
+index c6e58935bb0ee2..0cd7d3582c9ee6 100644
 --- a/src/cmd/go/internal/telemetrystats/telemetrystats.go
 +++ b/src/cmd/go/internal/telemetrystats/telemetrystats.go
-@@ -9,9 +9,17 @@ package telemetrystats
- import (
- 	"cmd/go/internal/base"
+@@ -11,7 +11,12 @@ import (
  	"cmd/go/internal/cfg"
-+	"cmd/go/internal/gover"
  	"cmd/go/internal/modload"
  	"cmd/internal/telemetry/counter"
-+	"crypto/sha256"
 +	"internal/buildcfg"
 +	"internal/platform"
-+	"math/big"
 +	"os"
  	"strings"
 +
@@ -61,7 +56,7 @@ index c6e58935bb0ee2..5244f2e039ce98 100644
  )
  
  func Increment() {
-@@ -39,6 +47,29 @@ func incrementConfig() {
+@@ -39,6 +44,18 @@ func incrementConfig() {
  		counter.Inc("go/cgo:disabled")
  	}
  
@@ -77,28 +72,37 @@ index c6e58935bb0ee2..5244f2e039ce98 100644
 +		}
 +	}
 +
-+	// Send a SHA-256 hash of the module path as a property on go/invocations.
-+	if gomod := modload.FindGoMod(base.Cwd()); gomod != "" {
-+		if data, err := os.ReadFile(gomod); err == nil {
-+			if mod := gover.GoModLookup(data, "module"); mod != "" {
-+				h := sha256.Sum256([]byte(mod))
-+				hash := new(big.Int).SetBytes(h[:]).String()
-+				counter.IncWithProperties("go/invocations", map[string]string{"msgo/module/hash": hash})
-+			}
-+		}
-+	}
-+
  	counter.Inc("go/platform/target/goos:" + cfg.Goos)
  	counter.Inc("go/platform/target/goarch:" + cfg.Goarch)
  	counter.Inc("go/platform/target/port:" + cfg.Goos + "-" + cfg.Goarch)
 diff --git a/src/cmd/go/main.go b/src/cmd/go/main.go
-index bba11a2fdeaaa6..cb7801588662a2 100644
+index bba11a2fdeaaa6..641f8ea631d992 100644
 --- a/src/cmd/go/main.go
 +++ b/src/cmd/go/main.go
-@@ -110,6 +110,14 @@ func main() {
+@@ -8,6 +8,8 @@ package main
+ 
+ import (
+ 	"context"
++	"crypto/sha256"
++	"encoding/hex"
+ 	"flag"
+ 	"fmt"
+ 	"internal/buildcfg"
+@@ -25,7 +27,9 @@ import (
+ 	"cmd/go/internal/doc"
+ 	"cmd/go/internal/envcmd"
+ 	"cmd/go/internal/fmtcmd"
++	"cmd/go/internal/fsys"
+ 	"cmd/go/internal/generate"
++	"cmd/go/internal/gover"
+ 	"cmd/go/internal/help"
+ 	"cmd/go/internal/list"
+ 	"cmd/go/internal/modcmd"
+@@ -110,7 +114,29 @@ func main() {
  	}
  	flag.Usage = base.Usage
  	flag.Parse()
+-	counter.Inc("go/invocations")
 +	if args := flag.Args(); len(args) > 0 {
 +		switch args[0] {
 +		case "build", "install", "run":
@@ -107,9 +111,24 @@ index bba11a2fdeaaa6..cb7801588662a2 100644
 +			base.AtExit(counter.CloseMicrosoft)
 +		}
 +	}
- 	counter.Inc("go/invocations")
++	// Send a SHA-256 hash of the module path as a property on go/invocations.
++	var moduleHash string
++	if gomod := modload.FindGoMod(base.Cwd()); gomod != "" {
++		if data, err := fsys.ReadFile(gomod); err == nil {
++			if mod := gover.GoModLookup(data, "module"); mod != "" {
++				h := sha256.Sum256([]byte(mod))
++				moduleHash = hex.EncodeToString(h[:])
++			}
++		}
++	}
++	if moduleHash != "" {
++		counter.IncWithProperties("go/invocations", map[string]string{"msgo/module/hash": moduleHash})
++	} else {
++		counter.Inc("go/invocations")
++	}
  	counter.CountFlags("go/flag:", *flag.CommandLine)
  
+ 	args := flag.Args()
 diff --git a/src/cmd/go/mstelemetry_test.go b/src/cmd/go/mstelemetry_test.go
 new file mode 100644
 index 00000000000000..010270fb6ad4cf


### PR DESCRIPTION
## Summary

Add a SHA-256 hash of the Go module path as a custom property on the `go/invocations` telemetry event, and vendor the updated `go-infra/telemetry` dependency (which includes support for counter properties and property filtering).

fixes: https://github.com/microsoft/go-lab/issues/382

## New telemetry

### `msgo/module/hash` property on `go/invocations`

When `go/invocations` is recorded, the nearest `go.mod` file is located and the module path is hashed using SHA-256. The resulting hash is sent as a custom property (`msgo/module/hash`) on the `go/invocations` event. This is a one-way hash — the original module path cannot be recovered from it.

The hash is only sent when a `go.mod` file is found. If no `go.mod` is present, `go/invocations` is sent without the property.

## Dependency changes

- Updated vendored `github.com/microsoft/go-infra/telemetry` to include support for `NewWithProperties()`, `PropertyFilter`, and counter property configuration in `config.json`.

## Patch changes

- **Patch 0001** (Vendor external dependencies): Updated go-infra/telemetry dependency version with property support.
- **Patch 0009** (Add appinsights telemetry): Added module hash computation and `NewWithProperties` call in `Inc()`.

## Documentation

- Updated `eng/doc/Telemetry.md` to document the new `msgo/module/hash` property and clarify that module names are not collected (only hashes).