### PR TITLE
windows/386: enable systemcrypto support

### DIFF
--- a/eng/doc/SupportedPlatforms.md
+++ b/eng/doc/SupportedPlatforms.md
@@ -19,6 +19,7 @@ Platforms outside this scope are supported on a best-effort basis with no guaran
 | linux/amd64 | Azure Linux 3.0, Ubuntu 22.04 |
 | linux/arm64 | Azure Linux 3.0, Ubuntu 22.04 |
 | linux/arm | Ubuntu 22.04 |
+| windows/386 | Windows 10, Windows Server 2016 (since Go 1.28) |
 | windows/amd64 | Windows 10, Windows Server 2016 |
 | windows/arm64 | Windows 11, Windows Server 2025 |
 

--- a/eng/pipeline/stages/go-builder-matrix-stages.yml
+++ b/eng/pipeline/stages/go-builder-matrix-stages.yml
@@ -68,9 +68,9 @@ stages:
         # Could be determined based on inputs (if more are added) but the caller can just tell us.
         - ${{ if parameters.buildandpack }}:
           - { os: linux, arch: amd64, config: buildandpack }
-          - { os: windows, arch: amd64, config: buildandpack }
           - { os: linux, arch: arm, hostArch: amd64, config: buildandpack }
           - { os: linux, arch: arm64, hostArch: amd64, config: buildandpack }
+          - { os: windows, arch: amd64, config: buildandpack }
           - { os: windows, arch: arm64, hostArch: amd64, config: buildandpack }
           - { os: darwin, arch: amd64, config: buildandpack }
           - { os: darwin, arch: arm64, config: buildandpack }
@@ -102,11 +102,13 @@ stages:
           - { os: linux, arch: amd64, config: nocgo, distro: azurelinux3, fips: true }
           - { nosystemcrypto: true, os: windows, arch: amd64, config: devscript }
           - { nosystemcrypto: true, os: windows, arch: amd64, config: test }
+          - { nosystemcrypto: true, os: windows, arch: 386, hostArch: amd64, config: test }
           - { os: windows, arch: amd64, config: test }
           - { os: windows, arch: amd64, config: test, fips: true }
+          - { os: windows, arch: 386, hostArch: amd64, config: test }
           - { experiment: ms_tls_config_schannel, os: windows, arch: amd64, config: test }
           # Test that buildandpack works on Windows x86-32, but don't release it.
-          - { nosystemcrypto: true, os: windows, hostArch: amd64, arch: 386, config: buildandpack }
+          - { os: windows, arch: 386, hostArch: amd64, config: buildandpack }
         - ${{ if parameters.outerloop }}:
           # Upstream builders.
           # - { nosystemcrypto: true, os: linux, arch: amd64, config: clang } https://github.com/microsoft/go/issues/342

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -229,7 +229,10 @@ stages:
 
               - pwsh: |
                   eng/run.ps1 go run github.com/microsoft/go-infra/cmd/getmingw diagnose
-                  eng/run.ps1 go run github.com/microsoft/go-infra/cmd/getmingw run -ci azdo -source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -exception seh -runtime msvcrt
+                  ${{ if eq(parameters.builder.arch, '386') }}:
+                    eng/run.ps1 go run github.com/microsoft/go-infra/cmd/getmingw run -ci azdo -source nixman -version 13.2.0-rt_v11-rev0 -arch i686 -threading posix -exception dwarf -runtime msvcrt
+                  ${{ else }}:
+                    eng/run.ps1 go run github.com/microsoft/go-infra/cmd/getmingw run -ci azdo -source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -exception seh -runtime msvcrt
                 displayName: Install MinGW
 
             # Build. This includes retry logic internally if necessary for this builder.

--- a/eng/pipeline/stages/run-stage.yml
+++ b/eng/pipeline/stages/run-stage.yml
@@ -229,10 +229,11 @@ stages:
 
               - pwsh: |
                   eng/run.ps1 go run github.com/microsoft/go-infra/cmd/getmingw diagnose
