### PR TITLE
Fix HKDF and HMAC with SHA-3 under system crypto backends

### DIFF
--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -38,7 +38,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/fips140/enforcement_test.go        |   4 +
  src/crypto/fips140/fips140.go                 |   3 +-
  src/crypto/hkdf/hkdf.go                       |  14 ++
- src/crypto/hkdf/hkdf_test.go                  |  25 ++-
+ src/crypto/hkdf/hkdf_test.go                  |  32 ++-
  src/crypto/hmac/hmac.go                       |  16 +-
  src/crypto/hmac/hmac_test.go                  |  25 ++-
  src/crypto/hpke/aead.go                       |  14 +-
@@ -101,7 +101,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- 97 files changed, 1562 insertions(+), 190 deletions(-)
+ 97 files changed, 1569 insertions(+), 190 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -1480,14 +1480,15 @@ index 88439922a5032e..5a3ae17e80efbc 100644
  }
  
 diff --git a/src/crypto/hkdf/hkdf_test.go b/src/crypto/hkdf/hkdf_test.go
-index 57d90f88e93e75..8306dbbf5ad515 100644
+index 57d90f88e93e75..772530c071c45a 100644
 --- a/src/crypto/hkdf/hkdf_test.go
 +++ b/src/crypto/hkdf/hkdf_test.go
-@@ -6,13 +6,15 @@ package hkdf
+@@ -6,13 +6,17 @@ package hkdf
  
  import (
  	"bytes"
 -	"crypto/internal/boring"
++	"crypto"
 +	boring "crypto/internal/backend"
  	"crypto/internal/fips140"
  	"crypto/md5"
@@ -1496,11 +1497,12 @@ index 57d90f88e93e75..8306dbbf5ad515 100644
 +	"crypto/sha3"
  	"crypto/sha512"
  	"hash"
++	"runtime"
 +	"strings"
  	"testing"
  )
  
-@@ -345,6 +347,27 @@ func TestHKDFLimit(t *testing.T) {
+@@ -345,6 +349,32 @@ func TestHKDFLimit(t *testing.T) {
  	}
  }
  
@@ -1516,9 +1518,14 @@ index 57d90f88e93e75..8306dbbf5ad515 100644
 +		if strings.Contains(err.Error(), "too large") {
 +			t.Fatalf("issue #2356 regression: %v", err)
 +		}
-+		// Some backends (for example macOS CryptoKit) do not implement HKDF
-+		// with SHA-3 at all. That is a separate limitation, not issue #2356.
-+		t.Skipf("backend does not support HKDF with SHA-3: %v", err)
++		// The macOS CryptoKit backend does not implement HKDF with SHA-3; that
++		// is a separate backend limitation, not issue #2356. Every other
++		// configuration is expected to succeed, so only skip in that known case
++		// and fail otherwise rather than hiding an unexpected error.
++		if boring.Enabled && runtime.GOOS == "darwin" && boring.SupportsHash(crypto.SHA3_256) {
++			t.Skipf("CryptoKit backend does not support HKDF with SHA-3: %v", err)
++		}
++		t.Fatalf("HKDF with SHA3-256 failed: %v", err)
 +	}
 +	if len(out) != 32 {
 +		t.Fatalf("HKDF with SHA3-256 produced %d bytes, want 32", len(out))

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -1517,14 +1517,12 @@ index 57d90f88e93e75..6d65a53579b83e 100644
 +		if strings.Contains(err.Error(), "too large") {
 +			t.Fatalf("issue #2356 regression: %v", err)
 +		}
-+		// The macOS CryptoKit backend does not implement HKDF with SHA-3 (it
-+		// supports only SHA-1 and the SHA-2 family), so it returns an error here
-+		// regardless of macOS version. That is a separate backend limitation,
-+		// not issue #2356. OpenSSL, CNG, and the pure Go path all support it, so
-+		// only skip on the CryptoKit backend and fail otherwise rather than
-+		// hiding an unexpected error.
-+		if boring.Enabled && runtime.GOOS == "darwin" {
-+			t.Skipf("CryptoKit backend does not support HKDF with SHA-3: %v", err)
++		// Some system backends currently return an "unsupported hash function"
++		// error for HKDF with SHA-3. That backend limitation is separate from
++		// issue #2356; still fail on all other errors so regressions are visible.
++		if boring.Enabled && strings.Contains(err.Error(), "unsupported hash function") &&
++			(runtime.GOOS == "darwin" || runtime.GOOS == "windows") {
++			t.Skipf("system backend does not support HKDF with SHA-3 on %s: %v", runtime.GOOS, err)
 +		}
 +		t.Fatalf("HKDF with SHA3-256 failed: %v", err)
 +	}

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -38,9 +38,9 @@ Subject: [PATCH] Use crypto backends
  src/crypto/fips140/enforcement_test.go        |   4 +
  src/crypto/fips140/fips140.go                 |   3 +-
  src/crypto/hkdf/hkdf.go                       |  14 ++
- src/crypto/hkdf/hkdf_test.go                  |   2 +-
+ src/crypto/hkdf/hkdf_test.go                  |  25 ++-
  src/crypto/hmac/hmac.go                       |  16 +-
- src/crypto/hmac/hmac_test.go                  |   2 +-
+ src/crypto/hmac/hmac_test.go                  |  25 ++-
  src/crypto/hpke/aead.go                       |  14 +-
  src/crypto/internal/cryptotest/allocations.go |   6 -
  src/crypto/internal/cryptotest/fips140.go     |   8 +
@@ -101,7 +101,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- 97 files changed, 1516 insertions(+), 190 deletions(-)
+ 97 files changed, 1562 insertions(+), 190 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -1480,10 +1480,10 @@ index 88439922a5032e..5a3ae17e80efbc 100644
  }
  
 diff --git a/src/crypto/hkdf/hkdf_test.go b/src/crypto/hkdf/hkdf_test.go
