### PR TITLE
eng/pipeline: allow test retries after result publishing

### DIFF
--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -293,6 +293,9 @@ stages:
               - task: PublishTestResults@2
                 displayName: Publish test results (${{ attempt }})
                 condition: and(ne(variables['TEST_BUILDER_SUCCESSFUL'], 'true'), succeededOrFailed())
+                ${{ if or(ne(attempt, 'FINAL'), eq(parameters.builder.broken, true)) }}:
+                  # A failed test run is expected to continue to the next retry attempt or be non-fatal for a broken builder.
+                  continueOnError: true
                 inputs:
                   testResultsFormat: JUnit
                   testResultsFiles: $(Build.SourcesDirectory)/eng/artifacts/RawTestOutput/TestResults-attempt-${{ attempt }}.xml


### PR DESCRIPTION
Test retry attempts currently require the job to be in a successful state. Non-final test commands use `ignoreLASTEXITCODE`, but `PublishTestResults` can still fail after publishing a failed JUnit result. That changes the job state before the next test attempt evaluates its `succeeded()` condition, causing all remaining retries to be skipped.

Mark non-final result-publishing tasks with `continueOnError`. Their expected failed-test result becomes `SucceededWithIssues`, which permits the existing retry condition to continue without weakening its protection against catastrophic build failures. Apply the same behavior to the final publisher for builders marked `broken`, preserving the existing policy that their final test failure is non-fatal.

Validation:
- `go test ./cmd/pipelineymlgen`
- YAML diagnostics
- `git diff --check`

Fixes #2264