-                  ${{ if eq(parameters.builder.arch, '386') }}:
+                  if ('${{ parameters.builder.arch }}' -eq '386') {
                     eng/run.ps1 go run github.com/microsoft/go-infra/cmd/getmingw run -ci azdo -source nixman -version 13.2.0-rt_v11-rev0 -arch i686 -threading posix -exception dwarf -runtime msvcrt
-                  ${{ else }}:
+                  } else {
                     eng/run.ps1 go run github.com/microsoft/go-infra/cmd/getmingw run -ci azdo -source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -exception seh -runtime msvcrt
+                  }
                 displayName: Install MinGW
 
             # Build. This includes retry logic internally if necessary for this builder.

--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -128,7 +128,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/fakecgo/abi_riscv64.h            |   74 +
  .../internal/fakecgo/asm_386.s                |   31 +
  .../internal/fakecgo/asm_amd64.s              |   41 +
- .../internal/fakecgo/asm_arm.s                |   52 +
+ .../internal/fakecgo/asm_arm.s                |   60 +
  .../internal/fakecgo/asm_arm64.s              |   37 +
  .../internal/fakecgo/asm_loong64.s            |   40 +
  .../internal/fakecgo/asm_ppc64le.s            |   81 +
@@ -156,7 +156,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/fakecgo/threadentry_noasm.go     |   26 +
  .../internal/fakecgo/trampolines_386.s        |  123 +
  .../internal/fakecgo/trampolines_amd64.s      |  126 +
- .../internal/fakecgo/trampolines_arm.s        |  124 +
+ .../internal/fakecgo/trampolines_arm.s        |  133 +
  .../internal/fakecgo/trampolines_arm64.s      |   83 +
  .../internal/fakecgo/trampolines_linux_386.s  |   80 +
  .../fakecgo/trampolines_linux_amd64.s         |   71 +
@@ -247,7 +247,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/LICENSE     |   21 +
  .../microsoft/go-crypto-winnative/cng/aes.go  |  435 +++
  .../go-crypto-winnative/cng/bbig/big.go       |   31 +
- .../microsoft/go-crypto-winnative/cng/big.go  |   30 +
+ .../microsoft/go-crypto-winnative/cng/big.go  |   28 +
  .../cng/chacha20poly1305.go                   |  119 +
  .../go-crypto-winnative/cng/cipher.go         |   52 +
  .../microsoft/go-crypto-winnative/cng/cng.go  |  140 +
@@ -261,13 +261,15 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/keys.go |  220 ++
  .../go-crypto-winnative/cng/mldsa.go          |  444 +++
  .../go-crypto-winnative/cng/mlkem.go          |  405 +++
- .../go-crypto-winnative/cng/pbkdf2.go         |   70 +
+ .../go-crypto-winnative/cng/pbkdf2.go         |   74 +
  .../microsoft/go-crypto-winnative/cng/rand.go |   28 +
  .../microsoft/go-crypto-winnative/cng/rc4.go  |   65 +
  .../microsoft/go-crypto-winnative/cng/rsa.go  |  404 +++
  .../microsoft/go-crypto-winnative/cng/sha3.go |  203 ++
  .../go-crypto-winnative/cng/tls1prf.go        |   91 +
- .../internal/bcrypt/bcrypt_windows.go         |  434 +++
+ .../internal/bcrypt/authinfo_windows.go       |   21 +
+ .../internal/bcrypt/authinfo_windows_386.go   |   23 +
+ .../internal/bcrypt/bcrypt_windows.go         |  417 +++
  .../internal/bcrypt/ntstatus_windows.go       |   45 +
  .../internal/bcrypt/zsyscall_windows.go       |  438 +++
  .../internal/subtle/aliasing.go               |   32 +
@@ -422,7 +424,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go/cryptobackend/tls13/tls13_openssl.go   |   18 +
  .../go/cryptobackend/tls13/tls13_windows.go   |   14 +
  src/vendor/modules.txt                        |   55 +
