### PR TITLE
Use FIPSCapable

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -207,39 +207,39 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go-crypto-openssl/openssl/aes.go          |  158 ++
  .../go-crypto-openssl/openssl/big.go          |   14 +
  .../openssl/chacha20poly1305.go               |  152 +
- .../go-crypto-openssl/openssl/cipher.go       |  666 +++++
+ .../go-crypto-openssl/openssl/cipher.go       |  665 +++++
  .../go-crypto-openssl/openssl/const.go        |  109 +
  .../go-crypto-openssl/openssl/cshake.go       |  256 ++
  .../go-crypto-openssl/openssl/des.go          |  121 +
- .../go-crypto-openssl/openssl/dsa.go          |  306 ++
+ .../go-crypto-openssl/openssl/dsa.go          |  296 ++
  .../microsoft/go-crypto-openssl/openssl/ec.go |  132 +
- .../go-crypto-openssl/openssl/ecdh.go         |  341 +++
- .../go-crypto-openssl/openssl/ecdsa.go        |  220 ++
+ .../go-crypto-openssl/openssl/ecdh.go         |  331 +++
+ .../go-crypto-openssl/openssl/ecdsa.go        |  212 ++
  .../go-crypto-openssl/openssl/ed25519.go      |  209 ++
- .../go-crypto-openssl/openssl/evp.go          |  615 ++++
+ .../go-crypto-openssl/openssl/evp.go          |  616 ++++
  .../go-crypto-openssl/openssl/hash.go         |  521 ++++
- .../go-crypto-openssl/openssl/hkdf.go         |  330 +++
- .../go-crypto-openssl/openssl/hmac.go         |  280 ++
+ .../go-crypto-openssl/openssl/hkdf.go         |  312 +++
+ .../go-crypto-openssl/openssl/hmac.go         |  269 ++
  .../go-crypto-openssl/openssl/mldsa.go        |  449 +++
  .../go-crypto-openssl/openssl/mlkem.go        |  369 +++
- .../go-crypto-openssl/openssl/openssl.go      |  183 ++
+ .../go-crypto-openssl/openssl/openssl.go      |  182 ++
  .../go-crypto-openssl/openssl/openssl_cgo.go  |   17 +
  .../openssl/openssl_nocgo.go                  |   35 +
  .../go-crypto-openssl/openssl/params.go       |  191 ++
- .../go-crypto-openssl/openssl/pbkdf2.go       |   86 +
- .../openssl/provideropenssl.go                |  250 ++
+ .../go-crypto-openssl/openssl/pbkdf2.go       |   82 +
+ .../openssl/provideropenssl.go                |  257 ++
  .../openssl/providersymcrypt.go               |  331 +++
  .../go-crypto-openssl/openssl/rand.go         |   37 +
  .../go-crypto-openssl/openssl/rc4.go          |   76 +
- .../go-crypto-openssl/openssl/rsa.go          |  712 +++++
- .../go-crypto-openssl/openssl/tls1prf.go      |  157 ++
+ .../go-crypto-openssl/openssl/rsa.go          |  706 +++++
+ .../go-crypto-openssl/openssl/tls1prf.go      |  147 +
  .../go-crypto-openssl/openssl/zaes.go         |   87 +
- .../go-crypto-openssl/osslsetup/fips.go       |   69 +
+ .../go-crypto-openssl/osslsetup/fips.go       |  115 +
  .../go-crypto-openssl/osslsetup/init.go       |  170 ++
  .../osslsetup/init_cgo_unix.go                |   34 +
  .../osslsetup/init_nocgo_unix.go              |   35 +
  .../osslsetup/init_windows.go                 |   37 +
- .../go-crypto-openssl/osslsetup/osslsetup.go  |  109 +
+ .../go-crypto-openssl/osslsetup/osslsetup.go  |  123 +
  .../osslsetup/osslsetup_cgo.go                |   12 +
  .../osslsetup/osslsetup_nocgo.go              |   24 +
  .../microsoft/go-crypto-winnative/LICENSE     |   21 +
