### PR TITLE
Use env flag for nosystemcrypto builders

### DIFF
--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -8,7 +8,7 @@ parameters:
   - name: ctx
     type: object
 
-  # [] of { id, os, arch, hostarch, config, distro?, experiment?, nosystemcrypto?, fips?, broken? }
+  # [] of { id, os, arch, hostArch, config, distro?, experiment?, nosystemcrypto?, fips?, broken? }
   - name: builders
     type: object
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.

--- a/eng/pipeline/stages/builders-to-stages.yml
+++ b/eng/pipeline/stages/builders-to-stages.yml
@@ -8,7 +8,7 @@ parameters:
   - name: ctx
     type: object
 
-  # [] of { id, os, arch, hostarch, config, distro?, experiment?, broken? }
+  # [] of { id, os, arch, hostarch, config, distro?, experiment?, nosystemcrypto?, fips?, broken? }
   - name: builders
     type: object
   # If true, include a signing stage+job that depends on all 'buildandpack' builder jobs finishing.

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -77,50 +77,50 @@ stages:
           - ${{ if parameters.includeArm64Host }}:
             - { os: linux, arch: arm64, config: buildandpack }
         - ${{ if parameters.innerloop }}:
-          - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: devscript }
-          - { experiment: nosystemcrypto, os: darwin, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: darwin, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: darwin, arch: amd64, config: nocgo }
-          - { experiment: systemcrypto, os: darwin, arch: amd64, config: test, fips: true }
-          - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: devscript }
-          - { experiment: nosystemcrypto, os: darwin, arch: arm64, config: test }
-          - { experiment: systemcrypto, os: darwin, arch: arm64, config: test }
-          - { experiment: systemcrypto, os: darwin, arch: arm64, config: test, fips: true }
-          # - { experiment: nosystemcrypto, os: windows, arch: arm64, config: test }
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: devscript }
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: test }
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, fips: true }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: nocgo, fips: true }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: ubuntu }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: nocgo, distro: ubuntu }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3 }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: nocgo, distro: azurelinux3 }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: nocgo, distro: azurelinux3, fips: true }
-          - { experiment: nosystemcrypto, os: windows, arch: amd64, config: devscript }
-          - { experiment: nosystemcrypto, os: windows, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: windows, arch: amd64, config: test }
-          - { experiment: systemcrypto, os: windows, arch: amd64, config: test, fips: true }
+          - { nosystemcrypto: true, os: darwin, arch: amd64, config: devscript }
+          - { nosystemcrypto: true, os: darwin, arch: amd64, config: test }
+          - { os: darwin, arch: amd64, config: test }
+          - { os: darwin, arch: amd64, config: nocgo }
+          - { os: darwin, arch: amd64, config: test, fips: true }
+          - { nosystemcrypto: true, os: darwin, arch: arm64, config: devscript }
+          - { nosystemcrypto: true, os: darwin, arch: arm64, config: test }
+          - { os: darwin, arch: arm64, config: test }
+          - { os: darwin, arch: arm64, config: test, fips: true }
+          # - { nosystemcrypto: true, os: windows, arch: arm64, config: test }
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: devscript }
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: test }
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: test, distro: ubuntu }
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: test, distro: azurelinux3 }
+          - { os: linux, arch: amd64, config: test }
+          - { os: linux, arch: amd64, config: test, fips: true }
+          - { os: linux, arch: amd64, config: nocgo, fips: true }
+          - { os: linux, arch: amd64, config: test, distro: ubuntu }
+          - { os: linux, arch: amd64, config: nocgo, distro: ubuntu }
+          - { os: linux, arch: amd64, config: test, distro: azurelinux3 }
+          - { os: linux, arch: amd64, config: nocgo, distro: azurelinux3 }
+          - { os: linux, arch: amd64, config: test, distro: azurelinux3, fips: true }
+          - { os: linux, arch: amd64, config: nocgo, distro: azurelinux3, fips: true }
+          - { nosystemcrypto: true, os: windows, arch: amd64, config: devscript }
+          - { nosystemcrypto: true, os: windows, arch: amd64, config: test }
+          - { os: windows, arch: amd64, config: test }
+          - { os: windows, arch: amd64, config: test, fips: true }
           - { experiment: ms_tls_config_schannel, os: windows, arch: amd64, config: test }
           # Test that buildandpack works on Windows x86-32, but don't release it.
-          - { experiment: nosystemcrypto, os: windows, hostArch: amd64, arch: 386, config: buildandpack }
+          - { nosystemcrypto: true, os: windows, hostArch: amd64, arch: 386, config: buildandpack }
         - ${{ if parameters.outerloop }}:
           # Upstream builders.
