### PR TITLE
[release-branch.go1.25] Upgrade openssl backend

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -72,26 +72,26 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-openssl/bbig/big.go   |   37 +
  .../go-crypto-openssl/internal/ossl/errors.go |  119 +
  .../go-crypto-openssl/internal/ossl/ossl.go   |   81 +
- .../go-crypto-openssl/internal/ossl/shims.h   |  399 ++++
- .../go-crypto-openssl/internal/ossl/zossl.c   | 1924 +++++++++++++++++
- .../go-crypto-openssl/internal/ossl/zossl.go  | 1329 ++++++++++++
- .../go-crypto-openssl/internal/ossl/zossl.h   |  335 +++
+ .../go-crypto-openssl/internal/ossl/shims.h   |  401 ++++
+ .../go-crypto-openssl/internal/ossl/zossl.c   | 1942 +++++++++++++++++
+ .../go-crypto-openssl/internal/ossl/zossl.go  | 1341 ++++++++++++
+ .../go-crypto-openssl/internal/ossl/zossl.h   |  337 +++
  .../internal/ossl/zossl_go124.go              |   37 +
  .../go-crypto-openssl/openssl/aes.go          |  146 ++
  .../go-crypto-openssl/openssl/big.go          |   11 +
- .../go-crypto-openssl/openssl/cipher.go       |  654 ++++++
- .../go-crypto-openssl/openssl/const.go        |   93 +
+ .../go-crypto-openssl/openssl/cipher.go       |  682 ++++++
+ .../go-crypto-openssl/openssl/const.go        |  104 +
  .../go-crypto-openssl/openssl/des.go          |  113 +
  .../go-crypto-openssl/openssl/dsa.go          |  309 +++
  .../microsoft/go-crypto-openssl/openssl/ec.go |   67 +
  .../go-crypto-openssl/openssl/ecdh.go         |  306 +++
  .../go-crypto-openssl/openssl/ecdsa.go        |  226 ++
  .../go-crypto-openssl/openssl/ed25519.go      |  229 ++
- .../go-crypto-openssl/openssl/evp.go          |  590 +++++
+ .../go-crypto-openssl/openssl/evp.go          |  612 ++++++
  .../go-crypto-openssl/openssl/hash.go         |  455 ++++
  .../go-crypto-openssl/openssl/hashclone.go    |   14 +
  .../openssl/hashclone_go125.go                |    9 +
- .../go-crypto-openssl/openssl/hkdf.go         |  434 ++++
+ .../go-crypto-openssl/openssl/hkdf.go         |  435 ++++
  .../go-crypto-openssl/openssl/hmac.go         |  283 +++
  .../go-crypto-openssl/openssl/init.go         |  157 ++
  .../go-crypto-openssl/openssl/init_unix.go    |   31 +
@@ -103,7 +103,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../openssl/providersymcrypt.go               |  338 +++
  .../go-crypto-openssl/openssl/rand.go         |   22 +
  .../go-crypto-openssl/openssl/rc4.go          |   69 +
- .../go-crypto-openssl/openssl/rsa.go          |  366 ++++
+ .../go-crypto-openssl/openssl/rsa.go          |  401 ++++
  .../go-crypto-openssl/openssl/tls1prf.go      |  159 ++
  .../go-crypto-openssl/openssl/zaes.go         |   86 +
  .../microsoft/go-crypto-winnative/LICENSE     |   21 +
@@ -134,7 +134,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   17 +
- 126 files changed, 19015 insertions(+), 7 deletions(-)
+ 126 files changed, 19146 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -1914,7 +1914,7 @@ index 00000000000000..f5dc9afe4b0ead
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index 83bcb73a5d1fd5..1eb2a37cfd88d1 100644
+index 83bcb73a5d1fd5..ada2e629f238f2 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -1924,25 +1924,25 @@ index 83bcb73a5d1fd5..1eb2a37cfd88d1 100644
 +
 +require (
 +	github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20260521141647-8d2a891ca446
++	github.com/microsoft/go-crypto-openssl v0.0.0-20260605084120-a6a7990d2462
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b
 +)
 diff --git a/src/go.sum b/src/go.sum