-index 57d90f88e93e75..4069ab057a2525 100644
+index 57d90f88e93e75..8306dbbf5ad515 100644
 --- a/src/crypto/hkdf/hkdf_test.go
 +++ b/src/crypto/hkdf/hkdf_test.go
-@@ -6,7 +6,7 @@ package hkdf
+@@ -6,13 +6,15 @@ package hkdf
  
  import (
  	"bytes"
@@ -1492,6 +1492,42 @@ index 57d90f88e93e75..4069ab057a2525 100644
  	"crypto/internal/fips140"
  	"crypto/md5"
  	"crypto/sha1"
+ 	"crypto/sha256"
++	"crypto/sha3"
+ 	"crypto/sha512"
+ 	"hash"
++	"strings"
+ 	"testing"
+ )
+ 
+@@ -345,6 +347,27 @@ func TestHKDFLimit(t *testing.T) {
+ 	}
+ }
+ 
++// TestHKDFSHA3 is a regression test for
++// https://github.com/microsoft/go/issues/2356. When a system crypto backend
++// provided SHA-3, the hash returned by [sha3.New256] reported Size() == 0 after
++// being unwrapped for the FIPS module, so HKDF computed a maximum output length
++// of 0 and rejected any positive key length with "requested key length too
++// large".
++func TestHKDFSHA3(t *testing.T) {
++	out, err := Key(sha3.New256, []byte("hkdf sha3 secret"), nil, "", 32)
++	if err != nil {
++		if strings.Contains(err.Error(), "too large") {
++			t.Fatalf("issue #2356 regression: %v", err)
++		}
++		// Some backends (for example macOS CryptoKit) do not implement HKDF
++		// with SHA-3 at all. That is a separate limitation, not issue #2356.
++		t.Skipf("backend does not support HKDF with SHA-3: %v", err)
++	}
++	if len(out) != 32 {
++		t.Fatalf("HKDF with SHA3-256 produced %d bytes, want 32", len(out))
++	}
++}
++
+ func Benchmark16ByteMD5Single(b *testing.B) {
+ 	benchmarkHKDF(md5.New, 16, b)
+ }
 diff --git a/src/crypto/hmac/hmac.go b/src/crypto/hmac/hmac.go
 index e7976e25193dfe..58b357ee52c328 100644
 --- a/src/crypto/hmac/hmac.go
@@ -1534,18 +1570,53 @@ index e7976e25193dfe..58b357ee52c328 100644
  }
  
 diff --git a/src/crypto/hmac/hmac_test.go b/src/crypto/hmac/hmac_test.go
-index 4046a9555a8e35..4721a2a7ac04f7 100644
+index 4046a9555a8e35..3915869b84a69b 100644
 --- a/src/crypto/hmac/hmac_test.go
 +++ b/src/crypto/hmac/hmac_test.go