-          # - { experiment: nosystemcrypto, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: longtest }
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: nocgo }
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: noopt }
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: race }
-          # - { os: experiment: nosystemcrypto, linux, arch: amd64, config: racecompile } https://github.com/microsoft/go/issues/54
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: regabi }
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: ssacheck }
-          - { experiment: nosystemcrypto, os: linux, arch: amd64, config: staticlockranking }
-          # - { experiment: systemcrypto, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: longtest }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: race }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: regabi }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: ssacheck }
-          - { experiment: systemcrypto, os: linux, arch: amd64, config: staticlockranking }
+          # - { nosystemcrypto: true, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: longtest }
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: nocgo }
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: noopt }
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: race }
+          # - { nosystemcrypto: true, os: linux, arch: amd64, config: racecompile } https://github.com/microsoft/go/issues/54
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: regabi }
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: ssacheck }
+          - { nosystemcrypto: true, os: linux, arch: amd64, config: staticlockranking }
+          # - { os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342
+          - { os: linux, arch: amd64, config: longtest }
+          - { os: linux, arch: amd64, config: race }
+          - { os: linux, arch: amd64, config: regabi }
+          - { os: linux, arch: amd64, config: ssacheck }
+          - { os: linux, arch: amd64, config: staticlockranking }

--- a/eng/pipeline/stages/run-codeql.yml
+++ b/eng/pipeline/stages/run-codeql.yml
@@ -8,7 +8,7 @@ parameters:
   - name: ctx
     type: object
 
-  # { id, os, arch, hostArch, config, distro?, experiment?, fips?, broken? }
+  # { id, os, arch, hostArch, config, distro?, experiment?, nosystemcrypto?, fips?, broken? }
   - name: builder
     type: object
 
@@ -45,11 +45,11 @@ stages:
   - stage: ${{ parameters.builder.id }}
     # For display name, try for readability. Use some parameters set by
     # shorthand-builders-to-builders.yml that let us add some formatting.
-    displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.fipsAcronym }}
+    displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.nosystemcryptoBrackets }} ${{ parameters.builder.fipsAcronym }}
     dependsOn: []
     jobs:
       - job: ${{ parameters.builder.id }}
-        displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.fipsAcronym }}
+        displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.nosystemcryptoBrackets }} ${{ parameters.builder.fipsAcronym }}
         workspace:
           clean: all
 

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -8,7 +8,7 @@ parameters:
   - name: ctx
     type: object
 
-  # { id, os, arch, hostArch, config, distro?, experiment?, fips?, broken? }
+  # { id, os, arch, hostArch, config, distro?, experiment?, nosystemcrypto?, fips?, broken? }
   - name: builder
     type: object
 
@@ -38,11 +38,11 @@ stages:
   - stage: ${{ parameters.builder.id }}
     # For display name, try for readability. Use some parameters set by
     # shorthand-builders-to-builders.yml that let us add some formatting.
-    displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.fipsAcronym }}
+    displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.nosystemcryptoBrackets }} ${{ parameters.builder.fipsAcronym }}
     dependsOn: []
     jobs:
       - job: ${{ parameters.builder.id }}
-        displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.fipsAcronym }}
+        displayName: ${{ parameters.builder.os }}-${{ parameters.builder.arch }} ${{ parameters.builder.hostParens}} ${{ parameters.builder.config }} ${{ parameters.builder.distroParens}} ${{ parameters.builder.experimentBrackets }} ${{ parameters.builder.nosystemcryptoBrackets }} ${{ parameters.builder.fipsAcronym }}
         workspace:
           clean: all
 
@@ -180,6 +180,8 @@ stages:
                   PACK_SOURCE_ARG: '-packsource'
                 ${{ if eq(variables.createPDB, true) }}:
                   CREATE_PDB_ARG: '-pdb'
+                ${{ if parameters.builder.nosystemcrypto }}:
+                  MS_GO_NOSYSTEMCRYPTO: 1
               displayName: Build and Pack
 
             # We want to create a checksum as early as possible, but Windows signing involves
@@ -237,6 +239,9 @@ stages:
                     -builder '${{ parameters.builder.os }}-${{ parameters.builder.arch }}-${{ parameters.builder.config }}' `
                     $(if ('${{ parameters.builder.experiment }}') { '-experiment'; '${{ parameters.builder.experiment }}' }) `
                     $(if ('${{ parameters.builder.fips }}') { '-fipsmode' })
+              ${{ if parameters.builder.nosystemcrypto }}:
+                env:
+                  MS_GO_NOSYSTEMCRYPTO: 1
               displayName: Build
 
             # Run each test retry attempt in its own step. Benefits over a single step:
