### PR TITLE
eng/doc/SupportedPlatforms.md edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ We build the Microsoft build of Go toolset with the following OS/Arch combinatio
 
 | OS | `amd64` | `arm64` | `armv6l` |
 | --- | :---: | :---: | :---: |
+| `darwin` (macOS) | ✓ | ✓ | |
 | `linux` | ✓ | ✓ | ✓ |
 | `windows` | ✓ | ✓ | |
-| `darwin` (macOS) | ✓ | ✓ | |
 
-For detailed platform support information across different Go versions, see [eng/doc/SupportedPlatforms.md](eng/doc/SupportedPlatforms.md).
+Check out the [Supported Platforms](eng/doc/SupportedPlatforms.md) documentation for detailed platform support information across different Go versions.
 
 Visit the [Migration Guide](eng/doc/MigrationGuide.md) for guidance about how we recommend migrating existing Go projects to use the Microsoft build of Go.
 This guide also helps resolve commonly encountered issues.

--- a/eng/doc/SupportedPlatforms.md
+++ b/eng/doc/SupportedPlatforms.md
@@ -3,7 +3,7 @@
 This document describes the platforms supported by the Microsoft build of Go.
 
 "Support" means that Microsoft will accept bug reports for these platforms and investigate issues.
-Platforms outside this scope are provided support on a best-effort basis with no guarantees.
+Platforms outside this scope are supported on a best-effort basis with no guarantees.
 
 > [!NOTE]
 > This document describes the platforms that a program built by the Microsoft build of Go can run on.
@@ -18,7 +18,7 @@ Platforms outside this scope are provided support on a best-effort basis with no
 | darwin/arm64 | macOS 13 |
 | linux/amd64 | Azure Linux 3.0, Ubuntu 22.04 |
 | linux/arm64 | Azure Linux 3.0, Ubuntu 22.04 |
-| linux/arm32 | Ubuntu 22.04 |
+| linux/arm | Ubuntu 22.04 |
 | windows/amd64 | Windows 10, Windows Server 2016 |
 | windows/arm64 | Windows 11, Windows Server 2025 |
 
@@ -32,7 +32,7 @@ The following OpenSSL versions are supported on Linux platforms:
 ## Getting Help
 
 If the Microsoft build of Go doesn't support a platform you need, please let us know.
-Look for an existing issue with the [![](https://img.shields.io/github/labels/microsoft/go/Area-Acquisition)](https://github.com/microsoft/go/labels/Area-Acquisition) label and leave a comment.
+Look for an existing issue with the [![Area-Acquisition](https://img.shields.io/github/labels/microsoft/go/Area-Acquisition)](https://github.com/microsoft/go/labels/Area-Acquisition) label and leave a comment.
 Otherwise, [file a new issue](https://github.com/microsoft/go/issues/new/choose).
 
 You can also get in contact using our other [support resources](/README.md#support).

--- a/eng/doc/SupportedPlatforms.md
+++ b/eng/doc/SupportedPlatforms.md
@@ -2,35 +2,37 @@
 
 This document describes the platforms supported by the Microsoft build of Go.
 
-"Support" means that Microsoft will accept bug reports for these platforms and
-investigate issues. Platforms outside this scope are provided support on a
-best-effort basis with no guarantees.
+"Support" means that Microsoft will accept bug reports for these platforms and investigate issues.
+Platforms outside this scope are provided support on a best-effort basis with no guarantees.
 
-For information about which platforms have prebuilt toolset binaries available,
-see [Downloads.md](Downloads.md).
+> [!NOTE]
+> This document describes the platforms that a program built by the Microsoft build of Go can run on.
+> We don't necessarily provide a toolset for every platform we support.
+> See the [Downloads](./Downloads.md) table for the list of prebuilt Go toolsets we provide, and [Installation](./Installation.md) for the list of ways we recommend installing them.
 
 ## Platform Support Matrix
 
-| OS/Arch | Minimum Versions | Crypto Backend | Notes |
-|---------|-----------------|----------------|-------|
-| linux/amd64 | Azure Linux 3.0+, Ubuntu 22.04+ | OpenSSL | |
-| linux/arm64 | Azure Linux 3.0+, Ubuntu 22.04+ | OpenSSL | |
-| linux/arm32 | Ubuntu 22.04+ | OpenSSL | |
-| windows/amd64 | Windows 10+, Windows Server 2016+ | CNG | |
-| windows/arm64 | Windows 11+, Windows Server 2025+ | CNG | |
-| darwin/amd64 | macOS 13+ | CryptoKit/CommonCrypto | Added in Go 1.24 |
-| darwin/arm64 | macOS 13+ | CryptoKit/CommonCrypto | Added in Go 1.24 |
+| Go OS/Arch | Minimum Versions |
+|---|---|
+| darwin/amd64 | macOS 13 |
+| darwin/arm64 | macOS 13 |
+| linux/amd64 | Azure Linux 3.0, Ubuntu 22.04 |
+| linux/arm64 | Azure Linux 3.0, Ubuntu 22.04 |
+| linux/arm32 | Ubuntu 22.04 |
+| windows/amd64 | Windows 10, Windows Server 2016 |
+| windows/arm64 | Windows 11, Windows Server 2025 |
 
 ## OpenSSL Versions
 
 The following OpenSSL versions are supported on Linux platforms:
 
-- OpenSSL 1.1.0 and 1.1.1
+- OpenSSL 1.1.1
 - OpenSSL 3.x (built-in providers, or SymCrypt provider v1.6.1+)
 
 ## Getting Help
 
-If you need support for an additional platform or encounter issues with a supported platform:
+If the Microsoft build of Go doesn't support a platform you need, please let us know.
+Look for an existing issue with the [![](https://img.shields.io/github/labels/microsoft/go/Area-Acquisition)](https://github.com/microsoft/go/labels/Area-Acquisition) label and leave a comment.
+Otherwise, [file a new issue](https://github.com/microsoft/go/issues/new/choose).
 
-1. Check existing issues with the [Area-Acquisition](https://github.com/microsoft/go/labels/Area-Acquisition) label
-1. [File a new issue](https://github.com/microsoft/go/issues/new/choose) if your platform or issue isn't already covered
+You can also get in contact using our other [support resources](/README.md#support).


### PR DESCRIPTION
* https://github.com/microsoft/go/pull/1776
* Make platform order consistent. (We would want to change the generator to not use alphabetic order if we want to change this across all locations.)
* Fix newline formatting.
* Try to be more specific about this being about runtime support.
  * There might be more we can do here... will have to look at this again in a bit to see if it's clear enough.
* Include link to install doc in addition to "raw" binary downloads.
* Remove info from table that AFAIK an ordinary reader has no need to know.
* Remove "+", column title already mentions minimum.
  * I'm skeptical we truly want to claim that we support *every* version above a value. But given the clear and limited definition of "support" in this context I don't think it's a pressing issue.
* Remove OpenSSL 1.1.0, [no longer supported](https://github.com/golang-fips/openssl/issues/401).
* Use same/similar support wording as other sections.