@@ -271,7 +271,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 263 files changed, 35730 insertions(+), 7 deletions(-)
+ 263 files changed, 35719 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -2378,7 +2378,7 @@ index 00000000000000..f5dc9afe4b0ead
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index 8703fad3b226c9..fe3cd514ef512d 100644
+index 8703fad3b226c9..92b03d8db89373 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2388,18 +2388,18 @@ index 8703fad3b226c9..fe3cd514ef512d 100644
 +
 +require (
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260512212935-d0ce8397e44b
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20260521090922-bd6798f35c69
++	github.com/microsoft/go-crypto-openssl v0.0.0-20260526094617-f3ee9e48499e
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20260512074019-00d811a4aefe
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 43554ff45c183e..01f4f244d6f7be 100644
+index 43554ff45c183e..30e68847197201 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260512212935-d0ce8397e44b h1:HADuteQytnLec1jmAOGPGCukWIxObrAm/CBYtVzuo5o=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260512212935-d0ce8397e44b/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260521090922-bd6798f35c69 h1:gtZRTEEfTbjAKMNbDGXeayGoReqVhBIw+J8QzgWuBEs=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260521090922-bd6798f35c69/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
++github.com/microsoft/go-crypto-openssl v0.0.0-20260526094617-f3ee9e48499e h1:969cC0h4W/zAzgFu09YW/6MwRkEDTAVlDB1CKiGG+Qs=
++github.com/microsoft/go-crypto-openssl v0.0.0-20260526094617-f3ee9e48499e/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260512074019-00d811a4aefe h1:WDbUuTTKY8VElMRA3JJ8Quvj9xK9GqEcTiBZ3BF+7mI=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260512074019-00d811a4aefe/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
  golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
@@ -26705,10 +26705,10 @@ index 00000000000000..410829738931c7
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/cipher.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/cipher.go
 new file mode 100644
-index 00000000000000..24615432053f01
+index 00000000000000..10f932a02d0b36
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/cipher.go
-@@ -0,0 +1,666 @@
+@@ -0,0 +1,665 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -26795,8 +26795,7 @@ index 00000000000000..24615432053f01
 +	}
 +	defer func() {
 +		if cipher != nil {
-+			switch major() {
-+			case 3, 4:
++			if major() != 1 {
 +				// On OpenSSL 3, directly operating on a EVP_CIPHER object
 +				// not created by EVP_CIPHER has negative performance
 +				// implications, as cipher operations will have
@@ -27881,10 +27880,10 @@ index 00000000000000..6ae4a6372f8d08
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/dsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/dsa.go
 new file mode 100644
-index 00000000000000..82b7b1081468de
+index 00000000000000..b2c643ab34a0c1
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/dsa.go
-@@ -0,0 +1,306 @@
+@@ -0,0 +1,296 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -27980,7 +27979,7 @@ index 00000000000000..82b7b1081468de
 +	case 1:
 +		dsa := getDSA(pkey)
 +		ossl.DSA_get0_pqg(dsa, &p, &q, &g)
-+	case 3, 4:
++	default:
 +		defer func() {
 +			ossl.BN_free(p)
 +			ossl.BN_free(q)
@@ -27995,8 +27994,6 @@ index 00000000000000..82b7b1081468de
 +		if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_G.ptr(), &g); err != nil {
 +			return DSAParameters{}, err
 +		}
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +
 +	return DSAParameters{
@@ -28046,7 +28043,7 @@ index 00000000000000..82b7b1081468de
 +	case 1:
 +		dsa := getDSA(pkey)
 +		ossl.DSA_get0_key(dsa, &by, &bx)
-+	case 3, 4:
++	default:
 +		defer func() {
 +			ossl.BN_clear_free(bx)
 +			ossl.BN_free(by)
@@ -28057,8 +28054,6 @@ index 00000000000000..82b7b1081468de
 +		if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &bx); err != nil {
 +			return nil, nil, err
 +		}
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +	return bnToBig(bx), bnToBig(by), nil
 +}
@@ -28077,16 +28072,12 @@ index 00000000000000..82b7b1081468de
 +	switch major() {
 +	case 1:
 +		return newDSA1(params, x, y)
-+	case 3, 4:
-+		return newDSA3(params, x, y)
 +	default:
-+		panic(errUnsupportedVersion())
++		return newDSA3(params, x, y)
 +	}
 +}
 +
 +func newDSA1(params DSAParameters, x, y BigInt) (pkey ossl.EVP_PKEY_PTR, err error) {
-+	checkMajorVersion(1)
-+
 +	dsa, err := ossl.DSA_new()
 +	if err != nil {
 +		return nil, err
@@ -28132,8 +28123,6 @@ index 00000000000000..82b7b1081468de
 +}
 +
 +func newDSA3(params DSAParameters, x, y BigInt) (ossl.EVP_PKEY_PTR, error) {
-+	checkMajorVersion(3, 4)
-+
 +	bld := newParamBuilder()
 +	defer bld.finalize()
 +
@@ -28331,10 +28320,10 @@ index 00000000000000..d871a04b37942b
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
 new file mode 100644
-index 00000000000000..7289538d753dc8
+index 00000000000000..60e56dfd573f47
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
-@@ -0,0 +1,341 @@
+@@ -0,0 +1,331 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -28444,7 +28433,7 @@ index 00000000000000..7289538d753dc8
 +			if bytes, err = encodeEcPoint(group, pt); err != nil {
 +				return nil, err
 +			}
-+		case 3, 4:
++		default:
 +			pkey = k._pkey
 +			if _, err := ossl.EVP_PKEY_up_ref(pkey); err != nil {
 +				return nil, err
@@ -28456,8 +28445,6 @@ index 00000000000000..7289538d753dc8
 +			}
 +			bytes = goBytes(unsafe.Pointer(cbytes), n)
 +			cryptoFree(unsafe.Pointer(cbytes))
-+		default:
-+			panic(errUnsupportedVersion())
 +		}
 +	}
 +	pub := &PublicKeyECDH{pkey, bytes}
@@ -28478,16 +28465,12 @@ index 00000000000000..7289538d753dc8
 +	switch major() {
 +	case 1:
 +		return newECDHPkey1(nid, bytes, isPrivate)
-+	case 3, 4:
-+		return newECDHPkey3(nid, bytes, isPrivate)
 +	default:
-+		panic(errUnsupportedVersion())
++		return newECDHPkey3(nid, bytes, isPrivate)
 +	}
 +}
 +
 +func newECDHPkey1(nid int32, bytes []byte, isPrivate bool) (pkey ossl.EVP_PKEY_PTR, err error) {
-+	checkMajorVersion(1)
-+
 +	key, err := ossl.EC_KEY_new_by_curve_name(nid)
 +	if err != nil {
 +		return nil, err
@@ -28540,8 +28523,6 @@ index 00000000000000..7289538d753dc8
 +}
 +
 +func newECDHPkey3(nid int32, bytes []byte, isPrivate bool) (ossl.EVP_PKEY_PTR, error) {
-+	checkMajorVersion(3, 4)
-+
 +	bld := newParamBuilder()
 +	defer bld.finalize()
 +	bld.addUTF8String(_OSSL_PKEY_PARAM_GROUP_NAME, ossl.OBJ_nid2sn(nid), 0)
@@ -28650,13 +28631,11 @@ index 00000000000000..7289538d753dc8
 +			if priv == nil {
 +				return nil, nil, fail("missing ECDH private key")
 +			}
-+		case 3, 4:
++		default:
 +			if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &priv); err != nil {
 +				return nil, nil, err
 +			}
 +			defer ossl.BN_clear_free(priv)
-+		default:
-+			panic(errUnsupportedVersion())
 +		}
 +		// We should not leak bit length of the secret scalar in the key.
 +		// For this reason, we use BN_bn2binpad instead of BN_bn2bin with fixed length.
@@ -28678,10 +28657,10 @@ index 00000000000000..7289538d753dc8
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 new file mode 100644
-index 00000000000000..d96c368fe1ca76
+index 00000000000000..ad6c0bcb821bc7
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
-@@ -0,0 +1,220 @@
+@@ -0,0 +1,212 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -28776,7 +28755,7 @@ index 00000000000000..d96c368fe1ca76
 +		}
 +		// Get Z. We don't need to free it, get0 does not increase the reference count.
 +		bd = ossl.EC_KEY_get0_private_key(key)
-+	case 3, 4:
++	default:
 +		if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_EC_PUB_X.ptr(), &bx); err != nil {
 +			return nil, nil, nil, err
 +		}
