### PR TITLE
Align cryptobackend KDF APIs with fips140

### DIFF
--- a/cryptobackend/go.mod
+++ b/cryptobackend/go.mod
@@ -3,7 +3,7 @@ module github.com/microsoft/go/cryptobackend
 go 1.26
 
 require (
-	github.com/microsoft/go-crypto-darwin v0.0.2
-	github.com/microsoft/go-crypto-openssl v0.0.0-20260605082236-c86f934c8ba7
+	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260606063346-8a6eda5eab53
+	github.com/microsoft/go-crypto-openssl v0.5.0
 	github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825
 )

--- a/cryptobackend/go.sum
+++ b/cryptobackend/go.sum
@@ -1,6 +1,6 @@
-github.com/microsoft/go-crypto-darwin v0.0.2 h1:AxcXTK+nBG9hWzkJJLKyB0T70z6JUCnAMAo8++F4ZoQ=
-github.com/microsoft/go-crypto-darwin v0.0.2/go.mod h1:MTii5PQwRlfUjYpGoF8CPLGwXSHTbLHGRN9FVNML5N0=
-github.com/microsoft/go-crypto-openssl v0.0.0-20260605082236-c86f934c8ba7 h1:5iOYJ5Z1aYu/RRlznK4llvmQnudH6eAC0SG009wjMUM=
-github.com/microsoft/go-crypto-openssl v0.0.0-20260605082236-c86f934c8ba7/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
+github.com/microsoft/go-crypto-darwin v0.0.3-0.20260606063346-8a6eda5eab53 h1:QOjrpqYAh/THNyiEQ/M6/TAcza7yZ7hPRFUm+5v86zA=
+github.com/microsoft/go-crypto-darwin v0.0.3-0.20260606063346-8a6eda5eab53/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
+github.com/microsoft/go-crypto-openssl v0.5.0 h1:wTcBB5QN4YtsKcZdqWojL5pWIF/P+PVGNBZ/SQOFiuQ=
+github.com/microsoft/go-crypto-openssl v0.5.0/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
 github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 h1:nmQ1K/L5GISW8UwbUwE376h3WXREEpREFdc3fNklcXc=
 github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=

--- a/cryptobackend/hkdf/hkdf.go
+++ b/cryptobackend/hkdf/hkdf.go
@@ -6,7 +6,7 @@ package hkdf
 
 import "hash"
 