@@ -267,6 +272,9 @@ stages:
                       $(if ('${{ parameters.builder.fips }}') { '-fipsmode' }) `
                       -junitout '$(Build.SourcesDirectory)/eng/artifacts/RawTestOutput/TestResults-attempt-${{ attempt }}.xml' `
                       -rawtestout '$(Build.SourcesDirectory)/eng/artifacts/RawTestOutput/raw-json-attempt-${{ attempt }}.txt'
+                ${{ if parameters.builder.nosystemcrypto }}:
+                  env:
+                    MS_GO_NOSYSTEMCRYPTO: 1
                 ${{ if eq(length(parameters.retryAttempts), 1) }}:
                   displayName: Test
                 ${{ else }}:

--- a/eng/pipeline/stages/shorthand-builders-to-builders.yml
+++ b/eng/pipeline/stages/shorthand-builders-to-builders.yml
@@ -14,14 +14,14 @@ parameters:
   - name: ctx
     type: object
 
-  # [] of { os, arch, hostArch, config, distro?, experiment?, broken? }
+  # [] of { os, arch, hostArch, config, distro?, experiment?, nosystemcrypto?, fips?, broken? }
   # If hostArch is not defined, defaults to the arch value.
   # The job ID is generated based on these values.
   - name: shorthandBuilders
     type: object
   # The inner jobs template to pass the filed-out builders into.
   #
-  # It should accept parameter "builders", [] of { id, os, arch, hostArch, config, distro?, fips?, broken? }
+  # It should accept parameter "builders", [] of { id, os, arch, hostArch, config, distro?, experiment?, nosystemcrypto?, fips?, broken? }
   - name: jobsTemplate
     type: string
   - name: jobsParameters
@@ -38,7 +38,7 @@ stages:
           - ${{ insert }}: ${{ builder }}
             # Use 'default' in place of null to define ID. This value just needs to be unique and
             # only contain "[A-z_]+".
-            id: ${{ builder.os }}_${{ coalesce(builder.distro, 'default') }}_${{ coalesce(builder.hostArch, 'default') }}_${{ builder.arch }}_${{ builder.config }}_${{ coalesce(replace(builder.experiment, ',', '_'), 'default') }}_${{ coalesce(builder.fips, false) }}
+            id: ${{ builder.os }}_${{ coalesce(builder.distro, 'default') }}_${{ coalesce(builder.hostArch, 'default') }}_${{ builder.arch }}_${{ builder.config }}_${{ coalesce(replace(builder.experiment, ',', '_'), 'default') }}_${{ coalesce(builder.nosystemcrypto, false) }}_${{ coalesce(builder.fips, false) }}
             ${{ if not(builder.hostArch) }}:
               hostArch: ${{ builder.arch }}
             ${{ if and(not(builder.distro), eq(builder.os, 'windows')) }}:
@@ -51,5 +51,7 @@ stages:
               hostParens: (${{ builder.hostArch }} host)
             ${{ if builder.experiment }}:
               experimentBrackets: '[${{ builder.experiment }}]'
+            ${{ if builder.nosystemcrypto }}:
+              nosystemcryptoBrackets: '[nosystemcrypto]'
             ${{ if builder.fips }}:
               fipsAcronym: 'FIPS'

--- a/eng/pipeline/stages/sign-stage.yml
+++ b/eng/pipeline/stages/sign-stage.yml
@@ -14,7 +14,7 @@ parameters:
   - name: pool
     type: object
 
-  # [] of { id, os, arch, config, distro?, experiment?, broken? }
+  # [] of { id, os, arch, config, distro?, experiment?, nosystemcrypto?, fips?, broken? }
   - name: builders
     type: object
 

--- a/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
+++ b/patches/0002-Add-crypto-backend-GOEXPERIMENTs.patch
@@ -17,6 +17,7 @@ maintain this feature. For more information, see the test files.
  src/cmd/go/internal/modindex/build_test.go    | 73 +++++++++++++++++++
  src/cmd/go/testdata/script/env_changed.txt    |  3 +
  src/go/build/buildbackend_test.go             | 50 +++++++++++++
+ src/go/build/deps_test.go                     |  2 +
  .../build/testdata/backendtags_system/main.go |  3 +
  .../backendtags_system/systemcrypto.go        |  3 +
  src/internal/buildcfg/cfg.go                  |  2 +
@@ -32,7 +33,9 @@ maintain this feature. For more information, see the test files.
  .../goexperiment/exp_systemcrypto_on.go       |  8 ++
  src/internal/goexperiment/flags.go            | 18 +++++
  src/internal/platform/supported.go            | 12 +++
