### PR TITLE
Remove stale hash boring files

### DIFF
--- a/patches/0002-Add-crypto-backends.patch
+++ b/patches/0002-Add-crypto-backends.patch
@@ -128,10 +128,8 @@ Subject: [PATCH] Add crypto backends
  src/go/build/deps_test.go                     |  90 +++++-
  .../build/testdata/backendtags_system/main.go |   3 +
  .../backendtags_system/systemcrypto.go        |   3 +
- src/hash/boring_test.go                       |   9 +
  src/hash/example_test.go                      |   2 +
  src/hash/marshal_test.go                      |   4 +
- src/hash/notboring_test.go                    |   9 +
  src/internal/buildcfg/cfg.go                  |   2 +
  src/internal/buildcfg/cfg_test.go             |  44 +++
  src/internal/buildcfg/exp.go                  |  20 ++
@@ -143,7 +141,7 @@ Subject: [PATCH] Add crypto backends
  src/os/exec/exec_test.go                      |   9 +
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/syscall_windows.go                |   3 +
- 139 files changed, 2827 insertions(+), 377 deletions(-)
+ 137 files changed, 2809 insertions(+), 377 deletions(-)
  create mode 100644 src/cmd/go/internal/modindex/build_test.go
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/dsa/boring.go
@@ -157,8 +155,6 @@ Subject: [PATCH] Add crypto backends
  create mode 100644 src/go/build/buildbackend_test.go
  create mode 100644 src/go/build/testdata/backendtags_system/main.go
  create mode 100644 src/go/build/testdata/backendtags_system/systemcrypto.go
- create mode 100644 src/hash/boring_test.go
- create mode 100644 src/hash/notboring_test.go
  create mode 100644 src/internal/systemcrypto/systemcrypto.go
  create mode 100644 src/internal/systemcrypto/systemcrypto_test.go
 
@@ -6619,21 +6615,6 @@ index 00000000000000..eb8a026982259c
 +//go:build goexperiment.systemcrypto
 +
 +package main
-diff --git a/src/hash/boring_test.go b/src/hash/boring_test.go
-new file mode 100644
-index 00000000000000..52748c44698076
---- /dev/null
-+++ b/src/hash/boring_test.go
-@@ -0,0 +1,9 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build goexperiment.systemcrypto
-+
-+package hash_test
-+
-+const boringEnabled = true
 diff --git a/src/hash/example_test.go b/src/hash/example_test.go
 index f07b9aaa2c4898..b380537215634d 100644
 --- a/src/hash/example_test.go
@@ -6669,21 +6650,6 @@ index 3091f7a67acede..fa3f0fd82cfd30 100644
  				t.Fatalf("MarshalBinary: %v", err)
  			}
  			if !bytes.Equal(enc, tt.golden) {
-diff --git a/src/hash/notboring_test.go b/src/hash/notboring_test.go
-new file mode 100644
-index 00000000000000..11dc691600b110
---- /dev/null
-+++ b/src/hash/notboring_test.go
-@@ -0,0 +1,9 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build !goexperiment.systemcrypto
-+
-+package hash_test
-+
-+const boringEnabled = false
 diff --git a/src/internal/buildcfg/cfg.go b/src/internal/buildcfg/cfg.go
 index 89fd74eb823162..6d266ff641d721 100644
 --- a/src/internal/buildcfg/cfg.go


### PR DESCRIPTION
`boringEnabled` is not used in the `hash` package. Can be removed.