### PR TITLE
Ship .asc signature alongside .sig

### DIFF
--- a/eng/_util/cmd/sign/archive.go
+++ b/eng/_util/cmd/sign/archive.go
@@ -428,7 +428,7 @@ func (a *archive) prepareArchiveSignatures(ctx context.Context) ([]*fileToSign, 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	// Copy the archive file with a ".sig" suffix. The signing process sends this file to get a
+	// Copy the archive file and add a ".sig" suffix. The signing process sends this new file to get a
 	// signature, then replaces its content in-place with the result. We need to preemptively make
 	// a renamed copy of the file so we end up with both the original file and signature on the
 	// machine.

--- a/eng/_util/cmd/sign/archive.go
+++ b/eng/_util/cmd/sign/archive.go
@@ -428,10 +428,10 @@ func (a *archive) prepareArchiveSignatures(ctx context.Context) ([]*fileToSign, 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	// Copy the archive file to have .sig suffix, e.g. "tar.gz" to "tar.gz.sig". The signing
-	// process sends the "tar.gz.sig" file to get a signature, then replaces the "tar.gz.sig"
-	// file's content in-place with the result. We need to preemptively make a renamed copy of the
-	// file so we end up with both the original file and sig on the machine.
+	// Copy the archive file with a ".sig" suffix. The signing process sends this file to get a
+	// signature, then replaces its content in-place with the result. We need to preemptively make
+	// a renamed copy of the file so we end up with both the original file and signature on the
+	// machine.
 	log.Printf("Copying file for signature generation: %q -> %q", a.latestPath(), a.sigPath())
 	if err := copyFile(a.sigPath(), a.latestPath()); err != nil {
 		return nil, err
@@ -459,6 +459,10 @@ func (a *archive) copyToDestination(ctx context.Context) error {
 		return err
 	}
 	if err := copyFile(filepath.Join(*destinationDir, a.name+".sig"), a.sigPath()); err != nil {
+		return err
+	}
+	// Also produce an .asc file (same content) to match upstream Go's convention.
+	if err := copyFile(filepath.Join(*destinationDir, a.name+".asc"), a.sigPath()); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Ship an `.asc` PGP signature file alongside the existing `.sig` for every archive. The `.sig` remains the default/primary extension; `.asc` is produced in parallel for compatibility with upstream Go tooling (e.g. official Dockerfiles).

For https://github.com/microsoft/go/issues/181

### Changes
- **sign tool (archive.go)**: Produce `.sig` via signing, then copy both `.sig` and `.asc` to the destination directory
- **sign tool (sign.go)**: Test mode handles `.sig` signature files
- **updatelinktable**: No change (`.sig` remains the advertised suffix)

### Companion PR
- https://github.com/microsoft/go-infra/pull/502