### PR TITLE
[release-branch.go1.26] Upgrade openssl backend

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -191,7 +191,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/ossl/errors_cgo.go               |   30 +
  .../internal/ossl/errors_nocgo.go             |   16 +
  .../go-crypto-openssl/internal/ossl/ossl.go   |   59 +
- .../go-crypto-openssl/internal/ossl/shims.h   |  434 +++
+ .../go-crypto-openssl/internal/ossl/shims.h   |  436 +++
  .../internal/ossl/syscall_nocgo.go            |   84 +
  .../internal/ossl/syscall_nocgo_darwin.go     |    5 +
  .../internal/ossl/syscall_nocgo_linux.go      |    5 +
@@ -199,17 +199,17 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/ossl/syscall_nocgo_windows.go    |   22 +
  .../go-crypto-openssl/internal/ossl/zdl.s     |   55 +
  .../internal/ossl/zdl_nocgo.go                |   45 +
- .../go-crypto-openssl/internal/ossl/zossl.c   | 2056 ++++++++++++++
+ .../go-crypto-openssl/internal/ossl/zossl.c   | 2074 ++++++++++++++
  .../go-crypto-openssl/internal/ossl/zossl.go  |   67 +
- .../go-crypto-openssl/internal/ossl/zossl.h   |  363 +++
- .../internal/ossl/zossl_cgo.go                | 1368 ++++++++++
+ .../go-crypto-openssl/internal/ossl/zossl.h   |  365 +++
+ .../internal/ossl/zossl_cgo.go                | 1380 ++++++++++
  .../internal/ossl/zossl_cgo_go124.go          |   45 +
- .../internal/ossl/zossl_nocgo.go              | 2390 +++++++++++++++++
+ .../internal/ossl/zossl_nocgo.go              | 2410 +++++++++++++++++
  .../go-crypto-openssl/openssl/aes.go          |  145 +
  .../go-crypto-openssl/openssl/big.go          |   11 +
  .../openssl/chacha20poly1305.go               |  149 +
- .../go-crypto-openssl/openssl/cipher.go       |  659 +++++
- .../go-crypto-openssl/openssl/const.go        |   91 +
+ .../go-crypto-openssl/openssl/cipher.go       |  687 +++++
+ .../go-crypto-openssl/openssl/const.go        |  102 +
  .../go-crypto-openssl/openssl/cshake.go       |  253 ++
  .../go-crypto-openssl/openssl/des.go          |  112 +
  .../go-crypto-openssl/openssl/dsa.go          |  308 +++
@@ -217,11 +217,11 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go-crypto-openssl/openssl/ecdh.go         |  343 +++
  .../go-crypto-openssl/openssl/ecdsa.go        |  222 ++
  .../go-crypto-openssl/openssl/ed25519.go      |  210 ++
- .../go-crypto-openssl/openssl/evp.go          |  620 +++++
+ .../go-crypto-openssl/openssl/evp.go          |  641 +++++
  .../go-crypto-openssl/openssl/hash.go         |  502 ++++
  .../go-crypto-openssl/openssl/hashclone.go    |   14 +
  .../openssl/hashclone_go125.go                |    9 +
- .../go-crypto-openssl/openssl/hkdf.go         |  445 +++
+ .../go-crypto-openssl/openssl/hkdf.go         |  446 +++
  .../go-crypto-openssl/openssl/hmac.go         |  282 ++
  .../go-crypto-openssl/openssl/mlkem.go        |  371 +++
  .../go-crypto-openssl/openssl/openssl.go      |  259 ++
@@ -274,7 +274,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 266 files changed, 34042 insertions(+), 7 deletions(-)
+ 266 files changed, 34157 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -535,7 +535,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/sysdll/sys_windows.go
 
 diff --git a/src/cmd/go.mod b/src/cmd/go.mod
-index 14107c2d8ed9f3..1b51923f77e32e 100644
+index 8ffd61a0242c2d..6b1de6e0ecf163 100644
 --- a/src/cmd/go.mod
 +++ b/src/cmd/go.mod
 @@ -4,6 +4,8 @@ go 1.26