@@ -28787,8 +28766,6 @@ index 00000000000000..d96c368fe1ca76
 +			return nil, nil, nil, err
 +		}
 +		defer ossl.BN_clear_free(bd)
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +
 +	// Get D.
@@ -28834,16 +28811,12 @@ index 00000000000000..d96c368fe1ca76
 +	switch major() {
 +	case 1:
 +		return newECDSAKey1(nid, bx, by, bd)
-+	case 3, 4:
-+		return newECDSAKey3(nid, bx, by, bd)
 +	default:
-+		panic(errUnsupportedVersion())
++		return newECDSAKey3(nid, bx, by, bd)
 +	}
 +}
 +
 +func newECDSAKey1(nid int32, bx, by, bd ossl.BIGNUM_PTR) (pkey ossl.EVP_PKEY_PTR, err error) {
-+	checkMajorVersion(1)
-+
 +	key, err := ossl.EC_KEY_new_by_curve_name(nid)
 +	if err != nil {
 +		return nil, err
@@ -28866,8 +28839,6 @@ index 00000000000000..d96c368fe1ca76
 +}
 +
 +func newECDSAKey3(nid int32, bx, by, bd ossl.BIGNUM_PTR) (ossl.EVP_PKEY_PTR, error) {
-+	checkMajorVersion(3, 4)
-+
 +	// Create the encoded public key public key from bx and by.
 +	pubBytes, err := generateAndEncodeEcPublicKey(nid, func(group ossl.EC_GROUP_PTR) (ossl.EC_POINT_PTR, error) {
 +		pt, err := ossl.EC_POINT_new(group)
@@ -28904,7 +28875,7 @@ index 00000000000000..d96c368fe1ca76
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ed25519.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ed25519.go
 new file mode 100644
-index 00000000000000..205b01cd36b206
+index 00000000000000..69565f949d4ac5
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ed25519.go
 @@ -0,0 +1,209 @@
@@ -28944,7 +28915,7 @@ index 00000000000000..205b01cd36b206
 +			ossl.EVP_PKEY_CTX_free(ctx)
 +			return true
 +		}
-+	case 3, 4:
++	default:
 +		sig, _ := ossl.EVP_SIGNATURE_fetch(nil, _KeyTypeED25519.ptr(), nil)
 +		if sig != nil {
 +			ossl.EVP_SIGNATURE_free(sig)
@@ -29119,10 +29090,10 @@ index 00000000000000..205b01cd36b206
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go
 new file mode 100644
-index 00000000000000..65f4d2ddcbc6fb
+index 00000000000000..3752d3ce4d18bd
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go
-@@ -0,0 +1,615 @@
+@@ -0,0 +1,616 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -29284,8 +29255,7 @@ index 00000000000000..65f4d2ddcbc6fb
 +	hash.ch = ch
 +	hash.size = int(ossl.EVP_MD_get_size(hash.md))
 +	hash.blockSize = int(ossl.EVP_MD_get_block_size(hash.md))
-+	switch major() {
-+	case 3, 4:
++	if major() != 1 {
 +		// On OpenSSL 3, directly operating on a EVP_MD object
 +		// not created by EVP_MD_fetch has negative performance
 +		// implications, as digest operations will have
@@ -29306,23 +29276,27 @@ index 00000000000000..65f4d2ddcbc6fb
 +	switch major() {
 +	case 1:
 +		hash.provider = providerOSSLDefault
-+	case 3, 4:
++	default:
 +		if prov := ossl.EVP_MD_get0_provider(hash.md); prov != nil {
 +			cname := ossl.OSSL_PROVIDER_get0_name(prov)
++			// Marshalability depends on knowing the EVP_MD_CTX internal
++			// layout for this major (see getOSSLDigetsContext). Untested
++			// majors loaded via GODEBUG=ms_opensslallowuntested=1 leave
++			// marshallable false so MarshalBinary/UnmarshalBinary return
++			// errMarshallUnsupported{} instead of touching unknown memory.
++			known := knownMajor()
 +			switch goString(cname) {
 +			case "default":
 +				hash.provider = providerOSSLDefault
-+				hash.marshallable = hash.magic != ""
++				hash.marshallable = known && hash.magic != ""
 +			case "fips":
 +				hash.provider = providerOSSLFIPS
-+				hash.marshallable = hash.magic != ""
++				hash.marshallable = known && hash.magic != ""
 +			case "symcryptprovider":
 +				hash.provider = providerSymCrypt
-+				hash.marshallable = hash.magic != "" && isSymCryptHashStateSerializable(hash.md)
++				hash.marshallable = known && hash.magic != "" && isSymCryptHashStateSerializable(hash.md)
 +			}
 +		}
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +
 +	cacheMD.Store(ch, &hash)
@@ -29358,7 +29332,7 @@ index 00000000000000..65f4d2ddcbc6fb
 +		if _, err := ossl.EVP_PKEY_keygen(ctx, &pkey); err != nil {
 +			return nil, err
 +		}
-+	case 3, 4:
++	default:
 +		var err error
 +		switch id {
 +		case ossl.EVP_PKEY_RSA:
@@ -29385,8 +29359,6 @@ index 00000000000000..65f4d2ddcbc6fb
 +		if err != nil {
 +			return nil, err
 +		}
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +
 +	return pkey, nil
@@ -29511,10 +29483,10 @@ index 00000000000000..65f4d2ddcbc6fb
 +		copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
 +		var err error
 +		switch major() {
-+		case 3, 4:
-+			_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Slice(clabel, len(label)))
-+		default:
++		case 1:
 +			_, err = ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_OAEP_LABEL, int32(len(label)), unsafe.Pointer(clabel))
++		default:
++			_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Slice(clabel, len(label)))
 +		}
 +		if err != nil {
 +			cryptoFree(unsafe.Pointer(clabel))
@@ -30267,10 +30239,10 @@ index 00000000000000..020323eb7be25e
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hkdf.go
 new file mode 100644
-index 00000000000000..75207faf1aa043
+index 00000000000000..6ae76c729a7aa0
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hkdf.go
-@@ -0,0 +1,330 @@
+@@ -0,0 +1,312 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -30289,11 +30261,9 @@ index 00000000000000..75207faf1aa043
 +	switch major() {
 +	case 1:
 +		return true
-+	case 3, 4:
++	default:
 +		_, err := fetchHKDF3()
 +		return err == nil
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +}
 +
@@ -30302,18 +30272,14 @@ index 00000000000000..75207faf1aa043
 +	switch major() {
 +	case 1:
 +		return false
-+	case 3, 4:
++	default:
 +		// TLS13-KDF is available in OpenSSL 3.0.0 and later.
 +		_, err := fetchTLS13_KDF()
 +		return err == nil
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +}
 +
 +func newHKDFCtx1(md ossl.EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, info []byte) (ctx ossl.EVP_PKEY_CTX_PTR, err error) {
-+	checkMajorVersion(1)
-+
 +	ctx, err = ossl.EVP_PKEY_CTX_new_id(ossl.EVP_PKEY_HKDF, nil)
 +	if err != nil {
 +		return nil, err
@@ -30402,7 +30368,7 @@ index 00000000000000..75207faf1aa043
 +			return nil, err
 +		}
 +		return out[:keylen], nil
-+	case 3, 4:
++	default:
 +		ctx, err := newHKDFCtx3(md, ossl.EVP_KDF_HKDF_MODE_EXTRACT_ONLY, secret, salt, nil, nil)
 +		if err != nil {
 +			return nil, err
@@ -30417,8 +30383,6 @@ index 00000000000000..75207faf1aa043
 +			return nil, err
 +		}
 +		return out, nil
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +}
 +
@@ -30451,7 +30415,7 @@ index 00000000000000..75207faf1aa043
 +		if _, err := ossl.EVP_PKEY_derive(ctx, out, &keylen); err != nil {
 +			return nil, err
 +		}
-+	case 3, 4:
++	default:
 +		ctx, err := newHKDFCtx3(md, ossl.EVP_KDF_HKDF_MODE_EXPAND_ONLY, nil, nil, pseudorandomKey, info)
 +		if err != nil {
 +			return nil, err
@@ -30466,8 +30430,6 @@ index 00000000000000..75207faf1aa043
 +		if _, err := ossl.EVP_KDF_derive(ctx, out, nil); err != nil {
 +			return nil, err
 +		}
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +	return out, nil
 +}
@@ -30501,8 +30463,6 @@ index 00000000000000..75207faf1aa043
 +// It is safe to call this function concurrently.
 +// The returned EVP_KDF_PTR shouldn't be freed.
 +var fetchTLS13_KDF = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
-+	checkMajorVersion(3, 4)
-+
 +	kdf, err := ossl.EVP_KDF_fetch(nil, _OSSL_KDF_NAME_TLS13_KDF.ptr(), nil)
 +	if err != nil {
 +		return nil, err
@@ -30512,8 +30472,6 @@ index 00000000000000..75207faf1aa043
 +
 +// newTLS13KDFExpandCtx3 fetches the "TLS13-KDF" for TLS 1.3 handshakes.
 +func newTLS13KDFExpandCtx3(md ossl.EVP_MD_PTR, label, context, pseudorandomKey []byte) (_ ossl.EVP_KDF_CTX_PTR, err error) {
-+	checkMajorVersion(3, 4)
-+
 +	kdf, err := fetchTLS13_KDF()
 +	if err != nil {
 +		return nil, err
@@ -30554,8 +30512,6 @@ index 00000000000000..75207faf1aa043
 +// It is safe to call this function concurrently.
 +// The returned EVP_KDF_PTR shouldn't be freed.
 +var fetchHKDF3 = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
-+	checkMajorVersion(3, 4)
-+
 +	kdf, err := ossl.EVP_KDF_fetch(nil, _OSSL_KDF_NAME_HKDF.ptr(), nil)
 +	if err != nil {
 +		return nil, err
@@ -30565,8 +30521,6 @@ index 00000000000000..75207faf1aa043
 +
 +// newHKDFCtx3 implements HKDF for OpenSSL 3 using the EVP_KDF API.
 +func newHKDFCtx3(md ossl.EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, info []byte) (_ ossl.EVP_KDF_CTX_PTR, err error) {
-+	checkMajorVersion(3, 4)
-+
 +	kdf, err := fetchHKDF3()
 +	if err != nil {
 +		return nil, err
@@ -30603,10 +30557,10 @@ index 00000000000000..75207faf1aa043
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
 new file mode 100644
-index 00000000000000..88f6ce7eb85ca1
+index 00000000000000..6402a9b3d0f30a
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hmac.go
-@@ -0,0 +1,280 @@
+@@ -0,0 +1,269 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -30653,14 +30607,12 @@ index 00000000000000..88f6ce7eb85ca1
 +			return nil
 +		}
 +		hmac.ctx1 = ctx
-+	case 3, 4:
++	default:
 +		ctx := newHMAC3(key, md)
 +		if ctx.ctx == nil {
 +			return nil
 +		}
 +		hmac.ctx3 = ctx
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
 +	return hmac
@@ -30778,12 +30730,10 @@ index 00000000000000..88f6ce7eb85ca1
 +		if _, err := ossl.HMAC_Init_ex(h.ctx1.ctx, nil, nil, nil); err != nil {
 +			panic(err)
 +		}
-+	case 3, 4:
++	default:
 +		if _, err := ossl.EVP_MAC_init(h.ctx3.ctx, h.ctx3.key, nil); err != nil {
 +			panic(err)
 +		}
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +
 +	runtime.KeepAlive(h) // Next line will keep h alive too; just making doubly sure.
@@ -30803,10 +30753,8 @@ index 00000000000000..88f6ce7eb85ca1
 +		switch major() {
 +		case 1:
 +			ossl.HMAC_Update(h.ctx1.ctx, p)
-+		case 3, 4:
-+			ossl.EVP_MAC_update(h.ctx3.ctx, p)
 +		default:
-+			panic(errUnsupportedVersion())
++			ossl.EVP_MAC_update(h.ctx3.ctx, p)
 +		}
 +	}
 +	runtime.KeepAlive(h)
@@ -30837,15 +30785,13 @@ index 00000000000000..88f6ce7eb85ca1
 +			panic(err)
 +		}
 +		ossl.HMAC_Final(ctx2, h.sum[:h.size], nil)
-+	case 3, 4:
++	default:
 +		ctx2, err := ossl.EVP_MAC_CTX_dup(h.ctx3.ctx)
 +		if err != nil {
 +			panic(err)
 +		}
 +		defer ossl.EVP_MAC_CTX_free(ctx2)
 +		ossl.EVP_MAC_final(ctx2, h.sum[:h.size], nil)
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +	return append(in, h.sum[:h.size]...)
 +}
@@ -30869,7 +30815,7 @@ index 00000000000000..88f6ce7eb85ca1
 +		runtime.SetFinalizer(cl, (*opensslHMAC).finalize)
 +		return cl, nil
 +
-+	case 3, 4:
++	default:
 +		ctx2, err := ossl.EVP_MAC_CTX_dup(h.ctx3.ctx)
 +		if err != nil {
 +			panic(err)
@@ -30882,9 +30828,6 @@ index 00000000000000..88f6ce7eb85ca1
 +		}
 +		runtime.SetFinalizer(cl, (*opensslHMAC).finalize)
 +		return cl, nil
-+
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/mldsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/mldsa.go
@@ -31719,10 +31662,10 @@ index 00000000000000..5c2ffbabe92e15
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
 new file mode 100644
-index 00000000000000..94fd563ac87978
+index 00000000000000..e0291c15a18c00
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/openssl.go
-@@ -0,0 +1,183 @@
+@@ -0,0 +1,182 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -31766,22 +31709,21 @@ index 00000000000000..94fd563ac87978
 +	return osslsetup.VersionPatch()
 +}
 +
++// knownMajor reports whether the loaded OpenSSL major is one this
++// backend has been tested against. Untested majors are only reachable
++// behind GODEBUG=ms_opensslallowuntested=1; code paths that rely on
++// version-specific layouts (e.g. EVP_MD_CTX internals) must guard on
++// this so they degrade safely instead of touching unknown memory.
++func knownMajor() bool {
++	return osslsetup.IsTestedMajor(major())
++}
++
 +func utoa(n int) string {
 +	return strconv.FormatUint(uint64(n), 10)
 +}
 +
 +func errUnsupportedVersion() error {
 +	return errors.New("openssl: unsupported OpenSSL version: " + utoa(major()) + "." + utoa(minor()) + "." + utoa(patch()) + " (minimum supported version is 1.1.1)")
-+}
-+
-+// checkMajorVersion panics if the current major version is not one of the expected versions.
-+func checkMajorVersion(expected ...int) {
-+	for _, v := range expected {
-+		if major() == v {
-+			return
-+		}
-+	}
-+	panic("openssl: incorrect major version (" + strconv.Itoa(major()) + ")")
 +}
 +
 +type fail string
@@ -32169,10 +32111,10 @@ index 00000000000000..8bd651d6493707
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/pbkdf2.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/pbkdf2.go
 new file mode 100644
-index 00000000000000..66af2060e2cf87
+index 00000000000000..6cba126ef9dee4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/pbkdf2.go
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,82 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -32191,11 +32133,9 @@ index 00000000000000..66af2060e2cf87
 +	switch major() {
 +	case 1:
 +		return true
-+	case 3, 4:
++	default:
 +		_, err := fetchPBKDF2()
 +		return err == nil
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +}
 +
@@ -32203,8 +32143,6 @@ index 00000000000000..66af2060e2cf87
 +// It is safe to call this function concurrently.
 +// The returned EVP_KDF_PTR shouldn't be freed.
 +var fetchPBKDF2 = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
-+	checkMajorVersion(3, 4)
-+
 +	kdf, err := ossl.EVP_KDF_fetch(nil, _OSSL_KDF_NAME_PBKDF2.ptr(), nil)
 +	if err != nil {
 +		return nil, err
@@ -32261,10 +32199,10 @@ index 00000000000000..66af2060e2cf87
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/provideropenssl.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/provideropenssl.go
 new file mode 100644
-index 00000000000000..f6a4b1ac20b654
+index 00000000000000..7c31310ff8a9ba
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/provideropenssl.go
-@@ -0,0 +1,250 @@
+@@ -0,0 +1,257 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -32462,7 +32400,14 @@ index 00000000000000..f6a4b1ac20b654
 +		}
 +		return (*mdCtx)(unsafe.Pointer(ctx)).algctx
 +	default:
-+		panic(errUnsupportedVersion())
++		// Unknown OpenSSL major: the EVP_MD_CTX internal layout is not
++		// known, so the running hash state cannot be safely extracted.
++		// loadHash marks hashes as not marshallable on untested majors
++		// (see evp.go), so MarshalBinary/UnmarshalBinary short-circuit
++		// with errMarshallUnsupported{} before calling this. The nil
++		// return is defense in depth against any future caller that
++		// bypasses that gate.
++		return nil
 +	}
 +}
 +
@@ -32979,10 +32924,10 @@ index 00000000000000..37d12ec889a91e
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 new file mode 100644
-index 00000000000000..36f84902a21ece
+index 00000000000000..a59ac6f76a1298
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
-@@ -0,0 +1,712 @@
+@@ -0,0 +1,706 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -33023,7 +32968,7 @@ index 00000000000000..36f84902a21ece
 +		N, E, D = bnToBig(n), bnToBig(e), bnToBig(d)
 +		P, Q = bnToBig(p), bnToBig(q)
 +		Dp, Dq, Qinv = bnToBig(dmp1), bnToBig(dmq1), bnToBig(iqmp)
-+	case 3, 4:
++	default:
 +		tmp, err := ossl.BN_new()
 +		if err != nil {
 +			return bad(err)
@@ -33052,8 +32997,6 @@ index 00000000000000..36f84902a21ece
 +			setBigInt(&Qinv, _OSSL_PKEY_PARAM_RSA_COEFFICIENT1)) {
 +			return bad(err)
 +		}
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +	return
 +}
@@ -33091,13 +33034,11 @@ index 00000000000000..36f84902a21ece
 +			ossl.EVP_PKEY_free(pkey)
 +			return nil, err
 +		}
-+	case 3, 4:
++	default:
 +		var err error
 +		if pkey, err = newRSAKey3(false, n, e, nil, nil, nil, nil, nil, nil); err != nil {
 +			return nil, err
 +		}
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +	k := &PublicKeyRSA{_pkey: pkey}
 +	runtime.SetFinalizer(k, (*PublicKeyRSA).finalize)
@@ -33170,13 +33111,11 @@ index 00000000000000..36f84902a21ece
 +			ossl.EVP_PKEY_free(pkey)
 +			return nil, err
 +		}
-+	case 3, 4:
++	default:
 +		var err error
 +		if pkey, err = newRSAKey3(true, n, e, d, p, q, dp, dq, qinv); err != nil {
 +			return nil, err
 +		}
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +	k := &PrivateKeyRSA{_pkey: pkey}
 +	runtime.SetFinalizer(k, (*PrivateKeyRSA).finalize)
@@ -33697,10 +33636,10 @@ index 00000000000000..36f84902a21ece
 +})
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/tls1prf.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/tls1prf.go
 new file mode 100644
