### PR TITLE
[release-branch.go1.26] re-vendor latest purego implementation in OpenSSL backend

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -120,55 +120,56 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-darwin/xcrypto/rsa.go |  208 ++
  .../microsoft/go-crypto-openssl/LICENSE       |   20 +
  .../microsoft/go-crypto-openssl/bbig/big.go   |   37 +
- .../internal/fakecgo/abi_amd64.h              |   99 +
- .../internal/fakecgo/abi_arm64.h              |   39 +
- .../internal/fakecgo/abi_loong64.h            |   60 +
- .../internal/fakecgo/abi_ppc64x.h             |  195 ++
- .../internal/fakecgo/asm_386.s                |   29 +
- .../internal/fakecgo/asm_amd64.s              |   39 +
+ .../internal/fakecgo/abi_amd64.h              |  101 +
+ .../internal/fakecgo/abi_arm64.h              |   41 +
+ .../internal/fakecgo/abi_loong64.h            |   62 +
+ .../internal/fakecgo/abi_ppc64x.h             |  197 ++
+ .../internal/fakecgo/abi_riscv64.h            |   74 +
+ .../internal/fakecgo/asm_386.s                |   31 +
+ .../internal/fakecgo/asm_amd64.s              |   41 +
  .../internal/fakecgo/asm_arm.s                |   52 +
- .../internal/fakecgo/asm_arm64.s              |   36 +
+ .../internal/fakecgo/asm_arm64.s              |   37 +
  .../internal/fakecgo/asm_loong64.s            |   40 +
- .../internal/fakecgo/asm_ppc64le.s            |   82 +
- .../internal/fakecgo/asm_riscv64.s            |   78 +
- .../internal/fakecgo/asm_s390x.s              |   55 +
- .../internal/fakecgo/callbacks.go             |   93 +
- .../internal/fakecgo/fakecgo.go               |   29 +
+ .../internal/fakecgo/asm_ppc64le.s            |   81 +
+ .../internal/fakecgo/asm_riscv64.s            |   38 +
+ .../internal/fakecgo/asm_s390x.s              |   54 +
+ .../internal/fakecgo/callbacks.go             |   95 +
+ .../internal/fakecgo/fakecgo.go               |   16 +
  .../internal/fakecgo/fakecgo.lock             |    3 +
  .../internal/fakecgo/generate.go              |    3 +
- .../internal/fakecgo/go_darwin.go             |   88 +
- .../internal/fakecgo/go_libinit.go            |   72 +
- .../internal/fakecgo/go_linux.go              |  100 +
- .../internal/fakecgo/go_setenv.go             |   18 +
- .../internal/fakecgo/go_util.go               |   38 +
- .../internal/fakecgo/iscgo.go                 |   19 +
- .../internal/fakecgo/libcgo.go                |   39 +
- .../internal/fakecgo/libcgo_darwin.go         |   26 +
- .../internal/fakecgo/libcgo_linux.go          |   20 +
- .../internal/fakecgo/linux.go                 |   34 +
- .../internal/fakecgo/setenv.go                |   19 +
- .../internal/fakecgo/trampolines_386.s        |  107 +
- .../internal/fakecgo/trampolines_amd64.s      |  107 +
- .../internal/fakecgo/trampolines_arm.s        |   81 +
- .../internal/fakecgo/trampolines_arm64.s      |   84 +
- .../internal/fakecgo/trampolines_loong64.s    |   88 +
- .../internal/fakecgo/trampolines_ppc64le.s    |  227 ++
- .../internal/fakecgo/trampolines_riscv64.s    |   72 +
- .../internal/fakecgo/trampolines_s390x.s      |  163 ++
- .../internal/fakecgo/zsymbols.go              |  165 ++
- .../internal/fakecgo/zsymbols_darwin.go       |   59 +
- .../internal/fakecgo/zsymbols_linux.go        |  294 ++
- .../internal/fakecgo/ztrampolines_darwin.s    |   19 +
- .../internal/fakecgo/ztrampolines_linux.s     |   16 +
- .../internal/fakecgo/ztrampolines_linux_386.s |  110 +
- .../fakecgo/ztrampolines_linux_amd64.s        |  102 +
- .../internal/fakecgo/ztrampolines_linux_arm.s |   74 +
- .../fakecgo/ztrampolines_linux_arm64.s        |   93 +
- .../fakecgo/ztrampolines_linux_loong64.s      |   92 +
- .../fakecgo/ztrampolines_linux_ppc64le.s      |  101 +
- .../fakecgo/ztrampolines_linux_riscv64.s      |   92 +
- .../fakecgo/ztrampolines_linux_s390x.s        |   90 +
- .../internal/fakecgo/ztrampolines_stubs.s     |   55 +
+ .../internal/fakecgo/go_darwin.go             |   90 +
+ .../internal/fakecgo/go_libinit.go            |   74 +
+ .../internal/fakecgo/go_linux.go              |   81 +
+ .../internal/fakecgo/go_setenv.go             |   20 +
+ .../internal/fakecgo/go_util.go               |   40 +
+ .../internal/fakecgo/iscgo.go                 |   21 +
+ .../internal/fakecgo/libcgo.go                |   41 +
+ .../internal/fakecgo/libcgo_darwin.go         |   28 +
+ .../internal/fakecgo/libcgo_linux.go          |   22 +
+ .../internal/fakecgo/linux.go                 |  186 ++
+ .../internal/fakecgo/setenv.go                |   21 +
+ .../internal/fakecgo/trampolines_386.s        |  123 +
+ .../internal/fakecgo/trampolines_amd64.s      |  109 +
+ .../internal/fakecgo/trampolines_arm.s        |  124 +
+ .../internal/fakecgo/trampolines_arm64.s      |   83 +
+ .../internal/fakecgo/trampolines_linux_386.s  |   80 +
+ .../fakecgo/trampolines_linux_amd64.s         |   71 +
+ .../internal/fakecgo/trampolines_linux_arm.s  |   71 +
+ .../fakecgo/trampolines_linux_arm64.s         |   62 +
+ .../fakecgo/trampolines_linux_loong64.s       |   62 +
+ .../fakecgo/trampolines_linux_ppc64le.s       |   71 +
+ .../fakecgo/trampolines_linux_riscv64.s       |   62 +
+ .../fakecgo/trampolines_linux_s390x.s         |   53 +
+ .../internal/fakecgo/trampolines_loong64.s    |   80 +
+ .../internal/fakecgo/trampolines_ppc64le.s    |  134 +
+ .../internal/fakecgo/trampolines_riscv64.s    |   78 +
+ .../internal/fakecgo/trampolines_s390x.s      |  160 ++
+ .../internal/fakecgo/zsymbols.go              |  167 ++
+ .../internal/fakecgo/zsymbols_darwin.go       |   61 +
+ .../internal/fakecgo/zsymbols_linux.go        |  160 ++
+ .../internal/fakecgo/ztrampolines_darwin.s    |   21 +
+ .../internal/fakecgo/ztrampolines_linux.s     |   48 +
+ .../internal/fakecgo/ztrampolines_stubs.s     |   57 +
  .../go-crypto-openssl/internal/ossl/asm_386.s |   98 +
  .../internal/ossl/asm_amd64.s                 |  120 +
  .../go-crypto-openssl/internal/ossl/asm_arm.s |  104 +