@@ -548,7 +548,7 @@ index 14107c2d8ed9f3..1b51923f77e32e 100644
  	golang.org/x/build v0.0.0-20251128064159-b9bfd88b30e8
  	golang.org/x/mod v0.30.1-0.20251115032019-269c237cf350
 diff --git a/src/cmd/go.sum b/src/cmd/go.sum
-index c4920417b21b3d..4591d4c5da550d 100644
+index 107b74bfc23781..ca4b2583b14f89 100644
 --- a/src/cmd/go.sum
 +++ b/src/cmd/go.sum
 @@ -4,6 +4,10 @@ github.com/google/pprof v0.0.0-20251114195745-4902fdda35c8 h1:3DsUAV+VNEQa2CUVLx
@@ -2157,7 +2157,7 @@ index 00000000000000..d592037b570130
 +	return ok
 +}
 diff --git a/src/cmd/vendor/modules.txt b/src/cmd/vendor/modules.txt
-index 4e2260af522911..e4a084bebaba13 100644
+index 781b9c8fb47af3..49f23d6a48983b 100644
 --- a/src/cmd/vendor/modules.txt
 +++ b/src/cmd/vendor/modules.txt
 @@ -16,6 +16,17 @@ github.com/google/pprof/third_party/svgpan
@@ -2207,7 +2207,7 @@ index 00000000000000..f5dc9afe4b0ead
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index b329ba18def47c..e322d27d046c87 100644
+index b329ba18def47c..d6048a72d918eb 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2217,18 +2217,18 @@ index b329ba18def47c..e322d27d046c87 100644
 +
 +require (
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260130143703-78cb726ef357
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20260521135756-859040d79e1a
++	github.com/microsoft/go-crypto-openssl v0.0.0-20260602094349-4d656068110f
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 37f908522c1926..1c0bd328a6003b 100644
+index 37f908522c1926..62224e4c37e433 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260130143703-78cb726ef357 h1:ILqgGD8SGjjtSweSBanrXyX8Aco33yFSJEqsnJgmXHU=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260130143703-78cb726ef357/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260521135756-859040d79e1a h1:x3FXTooDfKmV190a8yqa4xN/GaE4dVPnYuriLVdwTms=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260521135756-859040d79e1a/go.mod h1:4QCeILGRVUNXcRMpHlFIzULgpv3vJcnC34zEdDHdw98=
++github.com/microsoft/go-crypto-openssl v0.0.0-20260602094349-4d656068110f h1:Rg3Df9INlJ7g5iE1VR3jwc6M+lHOtXNyO4HfDRy5P54=
++github.com/microsoft/go-crypto-openssl v0.0.0-20260602094349-4d656068110f/go.mod h1:4QCeILGRVUNXcRMpHlFIzULgpv3vJcnC34zEdDHdw98=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9 h1:joliMChkkfHV3vAPKzu9kefdw0K+d89A8r9gTm3MFS4=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00 h1:JgcPM1rzpSOZS8y69FQvnY0xN0ciHlpQqwTXJcuZIA4=
@@ -18361,10 +18361,10 @@ index 00000000000000..9d38464e9fb964
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/shims.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/shims.h
 new file mode 100644
-index 00000000000000..d926c6adf17dda
+index 00000000000000..0607516a82b5fe
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/shims.h
-@@ -0,0 +1,434 @@
+@@ -0,0 +1,436 @@
 +// This header file is used by the mkcgo tool to generate cgo and Go bindings for the
 +// OpenSSL C API. Run "go generate ." to regenerate the bindings.
 +// Do not include this file, import "zossl.h" instead.
@@ -18637,6 +18637,7 @@ index 00000000000000..d926c6adf17dda
 +void EVP_CIPHER_CTX_free(_EVP_CIPHER_CTX_PTR arg0);
 +int EVP_CIPHER_CTX_ctrl(_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr);
 +int EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv, int enc);