-index 00000000000000..87fe3879ab48d3
+index 00000000000000..d53f18c9fbc24c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/tls1prf.go
-@@ -0,0 +1,157 @@
+@@ -0,0 +1,147 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -33720,11 +33659,9 @@ index 00000000000000..87fe3879ab48d3
 +	switch major() {
 +	case 1:
 +		return minor() >= 1
-+	case 3, 4:
++	default:
 +		_, err := fetchTLS1PRF3()
 +		return err == nil
-+	default:
-+		panic(errUnsupportedVersion())
 +	}
 +}
 +
@@ -33754,17 +33691,13 @@ index 00000000000000..87fe3879ab48d3
 +	switch major() {
 +	case 1:
 +		return tls1PRF1(result, secret, label, seed, md)
-+	case 3, 4:
-+		return tls1PRF3(result, secret, label, seed, md)
 +	default:
-+		return errUnsupportedVersion()
++		return tls1PRF3(result, secret, label, seed, md)
 +	}
 +}
 +
 +// tls1PRF1 implements TLS1PRF for OpenSSL 1 using the EVP_PKEY API.
 +func tls1PRF1(result, secret, label, seed []byte, md ossl.EVP_MD_PTR) error {
-+	checkMajorVersion(1)
-+
 +	ctx, err := ossl.EVP_PKEY_CTX_new_id(ossl.EVP_PKEY_TLS1_PRF, nil)
 +	if err != nil {
 +		return err
@@ -33818,8 +33751,6 @@ index 00000000000000..87fe3879ab48d3
 +// It is safe to call this function concurrently.
 +// The returned EVP_KDF_PTR shouldn't be freed.
 +var fetchTLS1PRF3 = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
-+	checkMajorVersion(3, 4)
-+
 +	kdf, err := ossl.EVP_KDF_fetch(nil, _OSSL_KDF_NAME_TLS1_PRF.ptr(), nil)
 +	if err != nil {
 +		return nil, err
@@ -33829,8 +33760,6 @@ index 00000000000000..87fe3879ab48d3
 +
 +// tls1PRF3 implements TLS1PRF for OpenSSL 3 using the EVP_KDF API.
 +func tls1PRF3(result, secret, label, seed []byte, md ossl.EVP_MD_PTR) error {
-+	checkMajorVersion(3, 4)
-+
 +	kdf, err := fetchTLS1PRF3()
 +	if err != nil {
 +		return err
@@ -33953,10 +33882,10 @@ index 00000000000000..ac79a864271eee
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/osslsetup/fips.go b/src/vendor/github.com/microsoft/go-crypto-openssl/osslsetup/fips.go
 new file mode 100644
-index 00000000000000..2084b384b9f3a9
+index 00000000000000..38e4b34472dd55
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/osslsetup/fips.go
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,115 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -33991,20 +33920,59 @@ index 00000000000000..2084b384b9f3a9
 +}
 +
 +const (
-+	_ProviderNameFips   cString = "fips\x00"
++	// Provider names
++	_ProviderNameFips cString = "fips\x00"
++
++	// Digest Names
 +	_DigestNameSHA2_256 cString = "SHA2-256\x00"
 +)
 +
-+// FIPS returns true if the provider used by default matches the `fips=yes` query.
-+// It is useful for checking whether OpenSSL is capable of running in FIPS mode regardless
-+// of whether the `fips=yes` query is explicitly enabled. For example, Azure Linux 3 doesn't set the
-+// `fips=yes` query in the default properties, but sets the default provider to be SCOSSL,
-+// which is FIPS-capable.
++// FIPS returns true if OpenSSL is running in FIPS mode and there is
++// a provider available that supports FIPS. It returns false otherwise.
++// All OpenSSL functions used in here should be tagged with "init_1" or "init_3" in shims.h.
 +func FIPS() bool {
 +	switch vMajor {
 +	case 1:
 +		return ossl.FIPS_mode() == 1
++	case 3, 4:
++		// Check if the default properties contain `fips=1`.
++		if ossl.EVP_default_properties_is_fips_enabled(nil) != 1 {
++			// Note that it is still possible that the provider used by default is FIPS-compliant,
++			// but that wouldn't be a system or user requirement.
++			return false
++		}
++		// Check if the SHA-256 algorithm is available. If it is, then we can be sure that there is a provider available that matches
++		// the `fips=1` query. Most notably, this works for the common case of using the built-in FIPS provider.
++		//
++		// Note that this approach has a small chance of false negative if the FIPS provider doesn't provide the SHA-256 algorithm,
++		// but that is highly unlikely because SHA-256 is one of the most common algorithms and fundamental to many cryptographic operations.
++		// It also has a small chance of false positive if the FIPS provider implements the SHA-256 algorithm but not the other algorithms
++		// used by the caller application, but that is also unlikely because the FIPS provider should provide all common algorithms.
++		return proveSHA256("")
 +	default:
++		panic(errUnsupportedVersion())
++	}
++}
++
++// FIPSCapable returns true if the provider used by default matches the `fips=yes` query.
++// It is useful for checking whether OpenSSL is capable of running in FIPS mode regardless
++// of whether FIPS mode is explicitly enabled. For example, Azure Linux 3 doesn't set the
++// `fips=yes` query in the default properties, but sets the default provider to be SCOSSL,
++// which is FIPS-capable.
++//
++// Considerations:
++//   - Can return true even if [FIPS] returns false, because [FIPS] also checks whether
++//     the default properties contain `fips=yes`.
++//   - When using OpenSSL 3, will always return true if [FIPS] returns true.
++//   - When using OpenSSL 1, will always return the same value as [FIPS].
++//   - OpenSSL 3 doesn't provide a way to know if a provider is FIPS-capable. This function uses
++//     some heuristics that should be treated as an implementation detail that may change in the future.
++func FIPSCapable() bool {
++	if FIPS() {
++		return true
++	}
++	switch vMajor {
++	case 3, 4:
 +		// Load the provider with and without the `fips=yes` query.
 +		// If the providers are the same, then the default provider is FIPS-capable.
 +		provFIPS := sha256Provider(_ProviderNameFips)
@@ -34014,6 +33982,7 @@ index 00000000000000..2084b384b9f3a9
 +		provDefault := sha256Provider("")
 +		return provFIPS == provDefault
 +	}
++	return false
 +}
 +
 +// sha256Provider returns the provider for the SHA-256 algorithm
@@ -34025,6 +33994,12 @@ index 00000000000000..2084b384b9f3a9
 +	}
 +	defer ossl.EVP_MD_free(md)
 +	return ossl.EVP_MD_get0_provider(md)
++}
++
++// proveSHA256 checks if the SHA-256 algorithm is available
++// using the given properties.
++func proveSHA256(props cString) bool {
++	return sha256Provider(props) != nil
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/osslsetup/init.go b/src/vendor/github.com/microsoft/go-crypto-openssl/osslsetup/init.go
 new file mode 100644
@@ -34328,10 +34303,10 @@ index 00000000000000..312dfc88d7f311
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/osslsetup/osslsetup.go b/src/vendor/github.com/microsoft/go-crypto-openssl/osslsetup/osslsetup.go
 new file mode 100644
-index 00000000000000..189335d93c80f8
+index 00000000000000..ed33d8efe1edbb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/osslsetup/osslsetup.go
-@@ -0,0 +1,109 @@
+@@ -0,0 +1,123 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -34356,6 +34331,20 @@ index 00000000000000..189335d93c80f8
 +// at 1.1.1+; that minor/patch constraint is enforced separately in
 +// [openLibrary].
 +var testedMajors = [...]int{1, 3, 4}
++
++// IsTestedMajor reports whether m is one of the OpenSSL major versions
++// this backend has been tested against (see [testedMajors]). Callers
++// that depend on version-specific layouts or behaviors should gate on
++// this so they degrade safely on untested majors loaded via
++// GODEBUG=ms_opensslallowuntested=1.
++func IsTestedMajor(m int) bool {
++	for _, v := range testedMajors {
++		if v == m {
++			return true
++		}
++	}
++	return false
++}
 +
 +// allowUntestedMajor reports whether the user has set
 +// GODEBUG=ms_opensslallowuntested=1. The "ms_" prefix marks this as a
@@ -39941,7 +39930,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index d72017d2a43c1e..277d1992ac034f 100644
+index d72017d2a43c1e..a81d4929faa013 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
@@ -39954,7 +39943,7 @@ index d72017d2a43c1e..277d1992ac034f 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-openssl v0.0.0-20260521090922-bd6798f35c69
++# github.com/microsoft/go-crypto-openssl v0.0.0-20260526094617-f3ee9e48499e
 +## explicit; go 1.25
 +github.com/microsoft/go-crypto-openssl/bbig
 +github.com/microsoft/go-crypto-openssl/internal/fakecgo

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -146,10 +146,10 @@ index 0e32e0769ee2e2..eda2d576acc6c6 100644
  	if doReplacement {
  		if testCompiler == "" {
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index de2c7be2e833f9..415f4baeff2510 100644
+index 78d55bec559987..bb3119ef0823d7 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -1398,6 +1398,80 @@ func toolenv() []string {
+@@ -1399,6 +1399,80 @@ func toolenv() []string {
  		// still have full paths for stack traces for compiler crashes and the like.
  		env = append(env, "GOFLAGS=-trimpath -ldflags=-w -gcflags=cmd/...=-dwarf=false")
  	}
@@ -230,7 +230,7 @@ index de2c7be2e833f9..415f4baeff2510 100644
  	return env
  }
  
-@@ -1640,12 +1714,12 @@ func cmdbootstrap() {
+@@ -1641,12 +1715,12 @@ func cmdbootstrap() {
  		os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
  		xprintf("Building packages and commands for target, %s/%s.\n", goos, goarch)
  	}
@@ -336,7 +336,7 @@ index 47839e0229b951..2d1a7fa99d551e 100644
  	tg.parallel()
  	defer tg.cleanup()
 diff --git a/src/cmd/go/internal/cfg/cfg.go b/src/cmd/go/internal/cfg/cfg.go
-index a4edd854f1d35a..10ee92536b96cd 100644
+index 78cbbb949e7c27..dcf9d04dd979f3 100644
 --- a/src/cmd/go/internal/cfg/cfg.go
 +++ b/src/cmd/go/internal/cfg/cfg.go
 @@ -19,6 +19,7 @@ import (
@@ -674,7 +674,7 @@ index 2f46a6b44bffe1..69071289e2de81 100644
  
  ! go build -o $devnull cmd/buildid
 diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index 07984396b7d44e..c7fbda270159f3 100644
+index d81b3a849cb975..bbeca248e4f8e4 100644
 --- a/src/cmd/internal/testdir/testdir_test.go
 +++ b/src/cmd/internal/testdir/testdir_test.go
 @@ -118,6 +118,13 @@ func Test(t *testing.T) {
@@ -1187,7 +1187,7 @@ index 00000000000000..73830cae246cbd
 +}
 diff --git a/src/crypto/internal/backend/backend_linux.go b/src/crypto/internal/backend/backend_linux.go
 new file mode 100644
-index 00000000000000..a28f644c950f86
+index 00000000000000..d8073b4f6c282e
 --- /dev/null
 +++ b/src/crypto/internal/backend/backend_linux.go
 @@ -0,0 +1,435 @@
@@ -1226,8 +1226,8 @@ index 00000000000000..a28f644c950f86
 +	// but they configure OpenSSL to use a FIPS-compliant provider (in the case of Azure Linux 3, the SCOSSL provider).
 +	// In this cases, openssl.FIPS would return `false` and openssl.FIPSCapable would return `true`.
 +	// We don't care about the `fips=yes` property as long as the provider is FIPS-compliant, so use
-+	// osslsetup.FIPS to determine whether FIPS mode is enabled.
-+	if err := fips140.Check(func() bool { return osslsetup.FIPS() }); err != nil {
++	// osslsetup.FIPSCapable to determine whether FIPS mode is enabled.
++	if err := fips140.Check(func() bool { return osslsetup.FIPSCapable() }); err != nil {
 +		// This path can be reached for the following reasons:
 +		// - In OpenSSL 1, the active engine doesn't support FIPS mode.
 +		// - In OpenSSL 1, the active engine supports FIPS mode, but it is not enabled.
@@ -3308,7 +3308,7 @@ index 00000000000000..7500bd3a86472b
 +	`
 +}
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 504426b5fe97f2..a8aee3a4bccda3 100644
+index 920e72e5cdbb9d..2135c64d86664d 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -368,7 +368,7 @@ var depsRules = `


### PR DESCRIPTION
A previous PR removed `FIPSCapable`, as the OpenSL backend merged it with `FIPS()`. Both functions are useful independently, so the OpenSSL backend reverted the change.