### PR TITLE
internal/fakecgo: use libthr.so.3 instead of libpthread.so on FreeBSD

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -2734,7 +2734,7 @@ index 00000000000000..d4671e1584dfa8
 +// This file is here just to declare cryptobackend dependencies.
 +// This allows tracking their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index 31cff08cfb0658..a77e67a1a93fe2 100644
+index 31cff08cfb0658..4fbf327344f9f2 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,11 +3,17 @@ module std
@@ -2744,7 +2744,7 @@ index 31cff08cfb0658..a77e67a1a93fe2 100644
 -	golang.org/x/crypto v0.54.1-0.20260714033321-10b54ffa51b1
 -	golang.org/x/net v0.57.1-0.20260714001123-e7e2eb826435
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f // indirect
-+	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260702080831-779d2f80165b // indirect
++	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae // indirect
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 // indirect
 +	golang.org/x/sys v0.47.0 // indirect
 +	golang.org/x/text v0.40.0 // indirect
@@ -2760,14 +2760,14 @@ index 31cff08cfb0658..a77e67a1a93fe2 100644
 +
 +replace github.com/microsoft/go/cryptobackend => ../../cryptobackend
 diff --git a/src/go.sum b/src/go.sum
-index 829e8fbf4b3026..4305da5bd0ebb4 100644
+index 829e8fbf4b3026..fe83c8851ce90d 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f h1:ksW7MznRoTYAoBaNIKyjqxR0Tp0aUqY1eALRaerngnk=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
-+github.com/microsoft/go-crypto-openssl v0.5.1-0.20260702080831-779d2f80165b h1:l2QuDBwmReDtL/D0Rzj4N3sitiHLJbGdU8dA9Y13K7s=
-+github.com/microsoft/go-crypto-openssl v0.5.1-0.20260702080831-779d2f80165b/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
++github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae h1:xSoD74/EAMa3AWS7h6+fWoBzTu4Yqh5J5X7dYdYNxkg=
++github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 h1:nmQ1K/L5GISW8UwbUwE376h3WXREEpREFdc3fNklcXc=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
  golang.org/x/crypto v0.54.1-0.20260714033321-10b54ffa51b1 h1:vGPAn+SBeT/HVkWqXTwgapJgtGQJztG0WR0OTuHzMAI=
@@ -15620,12 +15620,12 @@ index 00000000000000..17c6f83475ce5e
 +func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 new file mode 100644
-index 00000000000000..c0625f7dd69a23
+index 00000000000000..b835f8a4ac2e89
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 @@ -0,0 +1,3 @@
 +{
-+  "commit_hash": "48e0d42a22d76a4a9cd880be7eceea443a26b34b"
++  "commit_hash": "d476432ce7e3d8bb64b7cd257d332ee221ed6e7b"
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/freebsd.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/freebsd.go
 new file mode 100644
@@ -18240,7 +18240,7 @@ index 00000000000000..a7a0d9e69d4d8b
 +var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_freebsd.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_freebsd.go
 new file mode 100644
-index 00000000000000..d5a24b1cde00a7
+index 00000000000000..142ed25c720a7b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_freebsd.go
 @@ -0,0 +1,50 @@
@@ -18264,16 +18264,16 @@ index 00000000000000..d5a24b1cde00a7
 +//go:cgo_import_dynamic purego_sigfillset sigfillset "libc.so.7"
 +//go:cgo_import_dynamic purego_nanosleep nanosleep "libc.so.7"
 +//go:cgo_import_dynamic purego_abort abort "libc.so.7"
-+//go:cgo_import_dynamic purego_pthread_attr_init pthread_attr_init "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_create pthread_create "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_detach pthread_detach "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_sigmask pthread_sigmask "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_mutex_lock pthread_mutex_lock "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_mutex_unlock pthread_mutex_unlock "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_cond_broadcast pthread_cond_broadcast "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "libpthread.so"
++//go:cgo_import_dynamic purego_pthread_attr_init pthread_attr_init "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_create pthread_create "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_detach pthread_detach "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_sigmask pthread_sigmask "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_mutex_lock pthread_mutex_lock "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_mutex_unlock pthread_mutex_unlock "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_cond_broadcast pthread_cond_broadcast "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "libthr.so.3"
 +
 +//go:nosplit
 +//go:norace
@@ -45251,7 +45251,7 @@ index 00000000000000..b7ffeea07c6b8d
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 3592a83513f392..0490c07ab49be1 100644
+index 3592a83513f392..7e4233d48fc0ec 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,57 @@
@@ -45264,7 +45264,7 @@ index 3592a83513f392..0490c07ab49be1 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-openssl v0.5.1-0.20260702080831-779d2f80165b
++# github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae
 +## explicit; go 1.25
 +github.com/microsoft/go-crypto-openssl/bbig
 +github.com/microsoft/go-crypto-openssl/internal/fakecgo


### PR DESCRIPTION
Pulls down https://github.com/ebitengine/purego/commit/d476432ce7e3d8bb64b7cd257d332ee221ed6e7b