### PR TITLE
Bump go-crypto-winnative to latest

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -261,12 +261,12 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../microsoft/go-crypto-winnative/cng/keys.go |  220 ++
  .../go-crypto-winnative/cng/mldsa.go          |  444 +++
  .../go-crypto-winnative/cng/mlkem.go          |  405 +++
- .../go-crypto-winnative/cng/pbkdf2.go         |   74 +
+ .../go-crypto-winnative/cng/pbkdf2.go         |   76 +
  .../microsoft/go-crypto-winnative/cng/rand.go |   28 +
  .../microsoft/go-crypto-winnative/cng/rc4.go  |   65 +
  .../microsoft/go-crypto-winnative/cng/rsa.go  |  404 +++
  .../microsoft/go-crypto-winnative/cng/sha3.go |  203 ++
- .../go-crypto-winnative/cng/tls1prf.go        |   91 +
+ .../go-crypto-winnative/cng/tls1prf.go        |   95 +
  .../internal/bcrypt/authinfo_windows.go       |   21 +
  .../internal/bcrypt/authinfo_windows_386.go   |   23 +
  .../internal/bcrypt/bcrypt_windows.go         |  417 +++
@@ -424,7 +424,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go/cryptobackend/tls13/tls13_openssl.go   |   18 +
  .../go/cryptobackend/tls13/tls13_windows.go   |   14 +
  src/vendor/modules.txt                        |   55 +
- 416 files changed, 39751 insertions(+), 11 deletions(-)
+ 416 files changed, 39757 insertions(+), 11 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -2742,7 +2742,7 @@ index 00000000000000..d4671e1584dfa8
 +// This file is here just to declare cryptobackend dependencies.
 +// This allows tracking their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index d9c91d7b0dbcbb..b9ab966128818d 100644
+index d9c91d7b0dbcbb..437eb2862f0886 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,11 +3,17 @@ module std
@@ -2753,7 +2753,7 @@ index d9c91d7b0dbcbb..b9ab966128818d 100644
 -	golang.org/x/net v0.57.1-0.20260723204303-5a920b1a8090
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f // indirect
 +	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260813203406-afa6f0e831c4 // indirect
-+	github.com/microsoft/go-crypto-winnative v0.0.0-20260820121639-6c31d8dd0a62 // indirect
++	github.com/microsoft/go-crypto-winnative v0.0.0-20260821094543-418c3f76f8f8 // indirect
 +	golang.org/x/sys v0.47.0 // indirect
 +	golang.org/x/text v0.40.0 // indirect
  )
@@ -2768,7 +2768,7 @@ index d9c91d7b0dbcbb..b9ab966128818d 100644
 +
 +replace github.com/microsoft/go/cryptobackend => ../../cryptobackend
 diff --git a/src/go.sum b/src/go.sum
-index 2d4171d08a2857..fa91f87257de79 100644
+index 2d4171d08a2857..ff6ad0808a9225 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
@@ -2776,8 +2776,8 @@ index 2d4171d08a2857..fa91f87257de79 100644
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
 +github.com/microsoft/go-crypto-openssl v0.5.1-0.20260813203406-afa6f0e831c4 h1:GwGp/2YVw/jfHlhx78psGehiSXAUsOnn1spdsTIs1RQ=
 +github.com/microsoft/go-crypto-openssl v0.5.1-0.20260813203406-afa6f0e831c4/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260820121639-6c31d8dd0a62 h1:5drrAUhaq7DegGhvzlMiXNEGd8Cq2AXFHeOqUL+scz4=
-+github.com/microsoft/go-crypto-winnative v0.0.0-20260820121639-6c31d8dd0a62/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260821094543-418c3f76f8f8 h1:lrmG+TKKulC+OpxnJNxPZB/J3/owDWbWrmjGXrjWLHs=
++github.com/microsoft/go-crypto-winnative v0.0.0-20260821094543-418c3f76f8f8/go.mod h1:ic6qQ5ko8bzigvuQbGMknZ4WzS4/KDQ9cypGMdqn38s=
  golang.org/x/crypto v0.54.1-0.20260714033321-10b54ffa51b1 h1:vGPAn+SBeT/HVkWqXTwgapJgtGQJztG0WR0OTuHzMAI=
  golang.org/x/crypto v0.54.1-0.20260714033321-10b54ffa51b1/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
  golang.org/x/net v0.57.1-0.20260723204303-5a920b1a8090 h1:XtR9OCj3sl60bQa861zXyA2fXGYcpmj8o8fGZe8iCtQ=
@@ -37749,7 +37749,7 @@ index 00000000000000..88fd1969de9735
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
 new file mode 100644
-index 00000000000000..59da3c3eeb30cb
+index 00000000000000..039749441ee9cc
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/hkdf.go
 @@ -0,0 +1,133 @@
@@ -37866,13 +37866,13 @@ index 00000000000000..59da3c3eeb30cb
 +			Buffers: &bcrypt.Buffer{
 +				Length: uint32(len(info)),
 +				Type:   bcrypt.KDF_HKDF_INFO,
-+				Data:   uintptr(unsafe.Pointer(&info[0])),
++				Data:   unsafe.Pointer(&info[0]),
 +			},
 +		}
-+		defer runtime.KeepAlive(params)
 +	}
 +	var n uint32
 +	err = bcrypt.KeyDerivation(kh, params, out, &n, 0)
++	runtime.KeepAlive(params)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -39051,10 +39051,10 @@ index 00000000000000..f220e1d9d29794
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
 new file mode 100644