++int EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, const unsigned char *key, const unsigned char *iv, int enc, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 +int EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));
 +int EVP_EncryptInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv);
 +int EVP_EncryptUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));
@@ -18663,6 +18664,7 @@ index 00000000000000..d926c6adf17dda
 +int EVP_PKEY_up_ref(_EVP_PKEY_PTR key);
 +int EVP_PKEY_set1_EC_KEY(_EVP_PKEY_PTR pkey, _EC_KEY_PTR key) __attribute__((tag("legacy_1")));
 +int EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR ctx, void *label, int len) __attribute__((tag("3")));
++int EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 +int EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR pkey, unsigned char *pub, size_t *len) __attribute__((tag("111"),noescape,nocallback));
 +int EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR pkey, unsigned char *priv, size_t *len) __attribute__((tag("111"),noescape,nocallback));
 +int EVP_PKEY_fromdata_init(_EVP_PKEY_CTX_PTR ctx) __attribute__((tag("3")));
@@ -19079,10 +19081,10 @@ index 00000000000000..e4d870cecde36c
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.c b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.c
 new file mode 100644
-index 00000000000000..832ecd8558ffef
+index 00000000000000..5aa2f8f8867d80
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.c
-@@ -0,0 +1,2056 @@
+@@ -0,0 +1,2074 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +#include <stddef.h>
@@ -19149,6 +19151,7 @@ index 00000000000000..832ecd8558ffef
 +const char* (*_g_EVP_CIPHER_get0_name)(const _EVP_CIPHER_PTR);
 +int (*_g_EVP_CIPHER_get_block_size)(const _EVP_CIPHER_PTR);
 +int (*_g_EVP_CipherInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int);
++int (*_g_EVP_CipherInit_ex2)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR);
 +int (*_g_EVP_CipherUpdate)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int);
 +int (*_g_EVP_DecryptFinal_ex)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*);
 +int (*_g_EVP_DecryptInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*);
@@ -19212,6 +19215,7 @@ index 00000000000000..832ecd8558ffef
 +int (*_g_EVP_PKEY_CTX_set1_hkdf_salt)(_EVP_PKEY_CTX_PTR, const unsigned char*, int);
 +int (*_g_EVP_PKEY_CTX_set_hkdf_md)(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR);
 +int (*_g_EVP_PKEY_CTX_set_hkdf_mode)(_EVP_PKEY_CTX_PTR, int);
++int (*_g_EVP_PKEY_CTX_set_params)(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR);
 +_EVP_PKEY_PTR (*_g_EVP_PKEY_Q_keygen)(_OSSL_LIB_CTX_PTR, const char*, const char*, ...);
 +int (*_g_EVP_PKEY_assign)(_EVP_PKEY_PTR, int, void*);
 +int (*_g_EVP_PKEY_decapsulate)(_EVP_PKEY_CTX_PTR, unsigned char*, size_t*, const unsigned char*, size_t);
@@ -19592,6 +19596,7 @@ index 00000000000000..832ecd8558ffef
 +	__mkcgo__dlsym(EVP_CIPHER_fetch)
 +	__mkcgo__dlsym(EVP_CIPHER_get0_name)
 +	__mkcgo__dlsym(EVP_CIPHER_get_block_size)
++	__mkcgo__dlsym(EVP_CipherInit_ex2)
 +	__mkcgo__dlsym(EVP_KDF_CTX_free)
 +	__mkcgo__dlsym(EVP_KDF_CTX_get_kdf_size)
 +	__mkcgo__dlsym(EVP_KDF_CTX_new)
@@ -19627,6 +19632,7 @@ index 00000000000000..832ecd8558ffef
 +	__mkcgo__dlsym(EVP_PKEY_CTX_set1_hkdf_salt)
 +	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_md)
 +	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_mode)
