### PR TITLE
[release-branch.go1.27] Bump go-crypto-winnative to latest

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -259,12 +259,12 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/keys.go |  220 ++
  .../go-crypto-winnative/cng/mldsa.go          |  444 +++
  .../go-crypto-winnative/cng/mlkem.go          |  405 +++
- .../go-crypto-winnative/cng/pbkdf2.go         |   70 +
+ .../go-crypto-winnative/cng/pbkdf2.go         |   72 +
  .../microsoft/go-crypto-winnative/cng/rand.go |   28 +
  .../microsoft/go-crypto-winnative/cng/rc4.go  |   65 +
  .../microsoft/go-crypto-winnative/cng/rsa.go  |  404 +++
  .../microsoft/go-crypto-winnative/cng/sha3.go |  203 ++
- .../go-crypto-winnative/cng/tls1prf.go        |   91 +
+ .../go-crypto-winnative/cng/tls1prf.go        |   95 +
  .../internal/bcrypt/bcrypt_windows.go         |  434 +++
  .../internal/bcrypt/ntstatus_windows.go       |   45 +
  .../internal/bcrypt/zsyscall_windows.go       |  438 +++
@@ -420,7 +420,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go/cryptobackend/tls13/tls13_openssl.go   |   18 +
  .../go/cryptobackend/tls13/tls13_windows.go   |   14 +
  src/vendor/modules.txt                        |   55 +
- 412 files changed, 39651 insertions(+), 11 deletions(-)
+ 412 files changed, 39657 insertions(+), 11 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -2734,7 +2734,7 @@ index 00000000000000..d4671e1584dfa8
 +// This file is here just to declare cryptobackend dependencies.
 +// This allows tracking their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index 111f99e60629e1..1bb34e0220022e 100644
+index 111f99e60629e1..22ed4a6ad559de 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,11 +3,17 @@ module std
@@ -2745,7 +2745,7 @@ index 111f99e60629e1..1bb34e0220022e 100644
 -	golang.org/x/net v0.55.1-0.20260731170536-c1d18010be90
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f // indirect
 +	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae // indirect
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 // indirect
++	github.com/microsoft/go-crypto-winnative v0.0.0-20260821121710-8030c1795188 // indirect
 +	golang.org/x/sys v0.45.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
  )
@@ -2760,7 +2760,7 @@ index 111f99e60629e1..1bb34e0220022e 100644
 +
 +replace github.com/microsoft/go/cryptobackend => ../../cryptobackend
 diff --git a/src/go.sum b/src/go.sum
-index 20681d37cbe14c..35a399d7bcb2b4 100644
+index 20681d37cbe14c..012dd2dc4d47ae 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
@@ -2768,8 +2768,8 @@ index 20681d37cbe14c..35a399d7bcb2b4 100644
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
 +github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae h1:xSoD74/EAMa3AWS7h6+fWoBzTu4Yqh5J5X7dYdYNxkg=
 +github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825 h1:nmQ1K/L5GISW8UwbUwE376h3WXREEpREFdc3fNklcXc=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260821121710-8030c1795188 h1:hfhYN9B/qbrJCIpxMepm0zuVSSos63NeTSWvfSl9TpQ=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260821121710-8030c1795188/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
  golang.org/x/crypto v0.52.1-0.20260526024921-9beb694f9766 h1:ABD+jVg0H4Hwu2sGcUtKeb3T8mlS+jS3uWrkTAPcXjs=
  golang.org/x/crypto v0.52.1-0.20260526024921-9beb694f9766/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
  golang.org/x/net v0.55.1-0.20260731170536-c1d18010be90 h1:v8JYc8J0G5tszb4H3rnr1UU9fjQFKQLtPr8U6HjvVqI=
@@ -37660,7 +37660,7 @@ index 00000000000000..88fd1969de9735
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
 new file mode 100644
-index 00000000000000..59da3c3eeb30cb
+index 00000000000000..039749441ee9cc
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
 @@ -0,0 +1,133 @@
@@ -37777,13 +37777,13 @@ index 00000000000000..59da3c3eeb30cb
 +			Buffers: &bcrypt.Buffer{
 +				Length: uint32(len(info)),
 +				Type:   bcrypt.KDF_HKDF_INFO,
-+				Data:   uintptr(unsafe.Pointer(&info[0])),
++				Data:   unsafe.Pointer(&info[0]),
 +			},
 +		}
-+		defer runtime.KeepAlive(params)
 +	}
 +	var n uint32
 +	err = bcrypt.KeyDerivation(kh, params, out, &n, 0)
++	runtime.KeepAlive(params)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -38962,10 +38962,10 @@ index 00000000000000..f220e1d9d29794
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
 new file mode 100644