-func Key[H hash.Hash](h func() H, secret, salt, info []byte, keyLen int) ([]byte, error) {
+func Key[H hash.Hash](h func() H, secret, salt []byte, info string, keyLen int) ([]byte, error) {
 	prk, err := Extract(h, secret, salt)
 	if err != nil {
 		return nil, err

--- a/cryptobackend/hkdf/hkdf_darwin.go
+++ b/cryptobackend/hkdf/hkdf_darwin.go
@@ -16,6 +16,6 @@ func Supports() bool { return true }
 func Extract[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 	return xcrypto.ExtractHKDF(h, secret, salt)
 }
-func Expand[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLen int) ([]byte, error) {
-	return xcrypto.ExpandHKDF(h, pseudorandomKey, info, keyLen)
+func Expand[H hash.Hash](h func() H, pseudorandomKey []byte, info string, keyLen int) ([]byte, error) {
+	return xcrypto.ExpandHKDF(h, pseudorandomKey, []byte(info), keyLen)
 }

--- a/cryptobackend/hkdf/hkdf_linux.go
+++ b/cryptobackend/hkdf/hkdf_linux.go
@@ -16,6 +16,6 @@ func Supports() bool { return openssl.SupportsHKDF() }
 func Extract[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 	return openssl.ExtractHKDF(h, secret, salt)
 }
-func Expand[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLen int) ([]byte, error) {
-	return openssl.ExpandHKDF(h, pseudorandomKey, info, keyLen)
+func Expand[H hash.Hash](h func() H, pseudorandomKey []byte, info string, keyLen int) ([]byte, error) {
+	return openssl.ExpandHKDF(h, pseudorandomKey, []byte(info), keyLen)
 }

--- a/cryptobackend/hkdf/hkdf_windows.go
+++ b/cryptobackend/hkdf/hkdf_windows.go
@@ -16,6 +16,6 @@ func Supports() bool { return cng.SupportsHKDF() }
 func Extract[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 	return cng.ExtractHKDF(h, secret, salt)
 }
-func Expand[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLen int) ([]byte, error) {
-	return cng.ExpandHKDF(h, pseudorandomKey, info, keyLen)
+func Expand[H hash.Hash](h func() H, pseudorandomKey []byte, info string, keyLen int) ([]byte, error) {
+	return cng.ExpandHKDF(h, pseudorandomKey, []byte(info), keyLen)
 }

--- a/cryptobackend/hkdf/nobackend.go
+++ b/cryptobackend/hkdf/nobackend.go
@@ -12,6 +12,6 @@ func Supports() bool { panic("cryptobackend: not available") }
 func Extract[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 	panic("cryptobackend: not available")
 }
-func Expand[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLen int) ([]byte, error) {
+func Expand[H hash.Hash](h func() H, pseudorandomKey []byte, info string, keyLen int) ([]byte, error) {
 	panic("cryptobackend: not available")
 }

--- a/cryptobackend/pbkdf2/nobackend.go
+++ b/cryptobackend/pbkdf2/nobackend.go
@@ -9,6 +9,6 @@ package pbkdf2
 import "hash"
 
 func Supports() bool { panic("cryptobackend: not available") }
-func Key[H hash.Hash](h func() H, password, salt []byte, iter, keyLen int) ([]byte, error) {
+func Key[H hash.Hash](h func() H, password string, salt []byte, iter, keyLength int) ([]byte, error) {
 	panic("cryptobackend: not available")
 }

--- a/cryptobackend/pbkdf2/pbkdf2_darwin.go
+++ b/cryptobackend/pbkdf2/pbkdf2_darwin.go
@@ -13,6 +13,6 @@ import (
 )
 
 func Supports() bool { return true }
-func Key[H hash.Hash](h func() H, password, salt []byte, iter, keyLen int) ([]byte, error) {
-	return xcrypto.PBKDF2(password, salt, iter, keyLen, h)
+func Key[H hash.Hash](h func() H, password string, salt []byte, iter, keyLength int) ([]byte, error) {
+	return xcrypto.PBKDF2([]byte(password), salt, iter, keyLength, h)
 }

--- a/cryptobackend/pbkdf2/pbkdf2_linux.go
+++ b/cryptobackend/pbkdf2/pbkdf2_linux.go
@@ -13,6 +13,6 @@ import (
 )
 
 func Supports() bool { return openssl.SupportsPBKDF2() }
-func Key[H hash.Hash](h func() H, password, salt []byte, iter, keyLen int) ([]byte, error) {
-	return openssl.PBKDF2(password, salt, iter, keyLen, h)
+func Key[H hash.Hash](h func() H, password string, salt []byte, iter, keyLength int) ([]byte, error) {
+	return openssl.PBKDF2([]byte(password), salt, iter, keyLength, h)
 }

--- a/cryptobackend/pbkdf2/pbkdf2_windows.go
+++ b/cryptobackend/pbkdf2/pbkdf2_windows.go
@@ -13,6 +13,6 @@ import (
 )
 
 func Supports() bool { return true }
-func Key[H hash.Hash](h func() H, password, salt []byte, iter, keyLen int) ([]byte, error) {
-	return cng.PBKDF2(password, salt, iter, keyLen, h)
+func Key[H hash.Hash](h func() H, password string, salt []byte, iter, keyLength int) ([]byte, error) {
+	return cng.PBKDF2([]byte(password), salt, iter, keyLength, h)
 }

--- a/cryptobackend/tls12/nobackend.go
+++ b/cryptobackend/tls12/nobackend.go
@@ -9,6 +9,6 @@ package tls12
 import "hash"
 
 func SupportsPRF() bool { panic("cryptobackend: not available") }
-func PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
+func PRF(result, secret []byte, label string, seed []byte, h func() hash.Hash) error {
 	panic("cryptobackend: not available")
 }

--- a/cryptobackend/tls12/tls12_darwin.go
+++ b/cryptobackend/tls12/tls12_darwin.go
@@ -9,6 +9,6 @@ package tls12
 import "hash"
 
 func SupportsPRF() bool { return false }
-func PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
+func PRF(result, secret []byte, label string, seed []byte, h func() hash.Hash) error {
 	panic("cryptobackend: not available")
 }

--- a/cryptobackend/tls12/tls12_linux.go
+++ b/cryptobackend/tls12/tls12_linux.go
@@ -13,6 +13,6 @@ import (
 )
 
 func SupportsPRF() bool { return openssl.SupportsTLS1PRF() }
-func PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
-	return openssl.TLS1PRF(result, secret, label, seed, h)
+func PRF(result, secret []byte, label string, seed []byte, h func() hash.Hash) error {
+	return openssl.TLS1PRF(result, secret, []byte(label), seed, h)
 }

--- a/cryptobackend/tls12/tls12_windows.go
+++ b/cryptobackend/tls12/tls12_windows.go
@@ -13,6 +13,6 @@ import (
 )
 
 func SupportsPRF() bool { return true }
-func PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
-	return cng.TLS1PRF(result, secret, label, seed, h)
+func PRF(result, secret []byte, label string, seed []byte, h func() hash.Hash) error {
+	return cng.TLS1PRF(result, secret, []byte(label), seed, h)
 }

--- a/cryptobackend/tls13/nobackend.go
+++ b/cryptobackend/tls13/nobackend.go
@@ -9,6 +9,6 @@ package tls13
 import "hash"
 
 func SupportsKDF() bool { panic("cryptobackend: not available") }
-func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey, label, context []byte, keyLen int) ([]byte, error) {
+func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey []byte, label string, context []byte, keyLen int) ([]byte, error) {
 	panic("cryptobackend: not available")
 }

--- a/cryptobackend/tls13/tls13_darwin.go
+++ b/cryptobackend/tls13/tls13_darwin.go
@@ -9,6 +9,6 @@ package tls13
 import "hash"
 
 func SupportsKDF() bool { return false }
-func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey, label, context []byte, keyLen int) ([]byte, error) {
+func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey []byte, label string, context []byte, keyLen int) ([]byte, error) {
 	panic("cryptobackend: not available")
 }

--- a/cryptobackend/tls13/tls13_linux.go
+++ b/cryptobackend/tls13/tls13_linux.go
@@ -13,6 +13,6 @@ import (
 )
 
 func SupportsKDF() bool { return openssl.SupportsTLS13KDF() }
-func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey, label, context []byte, keyLen int) ([]byte, error) {
-	return openssl.ExpandTLS13KDF(h, pseudorandomKey, label, context, keyLen)
+func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey []byte, label string, context []byte, keyLen int) ([]byte, error) {
+	return openssl.ExpandTLS13KDF(h, pseudorandomKey, []byte(label), context, keyLen)
 }

--- a/cryptobackend/tls13/tls13_windows.go
+++ b/cryptobackend/tls13/tls13_windows.go
@@ -9,6 +9,6 @@ package tls13
 import "hash"
 
 func SupportsKDF() bool { return false }
-func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey, label, context []byte, keyLen int) ([]byte, error) {
+func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey []byte, label string, context []byte, keyLen int) ([]byte, error) {
 	panic("cryptobackend: not available")
 }

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -419,7 +419,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go/cryptobackend/tls13/tls13_linux.go     |   18 +
  .../go/cryptobackend/tls13/tls13_windows.go   |   14 +
  src/vendor/modules.txt                        |   55 +
- 411 files changed, 39290 insertions(+), 11 deletions(-)
+ 411 files changed, 39293 insertions(+), 11 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -825,7 +825,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_windows.go
 
 diff --git a/src/cmd/go.mod b/src/cmd/go.mod
-index 82ceadb04a273a..14a2aa30728fc6 100644
+index 326553a6a8e45f..7fcd181da63b96 100644
 --- a/src/cmd/go.mod
 +++ b/src/cmd/go.mod
 @@ -4,6 +4,8 @@ go 1.27
@@ -838,7 +838,7 @@ index 82ceadb04a273a..14a2aa30728fc6 100644
  	golang.org/x/build v0.0.0-20260522210304-d55d0041b921
  	golang.org/x/mod v0.36.1-0.20260520130633-087f6515dd3b
 diff --git a/src/cmd/go.sum b/src/cmd/go.sum
-index d9e3e3992ebb61..579fc05cbd0e33 100644
+index 3b88ef74339c5b..abeaf0b10b8aae 100644
 --- a/src/cmd/go.sum
 +++ b/src/cmd/go.sum
 @@ -4,6 +4,10 @@ github.com/google/pprof v0.0.0-20260507013755-92041b743c96 h1:YDDnaZ9afWajDboPMt
@@ -2664,7 +2664,7 @@ index 00000000000000..016de9bdd95956
 +	return filtered
 +}
 diff --git a/src/cmd/vendor/modules.txt b/src/cmd/vendor/modules.txt
-index 4774f1a02e905f..a8e955dc37675e 100644
+index 7df86f0bd319ba..786602a9bca103 100644
 --- a/src/cmd/vendor/modules.txt
 +++ b/src/cmd/vendor/modules.txt
 @@ -16,6 +16,17 @@ github.com/google/pprof/third_party/svgpan
@@ -2687,7 +2687,7 @@ index 4774f1a02e905f..a8e955dc37675e 100644
  golang.org/x/arch/arm/armasm
 diff --git a/src/crypto/deps_ignore.go b/src/crypto/deps_ignore.go
 new file mode 100644
-index 00000000000000..cae305b5923b8d
+index 00000000000000..d4671e1584dfa8
 --- /dev/null
 +++ b/src/crypto/deps_ignore.go
 @@ -0,0 +1,40 @@
@@ -2732,7 +2732,7 @@ index 00000000000000..cae305b5923b8d
 +// This file is here just to declare cryptobackend dependencies.
 +// This allows tracking their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index bb6abc93792f39..7c68bbbafda72a 100644
+index bb6abc93792f39..76c43955080813 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,11 +3,17 @@ module std
@@ -2741,8 +2741,8 @@ index bb6abc93792f39..7c68bbbafda72a 100644
  require (
 -	golang.org/x/crypto v0.52.1-0.20260526024921-9beb694f9766
 -	golang.org/x/net v0.55.1-0.20260526154343-657eb1317b5d
-+	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260605073440-7505334b131b // indirect
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20260605082236-c86f934c8ba7 // indirect
++	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260606063346-8a6eda5eab53 // indirect
++	github.com/microsoft/go-crypto-openssl v0.5.0 // indirect
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 // indirect
 +	golang.org/x/sys v0.45.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
@@ -2758,14 +2758,14 @@ index bb6abc93792f39..7c68bbbafda72a 100644
 +
 +replace github.com/microsoft/go/cryptobackend => ../../cryptobackend
 diff --git a/src/go.sum b/src/go.sum
-index ab34844da17757..76c16dd97f3fbd 100644
+index ab34844da17757..319cb2e1c9fbfb 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20260605073440-7505334b131b h1:uoj3rW1U1TrlBAv7O3SyFzmYEzO7XWtQFE9WozP8TGc=
-+github.com/microsoft/go-crypto-darwin v0.0.3-0.20260605073440-7505334b131b/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260605082236-c86f934c8ba7 h1:5iOYJ5Z1aYu/RRlznK4llvmQnudH6eAC0SG009wjMUM=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260605082236-c86f934c8ba7/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20260606063346-8a6eda5eab53 h1:QOjrpqYAh/THNyiEQ/M6/TAcza7yZ7hPRFUm+5v86zA=
++github.com/microsoft/go-crypto-darwin v0.0.3-0.20260606063346-8a6eda5eab53/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
++github.com/microsoft/go-crypto-openssl v0.5.0 h1:wTcBB5QN4YtsKcZdqWojL5pWIF/P+PVGNBZ/SQOFiuQ=
++github.com/microsoft/go-crypto-openssl v0.5.0/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 h1:nmQ1K/L5GISW8UwbUwE376h3WXREEpREFdc3fNklcXc=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
  golang.org/x/crypto v0.52.1-0.20260526024921-9beb694f9766 h1:ABD+jVg0H4Hwu2sGcUtKeb3T8mlS+jS3uWrkTAPcXjs=
@@ -2871,7 +2871,7 @@ index f65e709a72f6af..a71759adcb7363 100644
  	}
  	fset := token.NewFileSet()
 diff --git a/src/go/build/vendor_test.go b/src/go/build/vendor_test.go
-index 7f6237ffd59c11..18a3b42927d800 100644
+index 7f6237ffd59c11..3565b4ff5a04cb 100644
 --- a/src/go/build/vendor_test.go
 +++ b/src/go/build/vendor_test.go
 @@ -22,6 +22,11 @@ var allowedPackagePrefixes = []string{
@@ -40642,7 +40642,7 @@ index 00000000000000..1722410e5af193
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/README.md b/src/vendor/github.com/microsoft/go/cryptobackend/README.md
 new file mode 100644
-index 00000000000000..ce4f4d20892a6f
+index 00000000000000..2f688d6e8b7cb2
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/README.md
 @@ -0,0 +1,21 @@
@@ -41056,7 +41056,7 @@ index 00000000000000..35fb416a0b6981
 +import _ "github.com/microsoft/go/cryptobackend"
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/chacha20poly1305/chacha20poly1305_darwin.go b/src/vendor/github.com/microsoft/go/cryptobackend/chacha20poly1305/chacha20poly1305_darwin.go
 new file mode 100644
-index 00000000000000..a840478d38b9f5
+index 00000000000000..0ce838f9a5f7d3
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/chacha20poly1305/chacha20poly1305_darwin.go
 @@ -0,0 +1,24 @@
@@ -41086,7 +41086,7 @@ index 00000000000000..a840478d38b9f5
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/chacha20poly1305/chacha20poly1305_linux.go b/src/vendor/github.com/microsoft/go/cryptobackend/chacha20poly1305/chacha20poly1305_linux.go
 new file mode 100644
-index 00000000000000..1ed61f6848da91
+index 00000000000000..abfe43803b806b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/chacha20poly1305/chacha20poly1305_linux.go
 @@ -0,0 +1,24 @@
@@ -41740,7 +41740,7 @@ index 00000000000000..581418bf1b9809
 +import _ "github.com/microsoft/go/cryptobackend"
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/ecdh/nobackend.go b/src/vendor/github.com/microsoft/go/cryptobackend/ecdh/nobackend.go
 new file mode 100644
-index 00000000000000..ec110b3e1471ed
+index 00000000000000..e168a1b84d7532
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/ecdh/nobackend.go
 @@ -0,0 +1,22 @@
@@ -42182,7 +42182,7 @@ index 00000000000000..e5844f1d94a65d
 +func Approved(h hash.Hash) bool { panic("cryptobackend: not available") }
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf.go b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf.go
 new file mode 100644
-index 00000000000000..ac9d5cd23236c2
+index 00000000000000..8d9c6cc9fbd514
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf.go
 @@ -0,0 +1,15 @@
@@ -42194,7 +42194,7 @@ index 00000000000000..ac9d5cd23236c2
 +
 +import "hash"
 +
-+func Key[H hash.Hash](h func() H, secret, salt, info []byte, keyLen int) ([]byte, error) {
++func Key[H hash.Hash](h func() H, secret, salt []byte, info string, keyLen int) ([]byte, error) {
 +	prk, err := Extract(h, secret, salt)
 +	if err != nil {
 +		return nil, err
@@ -42203,7 +42203,7 @@ index 00000000000000..ac9d5cd23236c2
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf_darwin.go b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf_darwin.go
 new file mode 100644
-index 00000000000000..3393f3708ddfed
+index 00000000000000..c6d8af02b74f53
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf_darwin.go
 @@ -0,0 +1,21 @@
@@ -42225,12 +42225,12 @@ index 00000000000000..3393f3708ddfed
 +func Extract[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 +	return xcrypto.ExtractHKDF(h, secret, salt)
 +}
-+func Expand[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLen int) ([]byte, error) {
-+	return xcrypto.ExpandHKDF(h, pseudorandomKey, info, keyLen)
++func Expand[H hash.Hash](h func() H, pseudorandomKey []byte, info string, keyLen int) ([]byte, error) {
++	return xcrypto.ExpandHKDF(h, pseudorandomKey, []byte(info), keyLen)
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf_linux.go b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf_linux.go
 new file mode 100644
-index 00000000000000..25b816f14ef1bf
+index 00000000000000..672cb263fac81c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf_linux.go
 @@ -0,0 +1,21 @@
@@ -42252,12 +42252,12 @@ index 00000000000000..25b816f14ef1bf
 +func Extract[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 +	return openssl.ExtractHKDF(h, secret, salt)
 +}
-+func Expand[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLen int) ([]byte, error) {
-+	return openssl.ExpandHKDF(h, pseudorandomKey, info, keyLen)
++func Expand[H hash.Hash](h func() H, pseudorandomKey []byte, info string, keyLen int) ([]byte, error) {
++	return openssl.ExpandHKDF(h, pseudorandomKey, []byte(info), keyLen)
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf_windows.go b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf_windows.go
 new file mode 100644
-index 00000000000000..5e042f504c32d5
+index 00000000000000..bc7e40fa2a9cce
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/hkdf_windows.go
 @@ -0,0 +1,21 @@
@@ -42279,8 +42279,8 @@ index 00000000000000..5e042f504c32d5
 +func Extract[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 +	return cng.ExtractHKDF(h, secret, salt)
 +}
-+func Expand[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLen int) ([]byte, error) {
-+	return cng.ExpandHKDF(h, pseudorandomKey, info, keyLen)
++func Expand[H hash.Hash](h func() H, pseudorandomKey []byte, info string, keyLen int) ([]byte, error) {
++	return cng.ExpandHKDF(h, pseudorandomKey, []byte(info), keyLen)
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/init.go b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/init.go
 new file mode 100644
@@ -42297,7 +42297,7 @@ index 00000000000000..78838e1a5df924
 +import _ "github.com/microsoft/go/cryptobackend"
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/nobackend.go b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/nobackend.go
 new file mode 100644
-index 00000000000000..ccc52d824a2c4c
+index 00000000000000..58fdda2aea2d45
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/hkdf/nobackend.go
 @@ -0,0 +1,17 @@
@@ -42315,7 +42315,7 @@ index 00000000000000..ccc52d824a2c4c
 +func Extract[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 +	panic("cryptobackend: not available")
 +}
-+func Expand[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLen int) ([]byte, error) {
++func Expand[H hash.Hash](h func() H, pseudorandomKey []byte, info string, keyLen int) ([]byte, error) {
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/hmac/hmac_darwin.go b/src/vendor/github.com/microsoft/go/cryptobackend/hmac/hmac_darwin.go
@@ -43335,7 +43335,7 @@ index 00000000000000..89a597b39369ce
 +import _ "github.com/microsoft/go/cryptobackend"
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/nobackend.go b/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/nobackend.go
 new file mode 100644
-index 00000000000000..67b8f139f0bd58
+index 00000000000000..154fbc4f8feef2
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/nobackend.go
 @@ -0,0 +1,14 @@
@@ -43350,12 +43350,12 @@ index 00000000000000..67b8f139f0bd58
 +import "hash"
 +
 +func Supports() bool { panic("cryptobackend: not available") }
-+func Key[H hash.Hash](h func() H, password, salt []byte, iter, keyLen int) ([]byte, error) {
++func Key[H hash.Hash](h func() H, password string, salt []byte, iter, keyLength int) ([]byte, error) {
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/pbkdf2_darwin.go b/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/pbkdf2_darwin.go
 new file mode 100644
-index 00000000000000..6e3be3909d18c6
+index 00000000000000..df3b087cbc3758
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/pbkdf2_darwin.go
 @@ -0,0 +1,18 @@
@@ -43374,12 +43374,12 @@ index 00000000000000..6e3be3909d18c6
 +)
 +
 +func Supports() bool { return true }
-+func Key[H hash.Hash](h func() H, password, salt []byte, iter, keyLen int) ([]byte, error) {
-+	return xcrypto.PBKDF2(password, salt, iter, keyLen, h)
++func Key[H hash.Hash](h func() H, password string, salt []byte, iter, keyLength int) ([]byte, error) {
++	return xcrypto.PBKDF2([]byte(password), salt, iter, keyLength, h)
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/pbkdf2_linux.go b/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/pbkdf2_linux.go
 new file mode 100644
-index 00000000000000..6a709121ae5ddf
+index 00000000000000..6a5ce007955522
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/pbkdf2_linux.go
 @@ -0,0 +1,18 @@
@@ -43398,12 +43398,12 @@ index 00000000000000..6a709121ae5ddf
 +)
 +
 +func Supports() bool { return openssl.SupportsPBKDF2() }
-+func Key[H hash.Hash](h func() H, password, salt []byte, iter, keyLen int) ([]byte, error) {
-+	return openssl.PBKDF2(password, salt, iter, keyLen, h)
++func Key[H hash.Hash](h func() H, password string, salt []byte, iter, keyLength int) ([]byte, error) {
++	return openssl.PBKDF2([]byte(password), salt, iter, keyLength, h)
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/pbkdf2_windows.go b/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/pbkdf2_windows.go
 new file mode 100644
-index 00000000000000..f7d2ec9960a412
+index 00000000000000..c83a2cdd2db95d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/pbkdf2/pbkdf2_windows.go
 @@ -0,0 +1,18 @@
@@ -43422,8 +43422,8 @@ index 00000000000000..f7d2ec9960a412
 +)
 +
 +func Supports() bool { return true }
-+func Key[H hash.Hash](h func() H, password, salt []byte, iter, keyLen int) ([]byte, error) {
-+	return cng.PBKDF2(password, salt, iter, keyLen, h)
++func Key[H hash.Hash](h func() H, password string, salt []byte, iter, keyLength int) ([]byte, error) {
++	return cng.PBKDF2([]byte(password), salt, iter, keyLength, h)
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/rc4/init.go b/src/vendor/github.com/microsoft/go/cryptobackend/rc4/init.go
 new file mode 100644
@@ -44075,7 +44075,7 @@ index 00000000000000..a146988a3477cd
 +func Sum224(data []byte) [28]byte { return openssl.SHA224(data) }
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/sha256/sha256_windows.go b/src/vendor/github.com/microsoft/go/cryptobackend/sha256/sha256_windows.go
 new file mode 100644
-index 00000000000000..28c0487aa0f414
+index 00000000000000..7f5f581d28b5da
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/sha256/sha256_windows.go
 @@ -0,0 +1,20 @@
@@ -44272,7 +44272,7 @@ index 00000000000000..8aa8a443a46039
 +func SumSHAKE256(data []byte, length int) []byte { return openssl.SumSHAKE256(data, length) }
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/sha3/sha3_windows.go b/src/vendor/github.com/microsoft/go/cryptobackend/sha3/sha3_windows.go
 new file mode 100644
-index 00000000000000..f696161963cd1c
+index 00000000000000..4332f9599e1523
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/sha3/sha3_windows.go
 @@ -0,0 +1,40 @@
@@ -44421,7 +44421,7 @@ index 00000000000000..d2f65c859caa38
 +func Sum512_256(data []byte) [32]byte { return openssl.SHA512_256(data) }
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/sha512/sha512_windows.go b/src/vendor/github.com/microsoft/go/cryptobackend/sha512/sha512_windows.go
 new file mode 100644
-index 00000000000000..9803c63f320ba7
+index 00000000000000..4308a8fdab5565
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/sha512/sha512_windows.go
 @@ -0,0 +1,25 @@
@@ -44481,7 +44481,7 @@ index 00000000000000..11f4c37aaccefb
 +import _ "github.com/microsoft/go/cryptobackend"
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/tls12/nobackend.go b/src/vendor/github.com/microsoft/go/cryptobackend/tls12/nobackend.go
 new file mode 100644
-index 00000000000000..41c22794c3a622
+index 00000000000000..cb967817da26b7
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/tls12/nobackend.go
 @@ -0,0 +1,14 @@
@@ -44496,12 +44496,12 @@ index 00000000000000..41c22794c3a622
 +import "hash"
 +
 +func SupportsPRF() bool { panic("cryptobackend: not available") }
-+func PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
++func PRF(result, secret []byte, label string, seed []byte, h func() hash.Hash) error {
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/tls12/tls12_darwin.go b/src/vendor/github.com/microsoft/go/cryptobackend/tls12/tls12_darwin.go
 new file mode 100644
-index 00000000000000..d7fbd0c8ed14a4
+index 00000000000000..78014828c62b5e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/tls12/tls12_darwin.go
 @@ -0,0 +1,14 @@
@@ -44516,12 +44516,12 @@ index 00000000000000..d7fbd0c8ed14a4
 +import "hash"
 +
 +func SupportsPRF() bool { return false }
-+func PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
++func PRF(result, secret []byte, label string, seed []byte, h func() hash.Hash) error {
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/tls12/tls12_linux.go b/src/vendor/github.com/microsoft/go/cryptobackend/tls12/tls12_linux.go
 new file mode 100644
-index 00000000000000..beb3cecce069c1
+index 00000000000000..6196bc62437f04
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/tls12/tls12_linux.go
 @@ -0,0 +1,18 @@
@@ -44540,12 +44540,12 @@ index 00000000000000..beb3cecce069c1
 +)
 +
 +func SupportsPRF() bool { return openssl.SupportsTLS1PRF() }
-+func PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
-+	return openssl.TLS1PRF(result, secret, label, seed, h)
++func PRF(result, secret []byte, label string, seed []byte, h func() hash.Hash) error {
++	return openssl.TLS1PRF(result, secret, []byte(label), seed, h)
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/tls12/tls12_windows.go b/src/vendor/github.com/microsoft/go/cryptobackend/tls12/tls12_windows.go
 new file mode 100644
-index 00000000000000..6f3d4d19b3e12c
+index 00000000000000..9e50ac1bb7864f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/tls12/tls12_windows.go
 @@ -0,0 +1,18 @@
@@ -44564,8 +44564,8 @@ index 00000000000000..6f3d4d19b3e12c
 +)
 +
 +func SupportsPRF() bool { return true }
-+func PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
-+	return cng.TLS1PRF(result, secret, label, seed, h)
++func PRF(result, secret []byte, label string, seed []byte, h func() hash.Hash) error {
++	return cng.TLS1PRF(result, secret, []byte(label), seed, h)
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/tls13/init.go b/src/vendor/github.com/microsoft/go/cryptobackend/tls13/init.go
 new file mode 100644
@@ -44582,7 +44582,7 @@ index 00000000000000..7e1cd12b92cbdb
 +import _ "github.com/microsoft/go/cryptobackend"
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/tls13/nobackend.go b/src/vendor/github.com/microsoft/go/cryptobackend/tls13/nobackend.go
 new file mode 100644
-index 00000000000000..bd0fa1f4f1b34e
+index 00000000000000..a3d1aabebb382a
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/tls13/nobackend.go
 @@ -0,0 +1,14 @@
@@ -44597,12 +44597,12 @@ index 00000000000000..bd0fa1f4f1b34e
 +import "hash"
 +
 +func SupportsKDF() bool { panic("cryptobackend: not available") }
-+func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey, label, context []byte, keyLen int) ([]byte, error) {
++func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey []byte, label string, context []byte, keyLen int) ([]byte, error) {
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_darwin.go b/src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_darwin.go
 new file mode 100644
-index 00000000000000..dfefdaeeed2da9
+index 00000000000000..26d9e3256415a0
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_darwin.go
 @@ -0,0 +1,14 @@
@@ -44617,12 +44617,12 @@ index 00000000000000..dfefdaeeed2da9
 +import "hash"
 +
 +func SupportsKDF() bool { return false }
-+func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey, label, context []byte, keyLen int) ([]byte, error) {
++func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey []byte, label string, context []byte, keyLen int) ([]byte, error) {
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_linux.go b/src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_linux.go
 new file mode 100644
-index 00000000000000..3b6c4eee8d5375
+index 00000000000000..8b37e51156d27e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_linux.go
 @@ -0,0 +1,18 @@
@@ -44641,12 +44641,12 @@ index 00000000000000..3b6c4eee8d5375
 +)
 +
 +func SupportsKDF() bool { return openssl.SupportsTLS13KDF() }
-+func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey, label, context []byte, keyLen int) ([]byte, error) {
-+	return openssl.ExpandTLS13KDF(h, pseudorandomKey, label, context, keyLen)
++func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey []byte, label string, context []byte, keyLen int) ([]byte, error) {
++	return openssl.ExpandTLS13KDF(h, pseudorandomKey, []byte(label), context, keyLen)
 +}
 diff --git a/src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_windows.go b/src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_windows.go
 new file mode 100644
-index 00000000000000..dfefdaeeed2da9
+index 00000000000000..26d9e3256415a0
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_windows.go
 @@ -0,0 +1,14 @@
@@ -44661,15 +44661,15 @@ index 00000000000000..dfefdaeeed2da9
 +import "hash"
 +
 +func SupportsKDF() bool { return false }
-+func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey, label, context []byte, keyLen int) ([]byte, error) {
++func ExpandKDF[H hash.Hash](h func() H, pseudorandomKey []byte, label string, context []byte, keyLen int) ([]byte, error) {
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 54fcbab6a221c0..04b01df0f90b75 100644
+index 54fcbab6a221c0..294b64779e24c7 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,57 @@
-+# github.com/microsoft/go-crypto-darwin v0.0.3-0.20260605073440-7505334b131b
++# github.com/microsoft/go-crypto-darwin v0.0.3-0.20260606063346-8a6eda5eab53
 +## explicit; go 1.25
 +github.com/microsoft/go-crypto-darwin/bbig
 +github.com/microsoft/go-crypto-darwin/internal/commoncrypto
@@ -44678,7 +44678,7 @@ index 54fcbab6a221c0..04b01df0f90b75 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-openssl v0.0.0-20260605082236-c86f934c8ba7
++# github.com/microsoft/go-crypto-openssl v0.5.0
 +## explicit; go 1.25
 +github.com/microsoft/go-crypto-openssl/bbig
 +github.com/microsoft/go-crypto-openssl/internal/fakecgo

--- a/patches/0002-Add-crypto-backends.patch
+++ b/patches/0002-Add-crypto-backends.patch
@@ -64,7 +64,7 @@ Subject: [PATCH] Add crypto backends
  src/crypto/ed25519/notboring.go               |  16 ++
  src/crypto/fips140/enforcement_test.go        |   4 +
  src/crypto/fips140/fips140.go                 |   3 +-
- src/crypto/hkdf/hkdf.go                       |  16 ++
+ src/crypto/hkdf/hkdf.go                       |  12 +
  src/crypto/hkdf/hkdf_test.go                  |   2 +-
  src/crypto/hmac/hmac.go                       |  18 +-
  src/crypto/hmac/hmac_test.go                  |   2 +-
@@ -144,7 +144,7 @@ Subject: [PATCH] Add crypto backends
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/syscall_windows.go                |   3 +
- 141 files changed, 2943 insertions(+), 376 deletions(-)
+ 140 files changed, 2938 insertions(+), 376 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/dsa/boring.go
@@ -1291,7 +1291,7 @@ index 6702e9279b106b..09b92a3ed98df1 100644
  	if err != nil {
  		return false, err
 diff --git a/src/cmd/internal/testdir/testdir_test.go b/src/cmd/internal/testdir/testdir_test.go
-index d81b3a849cb975..f051b6dfa209dd 100644
+index 56842845a1d05e..f633c188719a4f 100644
 --- a/src/cmd/internal/testdir/testdir_test.go
 +++ b/src/cmd/internal/testdir/testdir_test.go
 @@ -14,6 +14,7 @@ import (
@@ -1302,7 +1302,7 @@ index d81b3a849cb975..f051b6dfa209dd 100644
  	"internal/testenv"
  	"io"
  	"io/fs"
-@@ -118,6 +119,11 @@ func Test(t *testing.T) {
+@@ -122,6 +123,11 @@ func Test(t *testing.T) {
  	goDebug = env.GODEBUG
  	tmpDir = t.TempDir()
  
@@ -2833,7 +2833,7 @@ index d3f63d3bf18fcb..bc6d8b62ae2103 100644
  
  // Version returns the FIPS 140-3 Go Cryptographic Module version (such as
 diff --git a/src/crypto/hkdf/hkdf.go b/src/crypto/hkdf/hkdf.go
-index 88439922a5032e..e6869c122e807e 100644
+index 88439922a5032e..33d41a773eff51 100644
 --- a/src/crypto/hkdf/hkdf.go
 +++ b/src/crypto/hkdf/hkdf.go
 @@ -16,6 +16,9 @@ import (
@@ -2861,21 +2861,17 @@ index 88439922a5032e..e6869c122e807e 100644
  	}
  
 +	if boring.Enabled && bhkdf.Supports() {
-+		return bhkdf.Expand(fh, pseudorandomKey, []byte(info), keyLength)
++		return bhkdf.Expand(fh, pseudorandomKey, info, keyLength)
 +	}
  	return hkdf.Expand(fh, pseudorandomKey, info, keyLength), nil
  }
  
-@@ -67,6 +76,13 @@ func Key[Hash hash.Hash](h func() Hash, secret, salt []byte, info string, keyLen
+@@ -67,6 +76,9 @@ func Key[Hash hash.Hash](h func() Hash, secret, salt []byte, info string, keyLen
  		return nil, errors.New("hkdf: requested key length too large")
  	}
  
 +	if boring.Enabled && bhkdf.Supports() {
-+		pseudorandomKey, err := bhkdf.Extract(fh, secret, salt)
-+		if err != nil {
-+			return nil, err
-+		}
-+		return bhkdf.Expand(fh, pseudorandomKey, []byte(info), keyLength)
++		return bhkdf.Key(fh, secret, salt, info, keyLength)
 +	}
  	return hkdf.Key(fh, secret, salt, info, keyLength), nil
  }
@@ -4127,7 +4123,7 @@ index e1c2ef49f15ce0..4635cc347880ec 100644
  	rand.Read(seed)
  	dk, err := NewDecapsulationKey768(seed)
 diff --git a/src/crypto/pbkdf2/pbkdf2.go b/src/crypto/pbkdf2/pbkdf2.go
-index 0bc14be888d9d6..f21f4559d2eb70 100644
+index 0bc14be888d9d6..d23a31b7582bd1 100644
 --- a/src/crypto/pbkdf2/pbkdf2.go
 +++ b/src/crypto/pbkdf2/pbkdf2.go
 @@ -16,6 +16,9 @@ import (
@@ -4148,7 +4144,7 @@ index 0bc14be888d9d6..f21f4559d2eb70 100644
 +		if keyLength <= 0 {
 +			return nil, errors.New("pkbdf2: keyLength must be larger than 0")
 +		}
-+		return bpbkdf2.Key(fh, []byte(password), salt, iter, keyLength)
++		return bpbkdf2.Key(fh, password, salt, iter, keyLength)
 +	}
  	return pbkdf2.Key(fh, password, salt, iter, keyLength)
  }
@@ -6215,7 +6211,7 @@ index 00000000000000..acfa551001af9c
 +package tls13
 diff --git a/src/crypto/tls/internal/tls13/tls13.go b/src/crypto/tls/internal/tls13/tls13.go
 new file mode 100644
-index 00000000000000..59c5933ade1d86
+index 00000000000000..535da69062b113
 --- /dev/null
 +++ b/src/crypto/tls/internal/tls13/tls13.go
 @@ -0,0 +1,197 @@
@@ -6258,7 +6254,7 @@ index 00000000000000..59c5933ade1d86
 +
 +	if boring.Enabled && btls13.SupportsKDF() {
 +		fh := fips140hash.UnwrapNew(hash)
-+		key, err := btls13.ExpandKDF(fh, secret, []byte(label), context, length)
++		key, err := btls13.ExpandKDF(fh, secret, label, context, length)
 +		if err != nil {
 +			panic(err)
 +		}
@@ -6431,7 +6427,7 @@ index 652a6489b899d6..36528e93156bef 100644
  	"hash"
  	"io"
 diff --git a/src/crypto/tls/prf.go b/src/crypto/tls/prf.go
-index bc59300f41c762..2512fa7f9e0bc7 100644
+index bc59300f41c762..a78e10c65cfa7e 100644
 --- a/src/crypto/tls/prf.go
 +++ b/src/crypto/tls/prf.go
 @@ -15,6 +15,9 @@ import (
@@ -6462,7 +6458,7 @@ index bc59300f41c762..2512fa7f9e0bc7 100644
  func prf10(secret []byte, label string, seed []byte, keyLen int) []byte {
  	result := make([]byte, keyLen)
 +	if boring.Enabled && btls12.SupportsPRF() {
-+		if err := btls12.PRF(result, secret, []byte(label), seed, nil); err != nil {
++		if err := btls12.PRF(result, secret, label, seed, nil); err != nil {
 +			panic(boringPRFError{fmt.Errorf("crypto/tls: prf10: %v", err)})
 +		}
 +		return result
@@ -6476,7 +6472,7 @@ index bc59300f41c762..2512fa7f9e0bc7 100644
  	return func(secret []byte, label string, seed []byte, keyLen int) []byte {
 +		if boring.Enabled && btls12.SupportsPRF() {
 +			result := make([]byte, keyLen)
-+			if err := btls12.PRF(result, secret, []byte(label), seed, hashFunc); err != nil {
++			if err := btls12.PRF(result, secret, label, seed, hashFunc); err != nil {
 +				panic(boringPRFError{fmt.Errorf("crypto/tls: prf12: %v", err)})
 +			}
 +			return result
@@ -6513,7 +6509,7 @@ index 8233985a62bd22..70fb5c9c4b8c2d 100644
  		in, _ := hex.DecodeString(test.preMasterSecret)
  		clientRandom, _ := hex.DecodeString(test.clientRandom)
 diff --git a/src/crypto/x509/verify_test.go b/src/crypto/x509/verify_test.go
-index 1d3e845d0f0a9c..eb4318faf13f7b 100644
+index d32d815261d9e1..0911f6bb20e2d2 100644
 --- a/src/crypto/x509/verify_test.go
 +++ b/src/crypto/x509/verify_test.go
 @@ -3127,7 +3127,7 @@ func dsaSelfSignedCNX(t *testing.T) []byte {


### PR DESCRIPTION
## Summary
- update cryptobackend to the newer OpenSSL and Darwin backend module versions
- align KDF-style cryptobackend APIs with the public/FIPS shapes by accepting string info/password/label parameters at the backend boundary
- refresh `0001-Vendor-external-dependencies.patch` and `0002-Add-crypto-backends.patch`

## Testing
- `eng/artifacts/toolbin/submodule-refresh.exe -shallow`
- `..\bin\go.exe test -short crypto/hkdf crypto/pbkdf2`
- `MS_GO_NOSYSTEMCRYPTO=1 ..\bin\go.exe test -short crypto/tls`
- `go test -mod=mod ./...` in `cryptobackend`

Note: a default `..\bin\go.exe test -short crypto/hkdf crypto/pbkdf2 crypto/tls` run still hits the known Windows systemcrypto TLS golden ClientHello mismatch; reran `crypto/tls` with `MS_GO_NOSYSTEMCRYPTO=1`.