++	__mkcgo__dlsym(EVP_PKEY_CTX_set_params)
 +	__mkcgo__dlsym(EVP_PKEY_Q_keygen)
 +	__mkcgo__dlsym(EVP_PKEY_decapsulate)
 +	__mkcgo__dlsym(EVP_PKEY_decapsulate_init)
@@ -19665,6 +19671,7 @@ index 00000000000000..832ecd8558ffef
 +	_g_EVP_CIPHER_fetch = NULL;
 +	_g_EVP_CIPHER_get0_name = NULL;
 +	_g_EVP_CIPHER_get_block_size = NULL;
++	_g_EVP_CipherInit_ex2 = NULL;
 +	_g_EVP_KDF_CTX_free = NULL;
 +	_g_EVP_KDF_CTX_get_kdf_size = NULL;
 +	_g_EVP_KDF_CTX_new = NULL;
@@ -19700,6 +19707,7 @@ index 00000000000000..832ecd8558ffef
 +	_g_EVP_PKEY_CTX_set1_hkdf_salt = NULL;
 +	_g_EVP_PKEY_CTX_set_hkdf_md = NULL;
 +	_g_EVP_PKEY_CTX_set_hkdf_mode = NULL;
++	_g_EVP_PKEY_CTX_set_params = NULL;
 +	_g_EVP_PKEY_Q_keygen = NULL;
 +	_g_EVP_PKEY_decapsulate = NULL;
 +	_g_EVP_PKEY_decapsulate_init = NULL;
@@ -20145,6 +20153,12 @@ index 00000000000000..832ecd8558ffef
 +	return _ret;
 +}
 +
++int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, const unsigned char* _arg2, const unsigned char* _arg3, int _arg4, const _OSSL_PARAM_PTR _arg5, uintptr_t *_err_state) {
++	int _ret = _g_EVP_CipherInit_ex2(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
++	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
++	return _ret;
++}
++
 +int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, const unsigned char* _arg3, int _arg4, uintptr_t *_err_state) {
 +	int _ret = _g_EVP_CipherUpdate(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
@@ -20495,6 +20509,12 @@ index 00000000000000..832ecd8558ffef
 +
 +int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR _arg0, int _arg1, uintptr_t *_err_state) {
 +	int _ret = _g_EVP_PKEY_CTX_set_hkdf_mode(_arg0, _arg1);
++	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
++	return _ret;
++}
++
++int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, uintptr_t *_err_state) {
++	int _ret = _g_EVP_PKEY_CTX_set_params(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
@@ -21214,10 +21234,10 @@ index 00000000000000..39b0a728fdd700
 +)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.h
 new file mode 100644
-index 00000000000000..e7513f3e402401
+index 00000000000000..53592be9032126
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.h
-@@ -0,0 +1,363 @@
+@@ -0,0 +1,365 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +#ifndef MKCGO_H // only include this header once
@@ -21395,6 +21415,7 @@ index 00000000000000..e7513f3e402401
 +const char* _mkcgo_EVP_CIPHER_get0_name(const _EVP_CIPHER_PTR);
 +int _mkcgo_EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR);
 +int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int, uintptr_t *);
++int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR, uintptr_t *);
 +int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int, uintptr_t *);
 +int _mkcgo_EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, uintptr_t *);
 +int _mkcgo_EVP_DecryptInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, uintptr_t *);
@@ -21458,6 +21479,7 @@ index 00000000000000..e7513f3e402401
 +int _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR, const unsigned char*, int, uintptr_t *);
 +int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR, uintptr_t *);
 +int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR, int, uintptr_t *);
++int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR, uintptr_t *);
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR, const char*, const char*, const char*, uintptr_t *);
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_MLKEM(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);
@@ -21583,10 +21605,10 @@ index 00000000000000..e7513f3e402401
 +#endif // MKCGO_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_cgo.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_cgo.go
 new file mode 100644
-index 00000000000000..059562f35df7b3
+index 00000000000000..1cc05ce8af17d9
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_cgo.go
-@@ -0,0 +1,1368 @@
+@@ -0,0 +1,1380 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +package ossl
@@ -21962,6 +21984,12 @@ index 00000000000000..059562f35df7b3
 +	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex", uintptr(_err))
 +}
 +