-@@ -5,7 +5,7 @@
+@@ -5,15 +5,18 @@
  package hmac
  
  import (
 -	"crypto/internal/boring"
++	"crypto"
 +	boring "crypto/internal/backend"
  	"crypto/internal/cryptotest"
  	"crypto/md5"
  	"crypto/sha1"
+ 	"crypto/sha256"
++	"crypto/sha3"
+ 	"crypto/sha512"
+ 	"errors"
+ 	"fmt"
+ 	"hash"
++	"runtime"
+ 	"testing"
+ )
+ 
+@@ -693,3 +696,23 @@ func BenchmarkNewWriteSum(b *testing.B) {
+ 		buf[0] = mac[0]
+ 	}
+ }
++
++// TestHMACSHA3 is a regression test for
++// https://github.com/microsoft/go/issues/2356. [New] used to spin forever when
++// given a SHA-3 hash under a system crypto backend, because the backend HMAC
++// constructor received the still-wrapped *sha3.SHA3 instead of the unwrapped
++// hash. The hash must now be unwrapped before the backend sees it.
++func TestHMACSHA3(t *testing.T) {
++	if boring.Enabled && runtime.GOOS == "darwin" && boring.SupportsHash(crypto.SHA3_256) {
++		// The macOS CryptoKit backend advertises SHA-3 hashing but aborts the
++		// process when asked for HMAC-SHA3. That is a separate backend
++		// limitation tracked on its own; skip so this regression test stays
++		// portable.
++		t.Skip("CryptoKit backend does not support HMAC-SHA3")
++	}
++	h := New(func() hash.Hash { return sha3.New256() }, []byte("key"))
++	h.Write([]byte("message"))
++	if got := len(h.Sum(nil)); got != 32 {
++		t.Fatalf("HMAC with SHA3-256 produced %d bytes, want 32", got)
++	}
++}
 diff --git a/src/crypto/hpke/aead.go b/src/crypto/hpke/aead.go
 index fb55c97ddf20c9..fb036863cde2dd 100644
 --- a/src/crypto/hpke/aead.go

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -39,13 +39,14 @@ Subject: [PATCH] Use crypto backends
  src/crypto/fips140/fips140.go                 |   3 +-
  src/crypto/hkdf/hkdf.go                       |  14 ++
  src/crypto/hkdf/hkdf_test.go                  |   2 +-
- src/crypto/hmac/hmac.go                       |   2 +-
+ src/crypto/hmac/hmac.go                       |  16 +-
  src/crypto/hmac/hmac_test.go                  |   2 +-
  src/crypto/hpke/aead.go                       |  14 +-
  src/crypto/internal/cryptotest/allocations.go |   6 -
  src/crypto/internal/cryptotest/fips140.go     |   8 +
  src/crypto/internal/cryptotest/hash.go        |   3 +-
  .../internal/cryptotest/implementations.go    |   2 +-
+ src/crypto/internal/fips140hash/hash.go       |   3 +-
  .../internal/fips140only/fips140only_test.go  |   6 +
  src/crypto/internal/fips140test/acvp_test.go  |   6 +
  src/crypto/internal/fips140test/cast_test.go  |   2 +
@@ -75,7 +76,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/sha1/sha1_test.go                  |  11 +-
  src/crypto/sha256/sha256.go                   |   6 +-
  src/crypto/sha256/sha256_test.go              |  44 ++--
- src/crypto/sha3/sha3.go                       | 124 +++++++++--
+ src/crypto/sha3/sha3.go                       | 129 ++++++++++--
  src/crypto/sha3/sha3_test.go                  |  18 +-
  src/crypto/sha512/sha512.go                   |   2 +-
  src/crypto/sha512/sha512_test.go              |  32 ++-
@@ -100,7 +101,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- 96 files changed, 1504 insertions(+), 180 deletions(-)
+ 97 files changed, 1516 insertions(+), 190 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -199,7 +200,7 @@ index fa445925b7c374..e36ac86fcaa58d 100644
  ! stdout runtime/cgo
  
 diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
-index 4aaf46b5d0f0dc..ec58a217400caa 100644
+index 4aaf46b5d0f0dc..995d53d0fed9aa 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
 +++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
 @@ -1,5 +1,14 @@
@@ -244,7 +245,7 @@ index 802fb35aee4e65..4416731b69ec26 100644
  			*mode = BuildModePIE
  		default:
 diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index 1427f9c7bc62dc..a00ada13a5d745 100644
+index 1427f9c7bc62dc..5a9d911ea36a6c 100644
 --- a/src/cmd/link/internal/ld/lib.go
 +++ b/src/cmd/link/internal/ld/lib.go
 @@ -1176,6 +1176,12 @@ var hostobj []Hostobj
@@ -1492,7 +1493,7 @@ index 57d90f88e93e75..4069ab057a2525 100644
  	"crypto/md5"
  	"crypto/sha1"
 diff --git a/src/crypto/hmac/hmac.go b/src/crypto/hmac/hmac.go
