### PR TITLE
Switch Windows ARM64 from cross-compile to native build and test

### DIFF
--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -71,7 +71,7 @@ stages:
           - { os: windows, arch: amd64, config: buildandpack }
           - { os: linux, arch: arm, hostArch: amd64, config: buildandpack }
           - { os: linux, arch: arm64, hostArch: amd64, config: buildandpack }
-          - { os: windows, arch: arm64, hostArch: amd64, config: buildandpack }
+          - { os: windows, arch: arm64, config: buildandpack }
           - { os: darwin, arch: amd64, config: buildandpack }
           - { os: darwin, arch: arm64, config: buildandpack }
           - ${{ if parameters.includeArm64Host }}:
@@ -86,7 +86,9 @@ stages:
           - { nosystemcrypto: true, os: darwin, arch: arm64, config: test }
           - { os: darwin, arch: arm64, config: test }
           - { os: darwin, arch: arm64, config: test, fips: true }
-          # - { nosystemcrypto: true, os: windows, arch: arm64, config: test }
+          - { nosystemcrypto: true, os: windows, arch: arm64, config: test }
+          - { os: windows, arch: arm64, config: test }
+          - { os: windows, arch: arm64, config: test, fips: true }
           - { nosystemcrypto: true, os: linux, arch: amd64, config: devscript }
           - { nosystemcrypto: true, os: linux, arch: amd64, config: test }
           - { nosystemcrypto: true, os: linux, arch: amd64, config: test, distro: ubuntu }

--- a/eng/pipeline/stages/pool-2.yml
+++ b/eng/pipeline/stages/pool-2.yml
@@ -32,7 +32,16 @@ stages:
         name: ${{ parameters.name }}
 
         ${{ if eq(parameters.os, 'windows') }}:
-          ${{ if parameters.ctx['Go1ESOfficial'] }}:
+          ${{ if eq(parameters.hostArch, 'arm64') }}:
+            ${{ if parameters.ctx['Go1ESOfficial'] }}:
+              image: windows.11.arm64
+              os: windows
+            ${{ elseif parameters.public }}:
+              demands: ImageOverride -equals windows.11.arm64.open
+            ${{ else }}:
+              demands: ImageOverride -equals windows.11.arm64
+              os: windows
+          ${{ elseif parameters.ctx['Go1ESOfficial'] }}:
             image: 1es-windows-${{ parameters.distro }}
             os: windows
           ${{ elseif parameters.public }}:


### PR DESCRIPTION
Use windows.11.arm64 / windows.11.arm64.open pools for native Windows ARM64 builds. Remove hostArch: amd64 from the buildandpack entry and enable innerloop test configurations (nosystemcrypto, systemcrypto, FIPS).