- 21 files changed, 271 insertions(+), 1 deletion(-)
+ src/internal/systemcrypto/systemcrypto.go     | 20 +++++
+ .../systemcrypto/systemcrypto_test.go         | 58 +++++++++++++++
+ 24 files changed, 351 insertions(+), 1 deletion(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_system/main.go
@@ -45,6 +48,8 @@ maintain this feature. For more information, see the test files.
  create mode 100644 src/internal/goexperiment/exp_opensslcrypto_on.go
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_off.go
  create mode 100644 src/internal/goexperiment/exp_systemcrypto_on.go
+ create mode 100644 src/internal/systemcrypto/systemcrypto.go
+ create mode 100644 src/internal/systemcrypto/systemcrypto_test.go
 
 diff --git a/src/cmd/go/alldocs.go b/src/cmd/go/alldocs.go
 index 74cafe9613917d..31ce076273aba2 100644
@@ -258,6 +263,19 @@ index 00000000000000..ffb835ce34a2f7
 +		t.Errorf("GoFiles = %v, want %v", p.GoFiles, wantFiles)
 +	}
 +}
+diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
+index 920e72e5cdbb9d..7834d307b0426d 100644
+--- a/src/go/build/deps_test.go
++++ b/src/go/build/deps_test.go
+@@ -370,6 +370,8 @@ var depsRules = `
+ 
+ 	FMT, internal/goexperiment
+ 	< internal/buildcfg;
++	internal/buildcfg
++	< internal/systemcrypto;
+ 
+ 	# The vast majority of standard library packages should not be resorting to regexp.
+ 	# go/types is a good chokepoint. It shouldn't use regexp, nor should anything
 diff --git a/src/go/build/testdata/backendtags_system/main.go b/src/go/build/testdata/backendtags_system/main.go
 new file mode 100644
 index 00000000000000..38dd16da61accb
@@ -539,5 +557,95 @@ index 6f37e368596498..471c5cc430bb29 100644
 +		return goarch == "amd64" || goarch == "arm64"
 +	default:
 +		return false
++	}
++}
+diff --git a/src/internal/systemcrypto/systemcrypto.go b/src/internal/systemcrypto/systemcrypto.go
+new file mode 100644
+index 00000000000000..71c1923a270646
+--- /dev/null
++++ b/src/internal/systemcrypto/systemcrypto.go
+@@ -0,0 +1,20 @@
++// Copyright 2026 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package systemcrypto
++
++import (
++	"internal/buildcfg"
++	"internal/platform"
++)
++
++// Enabled reports whether system crypto is enabled for the current build target.
++func Enabled() bool {
++	return EnabledFor(buildcfg.GOOS, buildcfg.GOARCH)
++}
++
++// EnabledFor reports whether system crypto is enabled for goos/goarch.
++func EnabledFor(goos, goarch string) bool {
++	return platform.SystemCryptoSupported(goos, goarch) && !buildcfg.SystemCryptoDisabled
++}
+diff --git a/src/internal/systemcrypto/systemcrypto_test.go b/src/internal/systemcrypto/systemcrypto_test.go
+new file mode 100644
+index 00000000000000..c37e436bf274e4
+--- /dev/null
++++ b/src/internal/systemcrypto/systemcrypto_test.go
+@@ -0,0 +1,58 @@
++// Copyright 2026 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package systemcrypto
++
++import (
++	"internal/buildcfg"
++	"internal/platform"
++	"testing"
++)
++
++func TestEnabledFor(t *testing.T) {
++	old := buildcfg.SystemCryptoDisabled
++	t.Cleanup(func() { buildcfg.SystemCryptoDisabled = old })
++
++	buildcfg.SystemCryptoDisabled = false
++	tests := []struct {
++		goos   string
++		goarch string
++		want   bool
++	}{
++		{"linux", "amd64", true},
++		{"linux", "386", true},
++		{"darwin", "arm64", true},
++		{"windows", "amd64", true},
++		{"windows", "386", false},
++		{"freebsd", "amd64", false},
++	}
++	for _, tt := range tests {
++		if got := EnabledFor(tt.goos, tt.goarch); got != tt.want {
++			t.Errorf("EnabledFor(%q, %q) = %v, want %v", tt.goos, tt.goarch, got, tt.want)
++		}
++	}
++
++	buildcfg.SystemCryptoDisabled = true
++	for _, tt := range tests {
++		if got := EnabledFor(tt.goos, tt.goarch); got {
++			t.Errorf("EnabledFor(%q, %q) with SystemCryptoDisabled = true = %v, want false", tt.goos, tt.goarch, got)
++		}
++	}
++}
++
++func TestEnabledUsesBuildConfig(t *testing.T) {
++	old := buildcfg.SystemCryptoDisabled
++	t.Cleanup(func() { buildcfg.SystemCryptoDisabled = old })
++
++	buildcfg.SystemCryptoDisabled = false
++	want := platform.SystemCryptoSupported(buildcfg.GOOS, buildcfg.GOARCH)
++	if got := Enabled(); got != want {
++		t.Fatalf("Enabled() = %v, want %v", got, want)
++	}
++
++	buildcfg.SystemCryptoDisabled = true
++	if got := Enabled(); got {
++		t.Fatalf("Enabled() with SystemCryptoDisabled = true = %v, want false", got)
 +	}
 +}

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   5 +
  src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  80 +++-
- src/cmd/dist/test.go                          |  18 +-
+ src/cmd/dist/test.go                          |  27 +-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
@@ -54,7 +54,7 @@ desired goexperiments and build tags.
  src/go/build/deps_test.go                     |  24 +-
  src/internal/buildcfg/exp.go                  |  48 +-
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2854 insertions(+), 27 deletions(-)
+ 45 files changed, 2861 insertions(+), 29 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_darwin.go
  create mode 100644 src/crypto/internal/backend/backend_linux.go
@@ -247,10 +247,18 @@ index 78d55bec559987..bb3119ef0823d7 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aadb1ff52b067f..dab28b6f1ced0a 100644
+index aadb1ff52b067f..2ef0d4219b57d1 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -158,10 +158,12 @@ func (t *tester) run() {
+@@ -9,6 +9,7 @@ import (
+ 	"encoding/json"
+ 	"flag"
+ 	"fmt"
++	"internal/systemcrypto"
+ 	"io"
+ 	"io/fs"
+ 	"log"
+@@ -158,10 +159,12 @@ func (t *tester) run() {
  		}
  	}
  
@@ -264,7 +272,7 @@ index aadb1ff52b067f..dab28b6f1ced0a 100644
  	}
  
  	if !t.listMode {
-@@ -178,9 +180,9 @@ func (t *tester) run() {
+@@ -178,9 +181,9 @@ func (t *tester) run() {
  			// and virtualization we usually start with a clean GOCACHE, so we would
  			// end up rebuilding large parts of the standard library that aren't
  			// otherwise relevant to the actual set of packages under test.
@@ -277,28 +285,48 @@ index aadb1ff52b067f..dab28b6f1ced0a 100644
  		}
  	}
  
-@@ -774,7 +776,9 @@ func (t *tester) registerTests() {
+@@ -774,7 +777,9 @@ func (t *tester) registerTests() {
  	}
  
  	// Test ios/amd64 for the iOS simulator.
 -	if goos == "darwin" && goarch == "amd64" && t.cgoEnabled {
 +	if goos == "darwin" && goarch == "amd64" && t.cgoEnabled &&
 +		// IOS is not supported with systemcrypto.
-+		!strings.Contains(goexperiment, "systemcrypto") {
++		!systemCryptoEnabled() {
  		t.registerTest("GOOS=ios on darwin/amd64",
  			&goTest{
  				variant:  "amd64ios",
-@@ -1023,7 +1027,9 @@ func (t *tester) registerTests() {
+@@ -1023,7 +1028,9 @@ func (t *tester) registerTests() {
  		t.registerRaceTests()
  	}
  
 -	if goos != "android" && !t.iOS() {
 +	// cmd/internal/testdir uses -buildmode=exe on darwin,
 +	// which is not supported by systemcrypto.
-+	if goos != "android" && !t.iOS() && !strings.Contains(goexperiment, "systemcrypto") {
++	if goos != "android" && !t.iOS() && !systemCryptoEnabled() {
  		// Only start multiple test dir shards on builders,
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
+@@ -1380,9 +1387,9 @@ func (t *tester) registerCgoTests(heading string) {
+ 			// a C linker warning on Linux.
+ 			// in function `bio_ip_and_port_to_socket_and_addr':
+ 			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
+-			if staticCheck.skip == nil && goos == "linux" && strings.Contains(goexperiment, "boringcrypto") {
++			if staticCheck.skip == nil && goos == "linux" && systemCryptoEnabled() {
+ 				staticCheck.skip = func(*distTest) (string, bool) {
+-					return "skipping static linking check on Linux when using boringcrypto to avoid C linker warning about getaddrinfo", true
++					return "skipping static linking check on Linux when using systemcrypto to avoid C linker warning about getaddrinfo", true
+ 				}
+ 			}
+ 
+@@ -1908,3 +1915,7 @@ func goexperiments(exps ...string) string {
+ 	return existing + strings.Join(exps, ",")
+ 
+ }
++
++func systemCryptoEnabled() bool {
++	return systemcrypto.EnabledFor(goos, goarch)
++}
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
 index 47839e0229b951..2d1a7fa99d551e 100644
 --- a/src/cmd/go/go_test.go
@@ -384,7 +412,7 @@ index 1d90061b065f5f..0d5d4fe0556564 100644
  	appendSetting("-compiler", cfg.BuildContext.Compiler)
  	if gccgoflags := BuildGccgoflags.String(); gccgoflags != "" && cfg.BuildContext.Compiler == "gccgo" {
 diff --git a/src/cmd/go/internal/tool/tool.go b/src/cmd/go/internal/tool/tool.go
-index 094c5b719bb291..4d2ab9e00395a8 100644
+index 97c27c8caa44d6..bb18bb112a314a 100644
 --- a/src/cmd/go/internal/tool/tool.go
 +++ b/src/cmd/go/internal/tool/tool.go
 @@ -335,6 +335,10 @@ func buildAndRunBuiltinTool(ld *modload.Loader, ctx context.Context, toolName, t
@@ -3308,7 +3336,7 @@ index 00000000000000..7500bd3a86472b
 +	`
 +}
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 920e72e5cdbb9d..2135c64d86664d 100644
+index 7834d307b0426d..148fff74886a58 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -368,7 +368,7 @@ var depsRules = `
@@ -3318,9 +3346,9 @@ index 920e72e5cdbb9d..2135c64d86664d 100644
 -	FMT, internal/goexperiment
 +	FMT, internal/goexperiment, internal/platform
  	< internal/buildcfg;
- 
- 	# The vast majority of standard library packages should not be resorting to regexp.
-@@ -553,6 +553,10 @@ var depsRules = `
+ 	internal/buildcfg
+ 	< internal/systemcrypto;
+@@ -555,6 +555,10 @@ var depsRules = `
  	< github.com/microsoft/go-crypto-winnative/internal/sysdll
  	< github.com/microsoft/go-crypto-winnative/internal/bcrypt;
  
@@ -3331,7 +3359,7 @@ index 920e72e5cdbb9d..2135c64d86664d 100644
  	FIPS, internal/godebug, embed
  	< crypto/internal/fips140only
  	< crypto
-@@ -573,6 +577,13 @@ var depsRules = `
+@@ -575,6 +579,13 @@ var depsRules = `
  	github.com/microsoft/go-crypto-winnative/internal/bcrypt
  	< github.com/microsoft/go-crypto-winnative/cng;
  
@@ -3345,7 +3373,7 @@ index 920e72e5cdbb9d..2135c64d86664d 100644
  	FIPS, internal/godebug, embed,
  	crypto/internal/boring/sig,
  	crypto/internal/boring/syso,
-@@ -612,8 +623,15 @@ var depsRules = `
+@@ -614,8 +625,15 @@ var depsRules = `
  	math/big, github.com/microsoft/go-crypto-darwin/xcrypto < github.com/microsoft/go-crypto-darwin/bbig;
  	math/big, github.com/microsoft/go-crypto-winnative/cng < github.com/microsoft/go-crypto-winnative/cng/bbig;
  

--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -13,7 +13,7 @@ desired goexperiments and build tags.
  .../compile/internal/logopt/logopt_test.go    |   5 +
  src/cmd/compile/script_test.go                |   8 +
  src/cmd/dist/build.go                         |  80 +++-
- src/cmd/dist/test.go                          |  27 +-
+ src/cmd/dist/test.go                          |  47 +-
  src/cmd/go/go_test.go                         |  11 +
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
@@ -54,7 +54,7 @@ desired goexperiments and build tags.
  src/go/build/deps_test.go                     |  24 +-
  src/internal/buildcfg/exp.go                  |  48 +-
  src/runtime/runtime_boring.go                 |   5 +
- 45 files changed, 2861 insertions(+), 29 deletions(-)
+ 45 files changed, 2881 insertions(+), 29 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_darwin.go
  create mode 100644 src/crypto/internal/backend/backend_linux.go
@@ -247,18 +247,10 @@ index 78d55bec559987..bb3119ef0823d7 100644
  	if debug {
  		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index aadb1ff52b067f..2ef0d4219b57d1 100644
+index aadb1ff52b067f..53d661338f2d72 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -9,6 +9,7 @@ import (
- 	"encoding/json"
- 	"flag"
- 	"fmt"
-+	"internal/systemcrypto"
- 	"io"
- 	"io/fs"
- 	"log"
-@@ -158,10 +159,12 @@ func (t *tester) run() {
+@@ -158,10 +158,12 @@ func (t *tester) run() {
  		}
  	}
  
@@ -272,7 +264,7 @@ index aadb1ff52b067f..2ef0d4219b57d1 100644
  	}
  
  	if !t.listMode {
-@@ -178,9 +181,9 @@ func (t *tester) run() {
+@@ -178,9 +180,9 @@ func (t *tester) run() {
  			// and virtualization we usually start with a clean GOCACHE, so we would
  			// end up rebuilding large parts of the standard library that aren't
  			// otherwise relevant to the actual set of packages under test.
@@ -285,7 +277,7 @@ index aadb1ff52b067f..2ef0d4219b57d1 100644
  		}
  	}
  
-@@ -774,7 +777,9 @@ func (t *tester) registerTests() {
+@@ -774,7 +776,9 @@ func (t *tester) registerTests() {
  	}
  
  	// Test ios/amd64 for the iOS simulator.
@@ -296,7 +288,7 @@ index aadb1ff52b067f..2ef0d4219b57d1 100644
  		t.registerTest("GOOS=ios on darwin/amd64",
  			&goTest{
  				variant:  "amd64ios",
-@@ -1023,7 +1028,9 @@ func (t *tester) registerTests() {
+@@ -1023,7 +1027,9 @@ func (t *tester) registerTests() {
  		t.registerRaceTests()
  	}
  
@@ -307,7 +299,7 @@ index aadb1ff52b067f..2ef0d4219b57d1 100644
  		// Only start multiple test dir shards on builders,
  		// where they get distributed to multiple machines.
  		// See issues 20141 and 31834.
-@@ -1380,9 +1387,9 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1380,9 +1386,9 @@ func (t *tester) registerCgoTests(heading string) {
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
@@ -319,13 +311,34 @@ index aadb1ff52b067f..2ef0d4219b57d1 100644
  				}
  			}
  
-@@ -1908,3 +1915,7 @@ func goexperiments(exps ...string) string {
+@@ -1908,3 +1914,28 @@ func goexperiments(exps ...string) string {
  	return existing + strings.Join(exps, ",")
  
  }
 +
 +func systemCryptoEnabled() bool {
-+	return systemcrypto.EnabledFor(goos, goarch)
++	// Keep this in sync with internal/systemcrypto.EnabledFor. cmd/dist is built
++	// by the bootstrap toolchain before internal/systemcrypto exists, so it can't
++	// import that package until the minimum bootstrap Go version is Go 1.27.
++	if os.Getenv("MS_GO_NOSYSTEMCRYPTO") == "1" {
++		return false
++	}
++	var enabled bool
++	switch goos {
++	case "linux", "darwin":
++		enabled = true
++	case "windows":
++		enabled = goarch == "amd64" || goarch == "arm64"
++	}
++	for _, exp := range strings.Split(goexperiment, ",") {
++		switch exp {
++		case "none", "nosystemcrypto":
++			enabled = false
++		case "systemcrypto":
++			enabled = true
++		}
++	}
++	return enabled
 +}
 diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
 index 47839e0229b951..2d1a7fa99d551e 100644

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -128,10 +128,10 @@ index f0e3575637c62a..9eab3b4e66e60b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index dab28b6f1ced0a..3263a1700e5980 100644
+index 2ef0d4219b57d1..6d0657b3e5afa0 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -722,7 +722,7 @@ func (t *tester) registerTests() {
+@@ -723,7 +723,7 @@ func (t *tester) registerTests() {
  	})
  
  	// Check that all crypto packages compile (and test correctly, in longmode) with fips.
@@ -140,14 +140,17 @@ index dab28b6f1ced0a..3263a1700e5980 100644
  		// Test standard crypto packages with fips140=on.
  		t.registerTest("GOFIPS140=latest go test crypto/...", &goTest{
  			variant: "gofips140",
-@@ -1386,12 +1386,11 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1383,7 +1383,7 @@ func (t *tester) registerCgoTests(heading string) {
+ 				}
+ 			}
+ 
+-			// Doing a static link with boringcrypto gets
++			// Doing a static link with systemcrypto gets
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
--			if staticCheck.skip == nil && goos == "linux" && strings.Contains(goexperiment, "boringcrypto") {
-+			if staticCheck.skip == nil && goos == "linux" && strings.Contains(goexperiment, "systemcrypto") {
- 				staticCheck.skip = func(*distTest) (string, bool) {
- 					return "skipping static linking check on Linux when using boringcrypto to avoid C linker warning about getaddrinfo", true
+@@ -1392,7 +1392,6 @@ func (t *tester) registerCgoTests(heading string) {
+ 					return "skipping static linking check on Linux when using systemcrypto to avoid C linker warning about getaddrinfo", true
  				}
  			}
 -
@@ -200,7 +203,7 @@ index fa445925b7c374..e4b9714df817ea 100644
  ! stdout runtime/cgo
  
 diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
-index 4aaf46b5d0f0dc..ec58a217400caa 100644
+index 4aaf46b5d0f0dc..995d53d0fed9aa 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
 +++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
 @@ -1,5 +1,14 @@
@@ -4349,10 +4352,10 @@ index 1d3e845d0f0a9c..eb4318faf13f7b 100644
  
  	var dsaPriv dsa.PrivateKey
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 7794e12bc86890..d6ef0bf10ebc1c 100644
+index 148fff74886a58..5d3f4a9850e259 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -533,7 +533,7 @@ var depsRules = `
+@@ -535,7 +535,7 @@ var depsRules = `
  	< crypto/internal/fips140/edwards25519
  	< crypto/internal/fips140/ed25519
  	< crypto/internal/fips140/rsa
@@ -4361,7 +4364,7 @@ index 7794e12bc86890..d6ef0bf10ebc1c 100644
  
  	crypto !< FIPS;
  
-@@ -557,7 +557,12 @@ var depsRules = `
+@@ -559,7 +559,12 @@ var depsRules = `
  	< crypto/internal/backend/internal/opensslsetup
  	< crypto/internal/backend/fips140;
  
@@ -4375,7 +4378,7 @@ index 7794e12bc86890..d6ef0bf10ebc1c 100644
  	< crypto/internal/fips140only
  	< crypto
  	< crypto/subtle
-@@ -591,7 +596,8 @@ var depsRules = `
+@@ -593,7 +598,8 @@ var depsRules = `
  	crypto/internal/fips140only,
  	crypto,
  	crypto/subtle,
@@ -4385,7 +4388,7 @@ index 7794e12bc86890..d6ef0bf10ebc1c 100644
  	< crypto/sha3
  	< crypto/internal/fips140hash
  	< crypto/internal/boring
-@@ -610,6 +616,7 @@ var depsRules = `
+@@ -612,6 +618,7 @@ var depsRules = `
  	  crypto/ecdh,
  	  crypto/mlkem,
  	  crypto/mldsa

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -128,10 +128,10 @@ index f0e3575637c62a..9eab3b4e66e60b 100644
  package main
  
 diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
-index 2ef0d4219b57d1..6d0657b3e5afa0 100644
+index 53d661338f2d72..f87b5a6c5fd7fe 100644
 --- a/src/cmd/dist/test.go
 +++ b/src/cmd/dist/test.go
-@@ -723,7 +723,7 @@ func (t *tester) registerTests() {
+@@ -722,7 +722,7 @@ func (t *tester) registerTests() {
  	})
  
  	// Check that all crypto packages compile (and test correctly, in longmode) with fips.
@@ -140,7 +140,7 @@ index 2ef0d4219b57d1..6d0657b3e5afa0 100644
  		// Test standard crypto packages with fips140=on.
  		t.registerTest("GOFIPS140=latest go test crypto/...", &goTest{
  			variant: "gofips140",
-@@ -1383,7 +1383,7 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1382,7 +1382,7 @@ func (t *tester) registerCgoTests(heading string) {
  				}
  			}
  
@@ -149,7 +149,7 @@ index 2ef0d4219b57d1..6d0657b3e5afa0 100644
  			// a C linker warning on Linux.
  			// in function `bio_ip_and_port_to_socket_and_addr':
  			// warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
-@@ -1392,7 +1392,6 @@ func (t *tester) registerCgoTests(heading string) {
+@@ -1391,7 +1391,6 @@ func (t *tester) registerCgoTests(heading string) {
  					return "skipping static linking check on Linux when using systemcrypto to avoid C linker warning about getaddrinfo", true
  				}
  			}
@@ -1905,7 +1905,7 @@ index 7f2824ca9ac052..f0d3b2a8459871 100644
  	"crypto/internal/fips140/aes"
  	"crypto/internal/fips140/aes/gcm"
 diff --git a/src/crypto/internal/rand/rand.go b/src/crypto/internal/rand/rand.go
-index 5845cfe92bbffb..26f23eac5855dc 100644
+index d12cc7586c45cc..c314c08c3186fb 100644
 --- a/src/crypto/internal/rand/rand.go
 +++ b/src/crypto/internal/rand/rand.go
 @@ -5,7 +5,7 @@


### PR DESCRIPTION
## Summary
- replace nosystemcrypto GOEXPERIMENT matrix entries with a dedicated nosystemcrypto builder flag
- include nosystemcrypto in generated builder IDs and display names
- set MS_GO_NOSYSTEMCRYPTO=1 in run-stage build/test steps for nosystemcrypto builders
- Remove `experiment: systemcrypto` flags. Systemcrypto is enabled by default, no need to explicitly set it.

## Motivation
- `GOEXPERIMENT=systemcrypto` support will be removed in Go 1.27, see #2261.

## Validation
- VS Code YAML diagnostics: no errors
- git diff --check