- 414 files changed, 39705 insertions(+), 11 deletions(-)
+ 416 files changed, 39751 insertions(+), 11 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -675,6 +677,8 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/rsa.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/sha3.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/authinfo_windows.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/authinfo_windows_386.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/ntstatus_windows.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/zsyscall_windows.go
@@ -2738,7 +2742,7 @@ index 00000000000000..d4671e1584dfa8
 +// This file is here just to declare cryptobackend dependencies.
 +// This allows tracking their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index d9c91d7b0dbcbb..607c4dded38695 100644
+index d9c91d7b0dbcbb..b9ab966128818d 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,11 +3,17 @@ module std
@@ -2748,8 +2752,8 @@ index d9c91d7b0dbcbb..607c4dded38695 100644
 -	golang.org/x/crypto v0.54.1-0.20260714033321-10b54ffa51b1
 -	golang.org/x/net v0.57.1-0.20260723204303-5a920b1a8090
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f // indirect
-+	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260731132607-9fc2a2ab131d // indirect
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 // indirect
++	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260813203406-afa6f0e831c4 // indirect
++	github.com/microsoft/go-crypto-winnative v0.0.0-20260820121639-6c31d8dd0a62 // indirect
 +	golang.org/x/sys v0.47.0 // indirect
 +	golang.org/x/text v0.40.0 // indirect
  )
@@ -2764,21 +2768,21 @@ index d9c91d7b0dbcbb..607c4dded38695 100644
 +
 +replace github.com/microsoft/go/cryptobackend => ../../cryptobackend
 diff --git a/src/go.sum b/src/go.sum
-index 2d4171d08a2857..504df8a325c78a 100644
+index 2d4171d08a2857..fa91f87257de79 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f h1:ksW7MznRoTYAoBaNIKyjqxR0Tp0aUqY1eALRaerngnk=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
-+github.com/microsoft/go-crypto-openssl v0.5.1-0.20260731132607-9fc2a2ab131d h1:Whi7ZQB1mjFKhFHiKtyxCYg0OlI+MnNpwcH47+T/Vdw=
-+github.com/microsoft/go-crypto-openssl v0.5.1-0.20260731132607-9fc2a2ab131d/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 h1:nmQ1K/L5GISW8UwbUwE376h3WXREEpREFdc3fNklcXc=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
++github.com/microsoft/go-crypto-openssl v0.5.1-0.20260813203406-afa6f0e831c4 h1:GwGp/2YVw/jfHlhx78psGehiSXAUsOnn1spdsTIs1RQ=
++github.com/microsoft/go-crypto-openssl v0.5.1-0.20260813203406-afa6f0e831c4/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260820121639-6c31d8dd0a62 h1:5drrAUhaq7DegGhvzlMiXNEGd8Cq2AXFHeOqUL+scz4=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260820121639-6c31d8dd0a62/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
  golang.org/x/crypto v0.54.1-0.20260714033321-10b54ffa51b1 h1:vGPAn+SBeT/HVkWqXTwgapJgtGQJztG0WR0OTuHzMAI=
  golang.org/x/crypto v0.54.1-0.20260714033321-10b54ffa51b1/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
  golang.org/x/net v0.57.1-0.20260723204303-5a920b1a8090 h1:XtR9OCj3sl60bQa861zXyA2fXGYcpmj8o8fGZe8iCtQ=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 314608372954ce..6ddb9afc7f82a4 100644