++func EVP_CipherInit_ex2(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, key *byte, iv *byte, enc int32, params OSSL_PARAM_PTR) (int32, error) {
++	var _err C.uintptr_t
++	_ret := C._mkcgo_EVP_CipherInit_ex2(ctx, __type, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv)), C.int(enc), params, mkcgoNoEscape(&_err))
++	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex2", uintptr(_err))
++}
++
 +func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 +	var _err C.uintptr_t
 +	_ret := C._mkcgo_EVP_CipherUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl), mkcgoNoEscape(&_err))
@@ -22314,6 +22342,12 @@ index 00000000000000..059562f35df7b3
 +	var _err C.uintptr_t
 +	_ret := C._mkcgo_EVP_PKEY_CTX_set_hkdf_mode(arg0, C.int(arg1), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_mode", uintptr(_err))
++}
++
++func EVP_PKEY_CTX_set_params(ctx EVP_PKEY_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
++	var _err C.uintptr_t
++	_ret := C._mkcgo_EVP_PKEY_CTX_set_params(ctx, params, mkcgoNoEscape(&_err))
++	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_params", uintptr(_err))
 +}
 +
 +func EVP_PKEY_Q_keygen_EC(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 *byte) (EVP_PKEY_PTR, error) {
@@ -23008,10 +23042,10 @@ index 00000000000000..677ef1d157a670
 +import "C"
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_nocgo.go
 new file mode 100644
-index 00000000000000..56b1f871c7fcbf
+index 00000000000000..fce5c995d60482
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_nocgo.go
-@@ -0,0 +1,2390 @@
+@@ -0,0 +1,2410 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +//go:build !cgo
@@ -23427,6 +23461,14 @@ index 00000000000000..56b1f871c7fcbf
 +	var _err uintptr
 +	r0, _ := syscallN(3, _mkcgo_EVP_CipherInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(enc), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_CipherInit_ex", _err)
++}
++
++var _mkcgo_EVP_CipherInit_ex2 uintptr
++
++func EVP_CipherInit_ex2(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, key *byte, iv *byte, enc int32, params OSSL_PARAM_PTR) (int32, error) {
++	var _err uintptr
++	r0, _ := syscallN(3, _mkcgo_EVP_CipherInit_ex2, uintptr(ctx), uintptr(__type), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(enc), uintptr(params), uintptr(unsafe.Pointer(&_err)))
++	return int32(r0), newMkcgoErr("EVP_CipherInit_ex2", _err)
 +}
 +
 +var _mkcgo_EVP_CipherUpdate uintptr
@@ -23912,6 +23954,14 @@ index 00000000000000..56b1f871c7fcbf
 +	var _err uintptr
 +	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set_hkdf_mode, uintptr(arg0), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
 +	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_mode", _err)
++}
++
++var _mkcgo_EVP_PKEY_CTX_set_params uintptr
++
++func EVP_PKEY_CTX_set_params(ctx EVP_PKEY_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
++	var _err uintptr
++	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set_params, uintptr(ctx), uintptr(params), uintptr(unsafe.Pointer(&_err)))
++	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set_params", _err)
 +}
 +
 +var _mkcgo_EVP_PKEY_Q_keygen uintptr
@@ -25112,6 +25162,7 @@ index 00000000000000..56b1f871c7fcbf
 +	_mkcgo_EVP_CIPHER_fetch = dlsym(handle, "EVP_CIPHER_fetch\x00", false)
 +	_mkcgo_EVP_CIPHER_get0_name = dlsym(handle, "EVP_CIPHER_get0_name\x00", false)
 +	_mkcgo_EVP_CIPHER_get_block_size = dlsym(handle, "EVP_CIPHER_get_block_size\x00", false)
