### PR TITLE
Remove stale crypto/ecdsa/badlinkname.go

### DIFF
--- a/patches/0002-Add-crypto-backends.patch
+++ b/patches/0002-Add-crypto-backends.patch
@@ -54,7 +54,6 @@ Subject: [PATCH] Add crypto backends
  src/crypto/ecdh/ecdh_test.go                  |  19 +-
  src/crypto/ecdh/nist.go                       |  54 ++--
  src/crypto/ecdh/x25519.go                     |  51 ++++
- src/crypto/ecdsa/badlinkname.go               |  19 ++
  src/crypto/ecdsa/boring.go                    |  19 +-
  src/crypto/ecdsa/ecdsa.go                     |  19 +-
  src/crypto/ecdsa/notboring.go                 |   8 +-
@@ -143,12 +142,11 @@ Subject: [PATCH] Add crypto backends
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/syscall_windows.go                |   3 +
- 139 files changed, 2827 insertions(+), 377 deletions(-)
+ 138 files changed, 2808 insertions(+), 377 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/dsa/boring.go
  create mode 100644 src/crypto/dsa/notboring.go
- create mode 100644 src/crypto/ecdsa/badlinkname.go
  create mode 100644 src/crypto/ed25519/boring.go
  create mode 100644 src/crypto/ed25519/notboring.go
  create mode 100644 src/crypto/systemcrypto_nocgo_linux.go
@@ -2288,31 +2286,6 @@ index 21a921aa12d44d..075b2f679d2238 100644
  	out := make([]byte, x25519SharedSecretSize)
  	x25519ScalarMult(out, local.privateKey, remote.publicKey)
  	if isZero(out) {
-diff --git a/src/crypto/ecdsa/badlinkname.go b/src/crypto/ecdsa/badlinkname.go
-new file mode 100644
-index 00000000000000..168efdb820c85b
---- /dev/null
-+++ b/src/crypto/ecdsa/badlinkname.go
-@@ -0,0 +1,19 @@
-+// Copyright 2025 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build goexperiment.systemcrypto
-+
-+package ecdsa
-+
-+import _ "unsafe"
-+
-+// The symbols below are pulled by some crypto backend in the Microsoft build of Go compiler.
-+// We provide a push linkname here, to keep them accessible with pull linknames.
-+
-+//go:linkname encodeSignature
-+//go:linkname parseSignature
-+
-+// This supplements other linknames that are already added by
-+// https://github.com/golang/go/commit/41aab30bd260297ad8ddad47e98fdf8390a9a67e
-+// See that commit for more information.
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
 index 275c60b4de49eb..a5b6ae9dc90505 100644
 --- a/src/crypto/ecdsa/boring.go


### PR DESCRIPTION
`crypto/ecdsa/badlinkname.go` is no longer needed since #2371.