-index e7976e25193dfe..9578e1e985c02d 100644
+index e7976e25193dfe..58b357ee52c328 100644
 --- a/src/crypto/hmac/hmac.go
 +++ b/src/crypto/hmac/hmac.go
 @@ -22,7 +22,7 @@ timing side-channels:
@@ -1504,6 +1505,34 @@ index e7976e25193dfe..9578e1e985c02d 100644
  	"crypto/internal/fips140/hmac"
  	"crypto/internal/fips140hash"
  	"crypto/internal/fips140only"
+@@ -37,13 +37,6 @@ import (
+ // the returned Hash does not implement [encoding.BinaryMarshaler]
+ // or [encoding.BinaryUnmarshaler].
+ func New(h func() hash.Hash, key []byte) hash.Hash {
+-	if boring.Enabled {
+-		hm := boring.NewHMAC(h, key)
+-		if hm != nil {
+-			return hm
+-		}
+-		// BoringCrypto did not recognize h, so fall through to standard Go code.
+-	}
+ 	h = fips140hash.UnwrapNew(h)
+ 	if fips140only.Enforced() {
+ 		if len(key) < 112/8 {
+@@ -53,6 +46,13 @@ func New(h func() hash.Hash, key []byte) hash.Hash {
+ 			panic("crypto/hmac: use of hash functions other than SHA-2 or SHA-3 is not allowed in FIPS 140-only mode")
+ 		}
+ 	}
++	if boring.Enabled {
++		hm := boring.NewHMAC(h, key)
++		if hm != nil {
++			return hm
++		}
++		// BoringCrypto did not recognize h, so fall through to standard Go code.
++	}
+ 	return hmac.New(h, key)
+ }
+ 
 diff --git a/src/crypto/hmac/hmac_test.go b/src/crypto/hmac/hmac_test.go
 index 4046a9555a8e35..4721a2a7ac04f7 100644
 --- a/src/crypto/hmac/hmac_test.go
@@ -1633,6 +1662,26 @@ index 2b6cf4b75fc6b7..3a1b9e5cc67ecc 100644
  	"crypto/internal/impl"
  	"internal/goarch"
  	"internal/goos"
+diff --git a/src/crypto/internal/fips140hash/hash.go b/src/crypto/internal/fips140hash/hash.go
+index 6d67ee8b3429a1..8f8d5937ea913c 100644
+--- a/src/crypto/internal/fips140hash/hash.go
++++ b/src/crypto/internal/fips140hash/hash.go
+@@ -5,14 +5,13 @@
+ package fips140hash
+ 
+ import (
+-	fsha3 "crypto/internal/fips140/sha3"
+ 	"crypto/sha3"
+ 	"hash"
+ 	_ "unsafe"
+ )
+ 
+ //go:linkname sha3Unwrap
+-func sha3Unwrap(*sha3.SHA3) *fsha3.Digest
++func sha3Unwrap(*sha3.SHA3) hash.Hash
+ 
+ // Unwrap returns h, or a crypto/internal/fips140 inner implementation of h.
+ //
 diff --git a/src/crypto/internal/fips140only/fips140only_test.go b/src/crypto/internal/fips140only/fips140only_test.go
 index 96df536d56f345..5ed6026962a17c 100644
 --- a/src/crypto/internal/fips140only/fips140only_test.go
@@ -2935,7 +2984,7 @@ index a18a536ba2896f..7b3b37c3b0c10d 100644
  	}
  }
 diff --git a/src/crypto/sha3/sha3.go b/src/crypto/sha3/sha3.go
-index 48c67e9fe11005..3fe46309e0fda8 100644
+index 48c67e9fe11005..1ab7ae42462ef6 100644
 --- a/src/crypto/sha3/sha3.go
 +++ b/src/crypto/sha3/sha3.go
 @@ -8,6 +8,7 @@ package sha3
@@ -3006,7 +3055,7 @@ index 48c67e9fe11005..3fe46309e0fda8 100644
  	// Outline the allocation for up to 512 bits of output to the caller's stack.
  	out := make([]byte, 64)
  	return sumSHAKE256(out, data, length)