++	_mkcgo_EVP_CipherInit_ex2 = dlsym(handle, "EVP_CipherInit_ex2\x00", false)
 +	_mkcgo_EVP_KDF_CTX_free = dlsym(handle, "EVP_KDF_CTX_free\x00", false)
 +	_mkcgo_EVP_KDF_CTX_get_kdf_size = dlsym(handle, "EVP_KDF_CTX_get_kdf_size\x00", false)
 +	_mkcgo_EVP_KDF_CTX_new = dlsym(handle, "EVP_KDF_CTX_new\x00", false)
@@ -25147,6 +25198,7 @@ index 00000000000000..56b1f871c7fcbf
 +	_mkcgo_EVP_PKEY_CTX_set1_hkdf_salt = dlsym(handle, "EVP_PKEY_CTX_set1_hkdf_salt\x00", false)
 +	_mkcgo_EVP_PKEY_CTX_set_hkdf_md = dlsym(handle, "EVP_PKEY_CTX_set_hkdf_md\x00", false)
 +	_mkcgo_EVP_PKEY_CTX_set_hkdf_mode = dlsym(handle, "EVP_PKEY_CTX_set_hkdf_mode\x00", false)
++	_mkcgo_EVP_PKEY_CTX_set_params = dlsym(handle, "EVP_PKEY_CTX_set_params\x00", false)
 +	_mkcgo_EVP_PKEY_Q_keygen = dlsym(handle, "EVP_PKEY_Q_keygen\x00", false)
 +	_mkcgo_EVP_PKEY_decapsulate = dlsym(handle, "EVP_PKEY_decapsulate\x00", false)
 +	_mkcgo_EVP_PKEY_decapsulate_init = dlsym(handle, "EVP_PKEY_decapsulate_init\x00", false)
@@ -25185,6 +25237,7 @@ index 00000000000000..56b1f871c7fcbf
 +	_mkcgo_EVP_CIPHER_fetch = 0
 +	_mkcgo_EVP_CIPHER_get0_name = 0
 +	_mkcgo_EVP_CIPHER_get_block_size = 0
++	_mkcgo_EVP_CipherInit_ex2 = 0
 +	_mkcgo_EVP_KDF_CTX_free = 0
 +	_mkcgo_EVP_KDF_CTX_get_kdf_size = 0
 +	_mkcgo_EVP_KDF_CTX_new = 0
@@ -25220,6 +25273,7 @@ index 00000000000000..56b1f871c7fcbf
 +	_mkcgo_EVP_PKEY_CTX_set1_hkdf_salt = 0
 +	_mkcgo_EVP_PKEY_CTX_set_hkdf_md = 0
 +	_mkcgo_EVP_PKEY_CTX_set_hkdf_mode = 0
++	_mkcgo_EVP_PKEY_CTX_set_params = 0
 +	_mkcgo_EVP_PKEY_Q_keygen = 0
 +	_mkcgo_EVP_PKEY_decapsulate = 0
 +	_mkcgo_EVP_PKEY_decapsulate_init = 0
@@ -25404,7 +25458,7 @@ index 00000000000000..56b1f871c7fcbf
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
 new file mode 100644
-index 00000000000000..654566d2bff4e0
+index 00000000000000..0bb57aecc9896e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/aes.go
 @@ -0,0 +1,145 @@
@@ -25417,8 +25471,8 @@ index 00000000000000..654566d2bff4e0
 +	"errors"
 +)
 +
-+//go:generate go run github.com/golang-fips/openssl/v2/cmd/genaesmodes -in aes.go -modes CBC,CTR,GCM -out zaes.go
-+//go:generate go run github.com/golang-fips/openssl/v2/cmd/gentestvectors -out vectors_test.go
++//go:generate go run github.com/microsoft/go-crypto-openssl/cmd/genaesmodes -in aes.go -modes CBC,CTR,GCM -out zaes.go
++//go:generate go run github.com/microsoft/go-crypto-openssl/cmd/gentestvectors -out vectors_test.go
 +
 +// Steps to support a new AES mode, e.g. `FOO`:
 +// 1. Add `FOO` to the list of modes in the `genaesmodes` command.