@@ -266,7 +267,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 258 files changed, 34730 insertions(+), 7 deletions(-)
+ 259 files changed, 34561 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -376,6 +377,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_arm64.h
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_loong64.h
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_ppc64x.h
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_riscv64.h
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_386.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_amd64.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s
@@ -403,6 +405,14 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_amd64.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_386.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_amd64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_arm.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_arm64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_loong64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_ppc64le.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_riscv64.s
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_s390x.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_loong64.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_ppc64le.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_riscv64.s
@@ -412,14 +422,6 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_linux.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_darwin.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux.s
- create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_386.s
- create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_amd64.s
- create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_arm.s
- create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_arm64.s
- create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_loong64.s
- create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_ppc64le.s
- create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_riscv64.s
- create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_s390x.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_stubs.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/asm_386.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/asm_amd64.s
@@ -2191,7 +2193,7 @@ index 00000000000000..f5dc9afe4b0ead
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index b329ba18def47c..b3bc1492185d6c 100644
+index b329ba18def47c..3b633611d198ec 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2201,18 +2203,18 @@ index b329ba18def47c..b3bc1492185d6c 100644
 +
 +require (
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260612173401-95c9561b6f25
-+	github.com/microsoft/go-crypto-openssl v0.0.0-20260602094349-4d656068110f
++	github.com/microsoft/go-crypto-openssl v0.0.0-20260709090821-4e7f148608fd
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 37f908522c1926..8d3b889ca5585a 100644
+index 37f908522c1926..fff82a95d3ec12 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260612173401-95c9561b6f25 h1:5bQuXeMJRSGTu+Y4foxojAaz2hAqeoAuYYHa2yUCpOA=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260612173401-95c9561b6f25/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260602094349-4d656068110f h1:Rg3Df9INlJ7g5iE1VR3jwc6M+lHOtXNyO4HfDRy5P54=
-+github.com/microsoft/go-crypto-openssl v0.0.0-20260602094349-4d656068110f/go.mod h1:4QCeILGRVUNXcRMpHlFIzULgpv3vJcnC34zEdDHdw98=
++github.com/microsoft/go-crypto-openssl v0.0.0-20260709090821-4e7f148608fd h1:RpGecuDCHiv/wk/i4Ih0utGQoF0bhySMS528I6yVJV0=
++github.com/microsoft/go-crypto-openssl v0.0.0-20260709090821-4e7f148608fd/go.mod h1:4QCeILGRVUNXcRMpHlFIzULgpv3vJcnC34zEdDHdw98=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9 h1:joliMChkkfHV3vAPKzu9kefdw0K+d89A8r9gTm3MFS4=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00 h1:JgcPM1rzpSOZS8y69FQvnY0xN0ciHlpQqwTXJcuZIA4=
@@ -13776,10 +13778,12 @@ index 00000000000000..1bf236d9d4b29d
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_amd64.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_amd64.h
 new file mode 100644
-index 00000000000000..9949435fe9e0ae
+index 00000000000000..6bb31c929849a8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_amd64.h
-@@ -0,0 +1,99 @@
+@@ -0,0 +1,101 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2021 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -13881,10 +13885,12 @@ index 00000000000000..9949435fe9e0ae
 +#endif
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_arm64.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_arm64.h
 new file mode 100644
-index 00000000000000..5d5061ec1dbf8c
+index 00000000000000..4957e129eae27e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_arm64.h
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,41 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2021 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -13926,10 +13932,12 @@ index 00000000000000..5d5061ec1dbf8c
 +	FLDPD	((offset)+6*8)(RSP), (F14, F15)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_loong64.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_loong64.h
 new file mode 100644
-index 00000000000000..b10d83732f1c6e
+index 00000000000000..3752c54045960b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_loong64.h
-@@ -0,0 +1,60 @@
+@@ -0,0 +1,62 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -13992,10 +14000,12 @@ index 00000000000000..b10d83732f1c6e
 +	MOVD	((offset)+(7*8))(R3), F31
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_ppc64x.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_ppc64x.h
 new file mode 100644
-index 00000000000000..245a5266f6e9fa
+index 00000000000000..4a6086502ee07b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_ppc64x.h
-@@ -0,0 +1,195 @@
+@@ -0,0 +1,197 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2023 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -14191,12 +14201,94 @@ index 00000000000000..245a5266f6e9fa
 +	MOVD	R0, LR                                                \
 +	MOVD	8(R1), R0                                             \
 +	MOVW	R0, CR
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_riscv64.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_riscv64.h
+new file mode 100644
+index 00000000000000..f728bd3300cf18
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/abi_riscv64.h
+@@ -0,0 +1,74 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// Copyright 2026 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Macros for transitioning from the host ABI to Go ABI0.
++//
++// These macros save and restore the callee-saved registers
++// from the stack, but they don't adjust stack pointer, so
++// the user should prepare stack space in advance.
++// SAVE_GPR(offset) saves X8, X9, X18-X27 to the stack space
++// of ((offset)+0*8)(X2) ~ ((offset)+11*8)(X2).
++//
++// SAVE_FPR(offset) saves F8, F9, F18-F27 to the stack space
++// of ((offset)+0*8)(X2) ~ ((offset)+11*8)(X2).
++//
++// Note: g is X27
++
++#define SAVE_GPR(offset) \
++	MOV X8, ((offset)+0*8)(X2)   \
++	MOV X9, ((offset)+1*8)(X2)   \
++	MOV X18, ((offset)+2*8)(X2)  \
++	MOV X19, ((offset)+3*8)(X2)  \
++	MOV X20, ((offset)+4*8)(X2)  \
++	MOV X21, ((offset)+5*8)(X2)  \
++	MOV X22, ((offset)+6*8)(X2)  \
++	MOV X23, ((offset)+7*8)(X2)  \
++	MOV X24, ((offset)+8*8)(X2)  \
++	MOV X25, ((offset)+9*8)(X2)  \
++	MOV X26, ((offset)+10*8)(X2) \
++	MOV g, ((offset)+11*8)(X2)
++
++#define RESTORE_GPR(offset) \
++	MOV ((offset)+0*8)(X2), X8   \
++	MOV ((offset)+1*8)(X2), X9   \
++	MOV ((offset)+2*8)(X2), X18  \
++	MOV ((offset)+3*8)(X2), X19  \
++	MOV ((offset)+4*8)(X2), X20  \
++	MOV ((offset)+5*8)(X2), X21  \
++	MOV ((offset)+6*8)(X2), X22  \
++	MOV ((offset)+7*8)(X2), X23  \
++	MOV ((offset)+8*8)(X2), X24  \
++	MOV ((offset)+9*8)(X2), X25  \
++	MOV ((offset)+10*8)(X2), X26 \
++	MOV ((offset)+11*8)(X2), g
++
++#define SAVE_FPR(offset) \
++	MOVD F8, ((offset)+0*8)(X2)   \
++	MOVD F9, ((offset)+1*8)(X2)   \
++	MOVD F18, ((offset)+2*8)(X2)  \
++	MOVD F19, ((offset)+3*8)(X2)  \
++	MOVD F20, ((offset)+4*8)(X2)  \
++	MOVD F21, ((offset)+5*8)(X2)  \
++	MOVD F22, ((offset)+6*8)(X2)  \
++	MOVD F23, ((offset)+7*8)(X2)  \
++	MOVD F24, ((offset)+8*8)(X2)  \
++	MOVD F25, ((offset)+9*8)(X2)  \
++	MOVD F26, ((offset)+10*8)(X2) \
++	MOVD F27, ((offset)+11*8)(X2)
++
++#define RESTORE_FPR(offset) \
++	MOVD ((offset)+0*8)(X2), F8   \
++	MOVD ((offset)+1*8)(X2), F9   \
++	MOVD ((offset)+2*8)(X2), F18  \
++	MOVD ((offset)+3*8)(X2), F19  \
++	MOVD ((offset)+4*8)(X2), F20  \
++	MOVD ((offset)+5*8)(X2), F21  \
++	MOVD ((offset)+6*8)(X2), F22  \
++	MOVD ((offset)+7*8)(X2), F23  \
++	MOVD ((offset)+8*8)(X2), F24  \
++	MOVD ((offset)+9*8)(X2), F25  \
++	MOVD ((offset)+10*8)(X2), F26 \
++	MOVD ((offset)+11*8)(X2), F27
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_386.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_386.s
 new file mode 100644
-index 00000000000000..7475ec8a0b21fc
+index 00000000000000..350233acccc89b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_386.s
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,31 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2009 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -14228,10 +14320,12 @@ index 00000000000000..7475ec8a0b21fc
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_amd64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_amd64.s
 new file mode 100644
-index 00000000000000..2b7eb57f8ae783
+index 00000000000000..623852da4937cb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_amd64.s
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,41 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2009 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -14273,10 +14367,12 @@ index 00000000000000..2b7eb57f8ae783
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s
 new file mode 100644
-index 00000000000000..68034e6035aa44
+index 00000000000000..2a24150b337120
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s
 @@ -0,0 +1,52 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2012 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -14311,8 +14407,6 @@ index 00000000000000..68034e6035aa44
 +	MOVD F14, (13*4+8*7)(R13)
 +	MOVD F15, (13*4+8*8)(R13)
 +
-+	BL runtime·load_g(SB)
-+
 +	// We set up the arguments to cgocallback when saving registers above.
 +	BL runtime·cgocallback(SB)
 +
@@ -14331,10 +14425,12 @@ index 00000000000000..68034e6035aa44
 +	MOVW     R14, R15
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm64.s
 new file mode 100644
-index 00000000000000..50e5261d922c56
+index 00000000000000..ff58b16c050af6
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm64.s
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,37 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2015 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -14362,7 +14458,6 @@ index 00000000000000..50e5261d922c56
 +	STP (R29, R30), (8*22)(RSP)
 +
 +	// Initialize Go ABI environment
-+	BL runtime·load_g(SB)
 +	BL runtime·cgocallback(SB)
 +
 +	RESTORE_R19_TO_R28(8*4)
@@ -14373,10 +14468,12 @@ index 00000000000000..50e5261d922c56
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_loong64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_loong64.s
 new file mode 100644
-index 00000000000000..e81df86a56e4ad
+index 00000000000000..e3c8afb0d7f7de
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_loong64.s
 @@ -0,0 +1,40 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2022 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -14406,8 +14503,6 @@ index 00000000000000..e81df86a56e4ad
 +	MOVV R1, (22*8)(R3)
 +
 +	// Initialize Go ABI environment
-+	JAL runtime·load_g(SB)
-+
 +	JAL runtime·cgocallback(SB)
 +
 +	RESTORE_R22_TO_R31((4*8))
@@ -14419,10 +14514,12 @@ index 00000000000000..e81df86a56e4ad
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_ppc64le.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_ppc64le.s
 new file mode 100644
-index 00000000000000..6d1938cd8d8bcd
+index 00000000000000..98fa0d54133219
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_ppc64le.s
-@@ -0,0 +1,82 @@
+@@ -0,0 +1,81 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2014 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -14475,9 +14572,6 @@ index 00000000000000..6d1938cd8d8bcd
 +	// Initialize R0 to 0 as expected by Go
 +	MOVD $0, R0
 +
-+	// Load the current g.
-+	BL runtime·load_g(SB)
-+
 +	// Set up arguments for cgocallback
 +	MOVD R3, FIXED_FRAME+0(R1) // fn unsafe.Pointer
 +	MOVD R4, FIXED_FRAME+8(R1) // a unsafe.Pointer
@@ -14507,15 +14601,18 @@ index 00000000000000..6d1938cd8d8bcd
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_riscv64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_riscv64.s
 new file mode 100644
-index 00000000000000..acf82c1b5ae501
+index 00000000000000..4bb9b1d3a0a2ad
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_riscv64.s
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,38 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2020 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
 +#include "textflag.h"
++#include "abi_riscv64.h"
 +
 +// Called by C code generated by cmd/cgo.
 +// func crosscall2(fn, a unsafe.Pointer, n int32, ctxt uintptr)
@@ -14527,74 +14624,33 @@ index 00000000000000..acf82c1b5ae501
 + * registers. Note that at procedure entry the first argument is at
 + * 8(X2).
 + */
-+	ADD  $(-8*29), X2
-+	MOV  X10, (8*1)(X2)  // fn unsafe.Pointer
-+	MOV  X11, (8*2)(X2)  // a unsafe.Pointer
-+	MOV  X13, (8*3)(X2)  // ctxt uintptr
-+	MOV  X8, (8*4)(X2)
-+	MOV  X9, (8*5)(X2)
-+	MOV  X18, (8*6)(X2)
-+	MOV  X19, (8*7)(X2)
-+	MOV  X20, (8*8)(X2)
-+	MOV  X21, (8*9)(X2)
-+	MOV  X22, (8*10)(X2)
-+	MOV  X23, (8*11)(X2)
-+	MOV  X24, (8*12)(X2)
-+	MOV  X25, (8*13)(X2)
-+	MOV  X26, (8*14)(X2)
-+	MOV  g, (8*15)(X2)
-+	MOV  X1, (8*16)(X2)
-+	MOVD F8, (8*17)(X2)
-+	MOVD F9, (8*18)(X2)
-+	MOVD F18, (8*19)(X2)
-+	MOVD F19, (8*20)(X2)
-+	MOVD F20, (8*21)(X2)
-+	MOVD F21, (8*22)(X2)
-+	MOVD F22, (8*23)(X2)
-+	MOVD F23, (8*24)(X2)
-+	MOVD F24, (8*25)(X2)
-+	MOVD F25, (8*26)(X2)
-+	MOVD F26, (8*27)(X2)
-+	MOVD F27, (8*28)(X2)
++	ADD $(-8*29), X2
++	MOV X10, (8*1)(X2) // fn unsafe.Pointer
++	MOV X11, (8*2)(X2) // a unsafe.Pointer
++	MOV X13, (8*3)(X2) // ctxt uintptr
++
++	SAVE_GPR((8*4))
++	MOV X1, (8*16)(X2)
++	SAVE_FPR((8*17))
 +
 +	// Initialize Go ABI environment
-+	CALL runtime·load_g(SB)
 +	CALL runtime·cgocallback(SB)
 +
-+	MOV  (8*4)(X2), X8
-+	MOV  (8*5)(X2), X9
-+	MOV  (8*6)(X2), X18
-+	MOV  (8*7)(X2), X19
-+	MOV  (8*8)(X2), X20
-+	MOV  (8*9)(X2), X21
-+	MOV  (8*10)(X2), X22
-+	MOV  (8*11)(X2), X23
-+	MOV  (8*12)(X2), X24
-+	MOV  (8*13)(X2), X25
-+	MOV  (8*14)(X2), X26
-+	MOV  (8*15)(X2), g
-+	MOV  (8*16)(X2), X1
-+	MOVD (8*17)(X2), F8
-+	MOVD (8*18)(X2), F9
-+	MOVD (8*19)(X2), F18
-+	MOVD (8*20)(X2), F19
-+	MOVD (8*21)(X2), F20
-+	MOVD (8*22)(X2), F21
-+	MOVD (8*23)(X2), F22
-+	MOVD (8*24)(X2), F23
-+	MOVD (8*25)(X2), F24
-+	MOVD (8*26)(X2), F25
-+	MOVD (8*27)(X2), F26
-+	MOVD (8*28)(X2), F27
-+	ADD  $(8*29), X2
++	RESTORE_GPR((8*4))
++	MOV (8*16)(X2), X1
++	RESTORE_FPR((8*17))
++
++	ADD $(8*29), X2
 +
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_s390x.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_s390x.s
 new file mode 100644
-index 00000000000000..b64466501dee38
+index 00000000000000..fb393d4c534a8b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_s390x.s
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,54 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2016 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -14624,9 +14680,6 @@ index 00000000000000..b64466501dee38
 +	FMOVD F14, 80(R15)
 +	FMOVD F15, 88(R15)
 +
-+	// Initialize Go ABI environment.
-+	BL runtime·load_g(SB)
-+
 +	MOVD R2, 8(R15)  // fn unsafe.Pointer
 +	MOVD R3, 16(R15) // a unsafe.Pointer
 +
@@ -14652,15 +14705,17 @@ index 00000000000000..b64466501dee38
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/callbacks.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/callbacks.go
 new file mode 100644
-index 00000000000000..5f70632fa7cc33
+index 00000000000000..b6ef14af7ef4f8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/callbacks.go
-@@ -0,0 +1,93 @@
+@@ -0,0 +1,95 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2011 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +package fakecgo
 +
@@ -14751,47 +14806,34 @@ index 00000000000000..5f70632fa7cc33
 +)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.go
 new file mode 100644