-index 00000000000000..dc55fee4ef2061
+index 00000000000000..66998cc9b0c93e
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/pbkdf2.go
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,76 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -39066,6 +39066,7 @@ index 00000000000000..dc55fee4ef2061
 +import (
 +	"errors"
 +	"hash"
++	"runtime"
 +	"unsafe"
 +
 +	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -39101,19 +39102,19 @@ index 00000000000000..dc55fee4ef2061
 +	buffers = append(buffers,
 +		bcrypt.Buffer{
 +			Type:   bcrypt.KDF_ITERATION_COUNT,
-+			Data:   uintptr(unsafe.Pointer(&iterations)),
++			Data:   unsafe.Pointer(&iterations),
 +			Length: 8,
 +		},
 +		bcrypt.Buffer{
 +			Type:   bcrypt.KDF_HASH_ALGORITHM,
-+			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
++			Data:   unsafe.Pointer(&u16HashID[0]),
 +			Length: uint32(len(u16HashID) * 2),
 +		})
 +	if len(salt) > 0 {
 +		// The salt is optional.
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_SALT,
-+			Data:   uintptr(unsafe.Pointer(&salt[0])),
++			Data:   unsafe.Pointer(&salt[0]),
 +			Length: uint32(len(salt)),
 +		})
 +	}
@@ -39124,6 +39125,7 @@ index 00000000000000..dc55fee4ef2061
 +	out := make([]byte, keyLen)
 +	var size uint32
 +	err = bcrypt.KeyDerivation(kh, params, out, &size, 0)
++	runtime.KeepAlive(params)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -39855,10 +39857,10 @@ index 00000000000000..c26c4bcf0d1afe
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
 new file mode 100644
-index 00000000000000..3418bf62f22d4d
+index 00000000000000..0e93206b5013a4
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/cng/tls1prf.go
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,95 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -39870,6 +39872,7 @@ index 00000000000000..3418bf62f22d4d
 +import (
 +	"errors"
 +	"hash"
++	"runtime"
 +	"unsafe"
 +
 +	"github.com/microsoft/go-crypto-winnative/internal/bcrypt"
@@ -39913,14 +39916,14 @@ index 00000000000000..3418bf62f22d4d
 +	if len(label) > 0 {
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_TLS_PRF_LABEL,
-+			Data:   uintptr(unsafe.Pointer(&label[0])),
++			Data:   unsafe.Pointer(&label[0]),
 +			Length: uint32(len(label)),
 +		})
 +	}
 +	if len(seed) > 0 {
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_TLS_PRF_SEED,
-+			Data:   uintptr(unsafe.Pointer(&seed[0])),
++			Data:   unsafe.Pointer(&seed[0]),
 +			Length: uint32(len(seed)),
 +		})
 +	}
@@ -39928,16 +39931,19 @@ index 00000000000000..3418bf62f22d4d
 +		u16HashID := utf16FromString(hashID)
 +		buffers = append(buffers, bcrypt.Buffer{
 +			Type:   bcrypt.KDF_HASH_ALGORITHM,
-+			Data:   uintptr(unsafe.Pointer(&u16HashID[0])),
++			Data:   unsafe.Pointer(&u16HashID[0]),
 +			Length: uint32(len(u16HashID) * 2),
 +		})
 +	}
 +	params := &bcrypt.BufferDesc{
-+		Count:   uint32(len(buffers)),
-+		Buffers: &buffers[0],
++		Count: uint32(len(buffers)),
++	}
++	if len(buffers) > 0 {
++		params.Buffers = &buffers[0]
 +	}
 +	var size uint32
 +	err = bcrypt.KeyDerivation(kh, params, result, &size, 0)
++	runtime.KeepAlive(params)
 +	if err != nil {
 +		return err
 +	}
@@ -40008,7 +40014,7 @@ index 00000000000000..fd70ebf36c9204
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 new file mode 100644
-index 00000000000000..cdf8c8990765da
+index 00000000000000..29ef9c8a3e3542
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-winnative/internal/bcrypt/bcrypt_windows.go
 @@ -0,0 +1,417 @@
@@ -40127,7 +40133,7 @@ index 00000000000000..cdf8c8990765da
 +type Buffer struct {
 +	Length uint32
 +	Type   uint32
-+	Data   uintptr
++	Data   unsafe.Pointer
 +}
 +
 +type BufferDesc struct {
@@ -45383,7 +45389,7 @@ index 00000000000000..b7ffeea07c6b8d
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 87a2fc95544420..ce596234fd591c 100644
+index 87a2fc95544420..c80d6261bb2a8c 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,57 @@
@@ -45403,8 +45409,8 @@ index 87a2fc95544420..ce596234fd591c 100644
 +github.com/microsoft/go-crypto-openssl/internal/ossl
 +github.com/microsoft/go-crypto-openssl/openssl
 +github.com/microsoft/go-crypto-openssl/osslsetup
-+# github.com/microsoft/go-crypto-winnative v0.0.0-20260820121639-6c31d8dd0a62
-+## explicit; go 1.25
++# github.com/microsoft/go-crypto-winnative v0.0.0-20260821094543-418c3f76f8f8
++## explicit; go 1.26
 +github.com/microsoft/go-crypto-winnative/cng
 +github.com/microsoft/go-crypto-winnative/cng/bbig
 +github.com/microsoft/go-crypto-winnative/internal/bcrypt


### PR DESCRIPTION
Updates go-crypto-winnative from 6c31d8dd0a62 to 418c3f76f8f8.

Tests:
- pwsh eng/run.ps1 submodule-refresh -shallow
- pwsh eng/run.ps1 build
- go test github.com/microsoft/go-crypto-winnative/cng/...
- go test github.com/microsoft/go/cryptobackend/...