@@ -25727,10 +25781,10 @@ index 00000000000000..83d1898b1ab93b
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/cipher.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/cipher.go
 new file mode 100644
-index 00000000000000..7d6754840e96af
+index 00000000000000..8a0aa0514cf7ae
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/cipher.go
-@@ -0,0 +1,659 @@
+@@ -0,0 +1,687 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -26348,6 +26402,10 @@ index 00000000000000..7d6754840e96af
 +	if cipher == nil {
 +		panic("crypto/cipher: unsupported cipher: " + kind.String())
 +	}
++	params, err := cipherInitParams(encrypt)
++	if err != nil {
++		return nil, err
++	}
 +	ctx, err := ossl.EVP_CIPHER_CTX_new()
 +	if err != nil {
 +		return nil, err
@@ -26370,10 +26428,34 @@ index 00000000000000..7d6754840e96af
 +		// Pass nil to the next call to EVP_CipherInit_ex to avoid resetting ctx's cipher.
 +		cipher = nil
 +	}
-+	if _, err := ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt)); err != nil {
++	if params != nil {
++		_, err = ossl.EVP_CipherInit_ex2(ctx, cipher, base(key), base(iv), int32(encrypt), params)
++	} else {
++		_, err = ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt))
++	}
++	if err != nil {
 +		return nil, err
 +	}
 +	return ctx, nil
++}
++
++var cipherEncryptCheckParams = sync.OnceValues(func() (ossl.OSSL_PARAM_PTR, error) {
++	bld, err := newParamBuilder()
++	if err != nil {
++		return nil, err
++	}
++	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
++	return bld.build()
++})
++
++func cipherInitParams(encrypt cipherOp) (ossl.OSSL_PARAM_PTR, error) {
++	if encrypt != cipherOpEncrypt || major() == 1 {
++		return nil, nil
++	}
++	// The returned params are cached for the lifetime of the process and must not be freed by callers.
++	// Setting the FIPS encrypt check to 0 allows encryption to proceed even if the key is not approved for use in FIPS mode.
++	// This check is done at the Go crypto level.
++	return cipherEncryptCheckParams()
 +}
 +
 +// The following two functions are a mirror of golang.org/x/crypto/internal/subtle.
@@ -26392,10 +26474,10 @@ index 00000000000000..7d6754840e96af
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/const.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/const.go
 new file mode 100644
-index 00000000000000..e4f8f5b5d0c4a7
+index 00000000000000..053adbeb1ca86c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/const.go
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,102 @@
 +package openssl
 +
 +import "unsafe"
@@ -26457,6 +26539,10 @@ index 00000000000000..e4f8f5b5d0c4a7
 +	_OSSL_KDF_PARAM_SALT   cString = "salt\x00"
 +	_OSSL_KDF_PARAM_MODE   cString = "mode\x00"
 +
++	// KDF FIPS parameters
++	_OSSL_KDF_PARAM_FIPS_KEY_CHECK        cString = "key-check\x00"
++	_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK cString = "encrypt-check\x00"
++
 +	// TLS3-KDF parameters
 +	_OSSL_KDF_PARAM_PREFIX cString = "prefix\x00"
 +	_OSSL_KDF_PARAM_LABEL  cString = "label\x00"
@@ -26483,6 +26569,13 @@ index 00000000000000..e4f8f5b5d0c4a7
 +	_OSSL_PKEY_PARAM_RSA_EXPONENT2      cString = "rsa-exponent2\x00"
 +	_OSSL_PKEY_PARAM_RSA_COEFFICIENT1   cString = "rsa-coefficient1\x00"
 +	_OSSL_PKEY_PARAM_ML_KEM_SEED        cString = "seed\x00"