-index 00000000000000..7927deb2785263
+index 00000000000000..17c6f83475ce5e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.go
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,16 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2025 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +package fakecgo
 +
-+import (
-+	"unsafe"
-+)
++import _ "unsafe"
 +
 +// setg_trampoline calls setg with the G provided
 +func setg_trampoline(setg uintptr, G uintptr)
 +
 +// call5 takes fn the C function and 5 arguments and calls the function with those arguments
 +func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
-+
-+// argset matches runtime/cgocall.go:argset.
-+type argset struct {
-+	args   *uintptr
-+	retval uintptr
-+}
-+
-+//go:nosplit
-+//go:norace
-+func (a *argset) arg(i int) unsafe.Pointer {
-+	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
-+	return *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(a.args), uintptr(i)*unsafe.Sizeof(uintptr(0))))
-+}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 new file mode 100644
-index 00000000000000..4e9bbeb5c4f3e3
+index 00000000000000..65ca1efea6f44d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 @@ -0,0 +1,3 @@
 +{
-+  "commit_hash": "585a4c527464bb6ef91b22aef08d55219c8fab09"
++  "commit_hash": "5f49e7c4932236f91b58b89323a50401a2ab47f1"
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/generate.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/generate.go
 new file mode 100644
@@ -14804,10 +14846,12 @@ index 00000000000000..ca8d5f843f8421
 +//go:generate go run update_tool.go
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_darwin.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_darwin.go
 new file mode 100644
-index 00000000000000..d0868f0f790351
+index 00000000000000..e49117058f381e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_darwin.go
-@@ -0,0 +1,88 @@
+@@ -0,0 +1,90 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2011 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -14898,14 +14942,16 @@ index 00000000000000..d0868f0f790351
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_libinit.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_libinit.go
 new file mode 100644
-index 00000000000000..0eadc51daecc75
+index 00000000000000..38ba01bb4f273d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_libinit.go
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,74 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +package fakecgo
 +
@@ -14976,10 +15022,12 @@ index 00000000000000..0eadc51daecc75
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_linux.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_linux.go
 new file mode 100644
-index 00000000000000..9f380c1b431807
+index 00000000000000..2018c6dc2e1b85
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_linux.go
-@@ -0,0 +1,100 @@
+@@ -0,0 +1,81 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2011 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -15049,47 +15097,28 @@ index 00000000000000..9f380c1b431807
 +//go:nosplit
 +func x_cgo_init(g *G, setg uintptr) {
 +	var size size_t
-+	var attr *pthread_attr_t
-+
-+	/* The memory sanitizer distributed with versions of clang
-+	   before 3.8 has a bug: if you call mmap before malloc, mmap
-+	   may return an address that is later overwritten by the msan
-+	   library.  Avoid this problem by forcing a call to malloc
-+	   here, before we ever call malloc.
-+
-+	   This is only required for the memory sanitizer, so it's
-+	   unfortunate that we always run it.  It should be possible
-+	   to remove this when we no longer care about versions of
-+	   clang before 3.8.  The test for this is
-+	   misc/cgo/testsanitizers.
-+
-+	   GCC works hard to eliminate a seemingly unnecessary call to
-+	   malloc, so we actually use the memory we allocate.  */
++	var attr pthread_attr_t
 +
 +	setg_func = setg
-+	attr = (*pthread_attr_t)(malloc(unsafe.Sizeof(*attr)))
-+	if attr == nil {
-+		println("fakecgo: malloc failed")
-+		abort()
-+	}
-+	pthread_attr_init(attr)
-+	pthread_attr_getstacksize(attr, &size)
++	pthread_attr_init(&attr)
++	pthread_attr_getstacksize(&attr, &size)
 +	// runtime/cgo uses __builtin_frame_address(0) instead of `uintptr(unsafe.Pointer(&size))`
 +	// but this should be OK since we are taking the address of the first variable in this function.
 +	g.stacklo = uintptr(unsafe.Pointer(&size)) - uintptr(size) + 4096
-+	pthread_attr_destroy(attr)
-+	free(unsafe.Pointer(attr))
++	pthread_attr_destroy(&attr)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_setenv.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_setenv.go
 new file mode 100644
-index 00000000000000..6c2f981d730980
+index 00000000000000..4d24dae4e11cc4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_setenv.go
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,20 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +package fakecgo
 +
@@ -15106,14 +15135,16 @@ index 00000000000000..6c2f981d730980
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_util.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_util.go
 new file mode 100644
-index 00000000000000..8a71c5a558610a
+index 00000000000000..6a1731e3bee8e5
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_util.go
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,40 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +package fakecgo
 +
@@ -15150,15 +15181,17 @@ index 00000000000000..8a71c5a558610a
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/iscgo.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/iscgo.go
 new file mode 100644
-index 00000000000000..ba142ec481d026
+index 00000000000000..eb8ec0e7f94b99
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/iscgo.go
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,21 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2010 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +// The runtime package contains an uninitialized definition
 +// for runtime·iscgo. Override it to tell the runtime we're here.
@@ -15175,14 +15208,16 @@ index 00000000000000..ba142ec481d026
 +var _iscgo bool = true
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo.go
 new file mode 100644
-index 00000000000000..8a0790faf1d5d9
+index 00000000000000..418a3951bfc621
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo.go
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,41 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +package fakecgo
 +
@@ -15220,10 +15255,12 @@ index 00000000000000..8a0790faf1d5d9
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo_darwin.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo_darwin.go
 new file mode 100644
-index 00000000000000..ecdcb2e7852560
+index 00000000000000..2f7a973b34a3a3
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo_darwin.go
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,28 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
@@ -15252,10 +15289,12 @@ index 00000000000000..ecdcb2e7852560
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo_linux.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo_linux.go
 new file mode 100644
-index 00000000000000..b08a44a1001bc0
+index 00000000000000..ace87e2201bfba
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo_linux.go
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,22 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
@@ -15278,18 +15317,33 @@ index 00000000000000..b08a44a1001bc0
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/linux.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/linux.go
 new file mode 100644
-index 00000000000000..42c2b7d0b8176f
+index 00000000000000..0fbf6bcac87f2b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/linux.go
-@@ -0,0 +1,34 @@
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
+@@ -0,0 +1,186 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// Copyright 2016 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
 +
 +//go:build !cgo && linux
 +
 +package fakecgo
 +
 +import "unsafe"
++
++// argset matches runtime/cgocall.go:argset.
++type argset struct {
++	args   *uintptr
++	retval uintptr
++}
++
++//go:nosplit
++//go:norace
++func (a *argset) arg(i int) unsafe.Pointer {
++	return *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(a.args), uintptr(i)*unsafe.Sizeof(uintptr(0))))
++}
 +
 +//go:linkname _cgo_libc_setegid syscall.cgo_libc_setegid
 +//go:linkname _cgo_libc_seteuid syscall.cgo_libc_seteuid
@@ -15311,22 +15365,161 @@ index 00000000000000..42c2b7d0b8176f
 +var _cgo_libc_setuid = &_cgo_purego_setuid_trampoline
 +var _cgo_libc_setgroups = &_cgo_purego_setgroups_trampoline
 +
++//go:nosplit
++//go:norace
 +func errno() int32 {
 +	// this indirection is to avoid go vet complaining about possible misuse of unsafe.Pointer
 +	loc := __errno_location()
 +	return **(**int32)(unsafe.Pointer(&loc))
 +}
