### PR TITLE
[release-branch.go1.26] Bump go-crypto-winnative to latest

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -255,19 +255,19 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/hmac.go |   70 +
  .../microsoft/go-crypto-winnative/cng/keys.go |  220 ++
  .../go-crypto-winnative/cng/mlkem.go          |  405 +++
- .../go-crypto-winnative/cng/pbkdf2.go         |   70 +
+ .../go-crypto-winnative/cng/pbkdf2.go         |   72 +
  .../microsoft/go-crypto-winnative/cng/rand.go |   28 +
  .../microsoft/go-crypto-winnative/cng/rc4.go  |   65 +
  .../microsoft/go-crypto-winnative/cng/rsa.go  |  404 +++
  .../microsoft/go-crypto-winnative/cng/sha3.go |  203 ++
- .../go-crypto-winnative/cng/tls1prf.go        |   89 +
+ .../go-crypto-winnative/cng/tls1prf.go        |   93 +
  .../internal/bcrypt/bcrypt_windows.go         |  414 +++
  .../internal/bcrypt/ntstatus_windows.go       |   45 +
  .../internal/bcrypt/zsyscall_windows.go       |  438 +++
  .../internal/subtle/aliasing.go               |   32 +
  .../internal/sysdll/sys_windows.go            |   55 +
  src/vendor/modules.txt                        |   23 +
- 259 files changed, 34561 insertions(+), 7 deletions(-)
+ 259 files changed, 34567 insertions(+), 7 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -2193,7 +2193,7 @@ index 00000000000000..f5dc9afe4b0ead
 +// that are used by the backend package. This allows to track
 +// their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index 620a311881f098..1d31de950c52f7 100644
+index 620a311881f098..ca1e0daedc3e5f 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -11,3 +11,9 @@ require (
@@ -2204,10 +2204,10 @@ index 620a311881f098..1d31de950c52f7 100644
 +require (
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260612173401-95c9561b6f25
 +	github.com/microsoft/go-crypto-openssl v0.0.0-20260709090821-4e7f148608fd
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9
++	github.com/microsoft/go-crypto-winnative v0.0.0-20260821121209-d3f2d4e543ce
 +)
 diff --git a/src/go.sum b/src/go.sum
-index 055a4281932ce4..4f663137c4e278 100644
+index 055a4281932ce4..0e5c251c6672be 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
@@ -2215,8 +2215,8 @@ index 055a4281932ce4..4f663137c4e278 100644
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260612173401-95c9561b6f25/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
 +github.com/microsoft/go-crypto-openssl v0.0.0-20260709090821-4e7f148608fd h1:RpGecuDCHiv/wk/i4Ih0utGQoF0bhySMS528I6yVJV0=
 +github.com/microsoft/go-crypto-openssl v0.0.0-20260709090821-4e7f148608fd/go.mod h1:4QCeILGRVUNXcRMpHlFIzULgpv3vJcnC34zEdDHdw98=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9 h1:joliMChkkfHV3vAPKzu9kefdw0K+d89A8r9gTm3MFS4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260821121209-d3f2d4e543ce h1:jAL/vVtmNugbSwOUygaHgESpYAZjEqa01IypvtGiR3s=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260821121209-d3f2d4e543ce/go.mod h1:gD686525Li/blRSYwSzFJ6/LJQVFJp7Y0MKp+dmqFbc=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00 h1:JgcPM1rzpSOZS8y69FQvnY0xN0ciHlpQqwTXJcuZIA4=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
  golang.org/x/net v0.47.1-0.20260731170545-cb1d721f7fb3 h1:qbgM8pnaNGo8FUbT74e+whlrJGZ0RVX6xdN8ANEYj3Y=
@@ -35981,7 +35981,7 @@ index 00000000000000..f86a9e9bfd47a9
 +type HashCloner = hash.Cloner
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
 new file mode 100644
-index 00000000000000..aa48b084d708da
+index 00000000000000..929a5b7ab3d5bb
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
 @@ -0,0 +1,133 @@
@@ -36098,13 +36098,13 @@ index 00000000000000..aa48b084d708da
 +			Buffers: &bcrypt.Buffer{
 +				Length: uint32(len(info)),
 +				Type:   bcrypt.KDF_HKDF_INFO,
-+				Data:   uintptr(unsafe.Pointer(&info[0])),
++				Data:   unsafe.Pointer(&info[0]),
 +			},
 +		}
-+		defer runtime.KeepAlive(params)
 +	}
 +	var n uint32
 +	err = bcrypt.KeyDerivation(kh, params, out, &n, 0)
++	runtime.KeepAlive(params)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -36833,10 +36833,10 @@ index 00000000000000..f220e1d9d29794
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
 new file mode 100644