-index 00000000000000..cb9dba21416c6d
+index 00000000000000..6745bb6b6673f2
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,72 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -38977,6 +38977,7 @@ index 00000000000000..cb9dba21416c6d
 +import (
 +	"errors"
 +	"hash"
++	"runtime"
 +	"unsafe"
 +
 +	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -39008,19 +39009,19 @@ index 00000000000000..cb9dba21416c6d
 +	buffers = append(buffers,
 +		bcrypt.Buffer{
 +			Type:   bcrypt.KDF_ITERATION_COUNT,
-+			Data:   uintptr(unsafe.Pointer(&iter)),
++			Data:   unsafe.Pointer(&iter),
 +			Length: 8,
 +		},
 +		bcrypt.Buffer{
 +			Type:   bcrypt.KDF_HASH_ALGORITHM,
-+			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
++			Data:   unsafe.Pointer(&u16HashID[0]),
 +			Length: uint32(len(u16HashID) * 2),
 +		})
 +	if len(salt) > 0 {
 +		// The salt is optional.
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_SALT,
-+			Data:   uintptr(unsafe.Pointer(&salt[0])),
++			Data:   unsafe.Pointer(&salt[0]),
 +			Length: uint32(len(salt)),
 +		})
 +	}
@@ -39031,6 +39032,7 @@ index 00000000000000..cb9dba21416c6d
 +	out := make([]byte, keyLen)
 +	var size uint32
 +	err = bcrypt.KeyDerivation(kh, params, out, &size, 0)
++	runtime.KeepAlive(params)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -39762,10 +39764,10 @@ index 00000000000000..c26c4bcf0d1afe
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
 new file mode 100644
-index 00000000000000..3418bf62f22d4d
+index 00000000000000..0e93206b5013a4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,95 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -39777,6 +39779,7 @@ index 00000000000000..3418bf62f22d4d
 +import (
 +	"errors"
 +	"hash"
++	"runtime"
 +	"unsafe"
 +
 +	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -39820,14 +39823,14 @@ index 00000000000000..3418bf62f22d4d
 +	if len(label) > 0 {
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_TLS_PRF_LABEL,
-+			Data:   uintptr(unsafe.Pointer(&label[0])),
++			Data:   unsafe.Pointer(&label[0]),
 +			Length: uint32(len(label)),
 +		})
 +	}
 +	if len(seed) > 0 {
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_TLS_PRF_SEED,
-+			Data:   uintptr(unsafe.Pointer(&seed[0])),
++			Data:   unsafe.Pointer(&seed[0]),
 +			Length: uint32(len(seed)),
 +		})
 +	}
@@ -39835,16 +39838,19 @@ index 00000000000000..3418bf62f22d4d
 +		u16HashID := utf16FromString(hashID)
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_HASH_ALGORITHM,
-+			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
++			Data:   unsafe.Pointer(&u16HashID[0]),
 +			Length: uint32(len(u16HashID) * 2),
 +		})
 +	}
 +	params := &bcrypt.BufferDesc{
-+		Count:   uint32(len(buffers)),
-+		Buffers: &buffers[0],
++		Count: uint32(len(buffers)),
++	}
++	if len(buffers) > 0 {
++		params.Buffers = &buffers[0]
 +	}
 +	var size uint32
 +	err = bcrypt.KeyDerivation(kh, params, result, &size, 0)
++	runtime.KeepAlive(params)
 +	if err != nil {
 +		return err
 +	}
@@ -39859,7 +39865,7 @@ index 00000000000000..3418bf62f22d4d
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000000..7c24727f821191
+index 00000000000000..7a93ffd7eb58a9
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 @@ -0,0 +1,434 @@
@@ -39978,7 +39984,7 @@ index 00000000000000..7c24727f821191
 +type Buffer struct {
 +	Length uint32
 +	Type   uint32
-+	Data   uintptr
++	Data   unsafe.Pointer
 +}
 +
 +type BufferDesc struct {
@@ -45251,7 +45257,7 @@ index 00000000000000..b7ffeea07c6b8d
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b34527fdb12010..9f653626f97532 100644
+index b34527fdb12010..378db1df78691f 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,57 @@
@@ -45271,7 +45277,7 @@ index b34527fdb12010..9f653626f97532 100644
 +github.com/microsoft/go-crypto-openssl/internal/ossl
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/osslsetup
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20260605073512-713d2add0825
++# github.com/microsoft/go-crypto-winnative v0.0.0-20260821121710-8030c1795188
 +## explicit; go 1.25
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig


### PR DESCRIPTION
Updates go-crypto-winnative from 713d2add0825 to the latest Go 1.27 support revision, 8030c1795188.

Tests:
- pwsh eng/run.ps1 submodule-refresh -shallow
- pwsh eng/run.ps1 build
- go test github.com/microsoft/go-crypto-winnative/cng/...
- go test github.com/microsoft/go/cryptobackend/...