-index e61a311a128012..42117e45cb313a 100644
+index e61a311a128012..f228ec6ab935a7 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7 h1:6a0YcJOAJWLtEqDW55bUhhe4Nx/9Rpmm80KVMUxD6B4=
 +github.com/microsoft/go-crypto-darwin v0.0.2-0.20250714125817-871ed82e87d7/go.mod h1:LyP4oZ0QcysEJdqUTOk9ngNFArRFK94YRImkoJ8julQ=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260521141647-8d2a891ca446 h1:2DvoWXOQqjeb/Tjlvg46BEXNMcm+KtjtD4IG6kyDiy8=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260521141647-8d2a891ca446/go.mod h1:zcqLMscmUJNmPj62PZjpwThp7/Un27PHel+yazZdMzs=
++github.com/microsoft/go-crypto-openssl v0.0.0-20260605084120-a6a7990d2462 h1:Ih5CmBQCZJjfmPWzIFsd7OTvR2F5+2b+0Zr2lyAaLao=
++github.com/microsoft/go-crypto-openssl v0.0.0-20260605084120-a6a7990d2462/go.mod h1:zcqLMscmUJNmPj62PZjpwThp7/Un27PHel+yazZdMzs=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b h1:Yf6lm9r6Aid3PG5FoeSX2v4iU+xWnAmCRQNjBxgceWI=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20250703113837-e4483837c98b/go.mod h1:JkxQeL8dGcyCuKjn1Etz4NmQrOMImMy4BA9hptEfVFA=
  golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
  golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
  golang.org/x/net v0.41.1-0.20260417201234-a9171bc8c6f1 h1:m1pqrn0a8dUQblLBpuciZTjkJ34uU561s+HLlQi2Kec=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 641d1a325a5c07..4145c70f62440e 100644