-index 00000000000000..5466b180e60e5a
+index 00000000000000..976ca891b02e56
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,72 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -36848,6 +36848,7 @@ index 00000000000000..5466b180e60e5a
 +import (
 +	"errors"
 +	"hash"
++	"runtime"
 +	"unsafe"
 +
 +	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -36879,19 +36880,19 @@ index 00000000000000..5466b180e60e5a
 +	buffers = append(buffers,
 +		bcrypt.Buffer{
 +			Type:   bcrypt.KDF_ITERATION_COUNT,
-+			Data:   uintptr(unsafe.Pointer(&iter)),
++			Data:   unsafe.Pointer(&iter),
 +			Length: 8,
 +		},
 +		bcrypt.Buffer{
 +			Type:   bcrypt.KDF_HASH_ALGORITHM,
-+			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
++			Data:   unsafe.Pointer(&u16HashID[0]),
 +			Length: uint32(len(u16HashID) * 2),
 +		})
 +	if len(salt) > 0 {
 +		// The salt is optional.
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_SALT,
-+			Data:   uintptr(unsafe.Pointer(&salt[0])),
++			Data:   unsafe.Pointer(&salt[0]),
 +			Length: uint32(len(salt)),
 +		})
 +	}
@@ -36902,6 +36903,7 @@ index 00000000000000..5466b180e60e5a
 +	out := make([]byte, keyLen)
 +	var size uint32
 +	err = bcrypt.KeyDerivation(kh, params, out, &size, 0)
++	runtime.KeepAlive(params)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -37633,10 +37635,10 @@ index 00000000000000..c26c4bcf0d1afe
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
 new file mode 100644
-index 00000000000000..56131a6bc93d3f
+index 00000000000000..3637ebfadcc1f9
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,93 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -37648,6 +37650,7 @@ index 00000000000000..56131a6bc93d3f
 +import (
 +	"errors"
 +	"hash"
++	"runtime"
 +	"unsafe"
 +
 +	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -37689,14 +37692,14 @@ index 00000000000000..56131a6bc93d3f
 +	if len(label) > 0 {
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_TLS_PRF_LABEL,
-+			Data:   uintptr(unsafe.Pointer(&label[0])),
++			Data:   unsafe.Pointer(&label[0]),
 +			Length: uint32(len(label)),
 +		})
 +	}
 +	if len(seed) > 0 {
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_TLS_PRF_SEED,
-+			Data:   uintptr(unsafe.Pointer(&seed[0])),
++			Data:   unsafe.Pointer(&seed[0]),
 +			Length: uint32(len(seed)),
 +		})
 +	}
@@ -37704,16 +37707,19 @@ index 00000000000000..56131a6bc93d3f
 +		u16HashID := utf16FromString(hashID)
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_HASH_ALGORITHM,
-+			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
++			Data:   unsafe.Pointer(&u16HashID[0]),
 +			Length: uint32(len(u16HashID) * 2),
 +		})
 +	}
 +	params := &bcrypt.BufferDesc{
-+		Count:   uint32(len(buffers)),
-+		Buffers: &buffers[0],
++		Count: uint32(len(buffers)),
++	}
++	if len(buffers) > 0 {
++		params.Buffers = &buffers[0]
 +	}
 +	var size uint32
 +	err = bcrypt.KeyDerivation(kh, params, result, &size, 0)
++	runtime.KeepAlive(params)
 +	if err != nil {
 +		return err
 +	}
@@ -37728,7 +37734,7 @@ index 00000000000000..56131a6bc93d3f
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000000..3fe42f9334abd0
+index 00000000000000..c5a70da5b745ed
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 @@ -0,0 +1,414 @@
@@ -37843,7 +37849,7 @@ index 00000000000000..3fe42f9334abd0
 +type Buffer struct {
 +	Length uint32
 +	Type   uint32
-+	Data   uintptr
++	Data   unsafe.Pointer
 +}
 +
 +type BufferDesc struct {
@@ -38741,7 +38747,7 @@ index 00000000000000..1722410e5af193
 +	return getSystemDirectory() + "\\" + dll
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index aa2aa893310b0e..4ba42c8b8e5c65 100644
+index aa2aa893310b0e..9d2aa9e9e0888b 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,26 @@
@@ -38761,7 +38767,7 @@ index aa2aa893310b0e..4ba42c8b8e5c65 100644
 +github.com/microsoft/go-crypto-openssl/internal/ossl
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/osslsetup
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20260127024749-832b168a84e9
++# github.com/microsoft/go-crypto-winnative v0.0.0-20260821121209-d3f2d4e543ce
 +## explicit; go 1.24
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
Updates go-crypto-winnative from 832b168a84e9 to the latest Go 1.26 support revision, d3f2d4e543ce.

Tests:
- pwsh eng/run.ps1 submodule-refresh -shallow
- pwsh eng/run.ps1 build
- go test github.com/microsoft/go-crypto-winnative/cng/...
- GOEXPERIMENT=systemcrypto go test crypto/internal/backend/...