-@@ -99,7 +118,9 @@ func sumSHAKE256(out, data []byte, length int) []byte {
+@@ -99,36 +118,53 @@ func sumSHAKE256(out, data []byte, length int) []byte {
  // SHA3 is an instance of a SHA-3 hash. It implements [hash.Hash].
  // The zero value is a usable SHA3-256 hash.
  type SHA3 struct {
@@ -3017,7 +3066,13 @@ index 48c67e9fe11005..3fe46309e0fda8 100644
  }
  
  //go:linkname fips140hash_sha3Unwrap crypto/internal/fips140hash.sha3Unwrap
-@@ -109,26 +130,38 @@ func fips140hash_sha3Unwrap(sha3 *SHA3) *sha3.Digest {
+-func fips140hash_sha3Unwrap(sha3 *SHA3) *sha3.Digest {
++func fips140hash_sha3Unwrap(sha3 *SHA3) hash.Hash {
++	if sha3.boringS != nil {
++		return sha3.boringS
++	}
+ 	return &sha3.s
+ }
  
  // New224 creates a new SHA3-224 hash.
  func New224() *SHA3 {
@@ -3061,7 +3116,7 @@ index 48c67e9fe11005..3fe46309e0fda8 100644
  		*s = *New256()
  	}
  }
-@@ -136,53 +169,81 @@ func (s *SHA3) init() {
+@@ -136,53 +172,81 @@ func (s *SHA3) init() {
  // Write absorbs more data into the hash's state.
  func (s *SHA3) Write(p []byte) (n int, err error) {
  	s.init()
@@ -3144,7 +3199,7 @@ index 48c67e9fe11005..3fe46309e0fda8 100644
  	r := *d
  	return &r, nil
  }
-@@ -190,23 +251,30 @@ func (d *SHA3) Clone() (hash.Cloner, error) {
+@@ -190,23 +254,30 @@ func (d *SHA3) Clone() (hash.Cloner, error) {
  // SHAKE is an instance of a SHAKE extendable output function.
  // The zero value is a usable SHAKE256 hash.
  type SHAKE struct {
@@ -3179,7 +3234,7 @@ index 48c67e9fe11005..3fe46309e0fda8 100644
  }
  
  // NewCSHAKE128 creates a new cSHAKE128 XOF.
-@@ -215,7 +283,10 @@ func NewSHAKE256() *SHAKE {
+@@ -215,7 +286,10 @@ func NewSHAKE256() *SHAKE {
  // cSHAKE is desired. S is a customization byte string used for domain
  // separation. When N and S are both empty, this is equivalent to NewSHAKE128.
  func NewCSHAKE128(N, S []byte) *SHAKE {
@@ -3191,7 +3246,7 @@ index 48c67e9fe11005..3fe46309e0fda8 100644
  }
  
  // NewCSHAKE256 creates a new cSHAKE256 XOF.
-@@ -224,7 +295,10 @@ func NewCSHAKE128(N, S []byte) *SHAKE {
+@@ -224,7 +298,10 @@ func NewCSHAKE128(N, S []byte) *SHAKE {
  // cSHAKE is desired. S is a customization byte string used for domain
  // separation. When N and S are both empty, this is equivalent to NewSHAKE256.
  func NewCSHAKE256(N, S []byte) *SHAKE {
@@ -3203,7 +3258,7 @@ index 48c67e9fe11005..3fe46309e0fda8 100644
  }
  
  // Write absorbs more data into the XOF's state.
-@@ -232,6 +306,9 @@ func NewCSHAKE256(N, S []byte) *SHAKE {
+@@ -232,6 +309,9 @@ func NewCSHAKE256(N, S []byte) *SHAKE {
  // It panics if any output has already been read.
  func (s *SHAKE) Write(p []byte) (n int, err error) {
  	s.init()
@@ -3213,7 +3268,7 @@ index 48c67e9fe11005..3fe46309e0fda8 100644
  	return s.s.Write(p)
  }
  
-@@ -240,35 +317,54 @@ func (s *SHAKE) Write(p []byte) (n int, err error) {
+@@ -240,35 +320,54 @@ func (s *SHAKE) Write(p []byte) (n int, err error) {
  // Any call to Write after a call to Read will panic.
  func (s *SHAKE) Read(p []byte) (n int, err error) {
  	s.init()
@@ -3966,7 +4021,7 @@ index 1d3e845d0f0a9c..eb4318faf13f7b 100644
  
  	var dsaPriv dsa.PrivateKey
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index f52b6b1ac71711..f6f962f38b5d00 100644
+index 71f5fae52bd306..6e72b4dde85609 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -545,7 +545,7 @@ var depsRules = `

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -40,7 +40,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/hkdf/hkdf.go                       |  14 ++
  src/crypto/hkdf/hkdf_test.go                  |  33 ++-
  src/crypto/hmac/hmac.go                       |  16 +-
- src/crypto/hmac/hmac_test.go                  |  24 ++-
+ src/crypto/hmac/hmac_test.go                  |  23 ++-
  src/crypto/hpke/aead.go                       |  14 +-
  src/crypto/internal/cryptotest/allocations.go |   6 -
  src/crypto/internal/cryptotest/fips140.go     |   8 +
@@ -101,7 +101,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- 97 files changed, 1569 insertions(+), 190 deletions(-)
+ 97 files changed, 1568 insertions(+), 190 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -1578,16 +1578,17 @@ index e7976e25193dfe..58b357ee52c328 100644
  }
  
 diff --git a/src/crypto/hmac/hmac_test.go b/src/crypto/hmac/hmac_test.go
-index 4046a9555a8e35..2341c958cab497 100644
+index 4046a9555a8e35..6ad429e98c5d86 100644
 --- a/src/crypto/hmac/hmac_test.go
 +++ b/src/crypto/hmac/hmac_test.go
-@@ -5,15 +5,17 @@
+@@ -5,11 +5,13 @@
  package hmac
  
  import (
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
  	"crypto/internal/cryptotest"
++	"crypto/internal/fips140hash"
  	"crypto/md5"
  	"crypto/sha1"
  	"crypto/sha256"
@@ -1595,12 +1596,7 @@ index 4046a9555a8e35..2341c958cab497 100644
  	"crypto/sha512"
  	"errors"
  	"fmt"
- 	"hash"
-+	"runtime"
- 	"testing"
- )
- 
-@@ -693,3 +695,23 @@ func BenchmarkNewWriteSum(b *testing.B) {
+@@ -693,3 +695,22 @@ func BenchmarkNewWriteSum(b *testing.B) {
  		buf[0] = mac[0]
  	}
  }
@@ -1611,12 +1607,11 @@ index 4046a9555a8e35..2341c958cab497 100644
 +// constructor received the still-wrapped *sha3.SHA3 instead of the unwrapped
 +// hash. The hash must now be unwrapped before the backend sees it.
 +func TestHMACSHA3(t *testing.T) {
-+	if boring.Enabled && runtime.GOOS == "darwin" {
-+		// The macOS CryptoKit backend cannot compute HMAC with SHA-3. With the
-+		// current backend, asking for it on newer macOS aborts the process, so
-+		// skip on the CryptoKit backend; the OpenSSL and CNG builders exercise
-+		// the backend HMAC path.
-+		t.Skip("CryptoKit backend does not support HMAC with SHA-3")
++	if boring.Enabled {
++		// Probe backend support directly instead of OS-gating the test.
++		if hm := boring.NewHMAC(fips140hash.UnwrapNew(func() hash.Hash { return sha3.New256() }), []byte("key")); hm == nil {
++			t.Skip("system backend does not support HMAC with SHA-3")
++		}
 +	}
 +	h := New(func() hash.Hash { return sha3.New256() }, []byte("key"))
 +	h.Write([]byte("message"))

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -38,9 +38,9 @@ Subject: [PATCH] Use crypto backends
  src/crypto/fips140/enforcement_test.go        |   4 +
  src/crypto/fips140/fips140.go                 |   3 +-
  src/crypto/hkdf/hkdf.go                       |  14 ++
- src/crypto/hkdf/hkdf_test.go                  |  32 ++-
+ src/crypto/hkdf/hkdf_test.go                  |  33 ++-
  src/crypto/hmac/hmac.go                       |  16 +-
- src/crypto/hmac/hmac_test.go                  |  25 ++-
+ src/crypto/hmac/hmac_test.go                  |  24 ++-
  src/crypto/hpke/aead.go                       |  14 +-
  src/crypto/internal/cryptotest/allocations.go |   6 -
  src/crypto/internal/cryptotest/fips140.go     |   8 +
@@ -1480,15 +1480,14 @@ index 88439922a5032e..5a3ae17e80efbc 100644
  }
  
 diff --git a/src/crypto/hkdf/hkdf_test.go b/src/crypto/hkdf/hkdf_test.go
-index 57d90f88e93e75..772530c071c45a 100644
+index 57d90f88e93e75..6d65a53579b83e 100644
 --- a/src/crypto/hkdf/hkdf_test.go
 +++ b/src/crypto/hkdf/hkdf_test.go
-@@ -6,13 +6,17 @@ package hkdf
+@@ -6,13 +6,16 @@ package hkdf
  
  import (
  	"bytes"
 -	"crypto/internal/boring"
-+	"crypto"
 +	boring "crypto/internal/backend"
  	"crypto/internal/fips140"
  	"crypto/md5"
@@ -1502,7 +1501,7 @@ index 57d90f88e93e75..772530c071c45a 100644
  	"testing"
  )
  
-@@ -345,6 +349,32 @@ func TestHKDFLimit(t *testing.T) {
+@@ -345,6 +348,34 @@ func TestHKDFLimit(t *testing.T) {
  	}
  }
  
@@ -1518,11 +1517,13 @@ index 57d90f88e93e75..772530c071c45a 100644
 +		if strings.Contains(err.Error(), "too large") {
 +			t.Fatalf("issue #2356 regression: %v", err)
 +		}
-+		// The macOS CryptoKit backend does not implement HKDF with SHA-3; that
-+		// is a separate backend limitation, not issue #2356. Every other
-+		// configuration is expected to succeed, so only skip in that known case
-+		// and fail otherwise rather than hiding an unexpected error.
-+		if boring.Enabled && runtime.GOOS == "darwin" && boring.SupportsHash(crypto.SHA3_256) {
++		// The macOS CryptoKit backend does not implement HKDF with SHA-3 (it
++		// supports only SHA-1 and the SHA-2 family), so it returns an error here
++		// regardless of macOS version. That is a separate backend limitation,
++		// not issue #2356. OpenSSL, CNG, and the pure Go path all support it, so
++		// only skip on the CryptoKit backend and fail otherwise rather than
++		// hiding an unexpected error.
++		if boring.Enabled && runtime.GOOS == "darwin" {
 +			t.Skipf("CryptoKit backend does not support HKDF with SHA-3: %v", err)
 +		}
 +		t.Fatalf("HKDF with SHA3-256 failed: %v", err)
@@ -1577,15 +1578,14 @@ index e7976e25193dfe..58b357ee52c328 100644
  }
  
 diff --git a/src/crypto/hmac/hmac_test.go b/src/crypto/hmac/hmac_test.go
-index 4046a9555a8e35..3915869b84a69b 100644
+index 4046a9555a8e35..2341c958cab497 100644
 --- a/src/crypto/hmac/hmac_test.go
 +++ b/src/crypto/hmac/hmac_test.go
-@@ -5,15 +5,18 @@
+@@ -5,15 +5,17 @@
  package hmac
  
  import (
 -	"crypto/internal/boring"
-+	"crypto"
 +	boring "crypto/internal/backend"
  	"crypto/internal/cryptotest"
  	"crypto/md5"
@@ -1600,7 +1600,7 @@ index 4046a9555a8e35..3915869b84a69b 100644
  	"testing"
  )
  
-@@ -693,3 +696,23 @@ func BenchmarkNewWriteSum(b *testing.B) {
+@@ -693,3 +695,23 @@ func BenchmarkNewWriteSum(b *testing.B) {
  		buf[0] = mac[0]
  	}
  }
@@ -1611,12 +1611,12 @@ index 4046a9555a8e35..3915869b84a69b 100644
 +// constructor received the still-wrapped *sha3.SHA3 instead of the unwrapped
 +// hash. The hash must now be unwrapped before the backend sees it.
 +func TestHMACSHA3(t *testing.T) {
-+	if boring.Enabled && runtime.GOOS == "darwin" && boring.SupportsHash(crypto.SHA3_256) {
-+		// The macOS CryptoKit backend advertises SHA-3 hashing but aborts the
-+		// process when asked for HMAC-SHA3. That is a separate backend
-+		// limitation tracked on its own; skip so this regression test stays
-+		// portable.
-+		t.Skip("CryptoKit backend does not support HMAC-SHA3")
++	if boring.Enabled && runtime.GOOS == "darwin" {
++		// The macOS CryptoKit backend cannot compute HMAC with SHA-3. With the
++		// current backend, asking for it on newer macOS aborts the process, so
++		// skip on the CryptoKit backend; the OpenSSL and CNG builders exercise
++		// the backend HMAC path.
++		t.Skip("CryptoKit backend does not support HMAC with SHA-3")
 +	}
 +	h := New(func() hash.Hash { return sha3.New256() }, []byte("key"))
 +	h.Write([]byte("message"))

--- a/patches/0004-Use-crypto-backends.patch
+++ b/patches/0004-Use-crypto-backends.patch
@@ -38,7 +38,7 @@ Subject: [PATCH] Use crypto backends
  src/crypto/fips140/enforcement_test.go        |   4 +
  src/crypto/fips140/fips140.go                 |   3 +-
  src/crypto/hkdf/hkdf.go                       |  14 ++
- src/crypto/hkdf/hkdf_test.go                  |  33 ++-
+ src/crypto/hkdf/hkdf_test.go                  |  30 ++-
  src/crypto/hmac/hmac.go                       |  16 +-
  src/crypto/hmac/hmac_test.go                  |  23 ++-
  src/crypto/hpke/aead.go                       |  14 +-
@@ -101,7 +101,7 @@ Subject: [PATCH] Use crypto backends
  src/hash/notboring_test.go                    |   9 +
  src/net/lookup_test.go                        |   3 +
  src/os/exec/exec_test.go                      |   9 +
- 97 files changed, 1568 insertions(+), 190 deletions(-)
+ 97 files changed, 1565 insertions(+), 190 deletions(-)
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
  create mode 100644 src/crypto/ecdsa/badlinkname.go
@@ -1480,10 +1480,10 @@ index 88439922a5032e..5a3ae17e80efbc 100644
  }
  
 diff --git a/src/crypto/hkdf/hkdf_test.go b/src/crypto/hkdf/hkdf_test.go
-index 57d90f88e93e75..6d65a53579b83e 100644
+index 57d90f88e93e75..3d67a56bf61dad 100644
 --- a/src/crypto/hkdf/hkdf_test.go
 +++ b/src/crypto/hkdf/hkdf_test.go
-@@ -6,13 +6,16 @@ package hkdf
+@@ -6,13 +6,15 @@ package hkdf
  
  import (
  	"bytes"
@@ -1496,12 +1496,11 @@ index 57d90f88e93e75..6d65a53579b83e 100644
 +	"crypto/sha3"
  	"crypto/sha512"
  	"hash"
-+	"runtime"
 +	"strings"
  	"testing"
  )
  
-@@ -345,6 +348,34 @@ func TestHKDFLimit(t *testing.T) {
+@@ -345,6 +347,32 @@ func TestHKDFLimit(t *testing.T) {
  	}
  }
  
@@ -1517,12 +1516,12 @@ index 57d90f88e93e75..6d65a53579b83e 100644
 +		if strings.Contains(err.Error(), "too large") {
 +			t.Fatalf("issue #2356 regression: %v", err)
 +		}
-+		// Some system backends currently return an "unsupported hash function"
-+		// error for HKDF with SHA-3. That backend limitation is separate from
-+		// issue #2356; still fail on all other errors so regressions are visible.
-+		if boring.Enabled && strings.Contains(err.Error(), "unsupported hash function") &&
-+			(runtime.GOOS == "darwin" || runtime.GOOS == "windows") {
-+			t.Skipf("system backend does not support HKDF with SHA-3 on %s: %v", runtime.GOOS, err)
++		// A system crypto backend can lack HKDF support for SHA-3 (for example
++		// CryptoKit). The backend reports this with an "unsupported hash
++		// function" error, so skip when that happens instead of hardcoding which
++		// platforms are affected. Any other error is unexpected and fails.
++		if boring.Enabled && strings.Contains(err.Error(), "unsupported hash function") {
++			t.Skipf("system backend does not support HKDF with SHA-3: %v", err)
 +		}
 +		t.Fatalf("HKDF with SHA3-256 failed: %v", err)
 +	}


### PR DESCRIPTION
## Problem

In 1.26, SHA-3 is routed through the system crypto backend (e.g. OpenSSL on
Linux). When a backend is active and supports SHA-3, `sha3.New256` (and the
other constructors) return a `SHA3` whose backend hash is stored in `boringS`,
while the embedded pure-Go digest `s` is left as a zero value.

`fips140hash_sha3Unwrap` returned `&s.s` — that empty Go digest — whose
`Size()` and `BlockSize()` are both `0`. Unwrapping is used by HKDF and HMAC,
so:

- **HKDF** computed `limit := Size() * 255 == 0` and rejected any positive key
  length with the misleading error `hkdf: requested key length too large`.
- **HMAC** received a `BlockSize()` of `0`, writing the key into a zero-rate
  sponge whose absorb loop never makes progress — an infinite hang.

Both symptoms are specific to system-crypto builds; the pure-Go backend
(`GOEXPERIMENT=nosystemcrypto`) and upstream Go are unaffected.

## Fix

- Return `boringS` from `fips140hash_sha3Unwrap` when the `SHA3` is
  backend-backed, and widen the `sha3Unwrap` linkname signature to `hash.Hash`.
- Reorder `hmac.New` so `boring.NewHMAC` runs *after* the hash is unwrapped,
  so the backend receives its own hash type instead of the wrapped `*SHA3`.

## Testing

- `hkdf.Key(sha3.New256, …)` now succeeds.
- HMAC-SHA3 completes and matches both the pure-Go backend and OpenSSL's
  `openssl mac -digest SHA3-256`.

Related:
- https://github.com/microsoft/go/issues/2356