++
++//go:linkname _cgo_purego_setegid_trampoline _cgo_purego_setegid_trampoline
++var _cgo_purego_setegid_trampoline byte
++var x_cgo_purego_setegid_call = x_cgo_purego_setegid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setegid(c *argset) {
++	ret := setegid(uint32(uintptr(c.arg(0))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_seteuid_trampoline _cgo_purego_seteuid_trampoline
++var _cgo_purego_seteuid_trampoline byte
++var x_cgo_purego_seteuid_call = x_cgo_purego_seteuid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_seteuid(c *argset) {
++	ret := seteuid(uint32(uintptr(c.arg(0))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setgid_trampoline _cgo_purego_setgid_trampoline
++var _cgo_purego_setgid_trampoline byte
++var x_cgo_purego_setgid_call = x_cgo_purego_setgid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setgid(c *argset) {
++	ret := setgid(uint32(uintptr(c.arg(0))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setregid_trampoline _cgo_purego_setregid_trampoline
++var _cgo_purego_setregid_trampoline byte
++var x_cgo_purego_setregid_call = x_cgo_purego_setregid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setregid(c *argset) {
++	ret := setregid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setresgid_trampoline _cgo_purego_setresgid_trampoline
++var _cgo_purego_setresgid_trampoline byte
++var x_cgo_purego_setresgid_call = x_cgo_purego_setresgid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setresgid(c *argset) {
++	ret := setresgid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))), uint32(uintptr(c.arg(2))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setresuid_trampoline _cgo_purego_setresuid_trampoline
++var _cgo_purego_setresuid_trampoline byte
++var x_cgo_purego_setresuid_call = x_cgo_purego_setresuid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setresuid(c *argset) {
++	ret := setresuid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))), uint32(uintptr(c.arg(2))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setreuid_trampoline _cgo_purego_setreuid_trampoline
++var _cgo_purego_setreuid_trampoline byte
++var x_cgo_purego_setreuid_call = x_cgo_purego_setreuid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setreuid(c *argset) {
++	ret := setreuid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setuid_trampoline _cgo_purego_setuid_trampoline
++var _cgo_purego_setuid_trampoline byte
++var x_cgo_purego_setuid_call = x_cgo_purego_setuid
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setuid(c *argset) {
++	ret := setuid(uint32(uintptr(c.arg(0))))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
++
++//go:linkname _cgo_purego_setgroups_trampoline _cgo_purego_setgroups_trampoline
++var _cgo_purego_setgroups_trampoline byte
++var x_cgo_purego_setgroups_call = x_cgo_purego_setgroups
++
++//go:nosplit
++//go:norace
++func x_cgo_purego_setgroups(c *argset) {
++	ret := setgroups(uint32(uintptr(c.arg(0))), (*uint32)(c.arg(1)))
++	if ret == -1 {
++		c.retval = uintptr(errno())
++	} else {
++		c.retval = uintptr(ret)
++	}
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/setenv.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/setenv.go
 new file mode 100644
-index 00000000000000..8d7b9831d31fae
+index 00000000000000..30b9e8eb88c83d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/setenv.go
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,21 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Copyright 2011 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +package fakecgo
 +
@@ -15343,14 +15536,16 @@ index 00000000000000..8d7b9831d31fae
 +var _cgo_unsetenv = &x_cgo_unsetenv_trampoline
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_386.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_386.s
 new file mode 100644
-index 00000000000000..2e049260d4aad6
+index 00000000000000..80a9e968c6a8cd
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_386.s
-@@ -0,0 +1,107 @@
+@@ -0,0 +1,123 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (freebsd || linux)
 +
 +#include "textflag.h"
 +#include "go_asm.h"
@@ -15429,15 +15624,29 @@ index 00000000000000..2e049260d4aad6
 +	CALL BX
 +	RET
 +
-+TEXT threadentry_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                 // first C arg
-+	MOVL AX, 0(SP)                 // Go arg 1
++TEXT threadentry_trampoline(SB), NOSPLIT, $24-4
++	// Save callee-saved registers
++	MOVL BP, 20(SP)
++	MOVL BX, 16(SP)
++	MOVL SI, 12(SP)
++	MOVL DI, 8(SP)
++
++	// Move C argument (arg) to stack for Go function
++	MOVL arg+0(FP), AX
++	MOVL AX, 0(SP)
++
 +	MOVL ·threadentry_call(SB), CX
 +	MOVL (CX), CX
 +	CALL CX
++
++	// Restore callee-saved registers
++	MOVL 8(SP), DI
++	MOVL 12(SP), SI
++	MOVL 16(SP), BX
++	MOVL 20(SP), BP
 +	RET
 +
-+TEXT ·call5(SB), NOSPLIT, $20-28
++TEXT ·call5(SB), NOSPLIT, $24-28
 +	MOVL fn+0(FP), AX
 +	MOVL a1+4(FP), BX
 +	MOVL a2+8(FP), CX
@@ -15456,14 +15665,16 @@ index 00000000000000..2e049260d4aad6
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_amd64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_amd64.s
 new file mode 100644
-index 00000000000000..0e50f2a91f1b50
+index 00000000000000..049e2bbb1e7f44
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_amd64.s
-@@ -0,0 +1,107 @@
+@@ -0,0 +1,109 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +/*
 +trampoline for emulating required C functions for cgo in go (see cgo.go)
@@ -15569,14 +15780,16 @@ index 00000000000000..0e50f2a91f1b50
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s
 new file mode 100644
-index 00000000000000..b30bff6c63f411
+index 00000000000000..ae989a4e0e18c9
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,124 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (freebsd || linux)
 +
 +#include "textflag.h"
 +#include "go_asm.h"
@@ -15629,12 +15842,53 @@ index 00000000000000..b30bff6c63f411
 +	BL   (R12)
 +	RET
 +
-+TEXT threadentry_trampoline(SB), NOSPLIT, $8-0
-+	// See crosscall2.
-+	MOVW R0, 4(R13)
++TEXT threadentry_trampoline(SB), NOSPLIT, $104-0
++	// Save C callee-saved registers at C-to-Go boundary.
++	// See crosscall2 in asm_arm.s.
++	// ARM AAPCS callee-saved: R4-R11 (includes g=R10), D8-D15.
++	// LR is saved/restored by the Go-managed frame prologue/epilogue.
++	MOVW R0, 4(R13) // arg for threadentry_call
++
++	MOVW R4, 8(R13)
++	MOVW R5, 12(R13)
++	MOVW R6, 16(R13)
++	MOVW R7, 20(R13)
++	MOVW R8, 24(R13)
++	MOVW R9, 28(R13)
++	MOVW g, 32(R13)   // R10
++	MOVW R11, 36(R13)
++
++	MOVD F8, 40(R13)
++	MOVD F9, 48(R13)
++	MOVD F10, 56(R13)
++	MOVD F11, 64(R13)
++	MOVD F12, 72(R13)
++	MOVD F13, 80(R13)
++	MOVD F14, 88(R13)
++	MOVD F15, 96(R13)
++
 +	MOVW ·threadentry_call(SB), R12
 +	MOVW (R12), R12
 +	CALL (R12)
++
++	MOVD 40(R13), F8
++	MOVD 48(R13), F9
++	MOVD 56(R13), F10
++	MOVD 64(R13), F11
++	MOVD 72(R13), F12
++	MOVD 80(R13), F13
++	MOVD 88(R13), F14
++	MOVD 96(R13), F15
++
++	MOVW 8(R13), R4
++	MOVW 12(R13), R5
++	MOVW 16(R13), R6
++	MOVW 20(R13), R7
++	MOVW 24(R13), R8
++	MOVW 28(R13), R9
++	MOVW 32(R13), g
++	MOVW 36(R13), R11
++
 +	RET
 +
 +TEXT ·call5(SB), NOSPLIT, $8-28
@@ -15656,14 +15910,16 @@ index 00000000000000..b30bff6c63f411
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm64.s
 new file mode 100644
-index 00000000000000..ddd01434d04cda
+index 00000000000000..1a072538b12e3e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm64.s
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,83 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +#include "textflag.h"
 +#include "go_asm.h"
@@ -15720,7 +15976,6 @@ index 00000000000000..ddd01434d04cda
 +
 +	SAVE_R19_TO_R28(8*4)
 +	SAVE_F8_TO_F15(8*14)
-+	STP (R29, R30), (8*22)(RSP)
 +
 +	MOVD ·threadentry_call(SB), R9
 +	MOVD (R9), R9
@@ -15729,8 +15984,6 @@ index 00000000000000..ddd01434d04cda
 +
 +	RESTORE_R19_TO_R28(8*4)
 +	RESTORE_F8_TO_F15(8*14)
-+	LDP (8*22)(RSP), (R29, R30)
-+
 +	ADD $(8*24), RSP
 +	RET
 +
@@ -15744,16 +15997,598 @@ index 00000000000000..ddd01434d04cda
 +	CALL R9
 +	MOVD R0, ret+48(FP)
 +	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_386.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_386.s
+new file mode 100644
+index 00000000000000..a917675cc5862a
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_386.s
+@@ -0,0 +1,80 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
++
++//go:build !cgo && linux
++
++#include "textflag.h"
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX
++	MOVL AX, 0(SP)
++	MOVL ·x_cgo_purego_setegid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX
++	MOVL AX, 0(SP)
++	MOVL ·x_cgo_purego_seteuid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX
++	MOVL AX, 0(SP)
++	MOVL ·x_cgo_purego_setgid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX
++	MOVL AX, 0(SP)
++	MOVL ·x_cgo_purego_setregid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX
++	MOVL AX, 0(SP)
++	MOVL ·x_cgo_purego_setresgid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX
++	MOVL AX, 0(SP)
++	MOVL ·x_cgo_purego_setresuid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX
++	MOVL AX, 0(SP)
++	MOVL ·x_cgo_purego_setreuid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX
++	MOVL AX, 0(SP)
++	MOVL ·x_cgo_purego_setuid_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $4-0
++	MOVL 8(SP), AX
++	MOVL AX, 0(SP)
++	MOVL ·x_cgo_purego_setgroups_call(SB), CX
++	MOVL (CX), CX
++	CALL CX
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_amd64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_amd64.s
+new file mode 100644
+index 00000000000000..fc2e4476c4813c
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_amd64.s
+@@ -0,0 +1,71 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
++
++//go:build !cgo && linux
++
++#include "textflag.h"
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setegid_call(SB), R11
++	MOVQ (R11), R11
++	CALL R11
++	RET
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_seteuid_call(SB), R11
++	MOVQ (R11), R11
++	CALL R11
++	RET
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setgid_call(SB), R11
++	MOVQ (R11), R11
++	CALL R11
++	RET
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setregid_call(SB), R11
++	MOVQ (R11), R11
++	CALL R11
++	RET
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setresgid_call(SB), R11
++	MOVQ (R11), R11
++	CALL R11
++	RET
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setresuid_call(SB), R11
++	MOVQ (R11), R11
++	CALL R11
++	RET
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setreuid_call(SB), R11
++	MOVQ (R11), R11
++	CALL R11
++	RET
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setuid_call(SB), R11
++	MOVQ (R11), R11
++	CALL R11
++	RET
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8
++	MOVQ DI, AX
++	MOVQ ·x_cgo_purego_setgroups_call(SB), R11
++	MOVQ (R11), R11
++	CALL R11
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_arm.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_arm.s
+new file mode 100644
+index 00000000000000..4b84a54da30cc7
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_arm.s
+@@ -0,0 +1,71 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
++
++//go:build !cgo && linux
++
++#include "textflag.h"
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setegid_call(SB), R12
++	MOVW (R12), R12
++	CALL (R12)
++	RET
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_seteuid_call(SB), R12
++	MOVW (R12), R12
++	CALL (R12)
++	RET
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setgid_call(SB), R12
++	MOVW (R12), R12
++	CALL (R12)
++	RET
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setregid_call(SB), R12
++	MOVW (R12), R12
++	CALL (R12)
++	RET
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setresgid_call(SB), R12
++	MOVW (R12), R12
++	CALL (R12)
++	RET
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setresuid_call(SB), R12
++	MOVW (R12), R12
++	CALL (R12)
++	RET
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setreuid_call(SB), R12
++	MOVW (R12), R12
++	CALL (R12)
++	RET
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setuid_call(SB), R12
++	MOVW (R12), R12
++	CALL (R12)
++	RET
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8-0
++	MOVW R0, 4(R13)
++	MOVW ·x_cgo_purego_setgroups_call(SB), R12
++	MOVW (R12), R12
++	CALL (R12)
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_arm64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_arm64.s
+new file mode 100644
+index 00000000000000..1d895b9dea7a87
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_arm64.s
+@@ -0,0 +1,62 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
++
++//go:build !cgo && linux
++
++#include "textflag.h"
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_purego_setegid_call(SB), R9
++	MOVD (R9), R9
++	CALL R9
++	RET
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_purego_seteuid_call(SB), R9
++	MOVD (R9), R9
++	CALL R9
++	RET
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_purego_setgid_call(SB), R9
++	MOVD (R9), R9
++	CALL R9
++	RET
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_purego_setregid_call(SB), R9
++	MOVD (R9), R9
++	CALL R9
++	RET
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_purego_setresgid_call(SB), R9
++	MOVD (R9), R9
++	CALL R9
++	RET
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_purego_setresuid_call(SB), R9
++	MOVD (R9), R9
++	CALL R9
++	RET
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_purego_setreuid_call(SB), R9
++	MOVD (R9), R9
++	CALL R9
++	RET
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_purego_setuid_call(SB), R9
++	MOVD (R9), R9
++	CALL R9
++	RET
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0-0
++	MOVD ·x_cgo_purego_setgroups_call(SB), R9
++	MOVD (R9), R9
++	CALL R9
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_loong64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_loong64.s
+new file mode 100644
+index 00000000000000..d390a5f1da0af5
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_loong64.s
+@@ -0,0 +1,62 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
++
++//go:build !cgo && linux
++
++#include "textflag.h"
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8
++	MOVV ·x_cgo_purego_setegid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8
++	MOVV ·x_cgo_purego_seteuid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8
++	MOVV ·x_cgo_purego_setgid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8
++	MOVV ·x_cgo_purego_setregid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8
++	MOVV ·x_cgo_purego_setresgid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8
++	MOVV ·x_cgo_purego_setresuid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8
++	MOVV ·x_cgo_purego_setreuid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8
++	MOVV ·x_cgo_purego_setuid_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8
++	MOVV ·x_cgo_purego_setgroups_call(SB), R23
++	MOVV (R23), R23
++	CALL (R23)
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_ppc64le.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_ppc64le.s
+new file mode 100644
+index 00000000000000..1abccdc7a0ebdd
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_ppc64le.s
+@@ -0,0 +1,71 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
++
++//go:build !cgo && linux
++
++#include "textflag.h"
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8-0
++	MOVD ·x_cgo_purego_setegid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	CALL CTR
++	RET
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8-0
++	MOVD ·x_cgo_purego_seteuid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	CALL CTR
++	RET
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8-0
++	MOVD ·x_cgo_purego_setgid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	CALL CTR
++	RET
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8-0
++	MOVD ·x_cgo_purego_setregid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	CALL CTR
++	RET
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8-0
++	MOVD ·x_cgo_purego_setresgid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	CALL CTR
++	RET
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8-0
++	MOVD ·x_cgo_purego_setresuid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	CALL CTR
++	RET
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8-0
++	MOVD ·x_cgo_purego_setreuid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	CALL CTR
++	RET
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8-0
++	MOVD ·x_cgo_purego_setuid_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	CALL CTR
++	RET
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8-0
++	MOVD ·x_cgo_purego_setgroups_call(SB), R12
++	MOVD (R12), R12
++	MOVD R12, CTR
++	CALL CTR
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_riscv64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_riscv64.s
+new file mode 100644
+index 00000000000000..c78f98e8c89c09
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_riscv64.s
+@@ -0,0 +1,62 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
++
++//go:build !cgo && linux
++
++#include "textflag.h"
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $8
++	MOV  ·x_cgo_purego_setegid_call(SB), X5
++	MOV  (X5), X5
++	CALL X5
++	RET
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $8
++	MOV  ·x_cgo_purego_seteuid_call(SB), X5
++	MOV  (X5), X5
++	CALL X5
++	RET
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $8
++	MOV  ·x_cgo_purego_setgid_call(SB), X5
++	MOV  (X5), X5
++	CALL X5
++	RET
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $8
++	MOV  ·x_cgo_purego_setregid_call(SB), X5
++	MOV  (X5), X5
++	CALL X5
++	RET
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $8
++	MOV  ·x_cgo_purego_setresgid_call(SB), X5
++	MOV  (X5), X5
++	CALL X5
++	RET
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $8
++	MOV  ·x_cgo_purego_setresuid_call(SB), X5
++	MOV  (X5), X5
++	CALL X5
++	RET
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $8
++	MOV  ·x_cgo_purego_setreuid_call(SB), X5
++	MOV  (X5), X5
++	CALL X5
++	RET
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $8
++	MOV  ·x_cgo_purego_setuid_call(SB), X5
++	MOV  (X5), X5
++	CALL X5
++	RET
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $8
++	MOV  ·x_cgo_purego_setgroups_call(SB), X5
++	MOV  (X5), X5
++	CALL X5
++	RET
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_s390x.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_s390x.s
+new file mode 100644
+index 00000000000000..be563c097fc0a0
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_linux_s390x.s
+@@ -0,0 +1,53 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
++
++//go:build go1.27 && !cgo
++
++#include "textflag.h"
++
++TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setegid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_seteuid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setgid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setregid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setresgid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setresuid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setreuid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setuid_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
++
++TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT|NOFRAME, $0
++	MOVD ·x_cgo_purego_setgroups_call(SB), R1
++	MOVD (R1), R1
++	BR   R1
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_loong64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_loong64.s
 new file mode 100644
-index 00000000000000..89bf8813bade7a
+index 00000000000000..750e297dcd375e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_loong64.s
-@@ -0,0 +1,88 @@
+@@ -0,0 +1,80 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2025 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && linux
 +
 +#include "textflag.h"
 +#include "go_asm.h"
@@ -15763,29 +16598,24 @@ index 00000000000000..89bf8813bade7a
 +// R23 is used as temporary register.
 +
 +TEXT x_cgo_init_trampoline(SB), NOSPLIT, $16
-+	MOVV R4, 8(R3)
-+	MOVV R5, 16(R3)
 +	MOVV ·x_cgo_init_call(SB), R23
 +	MOVV (R23), R23
 +	CALL (R23)
 +	RET
 +
 +TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $8
-+	MOVV R4, 8(R3)
 +	MOVV ·x_cgo_thread_start_call(SB), R23
 +	MOVV (R23), R23
 +	CALL (R23)
 +	RET
 +
 +TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $8
-+	MOVV R4, 8(R3)
 +	MOVV ·x_cgo_setenv_call(SB), R23
 +	MOVV (R23), R23
 +	CALL (R23)
 +	RET
 +
 +TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $8
-+	MOVV R4, 8(R3)
 +	MOVV ·x_cgo_unsetenv_call(SB), R23
 +	MOVV (R23), R23
 +	CALL (R23)
@@ -15806,16 +16636,14 @@ index 00000000000000..89bf8813bade7a
 +	CALL (R23)
 +	RET
 +
-+TEXT threadentry_trampoline(SB), NOSPLIT, $0
++TEXT threadentry_trampoline(SB), NOSPLIT, $176
 +	// See crosscall2.
-+	ADDV $(-23*8), R3
 +	MOVV R4, (1*8)(R3) // fn unsafe.Pointer
 +	MOVV R5, (2*8)(R3) // a unsafe.Pointer
 +	MOVV R7, (3*8)(R3) // ctxt uintptr
 +
 +	SAVE_R22_TO_R31((4*8))
 +	SAVE_F24_TO_F31((14*8))
-+	MOVV R1, (22*8)(R3)
 +
 +	MOVV ·threadentry_call(SB), R23
 +	MOVV (R23), R23
@@ -15823,9 +16651,6 @@ index 00000000000000..89bf8813bade7a
 +
 +	RESTORE_R22_TO_R31((4*8))
 +	RESTORE_F24_TO_F31((14*8))
-+	MOVV (22*8)(R3), R1
-+
-+	ADDV $(23*8), R3
 +	RET
 +
 +TEXT ·call5(SB), NOSPLIT, $0-0
@@ -15840,199 +16665,106 @@ index 00000000000000..89bf8813bade7a
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_ppc64le.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_ppc64le.s
 new file mode 100644
-index 00000000000000..586ccaf91df1a4
+index 00000000000000..e3d1bf2305809c
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_ppc64le.s
-@@ -0,0 +1,227 @@
+@@ -0,0 +1,134 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && linux
 +
 +#include "textflag.h"
 +#include "go_asm.h"
++#include "abi_ppc64x.h"
 +
 +// These trampolines map the C ABI to Go ABI and call into the Go equivalent functions.
-+//
-+// PPC64LE ELFv2 ABI stack frame layout:
-+//   0(R1)  = backchain (pointer to caller's frame)
-+//   8(R1)  = CR save area
-+//   16(R1) = LR save area
-+//   24(R1) = reserved
-+//   32(R1) = parameter save area (minimum 64 bytes for 8 args)
-+//
-+// Two patterns are used depending on call direction:
-+//
-+// C→Go trampolines: The C caller already provides a 32-byte linkage area.
-+//   Save LR/CR into caller's frame at 16(R1)/8(R1) BEFORE allocating,
-+//   then use MOVDU to allocate and set backchain atomically.
-+//
-+// Go→C trampolines: Go callers don't provide ELFv2 linkage area.
-+//   Allocate frame first with MOVDU, then save LR/CR into OUR frame.
 +
-+TEXT x_cgo_init_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD LR, 16(R1)
-+	MOVW CR, R0
-+	MOVD R0, 8(R1)
-+
-+	MOVDU R1, -32(R1)
-+
-+	// R3, R4 already have the arguments
++TEXT x_cgo_init_trampoline(SB), NOSPLIT, $0-0
 +	MOVD ·x_cgo_init_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
-+
-+	ADD $32, R1
-+
-+	MOVD 16(R1), LR
-+	MOVD 8(R1), R0
-+	MOVW R0, CR
 +	RET
 +
-+TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD LR, 16(R1)
-+	MOVW CR, R0
-+	MOVD R0, 8(R1)
-+
-+	MOVDU R1, -32(R1)
-+
++TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $0-0
 +	MOVD ·x_cgo_thread_start_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
-+
-+	ADD $32, R1
-+
-+	MOVD 16(R1), LR
-+	MOVD 8(R1), R0
-+	MOVW R0, CR
 +	RET
 +
-+// void (*_cgo_setenv)(char**)
-+// C arg: R3 = pointer to env
-+// This is C→Go: caller is C ABI.
-+TEXT x_cgo_setenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD LR, 16(R1)
-+	MOVW CR, R0
-+	MOVD R0, 8(R1)
-+
-+	MOVDU R1, -32(R1)
-+
++TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $0-0
 +	MOVD ·x_cgo_setenv_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
-+
-+	ADD $32, R1
-+
-+	MOVD 16(R1), LR
-+	MOVD 8(R1), R0
-+	MOVW R0, CR
 +	RET
 +
-+TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD LR, 16(R1)
-+	MOVW CR, R0
-+	MOVD R0, 8(R1)
-+
-+	MOVDU R1, -32(R1)
-+
++TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $0-0
 +	MOVD ·x_cgo_unsetenv_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
-+
-+	ADD $32, R1
-+
-+	MOVD 16(R1), LR
-+	MOVD 8(R1), R0
-+	MOVW R0, CR
 +	RET
 +
-+TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD LR, 16(R1)
-+	MOVW CR, R0
-+	MOVD R0, 8(R1)
-+
-+	MOVDU R1, -32(R1)
-+
++TEXT x_cgo_notify_runtime_init_done_trampoline(SB), NOSPLIT, $0-0
 +	CALL ·x_cgo_notify_runtime_init_done(SB)
-+
-+	ADD $32, R1
-+
-+	MOVD 16(R1), LR
-+	MOVD 8(R1), R0
-+	MOVW R0, CR
 +	RET
 +
-+TEXT x_cgo_bindm_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD LR, 16(R1)
-+	MOVW CR, R0
-+	MOVD R0, 8(R1)
-+
-+	MOVDU R1, -32(R1)
-+
++TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0-0
 +	CALL ·x_cgo_bindm(SB)
-+
-+	ADD $32, R1
-+
-+	MOVD 16(R1), LR
-+	MOVD 8(R1), R0
-+	MOVW R0, CR
 +	RET
 +
-+TEXT ·setg_trampoline(SB), NOSPLIT|NOFRAME, $0-16
-+	// Save LR, CR, and R31 to non-volatile registers (C ABI preserves R14-R31)
-+	MOVD LR, R20
-+	MOVW CR, R21
-+	MOVD R31, R22 // save R31 because load_g clobbers it
++// func setg_trampoline(setg uintptr, g uintptr)
++TEXT ·setg_trampoline(SB), NOSPLIT, $16-16
++	MOVD R31, 8(R1) // save R31
 +
-+	// Load arguments from Go stack
-+	MOVD 32(R1), R12 // setg function pointer
-+	MOVD 40(R1), R3  // g pointer → first C arg
++	MOVD setg+0(FP), R12
++	MOVD newg+8(FP), R3
 +
-+	// Allocate ELFv2 frame for the C callee (32 bytes minimum)
-+	MOVDU R1, -32(R1)
++	MOVD R3, 16(R1) // save newg before call
 +
-+	// Call setg_gcc which stores g to TLS
 +	MOVD R12, CTR
 +	CALL CTR
 +
-+	// setg_gcc stored g to TLS but restored old g in R30.
-+	// Call load_g to reload g from TLS into R30.
-+	// Note: load_g clobbers R31
-+	CALL runtime·load_g(SB)
++	// Assign g directly instead of calling runtime·load_g
++	// setg_gcc has already stored newg into TLS; put it in the g register too.
++	MOVD 16(R1), g
 +
-+	// Deallocate frame
-+	ADD $32, R1
-+
-+	// Clear R0 before returning to Go code.
-+	// Go uses R0 as a constant 0 for things like "std r0,X(r1)" to zero stack locations.
-+	// C/assembly functions may leave garbage in R0.
-+	XOR R0, R0, R0
-+
-+	// Restore LR, CR, and R31 from non-volatile registers
-+	MOVD R22, R31 // restore R31
-+	MOVD R20, LR
-+	MOVW R21, CR
++	MOVD 8(R1), R31
++	XOR  R0, R0, R0
 +	RET
 +
 +TEXT threadentry_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD LR, 16(R1)
++	// Called from C (pthread_create). Must save all C callee-saved registers.
++	// Uses NOFRAME for proper ELFv2 backchain via MOVDU.
++	MOVD LR, R0
++	MOVD R0, 16(R1)
 +	MOVW CR, R0
 +	MOVD R0, 8(R1)
 +
-+	MOVDU R1, -32(R1)
++	MOVDU R1, -320(R1)
++
++	SAVE_GPR(32)
++	SAVE_FPR(32+SAVE_GPR_SIZE)
++
++	MOVD $0, R0
 +
 +	MOVD ·threadentry_call(SB), R12
 +	MOVD (R12), R12
 +	MOVD R12, CTR
 +	CALL CTR
 +
-+	ADD $32, R1
++	RESTORE_FPR(32+SAVE_GPR_SIZE)
++	RESTORE_GPR(32)
 +
-+	MOVD 16(R1), LR
++	ADD $320, R1
++
++	MOVD 16(R1), R0
++	MOVD R0, LR
 +	MOVD 8(R1), R0
 +	MOVW R0, CR
 +	RET
@@ -16073,45 +16805,43 @@ index 00000000000000..586ccaf91df1a4
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_riscv64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_riscv64.s
 new file mode 100644
-index 00000000000000..50b364773606d1
+index 00000000000000..5a7dccde039cec
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_riscv64.s
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,78 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && linux
 +
 +#include "textflag.h"
 +#include "go_asm.h"
++#include "abi_riscv64.h"
 +
 +// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
 +// X5 is used as temporary register.
 +
 +TEXT x_cgo_init_trampoline(SB), NOSPLIT, $16
-+	MOV  X10, 8(SP)
-+	MOV  X11, 16(SP)
 +	MOV  ·x_cgo_init_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
 +	RET
 +
 +TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT, $8
-+	MOV  X10, 8(SP)
 +	MOV  ·x_cgo_thread_start_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
 +	RET
 +
 +TEXT x_cgo_setenv_trampoline(SB), NOSPLIT, $8
-+	MOV  X10, 8(SP)
 +	MOV  ·x_cgo_setenv_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
 +	RET
 +
 +TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT, $8
-+	MOV  X10, 8(SP)
 +	MOV  ·x_cgo_unsetenv_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
@@ -16132,11 +16862,19 @@ index 00000000000000..50b364773606d1
 +	CALL X5
 +	RET
 +
-+TEXT threadentry_trampoline(SB), NOSPLIT, $16
-+	MOV  X10, 8(SP)
++TEXT threadentry_trampoline(SB), NOSPLIT, $200
++	MOV X10, 8(SP)
++
++	SAVE_GPR(8*2)
++	SAVE_FPR(8*14)
++
 +	MOV  ·threadentry_call(SB), X5
 +	MOV  (X5), X5
 +	CALL X5
++
++	RESTORE_GPR(8*2)
++	RESTORE_FPR(8*14)
++
 +	RET
 +
 +TEXT ·call5(SB), NOSPLIT, $0-48
@@ -16151,10 +16889,12 @@ index 00000000000000..50b364773606d1
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_s390x.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_s390x.s
 new file mode 100644
-index 00000000000000..49fec0cf2f1718
+index 00000000000000..9b3aa12bbb7883
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_s390x.s
-@@ -0,0 +1,163 @@
+@@ -0,0 +1,160 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
 +
@@ -16163,35 +16903,31 @@ index 00000000000000..49fec0cf2f1718
 +#include "textflag.h"
 +#include "go_asm.h"
 +
-+// S390X ELF ABI: args R2-R6, return R2, callee-save R6-R13/R15/F8-F15, R14=LR, R15=SP
-+// CRITICAL: R0 as base register means "no base" (literal 0), not R0's value!
++// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
++// Note that C arguments are passed in R2-R6, which matches Go ABIInternal for the first five arguments.
++// R1 is used as a temporary register.
 +
-+// x_cgo_init_trampoline must preserve R9 for Go runtime
 +TEXT x_cgo_init_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD R14, R0
 +	MOVD R15, R1
 +	SUB  $192, R15
-+	MOVD R1, 0(R15)   // backchain
-+	MOVD R0, 160(R15) // save R14
-+	MOVD R1, 168(R15) // save old R15
-+	MOVD R9, 176(R15) // save R9 (Go runtime needs this preserved)
++	MOVD R1, 0(R15)    // backchain
++	MOVD R14, 160(R15) // save R14
++	MOVD R9, 168(R15)  // save R9 (Go runtime needs this preserved)
 +
 +	MOVD ·x_cgo_init_call(SB), R1
 +	MOVD (R1), R1
 +	BL   R1
 +
-+	MOVD 176(R15), R9
++	MOVD 168(R15), R9
 +	MOVD 160(R15), R14
-+	MOVD 168(R15), R15
++	ADD  $192, R15
 +	BR   R14
 +
-+// Standard trampoline pattern: save R14/R15, call via pointer, restore
 +TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD R14, R0
 +	MOVD R15, R1
 +	SUB  $176, R15
-+	MOVD R1, 0(R15)
-+	MOVD R0, 152(R15)
++	MOVD R1, 0(R15)    // backchain
++	MOVD R14, 152(R15) // save R14
 +
 +	MOVD ·x_cgo_thread_start_call(SB), R1
 +	MOVD (R1), R1
@@ -16202,11 +16938,10 @@ index 00000000000000..49fec0cf2f1718
 +	BR   R14
 +
 +TEXT x_cgo_setenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD R14, R0
 +	MOVD R15, R1
 +	SUB  $176, R15
-+	MOVD R1, 0(R15)
-+	MOVD R0, 152(R15)
++	MOVD R1, 0(R15)    // backchain
++	MOVD R14, 152(R15) // save R14
 +
 +	MOVD ·x_cgo_setenv_call(SB), R1
 +	MOVD (R1), R1
@@ -16217,11 +16952,10 @@ index 00000000000000..49fec0cf2f1718
 +	BR   R14
 +
 +TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-+	MOVD R14, R0
 +	MOVD R15, R1
 +	SUB  $176, R15
-+	MOVD R1, 0(R15)
-+	MOVD R0, 152(R15)
++	MOVD R1, 0(R15)    // backchain
++	MOVD R14, 152(R15) // save R14
 +
 +	MOVD ·x_cgo_unsetenv_call(SB), R1
 +	MOVD (R1), R1
@@ -16241,28 +16975,30 @@ index 00000000000000..49fec0cf2f1718
 +// setg_trampoline(setg uintptr, g uintptr) - called from Go
 +TEXT ·setg_trampoline(SB), NOSPLIT|NOFRAME, $0-16
 +	MOVD 8(R15), R1  // setg function pointer
-+	MOVD 16(R15), R2 // g pointer → C arg
++	MOVD 16(R15), R2 // g pointer -> C arg
 +
 +	MOVD R14, R0
 +	MOVD R15, R3
 +	SUB  $160, R15
 +	MOVD R3, 0(R15)
 +	MOVD R0, 112(R15)
++	MOVD R2, 120(R15)  // save newg before call
 +
-+	BL R1                 // call setg_gcc
-+	BL runtime·load_g(SB)
++	BL R1 // call setg_gcc
++
++	// Assign g directly instead of calling runtime·load_g
++	// setg_gcc has already stored newg into TLS; put it in the g register too.
++	MOVD 120(R15), g
 +
 +	MOVD 112(R15), R14
 +	ADD  $160, R15
 +	BR   R14
 +
-+// threadentry_trampoline - called FROM C (pthread_create), arg in R2
 +TEXT threadentry_trampoline(SB), NOSPLIT|NOFRAME, $0-0
 +	STMG R6, R15, 48(R15) // C save area
 +	MOVD R15, R1
 +	SUB  $176, R15
 +	MOVD R1, 0(R15)       // backchain
-+	MOVD R2, 8(R15)       // pthread arg → Go arg
 +
 +	MOVD ·threadentry_call(SB), R1
 +	MOVD (R1), R1
@@ -16272,7 +17008,6 @@ index 00000000000000..49fec0cf2f1718
 +	LMG 48(R15), R6, R15
 +	RET
 +
-+// call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr - Go calling C
 +TEXT ·call5(SB), NOSPLIT|NOFRAME, $0-56
 +	// Load Go args before modifying R15
 +	MOVD 8(R15), R1   // fn
@@ -16288,7 +17023,7 @@ index 00000000000000..49fec0cf2f1718
 +	ADD  $-128, R15
 +
 +	// Set up C frame with backchain
-+	MOVD R0, 0(R15) // backchain → original R15
++	MOVD R0, 0(R15) // backchain -> original R15
 +	MOVD R0, R3     // R3 = original R15 (can't use R0 as base!)
 +	MOVD 0(R3), R7  // save 0(original R15)
 +	MOVD $0, 0(R3)  // terminate backchain
@@ -16320,16 +17055,18 @@ index 00000000000000..49fec0cf2f1718
 +	BR   R14
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols.go
 new file mode 100644
-index 00000000000000..fb667453f207c0
+index 00000000000000..eb26fa04fee744
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols.go
-@@ -0,0 +1,165 @@
+@@ -0,0 +1,167 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +package fakecgo
 +
@@ -16491,10 +17228,12 @@ index 00000000000000..fb667453f207c0
 +var pthread_setspecificABI0 = uintptr(unsafe.Pointer(&_pthread_setspecific))
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_darwin.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_darwin.go
 new file mode 100644
-index 00000000000000..960f8168eb88d7
+index 00000000000000..a7a0d9e69d4d8b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_darwin.go
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,61 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -16556,10 +17295,12 @@ index 00000000000000..960f8168eb88d7
 +var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_linux.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_linux.go
 new file mode 100644
-index 00000000000000..38ee622a366042
+index 00000000000000..ab4e0d77cf70d0
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_linux.go
-@@ -0,0 +1,294 @@
+@@ -0,0 +1,160 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -16578,7 +17319,6 @@ index 00000000000000..38ee622a366042
 +//go:cgo_import_dynamic purego_sigfillset sigfillset "libc.so.6"
 +//go:cgo_import_dynamic purego_nanosleep nanosleep "libc.so.6"
 +//go:cgo_import_dynamic purego_abort abort "libc.so.6"
-+//go:cgo_import_dynamic purego_sigaltstack sigaltstack "libc.so.6"
 +//go:cgo_import_dynamic purego___errno_location __errno_location "libc.so.6"
 +//go:cgo_import_dynamic purego_setegid setegid "libc.so.6"
 +//go:cgo_import_dynamic purego_seteuid seteuid "libc.so.6"
@@ -16599,26 +17339,6 @@ index 00000000000000..38ee622a366042
 +//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "libpthread.so.0"
 +//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "libpthread.so.0"
-+
-+//go:nosplit
-+//go:norace
-+func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
-+	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
-+}
-+
-+//go:nosplit
-+//go:norace
-+func pthread_attr_destroy(attr *pthread_attr_t) int32 {
-+	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
-+}
-+
-+//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
-+var _pthread_attr_getstacksize uint8
-+var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
-+
-+//go:linkname _pthread_attr_destroy _pthread_attr_destroy
-+var _pthread_attr_destroy uint8
-+var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
 +
 +//go:nosplit
 +//go:norace
@@ -16680,6 +17400,18 @@ index 00000000000000..38ee622a366042
 +	return int32(call5(setgroupsABI0, uintptr(ngid), uintptr(unsafe.Pointer(gidset)), 0, 0, 0))
 +}
 +
++//go:nosplit
++//go:norace
++func pthread_attr_getstacksize(attr *pthread_attr_t, stacksize *size_t) int32 {
++	return int32(call5(pthread_attr_getstacksizeABI0, uintptr(unsafe.Pointer(attr)), uintptr(unsafe.Pointer(stacksize)), 0, 0, 0))
++}
++
++//go:nosplit
++//go:norace
++func pthread_attr_destroy(attr *pthread_attr_t) int32 {
++	return int32(call5(pthread_attr_destroyABI0, uintptr(unsafe.Pointer(attr)), 0, 0, 0, 0))
++}
++
 +//go:linkname ___errno_location ___errno_location
 +var ___errno_location uint8
 +var __errno_locationABI0 = uintptr(unsafe.Pointer(&___errno_location))
@@ -16720,146 +17452,21 @@ index 00000000000000..38ee622a366042
 +var _setgroups uint8
 +var setgroupsABI0 = uintptr(unsafe.Pointer(&_setgroups))
 +
-+//go:linkname _cgo_purego_setegid_trampoline _cgo_purego_setegid_trampoline
-+var _cgo_purego_setegid_trampoline byte
-+var x_cgo_purego_setegid_call = x_cgo_purego_setegid
++//go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
++var _pthread_attr_getstacksize uint8
++var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
 +
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setegid(c *argset) {
-+	ret := setegid(uint32(uintptr(c.arg(0))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_seteuid_trampoline _cgo_purego_seteuid_trampoline
-+var _cgo_purego_seteuid_trampoline byte
-+var x_cgo_purego_seteuid_call = x_cgo_purego_seteuid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_seteuid(c *argset) {
-+	ret := seteuid(uint32(uintptr(c.arg(0))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setgid_trampoline _cgo_purego_setgid_trampoline
-+var _cgo_purego_setgid_trampoline byte
-+var x_cgo_purego_setgid_call = x_cgo_purego_setgid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setgid(c *argset) {
-+	ret := setgid(uint32(uintptr(c.arg(0))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setregid_trampoline _cgo_purego_setregid_trampoline
-+var _cgo_purego_setregid_trampoline byte
-+var x_cgo_purego_setregid_call = x_cgo_purego_setregid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setregid(c *argset) {
-+	ret := setregid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setresgid_trampoline _cgo_purego_setresgid_trampoline
-+var _cgo_purego_setresgid_trampoline byte
-+var x_cgo_purego_setresgid_call = x_cgo_purego_setresgid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setresgid(c *argset) {
-+	ret := setresgid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))), uint32(uintptr(c.arg(2))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setresuid_trampoline _cgo_purego_setresuid_trampoline
-+var _cgo_purego_setresuid_trampoline byte
-+var x_cgo_purego_setresuid_call = x_cgo_purego_setresuid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setresuid(c *argset) {
-+	ret := setresuid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))), uint32(uintptr(c.arg(2))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setreuid_trampoline _cgo_purego_setreuid_trampoline
-+var _cgo_purego_setreuid_trampoline byte
-+var x_cgo_purego_setreuid_call = x_cgo_purego_setreuid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setreuid(c *argset) {
-+	ret := setreuid(uint32(uintptr(c.arg(0))), uint32(uintptr(c.arg(1))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setuid_trampoline _cgo_purego_setuid_trampoline
-+var _cgo_purego_setuid_trampoline byte
-+var x_cgo_purego_setuid_call = x_cgo_purego_setuid
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setuid(c *argset) {
-+	ret := setuid(uint32(uintptr(c.arg(0))))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
-+
-+//go:linkname _cgo_purego_setgroups_trampoline _cgo_purego_setgroups_trampoline
-+var _cgo_purego_setgroups_trampoline byte
-+var x_cgo_purego_setgroups_call = x_cgo_purego_setgroups
-+
-+//go:nosplit
-+//go:norace
-+func x_cgo_purego_setgroups(c *argset) {
-+	ret := setgroups(uint32(uintptr(c.arg(0))), (*uint32)(c.arg(1)))
-+	if ret == -1 {
-+		c.retval = uintptr(errno())
-+	} else {
-+		c.retval = uintptr(ret)
-+	}
-+}
++//go:linkname _pthread_attr_destroy _pthread_attr_destroy
++var _pthread_attr_destroy uint8
++var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_darwin.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_darwin.s
 new file mode 100644
-index 00000000000000..35ef7ac11cb955
+index 00000000000000..9038f8394965e8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_darwin.s
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,21 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -16881,10 +17488,12 @@ index 00000000000000..35ef7ac11cb955
 +	JMP purego_pthread_attr_setstacksize(SB)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux.s
 new file mode 100644
-index 00000000000000..da07005c0bc988
+index 00000000000000..561f4af7545d4e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux.s
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,48 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -16896,825 +17505,55 @@ index 00000000000000..da07005c0bc988
 +
 +// these stubs are here because it is not possible to go:linkname directly the C functions
 +
++TEXT ___errno_location(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego___errno_location(SB)
++
++TEXT _setegid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setegid(SB)
++
++TEXT _seteuid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_seteuid(SB)
++
++TEXT _setgid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setgid(SB)
++
++TEXT _setregid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setregid(SB)
++
++TEXT _setresgid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setresgid(SB)
++
++TEXT _setresuid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setresuid(SB)
++
++TEXT _setreuid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setreuid(SB)
++
++TEXT _setuid(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setuid(SB)
++
++TEXT _setgroups(SB), NOSPLIT|NOFRAME, $0-0
++	JMP purego_setgroups(SB)
++
 +TEXT _pthread_attr_getstacksize(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_attr_getstacksize(SB)
 +
 +TEXT _pthread_attr_destroy(SB), NOSPLIT|NOFRAME, $0-0
 +	JMP purego_pthread_attr_destroy(SB)
-diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_386.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_386.s
-new file mode 100644
-index 00000000000000..2903c5bdb7e54c
---- /dev/null
-+++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_386.s
-@@ -0,0 +1,110 @@
-+// Code generated by 'go generate' with gen.go. DO NOT EDIT.
-+
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo
-+
-+#include "textflag.h"
-+
-+TEXT ___errno_location(SB), NOSPLIT, $0-0
-+	JMP purego___errno_location(SB)
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                          // first C arg
-+	MOVL AX, 0(SP)                          // Go arg 1
-+	MOVL ·x_cgo_purego_setegid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setegid(SB), NOSPLIT, $0-0
-+	JMP purego_setegid(SB)
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                          // first C arg
-+	MOVL AX, 0(SP)                          // Go arg 1
-+	MOVL ·x_cgo_purego_seteuid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _seteuid(SB), NOSPLIT, $0-0
-+	JMP purego_seteuid(SB)
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                         // first C arg
-+	MOVL AX, 0(SP)                         // Go arg 1
-+	MOVL ·x_cgo_purego_setgid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setgid(SB), NOSPLIT, $0-0
-+	JMP purego_setgid(SB)
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                           // first C arg
-+	MOVL AX, 0(SP)                           // Go arg 1
-+	MOVL ·x_cgo_purego_setregid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setregid(SB), NOSPLIT, $0-0
-+	JMP purego_setregid(SB)
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                            // first C arg
-+	MOVL AX, 0(SP)                            // Go arg 1
-+	MOVL ·x_cgo_purego_setresgid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setresgid(SB), NOSPLIT, $0-0
-+	JMP purego_setresgid(SB)
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                            // first C arg
-+	MOVL AX, 0(SP)                            // Go arg 1
-+	MOVL ·x_cgo_purego_setresuid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setresuid(SB), NOSPLIT, $0-0
-+	JMP purego_setresuid(SB)
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                           // first C arg
-+	MOVL AX, 0(SP)                           // Go arg 1
-+	MOVL ·x_cgo_purego_setreuid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setreuid(SB), NOSPLIT, $0-0
-+	JMP purego_setreuid(SB)
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                         // first C arg
-+	MOVL AX, 0(SP)                         // Go arg 1
-+	MOVL ·x_cgo_purego_setuid_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setuid(SB), NOSPLIT, $0-0
-+	JMP purego_setuid(SB)
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $4-0
-+	MOVL 8(SP), AX                            // first C arg
-+	MOVL AX, 0(SP)                            // Go arg 1
-+	MOVL ·x_cgo_purego_setgroups_call(SB), CX
-+	MOVL (CX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setgroups(SB), NOSPLIT, $0-0
-+	JMP purego_setgroups(SB)
-diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_amd64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_amd64.s
-new file mode 100644
-index 00000000000000..776a6f3ad9533b
---- /dev/null
-+++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_amd64.s
-@@ -0,0 +1,102 @@
-+// Code generated by 'go generate' with gen.go. DO NOT EDIT.
-+
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo
-+
-+#include "textflag.h"
-+
-+TEXT ___errno_location(SB), NOSPLIT, $0-0
-+	JMP purego___errno_location(SB)
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setegid_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setegid(SB), NOSPLIT, $0-0
-+	JMP purego_setegid(SB)
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_seteuid_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _seteuid(SB), NOSPLIT, $0-0
-+	JMP purego_seteuid(SB)
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setgid_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setgid(SB), NOSPLIT, $0-0
-+	JMP purego_setgid(SB)
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setregid_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setregid(SB), NOSPLIT, $0-0
-+	JMP purego_setregid(SB)
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setresgid_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setresgid(SB), NOSPLIT, $0-0
-+	JMP purego_setresgid(SB)
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setresuid_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setresuid(SB), NOSPLIT, $0-0
-+	JMP purego_setresuid(SB)
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setreuid_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setreuid(SB), NOSPLIT, $0-0
-+	JMP purego_setreuid(SB)
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setuid_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setuid(SB), NOSPLIT, $0-0
-+	JMP purego_setuid(SB)
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
-+	MOVQ DI, AX
-+	MOVQ ·x_cgo_purego_setgroups_call(SB), DX
-+	MOVQ (DX), CX
-+	CALL CX
-+	RET
-+
-+TEXT _setgroups(SB), NOSPLIT, $0-0
-+	JMP purego_setgroups(SB)
-+
-diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_arm.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_arm.s
-new file mode 100644
-index 00000000000000..09401d72019bde
---- /dev/null
-+++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_arm.s
-@@ -0,0 +1,74 @@
-+// Code generated by 'go generate' with gen.go. DO NOT EDIT.
-+
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo
-+
-+#include "textflag.h"
-+
-+TEXT ___errno_location(SB), NOSPLIT, $0-0
-+	JMP purego___errno_location(SB)
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $4-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setegid_call(SB), R12
-+	MOVW (R12), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_seteuid_call(SB), R12
-+	MOVW (R12), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $4-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setgid_call(SB), R12
-+	MOVW (R12), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $4-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setregid_call(SB), R12
-+	MOVW (R12), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $4-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setresgid_call(SB), R12
-+	MOVW (R12), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setresuid_call(SB), R12
-+	MOVW (R12), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setreuid_call(SB), R12
-+	MOVW (R12), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $4-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setuid_call(SB), R12
-+	MOVW (R12), R2
-+	CALL (R2)
-+	RET
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $4-0
-+	MOVW R0, 4(R13)
-+	MOVW ·x_cgo_purego_setgroups_call(SB), R12
-+	MOVW (R12), R2
-+	CALL (R2)
-+	RET
-diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_arm64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_arm64.s
-new file mode 100644
-index 00000000000000..0b25425c004d38
---- /dev/null
-+++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_arm64.s
-@@ -0,0 +1,93 @@
-+// Code generated by 'go generate' with gen.go. DO NOT EDIT.
-+
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo
-+
-+#include "textflag.h"
-+
-+TEXT ___errno_location(SB), NOSPLIT, $0-0
-+	JMP purego___errno_location(SB)
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
-+	MOVD ·x_cgo_purego_setegid_call(SB), R26
-+	MOVD (R26), R2
-+	CALL R2
-+	RET
-+
-+TEXT _setegid(SB), NOSPLIT, $0-0
-+	JMP purego_setegid(SB)
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
-+	MOVD ·x_cgo_purego_seteuid_call(SB), R26
-+	MOVD (R26), R2
-+	CALL R2
-+	RET
-+
-+TEXT _seteuid(SB), NOSPLIT, $0-0
-+	JMP purego_seteuid(SB)
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
-+	MOVD ·x_cgo_purego_setgid_call(SB), R26
-+	MOVD (R26), R2
-+	CALL R2
-+	RET
-+
-+TEXT _setgid(SB), NOSPLIT, $0-0
-+	JMP purego_setgid(SB)
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
-+	MOVD ·x_cgo_purego_setregid_call(SB), R26
-+	MOVD (R26), R2
-+	CALL R2
-+	RET
-+
-+TEXT _setregid(SB), NOSPLIT, $0-0
-+	JMP purego_setregid(SB)
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
-+	MOVD ·x_cgo_purego_setresgid_call(SB), R26
-+	MOVD (R26), R2
-+	CALL R2
-+	RET
-+
-+TEXT _setresgid(SB), NOSPLIT, $0-0
-+	JMP purego_setresgid(SB)
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
-+	MOVD ·x_cgo_purego_setresuid_call(SB), R26
-+	MOVD (R26), R2
-+	CALL R2
-+	RET
-+
-+TEXT _setresuid(SB), NOSPLIT, $0-0
-+	JMP purego_setresuid(SB)
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
-+	MOVD ·x_cgo_purego_setreuid_call(SB), R26
-+	MOVD (R26), R2
-+	CALL R2
-+	RET
-+
-+TEXT _setreuid(SB), NOSPLIT, $0-0
-+	JMP purego_setreuid(SB)
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
-+	MOVD ·x_cgo_purego_setuid_call(SB), R26
-+	MOVD (R26), R2
-+	CALL R2
-+	RET
-+
-+TEXT _setuid(SB), NOSPLIT, $0-0
-+	JMP purego_setuid(SB)
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
-+	MOVD ·x_cgo_purego_setgroups_call(SB), R26
-+	MOVD (R26), R2
-+	CALL R2
-+	RET
-+
-+TEXT _setgroups(SB), NOSPLIT, $0-0
-+	JMP purego_setgroups(SB)
-+
-diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_loong64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_loong64.s
-new file mode 100644
-index 00000000000000..3c8a0d64e659fa
---- /dev/null
-+++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_loong64.s
-@@ -0,0 +1,92 @@
-+// Code generated by 'go generate' with gen.go. DO NOT EDIT.
-+
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo
-+
-+#include "textflag.h"
-+
-+TEXT ___errno_location(SB), NOSPLIT, $0-0
-+	JMP purego___errno_location(SB)
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
-+	MOVV ·x_cgo_purego_setegid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _setegid(SB), NOSPLIT, $0-0
-+	JMP purego_setegid(SB)
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
-+	MOVV ·x_cgo_purego_seteuid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _seteuid(SB), NOSPLIT, $0-0
-+	JMP purego_seteuid(SB)
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
-+	MOVV ·x_cgo_purego_setgid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _setgid(SB), NOSPLIT, $0-0
-+	JMP purego_setgid(SB)
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
-+	MOVV ·x_cgo_purego_setregid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _setregid(SB), NOSPLIT, $0-0
-+	JMP purego_setregid(SB)
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
-+	MOVV ·x_cgo_purego_setresgid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _setresgid(SB), NOSPLIT, $0-0
-+	JMP purego_setresgid(SB)
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
-+	MOVV ·x_cgo_purego_setresuid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _setresuid(SB), NOSPLIT, $0-0
-+	JMP purego_setresuid(SB)
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
-+	MOVV ·x_cgo_purego_setreuid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _setreuid(SB), NOSPLIT, $0-0
-+	JMP purego_setreuid(SB)
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
-+	MOVV ·x_cgo_purego_setuid_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _setuid(SB), NOSPLIT, $0-0
-+	JMP purego_setuid(SB)
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
-+	MOVV ·x_cgo_purego_setgroups_call(SB), R23
-+	MOVV (R23), R23
-+	CALL (R23)
-+	RET
-+
-+TEXT _setgroups(SB), NOSPLIT, $0-0
-+	JMP purego_setgroups(SB)
-diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_ppc64le.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_ppc64le.s
-new file mode 100644
-index 00000000000000..70c51e674587ef
---- /dev/null
-+++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_ppc64le.s
-@@ -0,0 +1,101 @@
-+// Code generated by 'go generate' with gen.go. DO NOT EDIT.
-+
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo
-+
-+#include "textflag.h"
-+
-+TEXT ___errno_location(SB), NOSPLIT, $0-0
-+	BR purego___errno_location(SB)
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
-+	MOVD R3, R3
-+	MOVD ·x_cgo_purego_setegid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	BR   (CTR)
-+
-+TEXT _setegid(SB), NOSPLIT, $0-0
-+	BR purego_setegid(SB)
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
-+	MOVD R3, R3
-+	MOVD ·x_cgo_purego_seteuid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	BR   (CTR)
-+
-+TEXT _seteuid(SB), NOSPLIT, $0-0
-+	BR purego_seteuid(SB)
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
-+	MOVD R3, R3
-+	MOVD ·x_cgo_purego_setgid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	BR   (CTR)
-+
-+TEXT _setgid(SB), NOSPLIT, $0-0
-+	BR purego_setgid(SB)
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
-+	MOVD R3, R3
-+	MOVD ·x_cgo_purego_setregid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	BR   (CTR)
-+
-+TEXT _setregid(SB), NOSPLIT, $0-0
-+	BR purego_setregid(SB)
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
-+	MOVD R3, R3
-+	MOVD ·x_cgo_purego_setresgid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	BR   (CTR)
-+
-+TEXT _setresgid(SB), NOSPLIT, $0-0
-+	BR purego_setresgid(SB)
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
-+	MOVD R3, R3
-+	MOVD ·x_cgo_purego_setresuid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	BR   (CTR)
-+
-+TEXT _setresuid(SB), NOSPLIT, $0-0
-+	BR purego_setresuid(SB)
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
-+	MOVD R3, R3
-+	MOVD ·x_cgo_purego_setreuid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	BR   (CTR)
-+
-+TEXT _setreuid(SB), NOSPLIT, $0-0
-+	BR purego_setreuid(SB)
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
-+	MOVD R3, R3
-+	MOVD ·x_cgo_purego_setuid_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	BR   (CTR)
-+
-+TEXT _setuid(SB), NOSPLIT, $0-0
-+	BR purego_setuid(SB)
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
-+	MOVD R3, R3
-+	MOVD ·x_cgo_purego_setgroups_call(SB), R12
-+	MOVD (R12), R12
-+	MOVD R12, CTR
-+	BR   (CTR)
-+
-+TEXT _setgroups(SB), NOSPLIT, $0-0
-+	BR purego_setgroups(SB)
-diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_riscv64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_riscv64.s
-new file mode 100644
-index 00000000000000..30dbb92f51fbb8
---- /dev/null
-+++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_riscv64.s
-@@ -0,0 +1,92 @@
-+// Code generated by 'go generate' with gen.go. DO NOT EDIT.
-+
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build !cgo
-+
-+#include "textflag.h"
-+
-+TEXT ___errno_location(SB), NOSPLIT, $0-0
-+	JMP purego___errno_location(SB)
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT, $0
-+	MOV  ·x_cgo_purego_setegid_call(SB), T0
-+	MOV  (T0), T1
-+	CALL T1
-+	RET
-+
-+TEXT _setegid(SB), NOSPLIT, $0-0
-+	JMP purego_setegid(SB)
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT, $0
-+	MOV  ·x_cgo_purego_seteuid_call(SB), T0
-+	MOV  (T0), T1
-+	CALL T1
-+	RET
-+
-+TEXT _seteuid(SB), NOSPLIT, $0-0
-+	JMP purego_seteuid(SB)
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT, $0
-+	MOV  ·x_cgo_purego_setgid_call(SB), T0
-+	MOV  (T0), T1
-+	CALL T1
-+	RET
-+
-+TEXT _setgid(SB), NOSPLIT, $0-0
-+	JMP purego_setgid(SB)
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT, $0
-+	MOV  ·x_cgo_purego_setregid_call(SB), T0
-+	MOV  (T0), T1
-+	CALL T1
-+	RET
-+
-+TEXT _setregid(SB), NOSPLIT, $0-0
-+	JMP purego_setregid(SB)
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT, $0
-+	MOV  ·x_cgo_purego_setresgid_call(SB), T0
-+	MOV  (T0), T1
-+	CALL T1
-+	RET
-+
-+TEXT _setresgid(SB), NOSPLIT, $0-0
-+	JMP purego_setresgid(SB)
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT, $0
-+	MOV  ·x_cgo_purego_setresuid_call(SB), T0
-+	MOV  (T0), T1
-+	CALL T1
-+	RET
-+
-+TEXT _setresuid(SB), NOSPLIT, $0-0
-+	JMP purego_setresuid(SB)
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT, $0
-+	MOV  ·x_cgo_purego_setreuid_call(SB), T0
-+	MOV  (T0), T1
-+	CALL T1
-+	RET
-+
-+TEXT _setreuid(SB), NOSPLIT, $0-0
-+	JMP purego_setreuid(SB)
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT, $0
-+	MOV  ·x_cgo_purego_setuid_call(SB), T0
-+	MOV  (T0), T1
-+	CALL T1
-+	RET
-+
-+TEXT _setuid(SB), NOSPLIT, $0-0
-+	JMP purego_setuid(SB)
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT, $0
-+	MOV  ·x_cgo_purego_setgroups_call(SB), T0
-+	MOV  (T0), T1
-+	CALL T1
-+	RET
-+
-+TEXT _setgroups(SB), NOSPLIT, $0-0
-+	JMP purego_setgroups(SB)
-diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_s390x.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_s390x.s
-new file mode 100644
-index 00000000000000..edc21761ddd8ad
---- /dev/null
-+++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_linux_s390x.s
-@@ -0,0 +1,90 @@
-+// Code generated by 'go generate' with gen.go. DO NOT EDIT.
-+
-+// SPDX-License-Identifier: Apache-2.0
-+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
-+
-+//go:build go1.27 && !cgo
-+
-+#include "textflag.h"
-+
-+TEXT ___errno_location(SB), NOSPLIT, $0-0
-+	JMP purego___errno_location(SB)
-+
-+TEXT _cgo_purego_setegid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	// R2 already has the argument from C caller
-+	MOVD ·x_cgo_purego_setegid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _setegid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setegid(SB)
-+
-+TEXT _cgo_purego_seteuid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_seteuid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _seteuid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_seteuid(SB)
-+
-+TEXT _cgo_purego_setgid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setgid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _setgid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setgid(SB)
-+
-+TEXT _cgo_purego_setregid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	// R2, R3 have arguments from C caller
-+	MOVD ·x_cgo_purego_setregid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _setregid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setregid(SB)
-+
-+TEXT _cgo_purego_setresgid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	// R2, R3, R4 have arguments from C caller
-+	MOVD ·x_cgo_purego_setresgid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _setresgid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setresgid(SB)
-+
-+TEXT _cgo_purego_setresuid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	// R2, R3, R4 have arguments from C caller
-+	MOVD ·x_cgo_purego_setresuid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _setresuid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setresuid(SB)
-+
-+TEXT _cgo_purego_setreuid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	// R2, R3 have arguments from C caller
-+	MOVD ·x_cgo_purego_setreuid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _setreuid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setreuid(SB)
-+
-+TEXT _cgo_purego_setuid_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	MOVD ·x_cgo_purego_setuid_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _setuid(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setuid(SB)
-+
-+TEXT _cgo_purego_setgroups_trampoline(SB), NOSPLIT|NOFRAME, $0
-+	// R2, R3 have arguments from C caller
-+	MOVD ·x_cgo_purego_setgroups_call(SB), R1
-+	MOVD (R1), R1
-+	BR   R1
-+
-+TEXT _setgroups(SB), NOSPLIT|NOFRAME, $0-0
-+	JMP purego_setgroups(SB)
-+
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_stubs.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_stubs.s
 new file mode 100644
-index 00000000000000..6a073bea0944d1
+index 00000000000000..6adce1818015af
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/ztrampolines_stubs.s
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,57 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
 +// Code generated by 'go generate' with gen.go. DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
 +// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
 +
-+//go:build !cgo && (darwin || linux)
++//go:build !cgo && (darwin || freebsd || linux)
 +
 +#include "textflag.h"
 +
@@ -38902,7 +38741,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index ceaebeb8a55620..caa33a63b93a33 100644
+index ceaebeb8a55620..1af909781beb20 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
@@ -38915,7 +38754,7 @@ index ceaebeb8a55620..caa33a63b93a33 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-openssl v0.0.0-20260602094349-4d656068110f
++# github.com/microsoft/go-crypto-openssl v0.0.0-20260709090821-4e7f148608fd
 +## explicit; go 1.24
 +github.com/microsoft/go-crypto-openssl/bbig
 +github.com/microsoft/go-crypto-openssl/internal/fakecgo


### PR DESCRIPTION
fixes: https://github.com/microsoft/go/issues/2406

We'd already fixed this in `microsoft/main` but we'd never updated the go-crypto-openssl 1.26 backport branch to contain this fix.