+index 889ed76852e926..b47c346cc9c4ec 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
 @@ -153,6 +153,13 @@ var depsRules = `
@@ -2795,7 +2799,7 @@ index 314608372954ce..6ddb9afc7f82a4 100644
  	# TIME is SYSCALL plus the core packages about time, including context.
  	SYSCALL
  	< time/tzdata
-@@ -541,16 +548,46 @@ var depsRules = `
+@@ -544,16 +551,46 @@ var depsRules = `
  	NONE < crypto/internal/boring/sig, crypto/internal/boring/syso;
  	sync/atomic < crypto/internal/boring/bcache;
  
@@ -2847,7 +2851,7 @@ index 314608372954ce..6ddb9afc7f82a4 100644
  	< crypto/internal/boring
  	< crypto/boring
  	< crypto/internal/rand
-@@ -576,6 +613,10 @@ var depsRules = `
+@@ -579,6 +616,10 @@ var depsRules = `
  
  	# CRYPTO-MATH is crypto that exposes math/big APIs - no cgo, net; fmt now ok.
  
@@ -2858,7 +2862,7 @@ index 314608372954ce..6ddb9afc7f82a4 100644
  	CRYPTO, FMT, math/big, internal/saferio
  	< crypto/internal/boring/bbig
  	< crypto/internal/fips140cache
-@@ -955,7 +996,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -958,7 +999,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -2867,7 +2871,7 @@ index 314608372954ce..6ddb9afc7f82a4 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -965,7 +1006,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -968,7 +1009,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}
@@ -15163,10 +15167,10 @@ index 00000000000000..623852da4937cb
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s
 new file mode 100644
-index 00000000000000..2a24150b337120
+index 00000000000000..f7a1d32b51b88f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,60 @@
 +// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
 +
 +// Copyright 2012 The Go Authors. All rights reserved.
@@ -15192,8 +15196,11 @@ index 00000000000000..2a24150b337120
 +	// starting at 4(R13).
 +	MOVW.W R14, -4(R13)
 +
++	// Skip floating point registers if runtime.goarmsoftfp!=0.
++	MOVB    runtime·goarmsoftfp(SB), R11
++	CMP     $0, R11
++	BNE     skipfpsave
 +	// Save VFP callee-saved registers D8-D15 (same as S16-S31).
-+	// Note: We always save these since we target hard-float ABI.
 +	MOVD F8, (13*4+8*1)(R13)
 +	MOVD F9, (13*4+8*2)(R13)
 +	MOVD F10, (13*4+8*3)(R13)
@@ -15203,9 +15210,13 @@ index 00000000000000..2a24150b337120
 +	MOVD F14, (13*4+8*7)(R13)
 +	MOVD F15, (13*4+8*8)(R13)
 +
++skipfpsave:
 +	// We set up the arguments to cgocallback when saving registers above.
 +	BL runtime·cgocallback(SB)
 +
++	MOVB    runtime·goarmsoftfp(SB), R11
++	CMP     $0, R11
++	BNE     skipfprest
 +	MOVD (13*4+8*1)(R13), F8
 +	MOVD (13*4+8*2)(R13), F9
 +	MOVD (13*4+8*3)(R13), F10
@@ -15215,6 +15226,7 @@ index 00000000000000..2a24150b337120
 +	MOVD (13*4+8*7)(R13), F14
 +	MOVD (13*4+8*8)(R13), F15
 +
++skipfprest:
 +	MOVW.P   4(R13), R14
 +	MOVM.IAW (R13), [R0, R1, R3, R4, R5, R6, R7, R8, R9, g, R11, R12]
 +	ADD      $(8*9), R13
@@ -15624,12 +15636,12 @@ index 00000000000000..17c6f83475ce5e
 +func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 new file mode 100644
-index 00000000000000..eaf9e8639e2c13
+index 00000000000000..994a32ad9332b8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 @@ -0,0 +1,3 @@
 +{
-+  "commit_hash": "077e9d53635a94054efc341688c8e1e7ed499382"
++  "commit_hash": "f9d41fc60f1f296d730749174bd3bec93c1ea13c"
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/freebsd.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/freebsd.go
 new file mode 100644
@@ -16795,10 +16807,10 @@ index 00000000000000..f6f09c6b2fc7d6
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s
 new file mode 100644
-index 00000000000000..ae989a4e0e18c9
+index 00000000000000..03bc68c27bd564
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s
-@@ -0,0 +1,124 @@
+@@ -0,0 +1,133 @@
 +// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -16873,6 +16885,10 @@ index 00000000000000..ae989a4e0e18c9
 +	MOVW g, 32(R13)   // R10
 +	MOVW R11, 36(R13)
 +
++	// Skip floating point registers if runtime.goarmsoftfp!=0.
++	MOVB    runtime·goarmsoftfp(SB), R11
++	CMP     $0, R11
++	BNE     skipfpsave
 +	MOVD F8, 40(R13)
 +	MOVD F9, 48(R13)
 +	MOVD F10, 56(R13)
@@ -16882,10 +16898,14 @@ index 00000000000000..ae989a4e0e18c9
 +	MOVD F14, 88(R13)
 +	MOVD F15, 96(R13)
 +
++skipfpsave:
 +	MOVW ·threadentry_call(SB), R12
 +	MOVW (R12), R12
 +	CALL (R12)
 +
++	MOVB    runtime·goarmsoftfp(SB), R11
++	CMP     $0, R11
++	BNE     skipfprest
 +	MOVD 40(R13), F8
 +	MOVD 48(R13), F9
 +	MOVD 56(R13), F10
@@ -16895,6 +16915,7 @@ index 00000000000000..ae989a4e0e18c9
 +	MOVD 88(R13), F14
 +	MOVD 96(R13), F15
 +
++skipfprest:
 +	MOVW 8(R13), R4
 +	MOVW 12(R13), R5
 +	MOVW 16(R13), R6
@@ -35998,10 +36019,10 @@ index 00000000000000..584f2069b1cd0a
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/big.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/big.go
 new file mode 100644
-index 00000000000000..36f0e0c6e278bc
+index 00000000000000..421d6c283b888b
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/big.go
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,28 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +package cng
@@ -36020,17 +36041,15 @@ index 00000000000000..36f0e0c6e278bc
 +// Conversion between BigInt and *big.Int is in cng/bbig.
 +type BigInt []byte
 +
-+const _S = bits.UintSize / 8 // word size in bytes
-+
 +// Length of x in bits.
 +func (x BigInt) bitLen() int {
 +	if len(x) == 0 {
 +		return 0
 +	}
 +	// x is normalized, so the length in bits is
-+	// the length in bits of x minus one byte (_S),
++	// the length in bits of x minus one byte,
 +	// plus the minimum number of bits to represent the first byte.
-+	return (len(x)-1)*_S + bits.Len(uint(x[0]))
++	return (len(x)-1)*8 + bits.Len8(x[0])
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/chacha20poly1305.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/chacha20poly1305.go
 new file mode 100644
@@ -39032,10 +39051,10 @@ index 00000000000000..f220e1d9d29794
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
 new file mode 100644
-index 00000000000000..cb9dba21416c6d
+index 00000000000000..dc55fee4ef2061
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,74 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -39074,11 +39093,15 @@ index 00000000000000..cb9dba21416c6d
 +	}
 +	defer bcrypt.DestroyKey(kh)
 +	u16HashID := utf16FromString(hashID)
++	if iter <= 0 {
++		return nil, errors.New("cng: invalid iteration count")
++	}
++	iterations := uint64(iter)
 +	buffers := make([]bcrypt.Buffer, 0, 3)
 +	buffers = append(buffers,
 +		bcrypt.Buffer{
 +			Type:   bcrypt.KDF_ITERATION_COUNT,
-+			Data:   uintptr(unsafe.Pointer(&iter)),
++			Data:   uintptr(unsafe.Pointer(&iterations)),
 +			Length: 8,
 +		},
 +		bcrypt.Buffer{
@@ -39927,12 +39950,68 @@ index 00000000000000..3418bf62f22d4d
 +	}
 +	return nil
 +}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/authinfo_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/authinfo_windows.go
+new file mode 100644
+index 00000000000000..947bc83f4f52f7
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/authinfo_windows.go
+@@ -0,0 +1,21 @@
++//go:build !386
++// +build !386
++
++package bcrypt
++
++// https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_authenticated_cipher_mode_info
++type AUTHENTICATED_CIPHER_MODE_INFO struct {
++	Size           uint32
++	InfoVersion    uint32
++	Nonce          *byte
++	NonceSize      uint32
++	AuthData       *byte
++	AuthDataSize   uint32
++	Tag            *byte
++	TagSize        uint32
++	MacContext     *byte
++	MacContextSize uint32
++	AADSize        uint32
++	DataSize       uint64
++	Flags          uint32
++}
+diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/authinfo_windows_386.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/authinfo_windows_386.go
+new file mode 100644
+index 00000000000000..fd70ebf36c9204
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/authinfo_windows_386.go
+@@ -0,0 +1,23 @@
++//go:build windows && 386
++// +build windows,386
++
++package bcrypt
++
++// https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_authenticated_cipher_mode_info
++type AUTHENTICATED_CIPHER_MODE_INFO struct {
++	Size           uint32
++	InfoVersion    uint32
++	Nonce          *byte
++	NonceSize      uint32
++	AuthData       *byte
++	AuthDataSize   uint32
++	Tag            *byte
++	TagSize        uint32
++	MacContext     *byte
++	MacContextSize uint32
++	AADSize        uint32
++	_              uint32
++	DataSize       uint64
++	Flags          uint32
++	_              uint32
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000000..7c24727f821191
+index 00000000000000..cdf8c8990765da
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
-@@ -0,0 +1,434 @@
+@@ -0,0 +1,417 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -40180,23 +40259,6 @@ index 00000000000000..7c24727f821191
 +	MinLength uint32
 +	MaxLength uint32
 +	Increment uint32
-+}
-+
-+// https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_authenticated_cipher_mode_info
-+type AUTHENTICATED_CIPHER_MODE_INFO struct {
-+	Size           uint32
-+	InfoVersion    uint32
-+	Nonce          *byte
-+	NonceSize      uint32
-+	AuthData       *byte
-+	AuthDataSize   uint32
-+	Tag            *byte
-+	TagSize        uint32
-+	MacContext     *byte
-+	MacContextSize uint32
-+	AADSize        uint32
-+	DataSize       uint64
-+	Flags          uint32
 +}
 +
 +func NewAUTHENTICATED_CIPHER_MODE_INFO(nonce, additionalData, tag []byte) *AUTHENTICATED_CIPHER_MODE_INFO {
@@ -45321,7 +45383,7 @@ index 00000000000000..b7ffeea07c6b8d
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 87a2fc95544420..63bd2e1385fcdb 100644
+index 87a2fc95544420..ce596234fd591c 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,57 @@
@@ -45334,14 +45396,14 @@ index 87a2fc95544420..63bd2e1385fcdb 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-openssl v0.5.1-0.20260731132607-9fc2a2ab131d
++# github.com/microsoft/go-crypto-openssl v0.5.1-0.20260813203406-afa6f0e831c4
 +## explicit; go 1.25
 +github.com/microsoft/go-crypto-openssl/bbig
 +github.com/microsoft/go-crypto-openssl/internal/fakecgo
 +github.com/microsoft/go-crypto-openssl/internal/ossl
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/osslsetup
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825
++# github.com/microsoft/go-crypto-winnative v0.0.0-20260820121639-6c31d8dd0a62
 +## explicit; go 1.25
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
## Summary
- enable systemcrypto by default on windows/386 now that go-crypto-winnative supports it
- add windows/386 AzDO test coverage with and without systemcrypto, and build the 386 distribution with systemcrypto enabled
- document windows/386 support starting with Go 1.28

## Testing
- focused internal/systemcrypto and internal/buildcfg tests
- GOOS=windows GOARCH=386 CGO_ENABLED=0 go build std
- pwsh eng/run.ps1 pipelineymlgen
- git diff --check
- patches 0001 and 0002 apply cleanly in sequence