++
++	// Signature parameters
++	_OSSL_SIGNATURE_PARAM_DIGEST                     cString = "digest\x00"
++	_OSSL_SIGNATURE_PARAM_PAD_MODE                   cString = "pad-mode\x00"
++	_OSSL_SIGNATURE_PARAM_PSS_SALTLEN                cString = "saltlen\x00"
++	_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK cString = "rsa-pss-saltlen-check\x00"
++	_OSSL_PKEY_RSA_PAD_MODE_PSS                      cString = "pss\x00"
 +
 +	// MAC parameters
 +	_OSSL_MAC_PARAM_DIGEST cString = "digest\x00"
@@ -28115,10 +28208,10 @@ index 00000000000000..03246d99789c25
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go
 new file mode 100644
-index 00000000000000..337e302e178b71
+index 00000000000000..d7b6f19b6370f8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go
-@@ -0,0 +1,620 @@
+@@ -0,0 +1,641 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -28444,19 +28537,40 @@ index 00000000000000..337e302e178b71
 +	if alg == nil {
 +		return errors.New("crypto/rsa: unsupported hash function")
 +	}
-+	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
-+		return err
-+	}
-+	// setPadding must happen after setting EVP_PKEY_CTRL_MD.
-+	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PSS_PADDING, nil); err != nil {
-+		return err
-+	}
-+	if saltLen != 0 {
-+		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
++	switch major() {
++	case 1:
++		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
 +			return err
 +		}
++		// setPadding must happen after setting EVP_PKEY_CTRL_MD.
++		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PSS_PADDING, nil); err != nil {
++			return err
++		}
++		if saltLen != 0 {
++			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
++				return err
++			}
++		}
++		return nil
++	default:
++		bld, err := newParamBuilder()
++		if err != nil {
++			return err
++		}
++		bld.addUTF8String(_OSSL_SIGNATURE_PARAM_DIGEST, ossl.EVP_MD_get0_name(alg.md), 0)
++		bld.addUTF8String(_OSSL_SIGNATURE_PARAM_PAD_MODE, _OSSL_PKEY_RSA_PAD_MODE_PSS.ptr(), 0)
++		if saltLen != 0 {
++			bld.addInt32(_OSSL_SIGNATURE_PARAM_PSS_SALTLEN, saltLen)
++		}
++		bld.addInt32(_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK, 0)
++		params, err := bld.build()
++		if err != nil {
++			return err
++		}
++		defer ossl.OSSL_PARAM_free(params)
++		_, err = ossl.EVP_PKEY_CTX_set_params(ctx, params)
++		return err
 +	}
-+	return nil
 +}
 +
 +func setPKCS1Padding(ctx ossl.EVP_PKEY_CTX_PTR, ch crypto.Hash) error {
@@ -29284,10 +29398,10 @@ index 00000000000000..f1f2364c7246d4
 +type HashCloner = hash.Cloner
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hkdf.go
 new file mode 100644
-index 00000000000000..a11f24b9ddb87c
+index 00000000000000..9381743df5a4fa
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hkdf.go
-@@ -0,0 +1,445 @@
+@@ -0,0 +1,446 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -29691,6 +29805,7 @@ index 00000000000000..a11f24b9ddb87c
 +	if err != nil {
 +		return ctx, err
 +	}
++	bld.addInt32(_OSSL_KDF_PARAM_FIPS_KEY_CHECK, 0)
 +	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 +	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(mode))
 +	bld.addOctetString(_OSSL_KDF_PARAM_KEY, secret)
@@ -38238,7 +38353,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index ceaebeb8a55620..a92d308b009efc 100644
+index ceaebeb8a55620..f229c43576d9fb 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
@@ -38251,7 +38366,7 @@ index ceaebeb8a55620..a92d308b009efc 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-openssl v0.0.0-20260521135756-859040d79e1a
++# github.com/microsoft/go-crypto-openssl v0.0.0-20260602094349-4d656068110f
 +## explicit; go 1.24
 +github.com/microsoft/go-crypto-openssl/bbig
 +github.com/microsoft/go-crypto-openssl/internal/fakecgo


### PR DESCRIPTION
The upgrade bring some OpenSSL 3.5 support improvements for #2322.