### PR TITLE
[release-branch.go1.27] internal/fakecgo: use libthr.so.3 instead of libpthread.so on FreeBSD

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -827,7 +827,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_windows.go
 
 diff --git a/src/cmd/go.mod b/src/cmd/go.mod
-index 326553a6a8e45f..7fcd181da63b96 100644
+index 9aa7c87ac0e0cf..5e85568ef92c29 100644
 --- a/src/cmd/go.mod
 +++ b/src/cmd/go.mod
 @@ -4,6 +4,8 @@ go 1.27
@@ -840,7 +840,7 @@ index 326553a6a8e45f..7fcd181da63b96 100644
  	golang.org/x/build v0.0.0-20260522210304-d55d0041b921
  	golang.org/x/mod v0.36.1-0.20260520130633-087f6515dd3b
 diff --git a/src/cmd/go.sum b/src/cmd/go.sum
-index 3b88ef74339c5b..abeaf0b10b8aae 100644
+index 9c6aa59dc288d6..17467e5a70382f 100644
 --- a/src/cmd/go.sum
 +++ b/src/cmd/go.sum
 @@ -4,6 +4,10 @@ github.com/google/pprof v0.0.0-20260507013755-92041b743c96 h1:YDDnaZ9afWajDboPMt
@@ -2666,7 +2666,7 @@ index 00000000000000..016de9bdd95956
 +	return filtered
 +}
 diff --git a/src/cmd/vendor/modules.txt b/src/cmd/vendor/modules.txt
-index 7df86f0bd319ba..786602a9bca103 100644
+index 6e513d8a5f175e..3fa585ff67412b 100644
 --- a/src/cmd/vendor/modules.txt
 +++ b/src/cmd/vendor/modules.txt
 @@ -16,6 +16,17 @@ github.com/google/pprof/third_party/svgpan
@@ -2734,7 +2734,7 @@ index 00000000000000..d4671e1584dfa8
 +// This file is here just to declare cryptobackend dependencies.
 +// This allows tracking their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index bb6abc93792f39..0e38b0d76e9ea6 100644
+index bb6abc93792f39..33f32c2e5ba232 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,11 +3,17 @@ module std
@@ -2744,7 +2744,7 @@ index bb6abc93792f39..0e38b0d76e9ea6 100644
 -	golang.org/x/crypto v0.52.1-0.20260526024921-9beb694f9766
 -	golang.org/x/net v0.55.1-0.20260526154343-657eb1317b5d
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f // indirect
-+	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260702080831-779d2f80165b // indirect
++	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae // indirect
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 // indirect
 +	golang.org/x/sys v0.45.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
@@ -2760,14 +2760,14 @@ index bb6abc93792f39..0e38b0d76e9ea6 100644
 +
 +replace github.com/microsoft/go/cryptobackend => ../../cryptobackend
 diff --git a/src/go.sum b/src/go.sum
-index ab34844da17757..d67f6d6610de55 100644
+index ab34844da17757..2187be9137b03e 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f h1:ksW7MznRoTYAoBaNIKyjqxR0Tp0aUqY1eALRaerngnk=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
-+github.com/microsoft/go-crypto-openssl v0.5.1-0.20260702080831-779d2f80165b h1:l2QuDBwmReDtL/D0Rzj4N3sitiHLJbGdU8dA9Y13K7s=
-+github.com/microsoft/go-crypto-openssl v0.5.1-0.20260702080831-779d2f80165b/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
++github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae h1:xSoD74/EAMa3AWS7h6+fWoBzTu4Yqh5J5X7dYdYNxkg=
++github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 h1:nmQ1K/L5GISW8UwbUwE376h3WXREEpREFdc3fNklcXc=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
  golang.org/x/crypto v0.52.1-0.20260526024921-9beb694f9766 h1:ABD+jVg0H4Hwu2sGcUtKeb3T8mlS+jS3uWrkTAPcXjs=
@@ -15620,12 +15620,12 @@ index 00000000000000..17c6f83475ce5e
 +func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 new file mode 100644
-index 00000000000000..c0625f7dd69a23
+index 00000000000000..b835f8a4ac2e89
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 @@ -0,0 +1,3 @@
 +{
-+  "commit_hash": "48e0d42a22d76a4a9cd880be7eceea443a26b34b"
++  "commit_hash": "d476432ce7e3d8bb64b7cd257d332ee221ed6e7b"
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/freebsd.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/freebsd.go
 new file mode 100644
@@ -18240,7 +18240,7 @@ index 00000000000000..a7a0d9e69d4d8b
 +var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_freebsd.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_freebsd.go
 new file mode 100644
-index 00000000000000..d5a24b1cde00a7
+index 00000000000000..142ed25c720a7b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/zsymbols_freebsd.go
 @@ -0,0 +1,50 @@
@@ -18264,16 +18264,16 @@ index 00000000000000..d5a24b1cde00a7
 +//go:cgo_import_dynamic purego_sigfillset sigfillset "libc.so.7"
 +//go:cgo_import_dynamic purego_nanosleep nanosleep "libc.so.7"
 +//go:cgo_import_dynamic purego_abort abort "libc.so.7"
-+//go:cgo_import_dynamic purego_pthread_attr_init pthread_attr_init "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_create pthread_create "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_detach pthread_detach "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_sigmask pthread_sigmask "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_mutex_lock pthread_mutex_lock "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_mutex_unlock pthread_mutex_unlock "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_cond_broadcast pthread_cond_broadcast "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "libpthread.so"
-+//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "libpthread.so"
++//go:cgo_import_dynamic purego_pthread_attr_init pthread_attr_init "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_create pthread_create "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_detach pthread_detach "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_sigmask pthread_sigmask "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_mutex_lock pthread_mutex_lock "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_mutex_unlock pthread_mutex_unlock "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_cond_broadcast pthread_cond_broadcast "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_setspecific pthread_setspecific "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_attr_getstacksize pthread_attr_getstacksize "libthr.so.3"
++//go:cgo_import_dynamic purego_pthread_attr_destroy pthread_attr_destroy "libthr.so.3"
 +
 +//go:nosplit
 +//go:norace
@@ -45251,7 +45251,7 @@ index 00000000000000..b7ffeea07c6b8d
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 54fcbab6a221c0..37d28d98d59f38 100644
+index 54fcbab6a221c0..7818f183b12cf3 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,57 @@
@@ -45264,7 +45264,7 @@ index 54fcbab6a221c0..37d28d98d59f38 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-openssl v0.5.1-0.20260702080831-779d2f80165b
++# github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae
 +## explicit; go 1.25
 +github.com/microsoft/go-crypto-openssl/bbig
 +github.com/microsoft/go-crypto-openssl/internal/fakecgo


### PR DESCRIPTION
Pulls down https://github.com/ebitengine/purego/commit/d476432ce7e3d8bb64b7cd257d332ee221ed6e7b