+index 641d1a325a5c07..7b40e0c9e84d4a 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -521,6 +521,24 @@ var depsRules = `
@@ -6349,10 +6349,10 @@ index 00000000000000..e0d0b8e8bd8cf3
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/shims.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/shims.h
 new file mode 100644
-index 00000000000000..5790defeb6eb55
+index 00000000000000..fd0213b82a5dfc
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/shims.h
-@@ -0,0 +1,399 @@
+@@ -0,0 +1,401 @@
 +// This header file is used by the mkcgo tool to generate cgo and Go bindings for the
 +// OpenSSL C API. Run "go generate ." to regenerate the bindings.
 +// Do not include this file, import "zossl.h" instead.
@@ -6601,6 +6601,7 @@ index 00000000000000..5790defeb6eb55
 +void EVP_CIPHER_CTX_free(_EVP_CIPHER_CTX_PTR arg0);
 +int EVP_CIPHER_CTX_ctrl(_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr);
 +int EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv, int enc);
++int EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, const unsigned char *key, const unsigned char *iv, int enc, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 +int EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));
 +int EVP_EncryptInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv);
 +int EVP_EncryptUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));
@@ -6626,6 +6627,7 @@ index 00000000000000..5790defeb6eb55
 +int EVP_PKEY_up_ref(_EVP_PKEY_PTR key) __attribute__((tag("3")));
 +int EVP_PKEY_set1_EC_KEY(_EVP_PKEY_PTR pkey, _EC_KEY_PTR key) __attribute__((tag("legacy_1")));
 +int EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR ctx, void *label, int len) __attribute__((tag("3")));
++int EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 +int EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR pkey, unsigned char *pub, size_t *len) __attribute__((tag("111"),noescape,nocallback));
 +int EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR pkey, unsigned char *priv, size_t *len) __attribute__((tag("111"),noescape,nocallback));
 +int EVP_PKEY_fromdata_init(_EVP_PKEY_CTX_PTR ctx) __attribute__((tag("3")));
@@ -6754,10 +6756,10 @@ index 00000000000000..5790defeb6eb55
 +#endif // _GO_OSSL_SHIMS_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.c b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.c
 new file mode 100644
-index 00000000000000..8124dfd70a22e3
+index 00000000000000..d69178b159f9d2
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.c
-@@ -0,0 +1,1924 @@
+@@ -0,0 +1,1942 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +#include <stddef.h>
@@ -6822,6 +6824,7 @@ index 00000000000000..8124dfd70a22e3
 +const char* (*_g_EVP_CIPHER_get0_name)(const _EVP_CIPHER_PTR);
 +int (*_g_EVP_CIPHER_get_block_size)(const _EVP_CIPHER_PTR);
 +int (*_g_EVP_CipherInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int);
++int (*_g_EVP_CipherInit_ex2)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR);
 +int (*_g_EVP_CipherUpdate)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int);
 +int (*_g_EVP_DecryptFinal_ex)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*);
 +int (*_g_EVP_DecryptInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*);
@@ -6881,6 +6884,7 @@ index 00000000000000..8124dfd70a22e3
 +int (*_g_EVP_PKEY_CTX_set1_hkdf_salt)(_EVP_PKEY_CTX_PTR, const unsigned char*, int);
 +int (*_g_EVP_PKEY_CTX_set_hkdf_md)(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR);
 +int (*_g_EVP_PKEY_CTX_set_hkdf_mode)(_EVP_PKEY_CTX_PTR, int);
++int (*_g_EVP_PKEY_CTX_set_params)(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR);
 +_EVP_PKEY_PTR (*_g_EVP_PKEY_Q_keygen)(_OSSL_LIB_CTX_PTR, const char*, const char*, ...);
 +int (*_g_EVP_PKEY_assign)(_EVP_PKEY_PTR, int, void*);
 +int (*_g_EVP_PKEY_decrypt)(_EVP_PKEY_CTX_PTR, unsigned char*, size_t*, const unsigned char*, size_t);
@@ -7244,6 +7248,7 @@ index 00000000000000..8124dfd70a22e3
 +	__mkcgo__dlsym(EVP_CIPHER_fetch)
 +	__mkcgo__dlsym(EVP_CIPHER_get0_name)
 +	__mkcgo__dlsym(EVP_CIPHER_get_block_size)
++	__mkcgo__dlsym(EVP_CipherInit_ex2)
 +	__mkcgo__dlsym(EVP_KDF_CTX_free)
 +	__mkcgo__dlsym(EVP_KDF_CTX_get_kdf_size)
 +	__mkcgo__dlsym(EVP_KDF_CTX_new)
@@ -7277,6 +7282,7 @@ index 00000000000000..8124dfd70a22e3
 +	__mkcgo__dlsym(EVP_PKEY_CTX_set1_hkdf_salt)
 +	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_md)
 +	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_mode)
++	__mkcgo__dlsym(EVP_PKEY_CTX_set_params)
 +	__mkcgo__dlsym(EVP_PKEY_Q_keygen)
 +	__mkcgo__dlsym(EVP_PKEY_fromdata)
 +	__mkcgo__dlsym(EVP_PKEY_fromdata_init)
@@ -7312,6 +7318,7 @@ index 00000000000000..8124dfd70a22e3
 +	_g_EVP_CIPHER_fetch = NULL;
 +	_g_EVP_CIPHER_get0_name = NULL;
 +	_g_EVP_CIPHER_get_block_size = NULL;
++	_g_EVP_CipherInit_ex2 = NULL;
 +	_g_EVP_KDF_CTX_free = NULL;
 +	_g_EVP_KDF_CTX_get_kdf_size = NULL;
 +	_g_EVP_KDF_CTX_new = NULL;
@@ -7345,6 +7352,7 @@ index 00000000000000..8124dfd70a22e3
 +	_g_EVP_PKEY_CTX_set1_hkdf_salt = NULL;
 +	_g_EVP_PKEY_CTX_set_hkdf_md = NULL;
 +	_g_EVP_PKEY_CTX_set_hkdf_mode = NULL;
++	_g_EVP_PKEY_CTX_set_params = NULL;
 +	_g_EVP_PKEY_Q_keygen = NULL;
 +	_g_EVP_PKEY_fromdata = NULL;
 +	_g_EVP_PKEY_fromdata_init = NULL;
@@ -7760,6 +7768,12 @@ index 00000000000000..8124dfd70a22e3
 +	return _ret;
 +}
 +
++int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, const unsigned char* _arg2, const unsigned char* _arg3, int _arg4, const _OSSL_PARAM_PTR _arg5, mkcgo_err_state *_err_state) {
++	int _ret = _g_EVP_CipherInit_ex2(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
++	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
++	return _ret;
++}
++
 +int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, const unsigned char* _arg3, int _arg4, mkcgo_err_state *_err_state) {
 +	int _ret = _g_EVP_CipherUpdate(_arg0, _arg1, _arg2, _arg3, _arg4);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
@@ -8088,6 +8102,12 @@ index 00000000000000..8124dfd70a22e3
 +
 +int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
 +	int _ret = _g_EVP_PKEY_CTX_set_hkdf_mode(_arg0, _arg1);
++	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
++	return _ret;
++}
++
++int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
++	int _ret = _g_EVP_PKEY_CTX_set_params(_arg0, _arg1);
 +	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 +	return _ret;
 +}
@@ -8684,10 +8704,10 @@ index 00000000000000..8124dfd70a22e3
 +
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.go
 new file mode 100644
-index 00000000000000..9079f7a0cffc40
+index 00000000000000..252e1a1fd7c452
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.go
-@@ -0,0 +1,1329 @@
+@@ -0,0 +1,1341 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +package ossl
@@ -9096,6 +9116,12 @@ index 00000000000000..9079f7a0cffc40
 +	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex", _err)
 +}
 +
++func EVP_CipherInit_ex2(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, key *byte, iv *byte, enc int32, params OSSL_PARAM_PTR) (int32, error) {
++	var _err C.mkcgo_err_state
++	_ret := C._mkcgo_EVP_CipherInit_ex2(ctx, __type, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv)), C.int(enc), params, mkcgoNoEscape(&_err))
++	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex2", _err)
++}
++
 +func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 +	var _err C.mkcgo_err_state
 +	_ret := C._mkcgo_EVP_CipherUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl), mkcgoNoEscape(&_err))
@@ -9426,6 +9452,12 @@ index 00000000000000..9079f7a0cffc40
 +	var _err C.mkcgo_err_state
 +	_ret := C._mkcgo_EVP_PKEY_CTX_set_hkdf_mode(arg0, C.int(arg1), mkcgoNoEscape(&_err))
 +	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_mode", _err)
++}
++
++func EVP_PKEY_CTX_set_params(ctx EVP_PKEY_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
++	var _err C.mkcgo_err_state
++	_ret := C._mkcgo_EVP_PKEY_CTX_set_params(ctx, params, mkcgoNoEscape(&_err))
++	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_params", _err)
 +}
 +
 +func EVP_PKEY_Q_keygen_EC(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 *byte) (EVP_PKEY_PTR, error) {
@@ -10019,10 +10051,10 @@ index 00000000000000..9079f7a0cffc40
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.h
 new file mode 100644
-index 00000000000000..335d129bb345cd
+index 00000000000000..c323372fca9bf5
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.h
-@@ -0,0 +1,335 @@
+@@ -0,0 +1,337 @@
 +// Code generated by mkcgo. DO NOT EDIT.
 +
 +#ifndef MKCGO_H // only include this header once
@@ -10184,6 +10216,7 @@ index 00000000000000..335d129bb345cd
 +const char* _mkcgo_EVP_CIPHER_get0_name(const _EVP_CIPHER_PTR);
 +int _mkcgo_EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR);
 +int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int, mkcgo_err_state *);
++int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR, mkcgo_err_state *);
 +int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int, mkcgo_err_state *);
 +int _mkcgo_EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, mkcgo_err_state *);
 +int _mkcgo_EVP_DecryptInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, mkcgo_err_state *);
@@ -10243,6 +10276,7 @@ index 00000000000000..335d129bb345cd
 +int _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR, const unsigned char*, int, mkcgo_err_state *);
 +int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR, mkcgo_err_state *);
 +int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR, int, mkcgo_err_state *);
++int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR, mkcgo_err_state *);
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR, const char*, const char*, const char*, mkcgo_err_state *);
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR, const char*, const char*, mkcgo_err_state *);
 +_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_RSA(_OSSL_LIB_CTX_PTR, const char*, const char*, size_t, mkcgo_err_state *);
@@ -10572,10 +10606,10 @@ index 00000000000000..6461f241f863fc
 +type BigInt []uint
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/cipher.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/cipher.go
 new file mode 100644
-index 00000000000000..dcbb66acdce48a
+index 00000000000000..97044c765090c8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/cipher.go
-@@ -0,0 +1,654 @@
+@@ -0,0 +1,682 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -11188,6 +11222,10 @@ index 00000000000000..dcbb66acdce48a
 +	if cipher == nil {
 +		panic("crypto/cipher: unsupported cipher: " + kind.String())
 +	}
++	params, err := cipherInitParams(encrypt)
++	if err != nil {
++		return nil, err
++	}
 +	ctx, err := ossl.EVP_CIPHER_CTX_new()
 +	if err != nil {
 +		return nil, err
@@ -11210,10 +11248,34 @@ index 00000000000000..dcbb66acdce48a
 +		// Pass nil to the next call to EVP_CipherInit_ex to avoid resetting ctx's cipher.
 +		cipher = nil
 +	}
-+	if _, err := ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt)); err != nil {
++	if params != nil {
++		_, err = ossl.EVP_CipherInit_ex2(ctx, cipher, base(key), base(iv), int32(encrypt), params)
++	} else {
++		_, err = ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt))
++	}
++	if err != nil {
 +		return nil, err
 +	}
 +	return ctx, nil
++}
++
++var cipherEncryptCheckParams = sync.OnceValues(func() (ossl.OSSL_PARAM_PTR, error) {
++	bld, err := newParamBuilder()
++	if err != nil {
++		return nil, err
++	}
++	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
++	return bld.build()
++})
++
++func cipherInitParams(encrypt cipherOp) (ossl.OSSL_PARAM_PTR, error) {
++	if encrypt != cipherOpEncrypt || vMajor == 1 {
++		return nil, nil
++	}
++	// The returned params are cached for the lifetime of the process and must not be freed by callers.
++	// Setting the FIPS encrypt check to 0 allows encryption to proceed even if the key is not approved for use in FIPS mode.
++	// This check is done at the Go crypto level.
++	return cipherEncryptCheckParams()
 +}
 +
 +// The following two functions are a mirror of golang.org/x/crypto/internal/subtle.
@@ -11232,10 +11294,10 @@ index 00000000000000..dcbb66acdce48a
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/const.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/const.go
 new file mode 100644
-index 00000000000000..9f99a9dc456242
+index 00000000000000..b4e5fe5e86a940
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/const.go
-@@ -0,0 +1,93 @@
+@@ -0,0 +1,104 @@
 +package openssl
 +
 +import "C"
@@ -11301,6 +11363,10 @@ index 00000000000000..9f99a9dc456242
 +	_OSSL_KDF_PARAM_SALT   cString = "salt\x00"
 +	_OSSL_KDF_PARAM_MODE   cString = "mode\x00"
 +
++	// KDF FIPS parameters
++	_OSSL_KDF_PARAM_FIPS_KEY_CHECK        cString = "key-check\x00"
++	_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK cString = "encrypt-check\x00"
++
 +	// TLS3-KDF parameters
 +	_OSSL_KDF_PARAM_PREFIX cString = "prefix\x00"
 +	_OSSL_KDF_PARAM_LABEL  cString = "label\x00"
@@ -11325,6 +11391,13 @@ index 00000000000000..9f99a9dc456242
 +	_OSSL_PKEY_PARAM_RSA_EXPONENT1    cString = "rsa-exponent1\x00"
 +	_OSSL_PKEY_PARAM_RSA_EXPONENT2    cString = "rsa-exponent2\x00"
 +	_OSSL_PKEY_PARAM_RSA_COEFFICIENT1 cString = "rsa-coefficient1\x00"
++
++	// Signature parameters
++	_OSSL_SIGNATURE_PARAM_DIGEST                     cString = "digest\x00"
++	_OSSL_SIGNATURE_PARAM_PAD_MODE                   cString = "pad-mode\x00"
++	_OSSL_SIGNATURE_PARAM_PSS_SALTLEN                cString = "saltlen\x00"
++	_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK cString = "rsa-pss-saltlen-check\x00"
++	_OSSL_PKEY_RSA_PAD_MODE_PSS                      cString = "pss\x00"
 +
 +	// MAC parameters
 +	_OSSL_MAC_PARAM_DIGEST cString = "digest\x00"
@@ -12617,10 +12690,10 @@ index 00000000000000..d4e8b90acb07cb
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go
 new file mode 100644
-index 00000000000000..f87534cd4510b7
+index 00000000000000..5104c579031bc8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go
-@@ -0,0 +1,590 @@
+@@ -0,0 +1,612 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -12960,15 +13033,37 @@ index 00000000000000..f87534cd4510b7
 +		if alg == nil {
 +			return nil, errors.New("crypto/rsa: unsupported hash function")
 +		}
-+		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
-+			return nil, err
-+		}
-+		// setPadding must happen after setting EVP_PKEY_CTRL_MD.
-+		if err := setPadding(); err != nil {
-+			return nil, err
-+		}
-+		if saltLen != 0 {
-+			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
++		switch vMajor {
++		case 1:
++			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
++				return nil, err
++			}
++			// setPadding must happen after setting EVP_PKEY_CTRL_MD.
++			if err := setPadding(); err != nil {
++				return nil, err
++			}
++			if saltLen != 0 {
++				if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
++					return nil, err
++				}
++			}
++		default:
++			bld, err := newParamBuilder()
++			if err != nil {
++				return nil, err
++			}
++			bld.addUTF8String(_OSSL_SIGNATURE_PARAM_DIGEST, ossl.EVP_MD_get0_name(alg.md), 0)
++			bld.addUTF8String(_OSSL_SIGNATURE_PARAM_PAD_MODE, _OSSL_PKEY_RSA_PAD_MODE_PSS.ptr(), 0)
++			if saltLen != 0 {
++				bld.addInt32(_OSSL_SIGNATURE_PARAM_PSS_SALTLEN, saltLen)
++			}
++			bld.addInt32(_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK, 0)
++			params, err := bld.build()
++			if err != nil {
++				return nil, err
++			}
++			defer ossl.OSSL_PARAM_free(params)
++			if _, err := ossl.EVP_PKEY_CTX_set_params(ctx, params); err != nil {
 +				return nil, err
 +			}
 +		}
@@ -13709,10 +13804,10 @@ index 00000000000000..f1f2364c7246d4
 +type HashCloner = hash.Cloner
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hkdf.go
 new file mode 100644
-index 00000000000000..ce6c9defc6a33d
+index 00000000000000..a4532e8fd77a09
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/hkdf.go
-@@ -0,0 +1,434 @@
+@@ -0,0 +1,435 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -14105,6 +14200,7 @@ index 00000000000000..ce6c9defc6a33d
 +	if err != nil {
 +		return ctx, err
 +	}
++	bld.addInt32(_OSSL_KDF_PARAM_FIPS_KEY_CHECK, 0)
 +	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 +	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(mode))
 +	bld.addOctetString(_OSSL_KDF_PARAM_KEY, secret)
@@ -16024,10 +16120,10 @@ index 00000000000000..1276de2124a9c4
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 new file mode 100644
-index 00000000000000..9731a8e2e83ac2
+index 00000000000000..b6a96dd67de2ff
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
-@@ -0,0 +1,366 @@
+@@ -0,0 +1,401 @@
 +//go:build !cmd_go_bootstrap
 +
 +package openssl
@@ -16039,6 +16135,7 @@ index 00000000000000..9731a8e2e83ac2
 +	"errors"
 +	"hash"
 +	"runtime"
++	"sync"
 +	"unsafe"
 +
 +	"github.com/microsoft/go-crypto-openssl/internal/ossl"
@@ -16254,6 +16351,40 @@ index 00000000000000..9731a8e2e83ac2
 +func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
 +	return evpEncrypt(pub.withKey, ossl.RSA_PKCS1_PADDING, nil, nil, nil, msg)
 +}
++
++// SupportsRSAPKCS1v15Encryption returns true if RSA PKCS1 v1.5 padding is supported for encryption and decryption.
++var SupportsRSAPKCS1v15Encryption = sync.OnceValue(func() bool {
++	n, e, _, _, _, _, _, _, err := GenerateKeyRSA(2048)
++	if err != nil {
++		return false
++	}
++	pub, err := NewPublicKeyRSA(n, e)
++	if err != nil {
++		return false
++	}
++	supported := false
++	_ = pub.withKey(func(pkey ossl.EVP_PKEY_PTR) error {
++		ctx, err := ossl.EVP_PKEY_CTX_new(pkey, nil)
++		if err != nil {
++			return err
++		}
++		defer ossl.EVP_PKEY_CTX_free(ctx)
++		if _, err := ossl.EVP_PKEY_encrypt_init(ctx); err != nil {
++			return err
++		}
++		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PADDING, nil); err != nil {
++			return err
++		}
++		in := []byte("test")
++		var outLen int
++		if _, err := ossl.EVP_PKEY_encrypt(ctx, nil, &outLen, base(in), len(in)); err != nil {
++			return err
++		}
++		supported = true
++		return nil
++	})
++	return supported
++})
 +
 +func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
 +	ret, err := evpDecrypt(priv.withKey, ossl.RSA_NO_PADDING, nil, nil, nil, ciphertext)
@@ -21134,7 +21265,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index a6b711219383c2..8668fcb28e0ba4 100644
+index a6b711219383c2..7b277a7480e15e 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,20 @@
@@ -21143,7 +21274,7 @@ index a6b711219383c2..8668fcb28e0ba4 100644
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/cryptokit
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-openssl v0.0.0-20260521141647-8d2a891ca446
++# github.com/microsoft/go-crypto-openssl v0.0.0-20260605084120-a6a7990d2462
 +## explicit; go 1.22
 +github.com/microsoft/go-crypto-openssl/bbig
 +github.com/microsoft/go-crypto-openssl/internal/ossl


### PR DESCRIPTION
The upgrade bring some OpenSSL 3.5 support improvements.

Fixes https://github.com/microsoft/go/issues/2322.