### PR TITLE
docs: document systemcrypto experiment removal

### DIFF
--- a/eng/doc/AdditionalFeatures.md
+++ b/eng/doc/AdditionalFeatures.md
@@ -19,10 +19,8 @@ See also the [Data Collection policy for the Microsoft build of Go](/README.md#d
 We have implemented changes to the Go standard library to call a platform-specific system-provided cryptography library rather than running the pure Go implementation.
 Its main purposes are to comply with Microsoft's internal cryptography policies and implement FIPS 140 compliance.
 
-As of Go 1.25 on Linux and Windows, and Go 1.26 on macOS, this feature is enabled by default on supported platforms.
+This feature is enabled by default on supported platforms.
 
-As of Go 1.27, `systemcrypto` is no longer configured with `GOEXPERIMENT`: `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` are rejected.
-If you need to disable the system-provided cryptography backend, set `MS_GO_NOSYSTEMCRYPTO=1` before building the program.
 
 See [the Migration Guide](/eng/doc/MigrationGuide.md) for more information about when, and how, to configure this feature.
 

--- a/eng/doc/AdditionalFeatures.md
+++ b/eng/doc/AdditionalFeatures.md
@@ -19,10 +19,10 @@ See also the [Data Collection policy for the Microsoft build of Go](/README.md#d
 We have implemented changes to the Go standard library to call a platform-specific system-provided cryptography library rather than running the pure Go implementation.
 Its main purposes are to comply with Microsoft's internal cryptography policies and implement FIPS 140 compliance.
 
-As of Go 1.25, this feature is enabled by default.
+As of Go 1.25 on Linux and Windows, and Go 1.26 on macOS, this feature is enabled by default on supported platforms.
 
-Prior to Go 1.25, this feature can be enabled by setting the `GOEXPERIMENT` environment variable to `systemcrypto` before building a Go program.
-Other methods of changing goexperiment settings also work.
+As of Go 1.27, `systemcrypto` is no longer configured with `GOEXPERIMENT`: `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` are rejected.
+If you need to disable the system-provided cryptography backend, set `MS_GO_NOSYSTEMCRYPTO=1` before building the program.
 
 See [the Migration Guide](/eng/doc/MigrationGuide.md) for more information about when, and how, to configure this feature.
 

--- a/eng/doc/MicrosoftToolsetIdentification.md
+++ b/eng/doc/MicrosoftToolsetIdentification.md
@@ -54,8 +54,10 @@ Otherwise, look for one of these clues:
 
 `systemcrypto` is unique to the Microsoft build of Go, so if either of these strings is present, it confirms that the binary is built by the Microsoft build of Go.
 
-If `GOEXPERIMENT=nosystemcrypto` is present in a binary built with Go 1.26 or earlier (note the `no` prefix), it also confirms that the binary was built with the Microsoft build of Go, but it shows that `systemcrypto` was explicitly disabled.
-In Go 1.27 and later, `systemcrypto` and `nosystemcrypto` are no longer `GOEXPERIMENT` values, so these strings are not expected.
+If `GOEXPERIMENT=nosystemcrypto` is present (note the `no` prefix), it also confirms that the binary was built with the Microsoft build of Go, but it shows that `systemcrypto` was explicitly disabled.
+
+> [!NOTE]
+> In Go 1.27 and later, `systemcrypto` and `nosystemcrypto` are no longer `GOEXPERIMENT` values, so it is expected that `microsoft_systemcrypto=1` will appear without a `GOEXPERIMENT` string.
 
 If none of the above are present, we can't confirm which build of Go was used.
 However, this situation means that the application doesn't meet Microsoft internal crypto policy, which may be enough information in some cases.

--- a/eng/doc/MicrosoftToolsetIdentification.md
+++ b/eng/doc/MicrosoftToolsetIdentification.md
@@ -50,11 +50,12 @@ Then, look for a line that contains `microsoft_toolset_version`.
 Otherwise, look for one of these clues:
 
 * `microsoft_systemcrypto=1`
-* `GOEXPERIMENT=systemcrypto`
+* `GOEXPERIMENT=systemcrypto` in binaries built with Go 1.26 or earlier
 
 `systemcrypto` is unique to the Microsoft build of Go, so if either of these strings is present, it confirms that the binary is built by the Microsoft build of Go.
 
-If `GOEXPERIMENT=nosystemcrypto` is present (note the `no` prefix), it also confirms that the binary was built with the Microsoft build of Go, but it shows that `systemcrypto` was explicitly disabled.
+If `GOEXPERIMENT=nosystemcrypto` is present in a binary built with Go 1.26 or earlier (note the `no` prefix), it also confirms that the binary was built with the Microsoft build of Go, but it shows that `systemcrypto` was explicitly disabled.
+In Go 1.27 and later, `systemcrypto` and `nosystemcrypto` are no longer `GOEXPERIMENT` values, so these strings are not expected.
 
 If none of the above are present, we can't confirm which build of Go was used.
 However, this situation means that the application doesn't meet Microsoft internal crypto policy, which may be enough information in some cases.

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -119,12 +119,12 @@ That page provides links that redirect to the latest version and also immutable 
 
 ## Enable `systemcrypto`
 
-Starting with Go 1.25 on Linux and Windows, and Go 1.26 on macOS, `systemcrypto` is enabled by default on supported platforms.
-Most projects don't need to set anything to enable it.
+`systemcrypto` is enabled by default on supported platforms in currently supported versions of the Microsoft build of Go.
+You don't need to set `GOEXPERIMENT=systemcrypto`.
 
-
-Starting with Go 1.27, `systemcrypto` is no longer a `GOEXPERIMENT` setting.
-Remove `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` from build scripts when moving to Go 1.27 or later; the go command rejects both because system crypto is selected automatically on supported platforms and disabled with `MS_GO_NOSYSTEMCRYPTO=1`.
+Starting with Go 1.27, `systemcrypto` and `nosystemcrypto` are no longer `GOEXPERIMENT` values.
+Remove them from `GOEXPERIMENT` when moving to Go 1.27 or later.
+If you need to opt out of `systemcrypto`, see [Disabling `systemcrypto`](#disabling-systemcrypto).
 
 See [the FIPS documentation sections about build configuration](fips/README.md#usage-common-configurations) for more detailed instructions.
 Even if you don't need FIPS compliance, the `systemcrypto` build configuration instructions are located in that document.
@@ -235,7 +235,7 @@ Alternatively, the `build-essential` package contains all of these packages and 
 
 If this isn't feasible, see [disabling systemcrypto](#disabling-systemcrypto).
 
-#### Unknown or removed GOEXPERIMENT systemcrypto
+#### Unknown GOEXPERIMENT systemcrypto
 
 ```
 go: unknown GOEXPERIMENT systemcrypto
@@ -245,7 +245,19 @@ go: unknown GOEXPERIMENT systemcrypto
 go.exe: unknown GOEXPERIMENT systemcrypto
 ```
 
-In Go 1.27 or later, the Microsoft build of Go reports a different error for the same obsolete build setting:
+This error usually indicates you aren't using the Microsoft build of Go.
+
+If you're trying to migrate to the Microsoft build of Go, check your build environment to ensure that the `go` command is the Microsoft build of Go.
+See [Microsoft Toolset Identification](./MicrosoftToolsetIdentification.md).
+
+If you're trying to make a build command compliant with Microsoft crypto policy but still compatible with **both the Microsoft build of Go and the official Go distribution**, remove `systemcrypto` from `GOEXPERIMENT`.
+`systemcrypto` is enabled by default in the Microsoft build of Go, so it's not necessary to specify it using `GOEXPERIMENT`.
+
+See [Disabling `systemcrypto`](#disabling-systemcrypto) for information about how to disable `systemcrypto` if you need to temporarily avoid migrating to it.
+
+#### Removed GOEXPERIMENT systemcrypto or nosystemcrypto
+
+In Go 1.27 or later, the Microsoft build of Go reports these errors when obsolete `GOEXPERIMENT` values are used:
 
 ```
 GOEXPERIMENT=systemcrypto has been removed; system crypto is enabled automatically on supported platforms and can be disabled with MS_GO_NOSYSTEMCRYPTO=1
@@ -257,15 +269,7 @@ GOEXPERIMENT=nosystemcrypto has been removed; use MS_GO_NOSYSTEMCRYPTO=1 to disa
 
 These errors happen when the `GOEXPERIMENT` environment variable includes `systemcrypto` or `nosystemcrypto`.
 In Go 1.27 and later, remove both values from `GOEXPERIMENT`.
-System crypto is enabled automatically on supported platforms, and it can be disabled with `MS_GO_NOSYSTEMCRYPTO=1` if you have an approved exception.
-
-The `unknown GOEXPERIMENT systemcrypto` form usually indicates you aren't using the Microsoft build of Go.
-
-If you're trying to migrate to the Microsoft build of Go, check your build environment to ensure that the `go` command is the Microsoft build of Go.
-See [Microsoft Toolset Identification](./MicrosoftToolsetIdentification.md).
-
-If you're trying to make a build command compliant with Microsoft crypto policy but still compatible with **both the Microsoft build of Go and the official Go distribution**, remove `systemcrypto` from `GOEXPERIMENT`.
-`systemcrypto` is enabled by default in the Microsoft build of Go, so it's not necessary to specify it using `GOEXPERIMENT`.
+The `systemcrypto` backend is enabled automatically on supported platforms, and it can be disabled with `MS_GO_NOSYSTEMCRYPTO=1` if you have an approved exception.
 
 See [Disabling `systemcrypto`](#disabling-systemcrypto) for information about how to disable `systemcrypto` if you need to temporarily avoid migrating to it.
 

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -251,7 +251,7 @@ GOEXPERIMENT=systemcrypto has been removed; system crypto is enabled automatical
 ```
 
 ```
-GOEXPERIMENT=nosystemcrypto has been removed; use MS_GO_NOSYSTEMCRYPTO=1 to disable system crypto
+GOEXPERIMENT=nosystemcrypto has been removed; use MS_GO_NOSYSTEMCRYPTO=1 to disable system crypto; note that systemcrypto supports CGO_ENABLED=0 since Go 1.27
 ```
 
 These errors happen when the `GOEXPERIMENT` environment variable includes `systemcrypto` or `nosystemcrypto`.

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -169,19 +169,20 @@ In Go 1.25, you may see this similar error:
 
 > [!NOTE]
 > In Go 1.26, there is a cgo-less experiment available for Linux: `ms_nocgo_opensslcrypto`.
-> In Go 1.27 and later, this behavior is part of `systemcrypto` and is selected automatically when cgo is disabled on a supported Linux architecture.
+>
+> In Go 1.27 and later, cgo-less behavior is part of `systemcrypto` and is selected automatically when cgo is disabled on a supported Linux architecture.
 >
 > For more details, see [cgo-less OpenSSL Backend](NocgoOpenSSL.md).
 
 When building a Go program that imports a `crypto` package (or has a dependency that imports a `crypto` package), the build will check that the build environment and target are compatible with the crypto backend being used.
 If it's incompatible, the build will fail with an error like the above.
 
-In Go 1.26 and earlier, targeting Linux with `systemcrypto` usually requires cgo unless the `ms_nocgo_opensslcrypto` experiment is enabled.
+In Go 1.26 and earlier, using `systemcrypto` on Linux requires cgo unless the `ms_nocgo_opensslcrypto` experiment is enabled.
 Cgo is disabled by default on some platforms or when a C compiler is not detected.
 Sometimes a project's build scripts might explicitly disable cgo.
 
 In this case, you should first try upgrading to Go 1.27 or later.
-If you need or want the cgo-based OpenSSL backend, install a C compiler, like `gcc`.
+If you need or want the cgo-based OpenSSL backend or the pre-1.27 Go version, install a C compiler, like `gcc`.
 
 You may also need to set the `CGO_ENABLED` environment variable to `1` or [otherwise enable cgo](https://pkg.go.dev/cmd/cgo).
 

--- a/eng/doc/MigrationGuide.md
+++ b/eng/doc/MigrationGuide.md
@@ -119,14 +119,15 @@ That page provides links that redirect to the latest version and also immutable 
 
 ## Enable `systemcrypto`
 
-These instructions are for projects using versions of Go that don't enable `systemcrypto` by default.
-Starting with 1.25 (Linux and Windows) and 1.26 (macOS), `systemcrypto` is enabled by default.
+Starting with Go 1.25 on Linux and Windows, and Go 1.26 on macOS, `systemcrypto` is enabled by default on supported platforms.
+Most projects don't need to set anything to enable it.
 
-To comply with Microsoft internal cryptography policy, enable the `systemcrypto` feature in your build environment before building your project.
-This is done by setting the `GOEXPERIMENT` environment variable to `systemcrypto`.
+
+Starting with Go 1.27, `systemcrypto` is no longer a `GOEXPERIMENT` setting.
+Remove `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` from build scripts when moving to Go 1.27 or later; the go command rejects both because system crypto is selected automatically on supported platforms and disabled with `MS_GO_NOSYSTEMCRYPTO=1`.
 
 See [the FIPS documentation sections about build configuration](fips/README.md#usage-common-configurations) for more detailed instructions.
-Even if you don't need FIPS compliance, the `GOEXPERIMENT` instructions are located in that document.
+Even if you don't need FIPS compliance, the `systemcrypto` build configuration instructions are located in that document.
 
 ## Testing
 
@@ -141,7 +142,8 @@ After switching to the Microsoft build of Go, you may encounter new build errors
 
 #### Cgo is not enabled
 
-You may see this error message if cgo is not enabled:
+In Go 1.27 and later, Linux `systemcrypto` can build with `CGO_ENABLED=0` on supported cgo-less OpenSSL architectures.
+If you're using Go 1.26 or earlier, you may see this error message if cgo is not enabled:
 
 ```
 # crypto
@@ -167,17 +169,19 @@ In Go 1.25, you may see this similar error:
 
 > [!NOTE]
 > In Go 1.26, there is a cgo-less experiment available for Linux: `ms_nocgo_opensslcrypto`.
+> In Go 1.27 and later, this behavior is part of `systemcrypto` and is selected automatically when cgo is disabled on a supported Linux architecture.
 >
 > For more details, see [cgo-less OpenSSL Backend](NocgoOpenSSL.md).
 
 When building a Go program that imports a `crypto` package (or has a dependency that imports a `crypto` package), the build will check that the build environment and target are compatible with the crypto backend being used.
 If it's incompatible, the build will fail with an error like the above.
 
-When targeting Linux, `systemcrypto` requires cgo.
+In Go 1.26 and earlier, targeting Linux with `systemcrypto` usually requires cgo unless the `ms_nocgo_opensslcrypto` experiment is enabled.
 Cgo is disabled by default on some platforms or when a C compiler is not detected.
 Sometimes a project's build scripts might explicitly disable cgo.
 
-In this case, you should first try to install a C compiler, like `gcc`.
+In this case, you should first try upgrading to Go 1.27 or later.
+If you need or want the cgo-based OpenSSL backend, install a C compiler, like `gcc`.
 
 You may also need to set the `CGO_ENABLED` environment variable to `1` or [otherwise enable cgo](https://pkg.go.dev/cmd/cgo).
 
@@ -185,7 +189,8 @@ If this isn't feasible, see [disabling systemcrypto](#disabling-systemcrypto).
 
 #### Missing C toolchain and dependencies
 
-A C toolchain is required to build programs that use `systemcrypto` on Linux.
+A C toolchain is required to build programs that use the cgo-based `systemcrypto` backend on Linux.
+In Go 1.27 and later, Linux builds with `CGO_ENABLED=0` use the cgo-less OpenSSL backend on supported architectures and don't require a C toolchain.
 The errors shown with a partially missing C toolchain can be unintuitive, so some errors and corresponding missing packages with the names they have on Azure Linux 3 are listed below.
 
 ```
@@ -229,7 +234,7 @@ Alternatively, the `build-essential` package contains all of these packages and 
 
 If this isn't feasible, see [disabling systemcrypto](#disabling-systemcrypto).
 
-#### Unknown GOEXPERIMENT systemcrypto
+#### Unknown or removed GOEXPERIMENT systemcrypto
 
 ```
 go: unknown GOEXPERIMENT systemcrypto
@@ -239,14 +244,27 @@ go: unknown GOEXPERIMENT systemcrypto
 go.exe: unknown GOEXPERIMENT systemcrypto
 ```
 
-This error indicates you aren't using the Microsoft build of Go.
-It happens when the `GOEXPERIMENT` environment variable includes `systemcrypto` (or `nosystemcrypto`) and the Go toolset doesn't recognize it.
+In Go 1.27 or later, the Microsoft build of Go reports a different error for the same obsolete build setting:
+
+```
+GOEXPERIMENT=systemcrypto has been removed; system crypto is enabled automatically on supported platforms and can be disabled with MS_GO_NOSYSTEMCRYPTO=1
+```
+
+```
+GOEXPERIMENT=nosystemcrypto has been removed; use MS_GO_NOSYSTEMCRYPTO=1 to disable system crypto
+```
+
+These errors happen when the `GOEXPERIMENT` environment variable includes `systemcrypto` or `nosystemcrypto`.
+In Go 1.27 and later, remove both values from `GOEXPERIMENT`.
+System crypto is enabled automatically on supported platforms, and it can be disabled with `MS_GO_NOSYSTEMCRYPTO=1` if you have an approved exception.
+
+The `unknown GOEXPERIMENT systemcrypto` form usually indicates you aren't using the Microsoft build of Go.
 
 If you're trying to migrate to the Microsoft build of Go, check your build environment to ensure that the `go` command is the Microsoft build of Go.
 See [Microsoft Toolset Identification](./MicrosoftToolsetIdentification.md).
 
 If you're trying to make a build command compliant with Microsoft crypto policy but still compatible with **both the Microsoft build of Go and the official Go distribution**, remove `systemcrypto` from `GOEXPERIMENT`.
-`systemcrypto` is enabled by default, so it's not necessary to specify it using `GOEXPERIMENT`.
+`systemcrypto` is enabled by default in the Microsoft build of Go, so it's not necessary to specify it using `GOEXPERIMENT`.
 
 See [Disabling `systemcrypto`](#disabling-systemcrypto) for information about how to disable `systemcrypto` if you need to temporarily avoid migrating to it.
 
@@ -315,7 +333,7 @@ Application code and libraries that use Windows paths may need to be updated to 
 ./app: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./app)
 ```
 
-When building a program with cgo on Linux (required when using `systemcrypto`), the system's glibc version is linked into the binary.
+When building a program with the cgo-based `systemcrypto` backend on Linux, the system's glibc version is linked into the binary.
 When the program runs on a different system with an older version of glibc, it may fail to start with an error like the above.
 
 There are several approaches to resolve this problem:

--- a/eng/doc/NocgoOpenSSL.md
+++ b/eng/doc/NocgoOpenSSL.md
@@ -1,21 +1,21 @@
 # No-cgo OpenSSL Backend
 
-This document describes how to enable and use the cgo-less OpenSSL backend for the Microsoft build of Go, available as an experimental feature starting in Go 1.26.
+This document describes how the Microsoft build of Go uses the cgo-less OpenSSL backend on Linux.
 
 ## Overview
 
-In Go 1.26, there is a cgo-less experiment available for Linux: `ms_nocgo_opensslcrypto`.
+In Go 1.27 and later, the cgo-less OpenSSL backend is part of `systemcrypto` on Linux.
+It is selected automatically when cgo is disabled and the target architecture is supported.
 
 > [!NOTE]
-> While `systemcrypto` is a fully supported `GOEXPERIMENT` value (it is not "experimental"), `ms_nocgo_opensslcrypto` **is** experimental in Go 1.26 and may have limitations.
-
-In Go 1.27, the experiment will be removed and the cgo requirement for `systemcrypto` on Linux will be lifted by default.
+> In Go 1.26, this backend was available as the experimental `GOEXPERIMENT=ms_nocgo_opensslcrypto` feature.
+> In Go 1.27, that experiment has been removed because the cgo-less backend is selected automatically when needed.
 
 This allows the use of OpenSSL without requiring cgo.
 
 ## Supported architectures
 
-Currently this experiment is supported on the following architectures:
+The cgo-less OpenSSL backend is supported on the following architectures:
 
 - 386
 - **amd64**
@@ -31,6 +31,9 @@ Architectures are added based on demand and available resources.
 To see existing requests or request support for additional architectures, use the [![](https://img.shields.io/github/labels/microsoft/go/Area-Nocgo)](https://github.com/microsoft/go/labels/Area-Nocgo) label.
 
 ## How the backend is selected
+
+Starting in Go 1.27, these rules apply without any additional `GOEXPERIMENT` value.
+In Go 1.26, they apply when `GOEXPERIMENT=ms_nocgo_opensslcrypto` is set.
 
 * If cgo is explicitly enabled with `CGO_ENABLED=1`, the cgo-based OpenSSL backend is used.
 * If cgo is disabled with `CGO_ENABLED=0`, then:

--- a/eng/doc/NocgoOpenSSL.md
+++ b/eng/doc/NocgoOpenSSL.md
@@ -9,6 +9,7 @@ It is selected automatically when cgo is disabled and the target architecture is
 
 > [!NOTE]
 > In Go 1.26, this backend was available as the experimental `GOEXPERIMENT=ms_nocgo_opensslcrypto` feature.
+>
 > In Go 1.27, that experiment has been removed because the cgo-less backend is selected automatically when needed.
 
 This allows the use of OpenSSL without requiring cgo.

--- a/eng/doc/Telemetry.md
+++ b/eng/doc/Telemetry.md
@@ -55,7 +55,7 @@ The counters and properties collected are defined in the [telemetry upload confi
 
 | Counter | Description |
 |---|---|
-| `msgo/systemcrypto:{enabled,disabled}` | Whether the system cryptography backend is enabled on platforms that support it. This reflects the default platform selection and the `MS_GO_NOSYSTEMCRYPTO=1` opt-out. |
+| `msgo/systemcrypto:{enabled,disabled}` | Whether the system cryptography backend is enabled. |
 
 ## What is NOT collected
 

--- a/eng/doc/Telemetry.md
+++ b/eng/doc/Telemetry.md
@@ -55,7 +55,7 @@ The counters and properties collected are defined in the [telemetry upload confi
 
 | Counter | Description |
 |---|---|
-| `msgo/systemcrypto:{enabled,disabled}` | Whether the system cryptography backend is enabled on platforms that support it. |
+| `msgo/systemcrypto:{enabled,disabled}` | Whether the system cryptography backend is enabled on platforms that support it. This reflects the default platform selection and the `MS_GO_NOSYSTEMCRYPTO=1` opt-out. |
 
 ## What is NOT collected
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -90,8 +90,8 @@ The following table summarizes common configurations and how suitable each one i
 | Default | `GO_OPENSSL_VERSION_OVERRIDE=1.1.1k-fips` | Compliant | Can be used to create a compliant app. On Linux, this environment variable causes the runtime to load `libcrypto.so.1.1.1k-fips` instead of using the automatic search behavior. This environment variable has no effect on Windows or macOS. |
 | `-tags=requirefips` | Default | Compliant | Can be used to create a compliant app. The behavior is the same as `GODEBUG=fips140=on` and `GOFIPS=1`, but no runtime configuration is necessary. See [the `requirefips` section](#build-option-to-require-fips-mode) for more information on when this "locked-in" approach may be useful rather than the flexible approach. |
 | `MS_GO_NOSYSTEMCRYPTO=1` | Default | Not compliant | Crypto usage is not FIPS compliant. |
-| `GOOS=linux CGO_ENABLED=0`, Go 1.27+ | Default | Compliant | Uses the [cgo-less OpenSSL backend](../NocgoOpenSSL.md) on supported architectures. Crypto usage is FIPS compliant. |
-| `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=ms_nocgo_opensslcrypto`, Go 1.26 only | Default | Compliant | [Experimental](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/NocgoOpenSSL.md). Crypto usage is FIPS compliant. |
+| `GOOS=linux CGO_ENABLED=0`, Go 1.27+ | Default | Compliant | Can be used to create a compliant app. Uses the [cgo-less OpenSSL backend](../NocgoOpenSSL.md) on supported architectures. |
+| `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=ms_nocgo_opensslcrypto`, Go 1.26 only | Default | Compliant | Can be used to create a compliant app with the [experimental cgo-less OpenSSL backend](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/NocgoOpenSSL.md). |
 
 Some configurations are invalid and intentionally result in a build error or runtime panic:
 
@@ -314,15 +314,24 @@ It's possible to disable `systemcrypto` and use the Go standard library's implem
 
 If it's acceptable to become noncompliant with the internal Microsoft crypto policy and FIPS, you can use the Go standard library cryptography implementation by disabling the `systemcrypto` backend:
 
-- Set the `MS_GO_NOSYSTEMCRYPTO` environment variable to `1`.
+- With Go 1.25.2 or later, set the `MS_GO_NOSYSTEMCRYPTO` environment variable to `1`.
+- With Go 1.25 through Go 1.26, set the `GOEXPERIMENT` environment variable to `nosystemcrypto`.
 
-In Go 1.25 and Go 1.26, `GOEXPERIMENT=nosystemcrypto` was also supported. It has been removed in Go 1.27.
-Remove `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` from build scripts when moving to Go 1.27 or later.
+Both of the above methods are supported in Go 1.25.2 through Go 1.26, but we encourage using `MS_GO_NOSYSTEMCRYPTO` instead of `GOEXPERIMENT`:
 
+- `GOEXPERIMENT=nosystemcrypto` may make your *build command* incompatible with the official Go toolset. ([microsoft/go#1880](https://github.com/microsoft/go/issues/1880))
 - `MS_GO_NOSYSTEMCRYPTO=1` doesn't involve the `GOEXPERIMENT` mechanism. It's simple to use and to incorporate into any build process.
 - Only the exact value `1` disables `systemcrypto`. Other values leave the default behavior in place.
 
+In Go 1.27 and later, `GOEXPERIMENT=nosystemcrypto` has been removed.
+Remove `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` from build scripts when moving to Go 1.27 or later.
+
 > [!WARNING]
+> In Go 1.25 and Go 1.26, `MS_GO_NOSYSTEMCRYPTO=1` has precedence over `GOEXPERIMENT` values.
+> It will disable the backend even if `GOEXPERIMENT=systemcrypto` is set.
+>
+> Specifically, `MS_GO_NOSYSTEMCRYPTO=1 GOEXPERIMENT=systemcrypto go build .` builds a program that uses Go standard library cryptography.
+>
 > Go 1.27 and later reject `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` with an error. Use `MS_GO_NOSYSTEMCRYPTO=1` to disable the backend.
 
 > [!NOTE]
@@ -350,6 +359,9 @@ This algorithm can be overridden by setting the environment variable `GO_OPENSSL
 
 ### Multiple GOEXPERIMENTS
 
+In Go 1.26 and earlier, when using `GOEXPERIMENT` to enable `systemcrypto`, you can enable other non-crypto experiments simultaneously using a comma separator, e.g. `GOEXPERIMENT=systemcrypto,loopvar`.
+Combining other experiments with `systemcrypto` is supported.
+
 In Go 1.27 and later, `systemcrypto` isn't configured through `GOEXPERIMENT`.
 Do not include `systemcrypto` or `nosystemcrypto` in `GOEXPERIMENT`; the go command rejects both values.
 
@@ -359,9 +371,13 @@ For more information about other Go experiments, read the output of the command 
 
 ### Build tags
 
-When `systemcrypto` is enabled, the Microsoft build of Go emits the `goexperiment.systemcrypto` build tag.
-It also emits one legacy per-platform tag for source compatibility: `goexperiment.opensslcrypto` on Linux, `goexperiment.cngcrypto` on Windows, and `goexperiment.darwincrypto` on macOS.
-These tags reflect the backend selected by the toolchain; they are not the supported way to enable or disable `systemcrypto`.
+In Go 1.26 and earlier, selecting most `GOEXPERIMENT`s can also be done by setting the corresponding `goexperiment.*` build tag.
+This is supported for all crypto backends.
+
+For example, the `go build -tags=goexperiment.systemcrypto` command will enable the same backend as setting `GOEXPERIMENT=systemcrypto` then running the build command.
+
+In Go 1.27 and later, `systemcrypto` is selected by the toolchain rather than by a `GOEXPERIMENT` value.
+Build tags are only for conditional source code; they are not the supported way to enable or disable `systemcrypto`.
 
 > [!NOTE]
 > Build tags can't disable `systemcrypto`, see [Disabling `systemcrypto`](../MigrationGuide.md#disabling-systemcrypto) for how to disable `systemcrypto`.
@@ -370,6 +386,10 @@ These tags reflect the backend selected by the toolchain; they are not the suppo
 ### Conditional behavior if a crypto backend is enabled
 
 Normally this is not necessary, but a shared package may need to change its implementation when compiled with a crypto backend rather than the ordinary Go backend. For example, the library may need to remove use of cryptographic algorithms that would not be permitted by FIPS, in a way that will still allow the library to function. This is done using [build constraints](https://pkg.go.dev/go/build#hdr-Build_Constraints), also known as build tags.
+
+When `systemcrypto` is enabled, the Microsoft build of Go emits the `goexperiment.systemcrypto` build tag.
+It also emits one legacy per-platform tag for source compatibility: `goexperiment.opensslcrypto` on Linux, `goexperiment.cngcrypto` on Windows, and `goexperiment.darwincrypto` on macOS.
+These tags reflect the backend selected by the toolchain.
 
 - `//go:build goexperiment.systemcrypto` conditionally includes the source file if *any* crypto backend is enabled.
 - `//go:build !goexperiment.systemcrypto` includes the file if *no* crypto backend is enabled.

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -50,8 +50,8 @@ The Microsoft build of Go provides several ways to configure the crypto backend 
 These are described in the following sections in detail.
 
 - Build-time configuration (`go build`):
-  - [`GOEXPERIMENT=<backend>crypto` environment variable](#usage-build)
-  - [`goexperiment.<backend>crypto` build tag](#usage-build)
+  - Default [`systemcrypto` backend selection](#usage-build)
+  - [`MS_GO_NOSYSTEMCRYPTO=1` environment variable](#build-option-to-use-go-crypto)
   - [`requirefips` build tag](#build-option-to-require-fips-mode)
   - [`GOFIPS140=latest` environment variable](#build-option-to-require-fips-mode)
   - [`import _ "crypto/tls/fipsonly"` source change](#tls-with-fips-compliant-settings)
@@ -72,6 +72,7 @@ The following table summarizes common configurations and how suitable each one i
 
 > [!NOTE]
 > Since Go 1.25, `systemcrypto` is enabled by default on Linux and Windows. There is no need to manually enable using OpenSSL/CNG under the hood anymore. See also [the Go 1.25 changelog](#go-125-aug-2025). Since Go 1.26, `systemcrypto` is also enabled by default on macOS.
+> Since Go 1.27, `systemcrypto` is no longer a `GOEXPERIMENT` setting. Supported platforms use it automatically unless it is disabled with `MS_GO_NOSYSTEMCRYPTO=1`.
 
 > [!TIP]
 > If an app uses no cryptography, FIPS compliance is not relevant and the internal Microsoft crypto policy doesn't apply.
@@ -79,20 +80,20 @@ The following table summarizes common configurations and how suitable each one i
 | Build-time config | Runtime config | Internal Microsoft crypto policy | FIPS behavior |
 | --- | --- | --- | --- |
 | Default | Default | Compliant | Can be used to create a compliant app. FIPS mode is determined by system-wide configuration. Make sure you are familiar with your platform's system-wide FIPS switch, described in [Usage: Runtime](#usage-runtime). |
-| `GOEXPERIMENT=systemcrypto` | Default | Compliant | Can be used to create a compliant app. The `GOEXPERIMENT` setting is redundant because `systemcrypto` is enabled by default. |
 | Default | `GODEBUG=fips140=on` or `GOFIPS=1` | Compliant | Can be used to create a compliant app. Depending on platform, the app enables FIPS mode, ensures it is already enabled, or doesn't do any additional checks. The app panics if there is a problem. See [Usage: Runtime](#usage-runtime). |
 | Default | `GODEBUG=fips140=only`, Go 1.27+ | Compliant | Same as `fips140=on`, but also panics if a non-FIPS-approved algorithm is used. Note: if the backend does not support a particular algorithm, the call panics rather than falling back to Go standard library crypto. See [Cross-Platform Cryptography](../CrossPlatformCryptography.md) to check algorithm support per platform, and [Usage: Runtime](#usage-runtime). |
 | Default | `GO_OPENSSL_VERSION_OVERRIDE=1.1.1k-fips` | Compliant | Can be used to create a compliant app. On Linux, this environment variable causes the runtime to load `libcrypto.so.1.1.1k-fips` instead of using the automatic search behavior. This environment variable has no effect on Windows or macOS. |
 | `-tags=requirefips` | Default | Compliant | Can be used to create a compliant app. The behavior is the same as `GODEBUG=fips140=on` and `GOFIPS=1`, but no runtime configuration is necessary. See [the `requirefips` section](#build-option-to-require-fips-mode) for more information on when this "locked-in" approach may be useful rather than the flexible approach. |
-| `MS_GO_NOSYSTEMCRYPTO=1` or `GOEXPERIMENT=nosystemcrypto` | Default | Not compliant | Crypto usage is not FIPS compliant. |
-| `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=ms_nocgo_opensslcrypto`, Go 1.26 | Default | Compliant | [Experimental](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/NocgoOpenSSL.md). Crypto usage is FIPS compliant. |
+| `MS_GO_NOSYSTEMCRYPTO=1` | Default | Not compliant | Crypto usage is not FIPS compliant. |
+| `GOOS=linux CGO_ENABLED=0`, Go 1.27+ | Default | Compliant | Uses the [cgo-less OpenSSL backend](../NocgoOpenSSL.md) on supported architectures. Crypto usage is FIPS compliant. |
+| `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=ms_nocgo_opensslcrypto`, Go 1.26 only | Default | Compliant | [Experimental](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/NocgoOpenSSL.md). Crypto usage is FIPS compliant. |
 
 Some configurations are invalid and intentionally result in a build error or runtime panic:
 
 | Build-time config | Runtime config | Behavior |
 | --- | --- | --- |
 | `MS_GO_NOSYSTEMCRYPTO=1` and `-tags=requirefips` | | The build fails. A crypto backend must be specified to enable FIPS features. |
-| `GOOS=linux CGO_ENABLED=0` | | The build fails. Cgo is required to use the OpenSSL backend. |
+| `GOOS=linux CGO_ENABLED=0` on a Linux architecture without cgo-less OpenSSL support | | The build fails. Cgo must be enabled unless the target architecture has a cgo-less OpenSSL implementation. |
 
 ## Usage: Build
 
@@ -103,10 +104,10 @@ See the [Migration Guide](/eng/doc/MigrationGuide.md) for more information on in
 If `systemcrypto` is disabled (see [build option to use Go crypto](#build-option-to-use-go-crypto)), Go standard library cryptography is used.
 
 > [!NOTE]
-> "Experiment" doesn't indicate the FIPS features are experimental. The original intent of `GOEXPERIMENT` is to use it to enable experimental features in the Go runtime and toolchain, but we and Google are now using `GOEXPERIMENT` for this FIPS-related feature because the mechanism itself perfectly fits our needs.
+> Prior to Go 1.27, `systemcrypto` could be selected with `GOEXPERIMENT=systemcrypto`. In Go 1.27 and later, `systemcrypto` is no longer a `GOEXPERIMENT` setting. It is enabled automatically on supported platforms, `go env GOEXPERIMENT` doesn't report it, and `GOEXPERIMENT=systemcrypto` is rejected.
 
 > [!NOTE]
-> Prior to Go 1.27, per-platform experiments (`opensslcrypto`, `cngcrypto`, `darwincrypto`) were available. These have been removed in Go 1.27. Use `systemcrypto` instead, which automatically selects the appropriate backend based on the target platform.
+> Prior to Go 1.27, per-platform experiments (`opensslcrypto`, `cngcrypto`, `darwincrypto`) were available. These have been removed in Go 1.27. The build tags associated with those names remain available for source compatibility when `systemcrypto` is enabled.
 
 The `systemcrypto` experiment uses platform-specific code via build constraints. The platform is determined by the target platform (`GOOS`), and the appropriate system cryptography library is used:
 
@@ -119,19 +120,20 @@ The `systemcrypto` experiment uses platform-specific code via build constraints.
 In a cross-build scenario, such as using Linux to build an app that will run on Windows, `GOOS=windows` will correctly use CNG-based code for the `systemcrypto` backend.
 
 A cross-build to Windows or macOS will typically work, because these backends use approaches like syscalls to call the crypto library rather than cgo.
-A cross-build to Linux, however, is more complicated (perhaps infeasible), because its backend uses cgo.
+On Linux in Go 1.27 and later, `systemcrypto` can also be used when cgo is disabled by selecting the [cgo-less OpenSSL backend](../NocgoOpenSSL.md) on supported architectures.
+If cgo is enabled on Linux, the cgo-based OpenSSL backend is used.
 
-The Linux backends' use of cgo also introduces the glibc compatibility problem.
+The Linux cgo-based backend introduces the glibc compatibility problem.
 Building a cgo program on a distro that uses a new glibc version and running that program on a distro with an older glibc version may fail due to missing glibc symbols.
 This is often mitigated by building on a distro with the oldest expected glibc version.
 We have also successfully used a rootfs to build on an older glibc version (and cross-compile arm64 binaries on an amd64 machine), with rough notes available in [microsoft/go#1866](https://github.com/microsoft/go/issues/1866).
 
 > [!TIP]
-> Go 1.26 introduces an experiment to use OpenSSL on Linux without cgo.
+> Go 1.27 uses the cgo-less OpenSSL backend automatically when Linux `systemcrypto` is enabled and cgo is disabled on a supported architecture. Go 1.26 provided this as the `GOEXPERIMENT=ms_nocgo_opensslcrypto` experiment.
 > See [No-cgo OpenSSL Backend](/eng/doc/NocgoOpenSSL.md) for more information.
 
 If a crypto backend is selected but isn't supported, the build fails.
-For example, attempting to use the OpenSSL backend without cgo enabled results in a build error.
+For example, attempting to use the cgo-less OpenSSL backend on an unsupported Linux architecture results in a build error.
 
 For more information about disabling the crypto backend, see [build option to use Go crypto](#build-option-to-use-go-crypto).
 
@@ -305,19 +307,16 @@ It's possible to disable `systemcrypto` and use the Go standard library's implem
 
 If it's acceptable to become noncompliant with the internal Microsoft crypto policy and FIPS, you can use the Go standard library cryptography implementation by disabling the `systemcrypto` backend:
 
-- With Go 1.25.2 or later, set the `MS_GO_NOSYSTEMCRYPTO` environment variable to `1`.
-- With Go 1.25 or later, set the `GOEXPERIMENT` environment variable to `nosystemcrypto`.
+- Set the `MS_GO_NOSYSTEMCRYPTO` environment variable to `1`.
 
-Both of the above methods are supported, but we encourage using `MS_GO_NOSYSTEMCRYPTO` instead of `GOEXPERIMENT`:
+In Go 1.25 and Go 1.26, `GOEXPERIMENT=nosystemcrypto` was also supported. It has been removed in Go 1.27.
+Remove `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` from build scripts when moving to Go 1.27 or later.
 
-- `GOEXPERIMENT=nosystemcrypto` may make your *build command* incompatible with the official Go toolset. ([microsoft/go#1880](https://github.com/microsoft/go/issues/1880))
-- `MS_GO_NOSYSTEMCRYPTO=1` doesn't involve the `GOEXPERIMENT` mechanism. It's simpler to use and to incorporate into any build process.
+- `MS_GO_NOSYSTEMCRYPTO=1` doesn't involve the `GOEXPERIMENT` mechanism. It's simple to use and to incorporate into any build process.
+- Only the exact value `1` disables `systemcrypto`. Other values leave the default behavior in place.
 
 > [!WARNING]
-> `MS_GO_NOSYSTEMCRYPTO=1` has precedence over `GOEXPERIMENT` values.
-> It will disable the backend even if `GOEXPERIMENT=systemcrypto` is set.
->
-> Specifically, `MS_GO_NOSYSTEMCRYPTO=1 GOEXPERIMENT=systemcrypto go build .` builds a program that uses Go standard library cryptography.
+> Go 1.27 and later reject `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` with an error. Use `MS_GO_NOSYSTEMCRYPTO=1` to disable the backend.
 
 > [!NOTE]
 > Your program may use Go crypto even if `systemcrypto` is enabled.
@@ -344,18 +343,21 @@ This algorithm can be overridden by setting the environment variable `GO_OPENSSL
 
 ### Multiple GOEXPERIMENTS
 
-When using `GOEXPERIMENT`, you can enable other non-crypto experiments simultaneously using a comma separator, e.g. `GOEXPERIMENT=systemcrypto,loopvar`. Combining other experiments with `systemcrypto` is supported.
+In Go 1.27 and later, `systemcrypto` isn't configured through `GOEXPERIMENT`.
+Do not include `systemcrypto` or `nosystemcrypto` in `GOEXPERIMENT`; the go command rejects both values.
+
+You can still use `GOEXPERIMENT` for other toolchain experiments, using a comma separator when enabling multiple values.
 
 For more information about other Go experiments, read the output of the command `go doc goexperiment.Flags` to see the experiments available in your specific build of the Go toolset, or check [the online goexperiment package doc](https://pkg.go.dev/internal/goexperiment) to see the options for other versions.
 
 ### Build tags
 
-Selecting most `GOEXPERIMENT`s can also be done by setting the corresponding `goexperiment.*` build tag. This is supported for all crypto backends.
-
-For example, `go build -tags=goexperiment.systemcrypto` command will enable the same backend as setting `GOEXPERIMENT=systemcrypto` then running the build command.
+When `systemcrypto` is enabled, the Microsoft build of Go emits the `goexperiment.systemcrypto` build tag.
+It also emits one legacy per-platform tag for source compatibility: `goexperiment.opensslcrypto` on Linux, `goexperiment.cngcrypto` on Windows, and `goexperiment.darwincrypto` on macOS.
+These tags reflect the backend selected by the toolchain; they are not the supported way to enable or disable `systemcrypto`.
 
 > [!NOTE]
-> Experiments can't be disabled by a build tag, see [Disabling `systemcrypto`](../MigrationGuide.md#disabling-systemcrypto) for how to disable `systemcrypto`.
+> Build tags can't disable `systemcrypto`, see [Disabling `systemcrypto`](../MigrationGuide.md#disabling-systemcrypto) for how to disable `systemcrypto`.
 > For example, `go build -tags=goexperiment.nosystemcrypto` has no effect.
 
 ### Conditional behavior if a crypto backend is enabled
@@ -460,9 +462,15 @@ This list of major changes is intended for quick reference and for access to his
   - The same applies to `GOLANG_FIPS`.
 - The per-platform GOEXPERIMENTs (`opensslcrypto`, `cngcrypto`, `darwincrypto`) have been removed.
   - Using any of the removed experiments will result in a build error.
-  - The `systemcrypto` GOEXPERIMENT has been the preferred way to select a crypto backend since it was introduced in Go 1.21. It is now the only way.
   - The build tags associated with the removed GOEXPERIMENTs remain supported for legacy source compatibility.
   - The `goexperiment.systemcrypto` build tag remains supported, and its behavior has not changed.
+- `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` have been removed.
+  - System crypto is enabled automatically on supported platforms.
+  - To disable system crypto, set `MS_GO_NOSYSTEMCRYPTO=1`.
+  - `systemcrypto` is no longer included in `go env GOEXPERIMENT`, `goexperiment.Flags`, or other GOEXPERIMENT-derived output.
+  - The `goexperiment.systemcrypto` build tag is still emitted when system crypto is enabled.
+- On Linux, `systemcrypto` now supports `CGO_ENABLED=0` on supported cgo-less OpenSSL architectures.
+  - The Go 1.26 `GOEXPERIMENT=ms_nocgo_opensslcrypto` experiment has been removed because this behavior is now part of the default `systemcrypto` backend selection.
 
 ### Go 1.26.3
 
@@ -491,12 +499,12 @@ This list of major changes is intended for quick reference and for access to his
 
 ### Go 1.25 (Aug 2025)
 
-- The `systemcrypto` goexperiment is now enabled by default on Windows and Linux. To disable it, set `GOEXPERIMENT=nosystemcrypto`.
+- The `systemcrypto` goexperiment is now enabled by default on Windows and Linux. In current releases, disable it with `MS_GO_NOSYSTEMCRYPTO=1`; in early Go 1.25 releases, `GOEXPERIMENT=nosystemcrypto` was the available disable knob.
 
 - Running `go version -m` on a binary which uses a system crypto backend now shows the `microsoft_systemcrypto=1` build setting.
 
 - The build-time backend compatibility check now only runs when a crypto package is required for the build.
-  - If your app doesn't depend on a crypto package, you may, for example, use `GOOS=linux CGO_ENABLED=0 GOEXPERIMENT=systemcrypto`.
+  - If your app doesn't depend on a crypto package, you may, for example, use `GOOS=linux CGO_ENABLED=0`.
   - If your app doesn't use a crypto package and you make a change that introduces a crypto package dependency, you will only encounter a compatibility check failure after the change. The change may be in your transitive dependencies: for example, depending on a new module that uses `crypto/sha256` may trigger the compatibility check. This is undesirable, but it's necessary to enable flexibility.
 
 - `GOFIPS=0` no longer causes a panic if FIPS mode is enabled.
@@ -505,7 +513,7 @@ This list of major changes is intended for quick reference and for access to his
 
 - `GOEXPERIMENT=boringcrypto` has been removed.
 
-- `GOEXPERIMENT=allowcryptofallback` has been removed. Instead, if it's necessary to opt out from using a system crypto backend, use `GOEXPERIMENT=nosystemcrypto`. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
+- `GOEXPERIMENT=allowcryptofallback` has been removed. Instead, if it's necessary to opt out from using a system crypto backend, use `MS_GO_NOSYSTEMCRYPTO=1` in current releases. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
 
 - The OpenSSL backend [no longer supports OpenSSL 1.0](https://github.com/golang-fips/openssl/issues/244). The supported versions are now OpenSSL 1.1.0, 1.1.1, and 3.x.
 

--- a/eng/doc/fips/README.md
+++ b/eng/doc/fips/README.md
@@ -71,8 +71,13 @@ The following table summarizes common configurations and how suitable each one i
 > This document assumes the use of a supported version of the Microsoft build of Go: 1.25 or later.
 
 > [!NOTE]
-> Since Go 1.25, `systemcrypto` is enabled by default on Linux and Windows. There is no need to manually enable using OpenSSL/CNG under the hood anymore. See also [the Go 1.25 changelog](#go-125-aug-2025). Since Go 1.26, `systemcrypto` is also enabled by default on macOS.
+> Since Go 1.25, `systemcrypto` is enabled by default on Linux and Windows. There is no need to manually enable using OpenSSL/CNG under the hood anymore.
+> See also [the Go 1.25 changelog](#go-125-aug-2025).
+>
+> Since Go 1.26, `systemcrypto` is also enabled by default on macOS.
+>
 > Since Go 1.27, `systemcrypto` is no longer a `GOEXPERIMENT` setting. Supported platforms use it automatically unless it is disabled with `MS_GO_NOSYSTEMCRYPTO=1`.
+> See also [the Go 1.27 changelog](#go-127-aug-2026).
 
 > [!TIP]
 > If an app uses no cryptography, FIPS compliance is not relevant and the internal Microsoft crypto policy doesn't apply.
@@ -107,7 +112,7 @@ If `systemcrypto` is disabled (see [build option to use Go crypto](#build-option
 > Prior to Go 1.27, `systemcrypto` could be selected with `GOEXPERIMENT=systemcrypto`. In Go 1.27 and later, `systemcrypto` is no longer a `GOEXPERIMENT` setting. It is enabled automatically on supported platforms, `go env GOEXPERIMENT` doesn't report it, and `GOEXPERIMENT=systemcrypto` is rejected.
 
 > [!NOTE]
-> Prior to Go 1.27, per-platform experiments (`opensslcrypto`, `cngcrypto`, `darwincrypto`) were available. These have been removed in Go 1.27. The build tags associated with those names remain available for source compatibility when `systemcrypto` is enabled.
+> Prior to Go 1.27, per-platform experiments (`opensslcrypto`, `cngcrypto`, `darwincrypto`) were available. These experiments have been removed in Go 1.27, but the build tag associated with each experiment remains supported, ensuring source compatibility.
 
 The `systemcrypto` experiment uses platform-specific code via build constraints. The platform is determined by the target platform (`GOOS`), and the appropriate system cryptography library is used:
 
@@ -120,7 +125,9 @@ The `systemcrypto` experiment uses platform-specific code via build constraints.
 In a cross-build scenario, such as using Linux to build an app that will run on Windows, `GOOS=windows` will correctly use CNG-based code for the `systemcrypto` backend.
 
 A cross-build to Windows or macOS will typically work, because these backends use approaches like syscalls to call the crypto library rather than cgo.
-On Linux in Go 1.27 and later, `systemcrypto` can also be used when cgo is disabled by selecting the [cgo-less OpenSSL backend](../NocgoOpenSSL.md) on supported architectures.
+
+A cross-build to Linux in Go 1.27 and later will work if the [cgo-less OpenSSL backend](../NocgoOpenSSL.md) is used.
+The cgo-less backend may be unavailable for some processor architectures that aren't commonly used at Microsoft.
 If cgo is enabled on Linux, the cgo-based OpenSSL backend is used.
 
 The Linux cgo-based backend introduces the glibc compatibility problem.
@@ -465,10 +472,10 @@ This list of major changes is intended for quick reference and for access to his
   - The build tags associated with the removed GOEXPERIMENTs remain supported for legacy source compatibility.
   - The `goexperiment.systemcrypto` build tag remains supported, and its behavior has not changed.
 - `GOEXPERIMENT=systemcrypto` and `GOEXPERIMENT=nosystemcrypto` have been removed.
-  - System crypto is enabled automatically on supported platforms.
-  - To disable system crypto, set `MS_GO_NOSYSTEMCRYPTO=1`.
+  - `systemcrypto` is enabled automatically on supported platforms.
+  - To disable `systemcrypto`, set `MS_GO_NOSYSTEMCRYPTO=1`.
   - `systemcrypto` is no longer included in `go env GOEXPERIMENT`, `goexperiment.Flags`, or other GOEXPERIMENT-derived output.
-  - The `goexperiment.systemcrypto` build tag is still emitted when system crypto is enabled.
+  - The `goexperiment.systemcrypto` build tag is still emitted when `systemcrypto` is enabled.
 - On Linux, `systemcrypto` now supports `CGO_ENABLED=0` on supported cgo-less OpenSSL architectures.
   - The Go 1.26 `GOEXPERIMENT=ms_nocgo_opensslcrypto` experiment has been removed because this behavior is now part of the default `systemcrypto` backend selection.
 
@@ -499,7 +506,7 @@ This list of major changes is intended for quick reference and for access to his
 
 ### Go 1.25 (Aug 2025)
 
-- The `systemcrypto` goexperiment is now enabled by default on Windows and Linux. In current releases, disable it with `MS_GO_NOSYSTEMCRYPTO=1`; in early Go 1.25 releases, `GOEXPERIMENT=nosystemcrypto` was the available disable knob.
+- The `systemcrypto` goexperiment is now enabled by default on Windows and Linux. In Go 1.25.0, `GOEXPERIMENT=nosystemcrypto` was the available disable knob, but the current supported disable knob is documented by the [Build option to use Go crypto](#build-option-to-use-go-crypto) section.
 
 - Running `go version -m` on a binary which uses a system crypto backend now shows the `microsoft_systemcrypto=1` build setting.
 
@@ -513,7 +520,7 @@ This list of major changes is intended for quick reference and for access to his
 
 - `GOEXPERIMENT=boringcrypto` has been removed.
 
-- `GOEXPERIMENT=allowcryptofallback` has been removed. Instead, if it's necessary to opt out from using a system crypto backend, use `MS_GO_NOSYSTEMCRYPTO=1` in current releases. This is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
+- `GOEXPERIMENT=allowcryptofallback` has been removed. Instead, if it's necessary to opt out from using a system crypto backend, use the disable knob documented by the [Build option to use Go crypto](#build-option-to-use-go-crypto) section. `allowcryptofallback` is an internal mechanism that is not intended for use when building a Go application. This document has always recommended against using it, so we anticipate that this change won't affect users of the Microsoft build of Go. Please [contact the maintainers of the Microsoft build of Go](https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md) if you need to use it so we can understand the scenario and help find a safer alternative.
 
 - The OpenSSL backend [no longer supports OpenSSL 1.0](https://github.com/golang-fips/openssl/issues/244). The supported versions are now OpenSSL 1.1.0, 1.1.1, and 3.x.
 


### PR DESCRIPTION
Documents PR 2320 follow-up:
- removal of systemcrypto and nosystemcrypto GOEXPERIMENT user guidance
- MS_GO_NOSYSTEMCRYPTO opt-out guidance
- retained goexperiment build tags for source compatibility
- Go 1.27 Linux CGO_ENABLED=0 no-cgo OpenSSL behavior

Validation:
- git diff --cached --check