### PR TITLE
Update project documentation structure and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,32 +28,33 @@ The submodule is updated regularly to the latest commit available in both the up
 
 ## Support
 
-This project follows the upstream Go
-[Release Policy](https://go.dev/doc/devel/release#policy).
-This means we support each major release (1.X) until there are two newer major
-releases. A new Go major version is
-[released every six months](https://github.com/golang/go/wiki/Go-Release-Cycle),
-so each Go major version is supported for about one year.
+See [SUPPORT.md](SUPPORT.md) for more information about reporting bugs, requesting features, and asking questions.
 
-When upstream Go releases a new minor version (1.X.Y), we release a
-corresponding microsoft/go version that may also include fork-specific changes.
+There are a few additional support resources internal to Microsoft:
+
+* [Languages at Microsoft: Introduction to Go](https://eng.ms/docs/more/languages-at-microsoft/go/articles/overview).
+* [Languages at Microsoft: Get Help with Go](https://eng.ms/docs/more/languages-at-microsoft/go/articles/support).
+  * Includes internal Microsoft support channels such as an email contact for our team and a community Teams group.
+
+## Release cycle and policy
+
+This project follows the upstream Go [Release Policy](https://go.dev/doc/devel/release#policy).
+This means we support each major release (1.X) until there are two newer major releases.
+A new Go major version is [released every six months](https://github.com/golang/go/wiki/Go-Release-Cycle), so each Go major version is supported for about one year.
+
+When upstream Go releases a new minor version (1.X.Y), we release a corresponding microsoft/go version that may also include fork-specific changes.
 This normally happens once a month.
 
 At any time, we may release a new revision (1.X.Y-Z) to fix an issue without waiting for the next upstream minor release.
 Revision releases are uncommon.
 
-Each microsoft/go release is announced at the
-[Microsoft for Go Developers](https://devblogs.microsoft.com/go/) blog.
-Check out the upstream [golang-announce mailing list](https://groups.google.com/g/golang-announce)
-for a summary of the changes in each upstream Go version.
+We announce each Microsoft build of Go release through the following channels:
 
-See [SUPPORT.md](SUPPORT.md) for more information about reporting bugs, requesting features, and asking questions.
+* [Microsoft for Go Developers blog](https://devblogs.microsoft.com/go/).
+* [Microsoft-internal email distribution list 📧 (instant join link)](https://idwebelements.microsoft.com/GroupManagement.aspx?Group=golang-announce&Operation=join).
 
-There are a few additional support resources internal to Microsoft:
-
-* [Languages at Microsoft: Go](https://eng.ms/docs/more/languages-at-microsoft/go/articles/overview).
-* [A Microsoft-internal email distribution list 📧 (instant join link)](https://idwebelements.microsoft.com/GroupManagement.aspx?Group=golang-announce&Operation=join)
-  for release announcements.
+The Go team announces upstream releases on the [golang-announce mailing list](https://groups.google.com/g/golang-announce).
+These announcement emails include a carefully written summary of the changes that may not be found elsewhere.
 
 ## Download and install
 
@@ -76,7 +77,7 @@ The [Installation](eng/doc/Installation.md) documentation contains sections desc
 * [Azure Pipelines `GoTool@0` task](eng/doc/Installation.md#azure-pipelines-gotool0-task)
 * [GitHub Actions `setup-go` action](eng/doc/Installation.md#github-actions-setup-go-action)
 * [The `go-install.ps1` script](eng/doc/Installation.md#the-go-installps1-script)
-* [Binary archive](eng/doc/Installation.md#binary-archive)
+* [Binary archive](eng/doc/Installation.md#binary-archive) (`tar.gz` and `zip`)
 * [Build from source](eng/doc/Installation.md#build-from-source)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ See [SUPPORT.md](SUPPORT.md) for more information about reporting bugs, requesti
 
 There are a few additional support resources internal to Microsoft:
 
-* [Languages at Microsoft: Introduction to Go](https://eng.ms/docs/more/languages-at-microsoft/go/articles/overview).
-* [Languages at Microsoft: Get Help with Go](https://eng.ms/docs/more/languages-at-microsoft/go/articles/support).
+* [(Microsoft-internal) Languages at Microsoft: Introduction to Go](https://eng.ms/docs/more/languages-at-microsoft/go/articles/overview).
+* [(Microsoft-internal) Languages at Microsoft: Get Help with Go](https://eng.ms/docs/more/languages-at-microsoft/go/articles/support).
   * Includes internal Microsoft support channels such as an email contact for our team and a community Teams group.
 
 ## Release cycle and policy

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,6 +4,9 @@ For help and questions about the Go programming language and tools, visit the of
 
 Take a look at the [Migration Guide](eng/doc/MigrationGuide.md) for more information about migrating from the official build of Go to the Microsoft build of Go, specifically.
 
+> [!TIP]
+> Additional support options internal to Microsoft are listed in the ["Support" section of the README file](README.md#support).
+
 ## How to file issues and get help
 
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing

--- a/eng/doc/README.md
+++ b/eng/doc/README.md
@@ -1,10 +1,23 @@
-This directory, `/eng/doc`, contains documents describing the Microsoft
-infrastructure used to build Go, in particular any designs that are not obvious
-by reading the infrastructure code itself.
+# `/eng/doc` - Documentation for the Microsoft build of Go
 
-For cryptography information, see the [CrossPlatformCryptography.md](CrossPlatformCryptography.md) doc.
-For dev scenario documentation, see the [DeveloperGuide.md](DeveloperGuide.md) doc.
-For telemetry details, see the [Telemetry.md](Telemetry.md) doc.
+This directory, `/eng/doc`, contains detailed documents describing the Microsoft build of Go.
 
-The [Downloads.md](Downloads.md) doc contains a table of links to the latest assets for each supported Go release branch.
-The [release-branch-links.json](release-branch-links.json) file contains the same data in JSON format suitable for parsing.
+> [!IMPORTANT]
+> These documents are only actively maintained in the `microsoft/main` branch.
+> If you're viewing this file in a release branch, it may be stale.
+> [If you're not sure, click here to go to the maintained version of this document.](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/README.md)
+
+## Setup
+
+* [Migration Guide](MigrationGuide.md)
+* [Installation](Installation.md)
+  * [Downloading a binary release](Downloads.md)
+* [Developer Guide](DeveloperGuide.md) (for new contributors to the Microsoft build of Go)
+
+## Features
+
+* [Additional Features Provided by the Microsoft build of Go](AdditionalFeatures.md)
+* [Cross-Platform Cryptography in the Microsoft build of Go](CrossPlatformCryptography.md)
+* [Microsoft Toolset Identification](MicrosoftToolsetIdentification.md)
+* [No-cgo OpenSSL Backend](NocgoOpenSSL.md)
+* [Telemetry in the Microsoft build of Go](Telemetry.md)


### PR DESCRIPTION
A few people tried to contact us recently and didn't all find the channels they were expecting. (If anyone sees this: issues are great! Pinging individual developers internally is also fine, but causes delayed responses.) With that in mind, took another look at these docs.

The main change is to focus the "Support" section on product support and move "what versions of Go do you support" to its own distinct section. I expect that some people see how the Support section starts and ignore the rest because it's the wrong kind of support.

Including a hint about what support details people will find on the internal page may entice users to go there. Sometimes eng.ms doesn't load cleanly (for me) and without knowing what I'm going to find there, I might not browse it. (This might also be a useful hint for anyone asking Copilot to find these details.)

Leave SUPPORT.md to be specific to GitHub, but include a link back to the readme to make the internal support channels more discoverable.

Add a "(`tar.gz` and `zip`)" note to the "Binary archive" link. That list has gotten busier, and sometimes I don't remember that name for what I'm looking for, and these terms stand out more. (Not all that related to the other changes, just a personal nitpick.)

Improve `eng/doc/README.md`: simplify the links by using descriptive names from headers, fill out the list, and tidy up.