### PR TITLE
[release-branch.go1.26] Suppress follow-on systemcrypto errors without cgo

### DIFF
--- a/patches/0003-Implement-crypto-internal-backend.patch
+++ b/patches/0003-Implement-crypto-internal-backend.patch
@@ -18,7 +18,7 @@ desired goexperiments and build tags.
  src/cmd/go/internal/cfg/cfg.go                |  16 +
  src/cmd/go/internal/load/pkg.go               |   3 +
  src/cmd/go/internal/tool/tool.go              |   9 +-
- src/cmd/go/systemcrypto_test.go               | 258 +++++++++++
+ src/cmd/go/systemcrypto_test.go               | 267 +++++++++++
  .../go/testdata/script/env_cross_build.txt    |   2 +
  .../script/test_android_issue62123.txt        |   2 +
  src/cmd/internal/testdir/testdir_test.go      |   7 +
@@ -53,7 +53,7 @@ desired goexperiments and build tags.
  src/internal/buildcfg/exp.go                  |  77 ++++
  src/runtime/runtime_boring.go                 |   5 +
  src/syscall/exec_linux_test.go                |   4 +
- 44 files changed, 2782 insertions(+), 16 deletions(-)
+ 44 files changed, 2791 insertions(+), 16 deletions(-)
  create mode 100644 src/cmd/go/systemcrypto_test.go
  create mode 100644 src/crypto/internal/backend/backend_test.go
  create mode 100644 src/crypto/internal/backend/bbig/big.go
@@ -446,10 +446,10 @@ index 92e8a803105f8d..95d47b625c28a7 100644
  	buildAndRunTool(loaderstate, ctx, tool, args, runFunc)
 diff --git a/src/cmd/go/systemcrypto_test.go b/src/cmd/go/systemcrypto_test.go
 new file mode 100644
-index 00000000000000..552ce078e780fb
+index 00000000000000..0751bbb2f1aa57
 --- /dev/null
 +++ b/src/cmd/go/systemcrypto_test.go
-@@ -0,0 +1,258 @@
+@@ -0,0 +1,267 @@
 +// Copyright 2025 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -568,11 +568,20 @@ index 00000000000000..552ce078e780fb
 +				tc.goexp += ",systemcrypto"
 +			}
 +			env := []string{"CGO_ENABLED=0", "GOOS=" + tc.goos, "GOARCH=" + tc.goarch, "GOEXPERIMENT=" + tc.goexp, "MS_GO_NOSYSTEMCRYPTO=0"}
-+			if out, ok := execGoTool(t, true, env, "build", "-o", outPath(t), cryptoFile); ok != tc.succeed {
++			out, ok := execGoTool(t, true, env, "build", "-o", outPath(t), cryptoFile)
++			if ok != tc.succeed {
 +				if tc.succeed {
 +					t.Fatalf("expected success, got failure: %s", out)
 +				} else {
 +					t.Fatalf("expected failure, got success")
++				}
++			}
++			if !tc.succeed && tc.goos == "linux" {
++				if !strings.Contains(out, "Using GOEXPERIMENT=systemcrypto on Linux requires CGO_ENABLED=1") {
++					t.Errorf("missing CGO diagnostic in output:\n%s", out)
++				}
++				if strings.Contains(out, "crypto/internal/backend/fips140") {
++					t.Errorf("unexpected FIPS backend diagnostic in output:\n%s", out)
 +				}
 +			}
 +		})
@@ -2023,7 +2032,7 @@ index 00000000000000..6f01b9a3524dee
 \ No newline at end of file
 diff --git a/src/crypto/internal/backend/fips140/nosystemcrypto.go b/src/crypto/internal/backend/fips140/nosystemcrypto.go
 new file mode 100644
-index 00000000000000..289d6594eac54b
+index 00000000000000..4aa6eebf6e50a8
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/nosystemcrypto.go
 @@ -0,0 +1,13 @@
@@ -2031,7 +2040,7 @@ index 00000000000000..289d6594eac54b
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
 +
-+//go:build !goexperiment.systemcrypto
++//go:build !goexperiment.systemcrypto || (goexperiment.opensslcrypto && !(cgo || goexperiment.ms_nocgo_opensslcrypto))
 +
 +package fips140
 +
@@ -2042,7 +2051,7 @@ index 00000000000000..289d6594eac54b
 +}
 diff --git a/src/crypto/internal/backend/fips140/openssl.go b/src/crypto/internal/backend/fips140/openssl.go
 new file mode 100644
-index 00000000000000..dff5387b547c48
+index 00000000000000..26491e7be3e2ed
 --- /dev/null
 +++ b/src/crypto/internal/backend/fips140/openssl.go
 @@ -0,0 +1,59 @@
@@ -2725,7 +2734,7 @@ index 00000000000000..c8f281d7fd1274
 +}
 diff --git a/src/crypto/internal/backend/openssl_linux.go b/src/crypto/internal/backend/openssl_linux.go
 new file mode 100644
-index 00000000000000..05a101496fcc1a
+index 00000000000000..d63c3d97369e45
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl_linux.go
 @@ -0,0 +1,424 @@


### PR DESCRIPTION
When systemcrypto is requested on Linux with CGO disabled, select the inert FIPS backend alongside the existing no-backend implementation. This preserves the intended CGO diagnostic while preventing follow-on undefined-symbol errors from crypto/internal/backend/fips140.

The cmd/go regression test now verifies that the CGO diagnostic is present and no FIPS backend diagnostic is emitted.

Tested with:

```
go test cmd/go -run '^TestSystemCryptoNoCgoChecks$' -count=1
```

Fixes #2473

