### PR TITLE
[release-branch.go1.27] Support ML-KEM with OpenSSL 3.3

### DIFF
--- a/patches/0001-Vendor-external-dependencies.patch
+++ b/patches/0001-Vendor-external-dependencies.patch
@@ -128,7 +128,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/fakecgo/abi_riscv64.h            |   74 +
  .../internal/fakecgo/asm_386.s                |   31 +
  .../internal/fakecgo/asm_amd64.s              |   41 +
- .../internal/fakecgo/asm_arm.s                |   52 +
+ .../internal/fakecgo/asm_arm.s                |   60 +
  .../internal/fakecgo/asm_arm64.s              |   37 +
  .../internal/fakecgo/asm_loong64.s            |   40 +
  .../internal/fakecgo/asm_ppc64le.s            |   81 +
@@ -139,10 +139,10 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/fakecgo/fakecgo.lock             |    3 +
  .../internal/fakecgo/freebsd.go               |   29 +
  .../internal/fakecgo/generate.go              |    6 +
- .../internal/fakecgo/go_darwin.go             |   90 +
- .../internal/fakecgo/go_freebsd.go            |   81 +
+ .../internal/fakecgo/go_darwin.go             |   88 +
+ .../internal/fakecgo/go_freebsd.go            |   79 +
  .../internal/fakecgo/go_libinit.go            |   74 +
- .../internal/fakecgo/go_linux.go              |   81 +
+ .../internal/fakecgo/go_linux.go              |   79 +
  .../internal/fakecgo/go_setenv.go             |   20 +
  .../internal/fakecgo/go_util.go               |   40 +
  .../internal/fakecgo/iscgo.go                 |   21 +
@@ -152,9 +152,11 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/fakecgo/libcgo_linux.go          |   22 +
  .../internal/fakecgo/linux.go                 |  186 ++
  .../internal/fakecgo/setenv.go                |   21 +
+ .../internal/fakecgo/threadentry_amd64.go     |   17 +
+ .../internal/fakecgo/threadentry_noasm.go     |   26 +
  .../internal/fakecgo/trampolines_386.s        |  123 +
- .../internal/fakecgo/trampolines_amd64.s      |  109 +
- .../internal/fakecgo/trampolines_arm.s        |  124 +
+ .../internal/fakecgo/trampolines_amd64.s      |  126 +
+ .../internal/fakecgo/trampolines_arm.s        |  133 +
  .../internal/fakecgo/trampolines_arm64.s      |   83 +
  .../internal/fakecgo/trampolines_linux_386.s  |   80 +
  .../fakecgo/trampolines_linux_amd64.s         |   71 +
@@ -190,7 +192,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/ossl/errors_cgo.go               |   33 +
  .../internal/ossl/errors_nocgo.go             |   19 +
  .../go-crypto-openssl/internal/ossl/ossl.go   |   62 +
- .../go-crypto-openssl/internal/ossl/shims.h   |  448 +++
+ .../go-crypto-openssl/internal/ossl/shims.h   |  438 +++
  .../internal/ossl/syscall_nocgo.go            |   87 +
  .../internal/ossl/syscall_nocgo_darwin.go     |    8 +
  .../internal/ossl/syscall_nocgo_freebsd.go    |    8 +
@@ -199,16 +201,16 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../internal/ossl/syscall_nocgo_windows.go    |   25 +
  .../go-crypto-openssl/internal/ossl/zdl.s     |   58 +
  .../internal/ossl/zdl_nocgo.go                |   61 +
- .../go-crypto-openssl/internal/ossl/zossl.c   | 2101 ++++++++++++++
- .../go-crypto-openssl/internal/ossl/zossl.go  |   76 +
- .../go-crypto-openssl/internal/ossl/zossl.h   |  377 +++
- .../internal/ossl/zossl_cgo.go                | 1527 ++++++++++
- .../internal/ossl/zossl_nocgo.go              | 2501 +++++++++++++++++
+ .../go-crypto-openssl/internal/ossl/zossl.c   | 2110 ++++++++++++++
+ .../go-crypto-openssl/internal/ossl/zossl.go  |   66 +
+ .../go-crypto-openssl/internal/ossl/zossl.h   |  368 +++
+ .../internal/ossl/zossl_cgo.go                | 1533 ++++++++++
+ .../internal/ossl/zossl_nocgo.go              | 2511 +++++++++++++++++
  .../go-crypto-openssl/openssl/aes.go          |  158 ++
  .../go-crypto-openssl/openssl/big.go          |   14 +
  .../openssl/chacha20poly1305.go               |  152 +
  .../go-crypto-openssl/openssl/cipher.go       |  690 +++++
- .../go-crypto-openssl/openssl/const.go        |  115 +
+ .../go-crypto-openssl/openssl/const.go        |  116 +
  .../go-crypto-openssl/openssl/cshake.go       |  256 ++
  .../go-crypto-openssl/openssl/des.go          |  121 +
  .../go-crypto-openssl/openssl/dsa.go          |  296 ++
@@ -216,11 +218,11 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go-crypto-openssl/openssl/ecdh.go         |  331 +++
  .../go-crypto-openssl/openssl/ecdsa.go        |  212 ++
  .../go-crypto-openssl/openssl/ed25519.go      |  209 ++
- .../go-crypto-openssl/openssl/evp.go          |  634 +++++
+ .../go-crypto-openssl/openssl/evp.go          |  624 ++++
  .../go-crypto-openssl/openssl/hash.go         |  518 ++++
  .../go-crypto-openssl/openssl/hkdf.go         |  312 ++
  .../go-crypto-openssl/openssl/hmac.go         |  269 ++
- .../go-crypto-openssl/openssl/mldsa.go        |  499 ++++
+ .../go-crypto-openssl/openssl/mldsa.go        |  495 ++++
  .../go-crypto-openssl/openssl/mlkem.go        |  369 +++
  .../go-crypto-openssl/openssl/openssl.go      |  182 ++
  .../go-crypto-openssl/openssl/openssl_cgo.go  |   17 +
@@ -420,7 +422,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  .../go/cryptobackend/tls13/tls13_openssl.go   |   18 +
  .../go/cryptobackend/tls13/tls13_windows.go   |   14 +
  src/vendor/modules.txt                        |   55 +
- 412 files changed, 39657 insertions(+), 11 deletions(-)
+ 414 files changed, 39711 insertions(+), 11 deletions(-)
  create mode 100644 src/cmd/internal/telemetry/counter/deps_ignore.go
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/LICENSE
  create mode 100644 src/cmd/vendor/github.com/microsoft/go-infra/telemetry/README.md
@@ -558,6 +560,8 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/libcgo_linux.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/linux.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/setenv.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/threadentry_amd64.go
+ create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/threadentry_noasm.go
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_386.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_amd64.s
  create mode 100644 src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s
@@ -827,7 +831,7 @@ Use a 'go' that was recently built by the current branch to ensure stable result
  create mode 100644 src/vendor/github.com/microsoft/go/cryptobackend/tls13/tls13_windows.go
 
 diff --git a/src/cmd/go.mod b/src/cmd/go.mod
-index c3e7be5ccd4fd7..a3e96b32d6a962 100644
+index 523528eae2e7c8..b0ecd9def64e2d 100644
 --- a/src/cmd/go.mod
 +++ b/src/cmd/go.mod
 @@ -4,6 +4,8 @@ go 1.27
@@ -840,7 +844,7 @@ index c3e7be5ccd4fd7..a3e96b32d6a962 100644
  	golang.org/x/build v0.0.0-20260522210304-d55d0041b921
  	golang.org/x/mod v0.36.1-0.20260813213634-8569e2639ca1
 diff --git a/src/cmd/go.sum b/src/cmd/go.sum
-index 504ca7c63c0213..356b4b45a3d8c2 100644
+index 12edd38b08e27f..f2d42bbac1b3f8 100644
 --- a/src/cmd/go.sum
 +++ b/src/cmd/go.sum
 @@ -4,6 +4,10 @@ github.com/google/pprof v0.0.0-20260507013755-92041b743c96 h1:YDDnaZ9afWajDboPMt
@@ -2666,7 +2670,7 @@ index 00000000000000..016de9bdd95956
 +	return filtered
 +}
 diff --git a/src/cmd/vendor/modules.txt b/src/cmd/vendor/modules.txt
-index 9dd15064276d3b..8aac6bff803737 100644
+index 27220d946fe80e..e3e5a7a01ad679 100644
 --- a/src/cmd/vendor/modules.txt
 +++ b/src/cmd/vendor/modules.txt
 @@ -16,6 +16,17 @@ github.com/google/pprof/third_party/svgpan
@@ -2734,7 +2738,7 @@ index 00000000000000..d4671e1584dfa8
 +// This file is here just to declare cryptobackend dependencies.
 +// This allows tracking their versions in a single patch file.
 diff --git a/src/go.mod b/src/go.mod
-index 111f99e60629e1..22ed4a6ad559de 100644
+index 111f99e60629e1..3d035598cfc842 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,11 +3,17 @@ module std
@@ -2744,7 +2748,7 @@ index 111f99e60629e1..22ed4a6ad559de 100644
 -	golang.org/x/crypto v0.52.1-0.20260526024921-9beb694f9766
 -	golang.org/x/net v0.55.1-0.20260731170536-c1d18010be90
 +	github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f // indirect
-+	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae // indirect
++	github.com/microsoft/go-crypto-openssl v0.5.1-0.20260904065618-5fd04832939d // indirect
 +	github.com/microsoft/go-crypto-winnative v0.0.0-20260821121710-8030c1795188 // indirect
 +	golang.org/x/sys v0.45.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
@@ -2760,14 +2764,14 @@ index 111f99e60629e1..22ed4a6ad559de 100644
 +
 +replace github.com/microsoft/go/cryptobackend => ../../cryptobackend
 diff --git a/src/go.sum b/src/go.sum
-index 20681d37cbe14c..012dd2dc4d47ae 100644
+index 20681d37cbe14c..820f0af0e000e6 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,9 @@
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f h1:ksW7MznRoTYAoBaNIKyjqxR0Tp0aUqY1eALRaerngnk=
 +github.com/microsoft/go-crypto-darwin v0.0.3-0.20260619075948-e554deeefa9f/go.mod h1:QahyqOoEDhEJ08aC1WtiWq691LyNgXq3qrjI4QmdPzM=
-+github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae h1:xSoD74/EAMa3AWS7h6+fWoBzTu4Yqh5J5X7dYdYNxkg=
-+github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
++github.com/microsoft/go-crypto-openssl v0.5.1-0.20260904065618-5fd04832939d h1:hhPXjMzZjkHpVfitQiN82G7MmeeTUk1gVBqovtENZEw=
++github.com/microsoft/go-crypto-openssl v0.5.1-0.20260904065618-5fd04832939d/go.mod h1:gJrjX+yWGi9pkbfPVDDh+ZbgjtQoRSXHjb/ZyjwKk34=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260821121710-8030c1795188 h1:hfhYN9B/qbrJCIpxMepm0zuVSSos63NeTSWvfSl9TpQ=
 +github.com/microsoft/go-crypto-winnative v0.0.0-20260821121710-8030c1795188/go.mod h1:a1Z07CJIuWa8WT/pzFIGNTTKS96s8o1B1TPOziAHUxw=
  golang.org/x/crypto v0.52.1-0.20260526024921-9beb694f9766 h1:ABD+jVg0H4Hwu2sGcUtKeb3T8mlS+jS3uWrkTAPcXjs=
@@ -15159,10 +15163,10 @@ index 00000000000000..623852da4937cb
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s
 new file mode 100644
-index 00000000000000..2a24150b337120
+index 00000000000000..f7a1d32b51b88f
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/asm_arm.s
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,60 @@
 +// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
 +
 +// Copyright 2012 The Go Authors. All rights reserved.
@@ -15188,8 +15192,11 @@ index 00000000000000..2a24150b337120
 +	// starting at 4(R13).
 +	MOVW.W R14, -4(R13)
 +
++	// Skip floating point registers if runtime.goarmsoftfp!=0.
++	MOVB    runtime·goarmsoftfp(SB), R11
++	CMP     $0, R11
++	BNE     skipfpsave
 +	// Save VFP callee-saved registers D8-D15 (same as S16-S31).
-+	// Note: We always save these since we target hard-float ABI.
 +	MOVD F8, (13*4+8*1)(R13)
 +	MOVD F9, (13*4+8*2)(R13)
 +	MOVD F10, (13*4+8*3)(R13)
@@ -15199,9 +15206,13 @@ index 00000000000000..2a24150b337120
 +	MOVD F14, (13*4+8*7)(R13)
 +	MOVD F15, (13*4+8*8)(R13)
 +
++skipfpsave:
 +	// We set up the arguments to cgocallback when saving registers above.
 +	BL runtime·cgocallback(SB)
 +
++	MOVB    runtime·goarmsoftfp(SB), R11
++	CMP     $0, R11
++	BNE     skipfprest
 +	MOVD (13*4+8*1)(R13), F8
 +	MOVD (13*4+8*2)(R13), F9
 +	MOVD (13*4+8*3)(R13), F10
@@ -15211,6 +15222,7 @@ index 00000000000000..2a24150b337120
 +	MOVD (13*4+8*7)(R13), F14
 +	MOVD (13*4+8*8)(R13), F15
 +
++skipfprest:
 +	MOVW.P   4(R13), R14
 +	MOVM.IAW (R13), [R0, R1, R3, R4, R5, R6, R7, R8, R9, g, R11, R12]
 +	ADD      $(8*9), R13
@@ -15620,12 +15632,12 @@ index 00000000000000..17c6f83475ce5e
 +func call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 new file mode 100644
-index 00000000000000..b835f8a4ac2e89
+index 00000000000000..994a32ad9332b8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/fakecgo.lock
 @@ -0,0 +1,3 @@
 +{
-+  "commit_hash": "d476432ce7e3d8bb64b7cd257d332ee221ed6e7b"
++  "commit_hash": "f9d41fc60f1f296d730749174bd3bec93c1ea13c"
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/freebsd.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/freebsd.go
 new file mode 100644
@@ -15676,10 +15688,10 @@ index 00000000000000..88c4cdf9ec04cc
 +//go:generate go run update_tool.go
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_darwin.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_darwin.go
 new file mode 100644
-index 00000000000000..e49117058f381e
+index 00000000000000..45b3a058e2b5f1
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_darwin.go
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,88 @@
 +// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
 +
 +// Copyright 2011 The Go Authors. All rights reserved.
@@ -15739,9 +15751,7 @@ index 00000000000000..e49117058f381e
 +	//#endif
 +	setg_trampoline(setg_func, uintptr(unsafe.Pointer(ts.g)))
 +
-+	// faking funcs in go is a bit a... involved - but the following works :)
-+	fn := uintptr(unsafe.Pointer(&ts.fn))
-+	(*(*func())(unsafe.Pointer(&fn)))()
++	callThreadEntryFn(ts.fn)
 +
 +	return nil
 +}
@@ -15772,10 +15782,10 @@ index 00000000000000..e49117058f381e
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_freebsd.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_freebsd.go
 new file mode 100644
-index 00000000000000..37c6b50e2e6e85
+index 00000000000000..92f946ddbbf415
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_freebsd.go
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,79 @@
 +// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
 +
 +// Copyright 2011 The Go Authors. All rights reserved.
@@ -15829,9 +15839,7 @@ index 00000000000000..37c6b50e2e6e85
 +
 +	setg_trampoline(setg_func, uintptr(unsafe.Pointer(ts.g)))
 +
-+	// faking funcs in go is a bit a... involved - but the following works :)
-+	fn := uintptr(unsafe.Pointer(&ts.fn))
-+	(*(*func())(unsafe.Pointer(&fn)))()
++	callThreadEntryFn(ts.fn)
 +
 +	return nil
 +}
@@ -15939,10 +15947,10 @@ index 00000000000000..38ba01bb4f273d
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_linux.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_linux.go
 new file mode 100644
-index 00000000000000..2018c6dc2e1b85
+index 00000000000000..781915f77d67c9
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/go_linux.go
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,79 @@
 +// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
 +
 +// Copyright 2011 The Go Authors. All rights reserved.
@@ -15996,9 +16004,7 @@ index 00000000000000..2018c6dc2e1b85
 +
 +	setg_trampoline(setg_func, uintptr(unsafe.Pointer(ts.g)))
 +
-+	// faking funcs in go is a bit a... involved - but the following works :)
-+	fn := uintptr(unsafe.Pointer(&ts.fn))
-+	(*(*func())(unsafe.Pointer(&fn)))()
++	callThreadEntryFn(ts.fn)
 +
 +	return nil
 +}
@@ -16479,6 +16485,61 @@ index 00000000000000..30b9e8eb88c83d
 +//go:linkname _cgo_unsetenv runtime._cgo_unsetenv
 +var x_cgo_unsetenv_trampoline byte
 +var _cgo_unsetenv = &x_cgo_unsetenv_trampoline
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/threadentry_amd64.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/threadentry_amd64.go
+new file mode 100644
+index 00000000000000..5c5b4625b90f62
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/threadentry_amd64.go
+@@ -0,0 +1,17 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
++
++//go:build !cgo && amd64 && (darwin || freebsd || linux)
++
++package fakecgo
++
++// callThreadEntryFn calls fn (runtime.mstart) while saving and restoring the
++// frame pointer and other callee-saved registers around the call. mstart
++// returns with BP clobbered, so without this shim the caller's frame-pointer
++// epilogue would fault. Implemented in trampolines_amd64.s.
++//
++//go:nosplit
++//go:norace
++func callThreadEntryFn(fn uintptr)
+diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/threadentry_noasm.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/threadentry_noasm.go
+new file mode 100644
+index 00000000000000..f73a6cd2d6780b
+--- /dev/null
++++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/threadentry_noasm.go
+@@ -0,0 +1,26 @@
++// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
++
++// SPDX-License-Identifier: Apache-2.0
++// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
++
++//go:build !cgo && !amd64 && (darwin || freebsd || linux)
++
++package fakecgo
++
++import "unsafe"
++
++// callThreadEntryFn calls fn (runtime.mstart). On architectures without the
++// amd64 frame-pointer epilogue issue this is a plain indirect call. It must be
++// nosplit and norace like the threadentry callers so it neither inserts a
++// morestack preamble nor runs race instrumentation during the fragile
++// thread-bootstrap window.
++//
++//go:nosplit
++//go:norace
++func callThreadEntryFn(fn uintptr) {
++	// fn is the code pointer. Build a func value whose first word is fn by
++	// pointing the closure at &fn, then call it (same trick fakecgo has always
++	// used to call a raw PC from Go).
++	fnPtr := uintptr(unsafe.Pointer(&fn))
++	(*(*func())(unsafe.Pointer(&fnPtr)))()
++}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_386.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_386.s
 new file mode 100644
 index 00000000000000..80a9e968c6a8cd
@@ -16610,10 +16671,10 @@ index 00000000000000..80a9e968c6a8cd
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_amd64.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_amd64.s
 new file mode 100644
-index 00000000000000..049e2bbb1e7f44
+index 00000000000000..f6f09c6b2fc7d6
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_amd64.s
-@@ -0,0 +1,109 @@
+@@ -0,0 +1,126 @@
 +// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -16701,6 +16762,23 @@ index 00000000000000..049e2bbb1e7f44
 +	POP_REGS_HOST_TO_ABI0()
 +	RET
 +
++// func callThreadEntryFn(fn uintptr)
++// Calls fn (runtime.mstart) with the frame pointer and other callee-saved
++// registers saved on the stack across the call. mstart returns with BP
++// clobbered (BP==0); saving/restoring BP here (as real cgo's crosscall does)
++// keeps the caller's frame-pointer LEAVE epilogue valid on return.
++TEXT ·callThreadEntryFn(SB), NOSPLIT, $0-8
++	MOVQ fn+0(FP), R11
++	PUSH_REGS_HOST_TO_ABI0()
++
++	// X15 is designated by Go as a fixed zero register.
++	PXOR X15, X15
++
++	CALL R11
++
++	POP_REGS_HOST_TO_ABI0()
++	RET
++
 +TEXT ·call5(SB), NOSPLIT, $0-56
 +	MOVQ fn+0(FP), R11
 +	MOVQ a1+8(FP), DI
@@ -16725,10 +16803,10 @@ index 00000000000000..049e2bbb1e7f44
 +	RET
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s
 new file mode 100644
-index 00000000000000..ae989a4e0e18c9
+index 00000000000000..03bc68c27bd564
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/fakecgo/trampolines_arm.s
-@@ -0,0 +1,124 @@
+@@ -0,0 +1,133 @@
 +// Code generated by update_tool.go from ebitengine/purego; DO NOT EDIT.
 +
 +// SPDX-License-Identifier: Apache-2.0
@@ -16803,6 +16881,10 @@ index 00000000000000..ae989a4e0e18c9
 +	MOVW g, 32(R13)   // R10
 +	MOVW R11, 36(R13)
 +
++	// Skip floating point registers if runtime.goarmsoftfp!=0.
++	MOVB    runtime·goarmsoftfp(SB), R11
++	CMP     $0, R11
++	BNE     skipfpsave
 +	MOVD F8, 40(R13)
 +	MOVD F9, 48(R13)
 +	MOVD F10, 56(R13)
@@ -16812,10 +16894,14 @@ index 00000000000000..ae989a4e0e18c9
 +	MOVD F14, 88(R13)
 +	MOVD F15, 96(R13)
 +
++skipfpsave:
 +	MOVW ·threadentry_call(SB), R12
 +	MOVW (R12), R12
 +	CALL (R12)
 +
++	MOVB    runtime·goarmsoftfp(SB), R11
++	CMP     $0, R11
++	BNE     skipfprest
 +	MOVD 40(R13), F8
 +	MOVD 48(R13), F9
 +	MOVD 56(R13), F10
@@ -16825,6 +16911,7 @@ index 00000000000000..ae989a4e0e18c9
 +	MOVD 88(R13), F14
 +	MOVD 96(R13), F15
 +
++skipfprest:
 +	MOVW 8(R13), R4
 +	MOVW 12(R13), R5
 +	MOVW 16(R13), R6
@@ -19816,10 +19903,10 @@ index 00000000000000..9acac55865dc17
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/shims.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/shims.h
 new file mode 100644
-index 00000000000000..f5f4918ac54163
+index 00000000000000..da75eb1a802a52
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/shims.h
-@@ -0,0 +1,448 @@
+@@ -0,0 +1,438 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -19876,11 +19963,6 @@ index 00000000000000..f5f4918ac54163
 +	_EVP_PKEY_HKDF        = 1036,
 +	_EVP_PKEY_ED25519     = 1087,
 +	_EVP_PKEY_DSA         = 116,
-+    _EVP_PKEY_MLKEM_768  = 1455,
-+    _EVP_PKEY_MLKEM_1024 = 1456,
-+    _EVP_PKEY_ML_DSA_44  = 1457,
-+    _EVP_PKEY_ML_DSA_65  = 1458,
-+    _EVP_PKEY_ML_DSA_87  = 1459,
 +	_EVP_PKEY_OP_DERIVE = (1 << 10), // this value differs between OpenSSL 1 and 3, but we only use it in 1
 +	_EVP_MAX_MD_SIZE    = 64,
 +
@@ -19907,12 +19989,6 @@ index 00000000000000..f5f4918ac54163
 +	_NID_secp224r1        = 713,
 +	_NID_secp384r1        = 715,
 +	_NID_secp521r1        = 716,
-+
-+	_NID_ML_KEM_768 = 1455,
-+	_NID_ML_KEM_1024 = 1456,
-+	_NID_ML_DSA_44 = 1457,
-+	_NID_ML_DSA_65 = 1458,
-+	_NID_ML_DSA_87 = 1459,
 +
 +	_RSA_PKCS1_PADDING                 = 1,
 +	_RSA_NO_PADDING                    = 3,
@@ -20161,6 +20237,7 @@ index 00000000000000..f5f4918ac54163
 +
 +_EVP_PKEY_CTX_PTR EVP_PKEY_CTX_new(_EVP_PKEY_PTR arg0, _ENGINE_PTR arg1);
 +_EVP_PKEY_CTX_PTR EVP_PKEY_CTX_new_id(int id, _ENGINE_PTR e);
++_EVP_PKEY_CTX_PTR EVP_PKEY_CTX_new_from_name(_OSSL_LIB_CTX_PTR libctx, const char *name, const char *propquery) __attribute__((tag("3")));
 +_EVP_PKEY_CTX_PTR EVP_PKEY_CTX_new_from_pkey(_OSSL_LIB_CTX_PTR libctx, _EVP_PKEY_PTR pkey, const char *propquery) __attribute__((tag("3")));
 +void EVP_PKEY_CTX_free(_EVP_PKEY_CTX_PTR arg0);
 +int EVP_PKEY_CTX_ctrl(_EVP_PKEY_CTX_PTR ctx, int keytype, int optype, int cmd, int p1, void *p2);
@@ -20596,10 +20673,10 @@ index 00000000000000..7d382b9a5c288c
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.c b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.c
 new file mode 100644
-index 00000000000000..18c2978e636dc8
+index 00000000000000..b5eeb856f43247
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.c
-@@ -0,0 +1,2101 @@
+@@ -0,0 +1,2110 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -20726,6 +20803,7 @@ index 00000000000000..18c2978e636dc8
 +int (*_g_EVP_PKEY_CTX_ctrl)(_EVP_PKEY_CTX_PTR, int, int, int, int, void*);
 +void (*_g_EVP_PKEY_CTX_free)(_EVP_PKEY_CTX_PTR);
 +_EVP_PKEY_CTX_PTR (*_g_EVP_PKEY_CTX_new)(_EVP_PKEY_PTR, _ENGINE_PTR);
++_EVP_PKEY_CTX_PTR (*_g_EVP_PKEY_CTX_new_from_name)(_OSSL_LIB_CTX_PTR, const char*, const char*);
 +_EVP_PKEY_CTX_PTR (*_g_EVP_PKEY_CTX_new_from_pkey)(_OSSL_LIB_CTX_PTR, _EVP_PKEY_PTR, const char*);
 +_EVP_PKEY_CTX_PTR (*_g_EVP_PKEY_CTX_new_id)(int, _ENGINE_PTR);
 +int (*_g_EVP_PKEY_CTX_set0_rsa_oaep_label)(_EVP_PKEY_CTX_PTR, unsigned char*, int);
@@ -21136,6 +21214,7 @@ index 00000000000000..18c2978e636dc8
 +	__mkcgo__dlsym(EVP_MD_get_size)
 +	__mkcgo__dlsym(EVP_MD_get_type)
 +	__mkcgo__dlsym(EVP_PKEY_CTX_add1_hkdf_info)
++	__mkcgo__dlsym(EVP_PKEY_CTX_new_from_name)
 +	__mkcgo__dlsym(EVP_PKEY_CTX_new_from_pkey)
 +	__mkcgo__dlsym(EVP_PKEY_CTX_set0_rsa_oaep_label)
 +	__mkcgo__dlsym(EVP_PKEY_CTX_set1_hkdf_key)
@@ -21213,6 +21292,7 @@ index 00000000000000..18c2978e636dc8
 +	_g_EVP_MD_get_size = NULL;
 +	_g_EVP_MD_get_type = NULL;
 +	_g_EVP_PKEY_CTX_add1_hkdf_info = NULL;
++	_g_EVP_PKEY_CTX_new_from_name = NULL;
 +	_g_EVP_PKEY_CTX_new_from_pkey = NULL;
 +	_g_EVP_PKEY_CTX_set0_rsa_oaep_label = NULL;
 +	_g_EVP_PKEY_CTX_set1_hkdf_key = NULL;
@@ -21997,6 +22077,12 @@ index 00000000000000..18c2978e636dc8
 +	return _ret;
 +}
 +
++_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_from_name(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, uintptr_t *_err_state) {
++	_EVP_PKEY_CTX_PTR _ret = _g_EVP_PKEY_CTX_new_from_name(_arg0, _arg1, _arg2);
++	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
++	return _ret;
++}
++
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_from_pkey(_OSSL_LIB_CTX_PTR _arg0, _EVP_PKEY_PTR _arg1, const char* _arg2, uintptr_t *_err_state) {
 +	_EVP_PKEY_CTX_PTR _ret = _g_EVP_PKEY_CTX_new_from_pkey(_arg0, _arg1, _arg2);
 +	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
@@ -22703,10 +22789,10 @@ index 00000000000000..18c2978e636dc8
 +
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.go
 new file mode 100644
-index 00000000000000..a73b6a785f0265
+index 00000000000000..07becbaa309233
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.go
-@@ -0,0 +1,76 @@
+@@ -0,0 +1,66 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -22733,11 +22819,6 @@ index 00000000000000..a73b6a785f0265
 +	EVP_PKEY_HKDF                       = 1036
 +	EVP_PKEY_ED25519                    = 1087
 +	EVP_PKEY_DSA                        = 116
-+	EVP_PKEY_MLKEM_768                  = 1455
-+	EVP_PKEY_MLKEM_1024                 = 1456
-+	EVP_PKEY_ML_DSA_44                  = 1457
-+	EVP_PKEY_ML_DSA_65                  = 1458
-+	EVP_PKEY_ML_DSA_87                  = 1459
 +	EVP_PKEY_OP_DERIVE                  = (1 << 10)
 +	EVP_MAX_MD_SIZE                     = 64
 +	EVP_PKEY_PUBLIC_KEY                 = 0x86
@@ -22758,11 +22839,6 @@ index 00000000000000..a73b6a785f0265
 +	NID_secp224r1                       = 713
 +	NID_secp384r1                       = 715
 +	NID_secp521r1                       = 716
-+	NID_ML_KEM_768                      = 1455
-+	NID_ML_KEM_1024                     = 1456
-+	NID_ML_DSA_44                       = 1457
-+	NID_ML_DSA_65                       = 1458
-+	NID_ML_DSA_87                       = 1459
 +	RSA_PKCS1_PADDING                   = 1
 +	RSA_NO_PADDING                      = 3
 +	RSA_PKCS1_OAEP_PADDING              = 4
@@ -22785,10 +22861,10 @@ index 00000000000000..a73b6a785f0265
 +)
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.h b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.h
 new file mode 100644
-index 00000000000000..95ba94df4e1c49
+index 00000000000000..0de25673891992
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl.h
-@@ -0,0 +1,377 @@
+@@ -0,0 +1,368 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -22849,11 +22925,6 @@ index 00000000000000..95ba94df4e1c49
 +	_EVP_PKEY_HKDF = 1036,
 +	_EVP_PKEY_ED25519 = 1087,
 +	_EVP_PKEY_DSA = 116,
-+	_EVP_PKEY_MLKEM_768 = 1455,
-+	_EVP_PKEY_MLKEM_1024 = 1456,
-+	_EVP_PKEY_ML_DSA_44 = 1457,
-+	_EVP_PKEY_ML_DSA_65 = 1458,
-+	_EVP_PKEY_ML_DSA_87 = 1459,
 +	_EVP_PKEY_OP_DERIVE = (1 << 10),
 +	_EVP_MAX_MD_SIZE = 64,
 +	_EVP_PKEY_PUBLIC_KEY = 0x86,
@@ -22874,11 +22945,6 @@ index 00000000000000..95ba94df4e1c49
 +	_NID_secp224r1 = 713,
 +	_NID_secp384r1 = 715,
 +	_NID_secp521r1 = 716,
-+	_NID_ML_KEM_768 = 1455,
-+	_NID_ML_KEM_1024 = 1456,
-+	_NID_ML_DSA_44 = 1457,
-+	_NID_ML_DSA_65 = 1458,
-+	_NID_ML_DSA_87 = 1459,
 +	_RSA_PKCS1_PADDING = 1,
 +	_RSA_NO_PADDING = 3,
 +	_RSA_PKCS1_OAEP_PADDING = 4,
@@ -23032,6 +23098,7 @@ index 00000000000000..95ba94df4e1c49
 +int _mkcgo_EVP_PKEY_CTX_ctrl(_EVP_PKEY_CTX_PTR, int, int, int, int, void*, uintptr_t *);
 +void _mkcgo_EVP_PKEY_CTX_free(_EVP_PKEY_CTX_PTR);
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new(_EVP_PKEY_PTR, _ENGINE_PTR, uintptr_t *);
++_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_from_name(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_from_pkey(_OSSL_LIB_CTX_PTR, _EVP_PKEY_PTR, const char*, uintptr_t *);
 +_EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_id(int, _ENGINE_PTR, uintptr_t *);
 +int _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR, unsigned char*, int, uintptr_t *);
@@ -23168,10 +23235,10 @@ index 00000000000000..95ba94df4e1c49
 +#endif // MKCGO_H
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_cgo.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_cgo.go
 new file mode 100644
-index 00000000000000..c774468b970dce
+index 00000000000000..21fb4c071dee50
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_cgo.go
-@@ -0,0 +1,1527 @@
+@@ -0,0 +1,1533 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -23975,6 +24042,12 @@ index 00000000000000..c774468b970dce
 +	return _ret, newMkcgoErr("EVP_PKEY_CTX_new", uintptr(_err))
 +}
 +
++func EVP_PKEY_CTX_new_from_name(libctx OSSL_LIB_CTX_PTR, name *byte, propquery *byte) (EVP_PKEY_CTX_PTR, error) {
++	var _err C.uintptr_t
++	_ret := C._mkcgo_EVP_PKEY_CTX_new_from_name(libctx, (*C.char)(unsafe.Pointer(name)), (*C.char)(unsafe.Pointer(propquery)), mkcgoNoEscape(&_err))
++	return _ret, newMkcgoErr("EVP_PKEY_CTX_new_from_name", uintptr(_err))
++}
++
 +func EVP_PKEY_CTX_new_from_pkey(libctx OSSL_LIB_CTX_PTR, pkey EVP_PKEY_PTR, propquery *byte) (EVP_PKEY_CTX_PTR, error) {
 +	var _err C.uintptr_t
 +	_ret := C._mkcgo_EVP_PKEY_CTX_new_from_pkey(libctx, pkey, (*C.char)(unsafe.Pointer(propquery)), mkcgoNoEscape(&_err))
@@ -24701,10 +24774,10 @@ index 00000000000000..c774468b970dce
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_nocgo.go b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_nocgo.go
 new file mode 100644
-index 00000000000000..a81137ddaf02f7
+index 00000000000000..42041b8d332062
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/internal/ossl/zossl_nocgo.go
-@@ -0,0 +1,2501 @@
+@@ -0,0 +1,2511 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -25608,6 +25681,14 @@ index 00000000000000..a81137ddaf02f7
 +	var _err uintptr
 +	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_CTX_new, uintptr(arg0), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
 +	return EVP_PKEY_CTX_PTR(r0), newMkcgoErr("EVP_PKEY_CTX_new", _err)
++}
++
++var _mkcgo_EVP_PKEY_CTX_new_from_name uintptr
++
++func EVP_PKEY_CTX_new_from_name(libctx OSSL_LIB_CTX_PTR, name *byte, propquery *byte) (EVP_PKEY_CTX_PTR, error) {
++	var _err uintptr
++	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_CTX_new_from_name, uintptr(libctx), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(name))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(propquery))), uintptr(unsafe.Pointer(&_err)))
++	return EVP_PKEY_CTX_PTR(r0), newMkcgoErr("EVP_PKEY_CTX_new_from_name", _err)
 +}
 +
 +var _mkcgo_EVP_PKEY_CTX_new_from_pkey uintptr
@@ -26934,6 +27015,7 @@ index 00000000000000..a81137ddaf02f7
 +	_mkcgo_EVP_MD_get_size = dlsym(handle, "EVP_MD_get_size\x00", false)
 +	_mkcgo_EVP_MD_get_type = dlsym(handle, "EVP_MD_get_type\x00", false)
 +	_mkcgo_EVP_PKEY_CTX_add1_hkdf_info = dlsym(handle, "EVP_PKEY_CTX_add1_hkdf_info\x00", false)
++	_mkcgo_EVP_PKEY_CTX_new_from_name = dlsym(handle, "EVP_PKEY_CTX_new_from_name\x00", false)
 +	_mkcgo_EVP_PKEY_CTX_new_from_pkey = dlsym(handle, "EVP_PKEY_CTX_new_from_pkey\x00", false)
 +	_mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label = dlsym(handle, "EVP_PKEY_CTX_set0_rsa_oaep_label\x00", false)
 +	_mkcgo_EVP_PKEY_CTX_set1_hkdf_key = dlsym(handle, "EVP_PKEY_CTX_set1_hkdf_key\x00", false)
@@ -27011,6 +27093,7 @@ index 00000000000000..a81137ddaf02f7
 +	_mkcgo_EVP_MD_get_size = 0
 +	_mkcgo_EVP_MD_get_type = 0
 +	_mkcgo_EVP_PKEY_CTX_add1_hkdf_info = 0
++	_mkcgo_EVP_PKEY_CTX_new_from_name = 0
 +	_mkcgo_EVP_PKEY_CTX_new_from_pkey = 0
 +	_mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label = 0
 +	_mkcgo_EVP_PKEY_CTX_set1_hkdf_key = 0
@@ -28246,10 +28329,10 @@ index 00000000000000..e69e0bcfe332df
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/const.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/const.go
 new file mode 100644
-index 00000000000000..c84521b3aa7d34
+index 00000000000000..eb5657a0d28208
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/const.go
-@@ -0,0 +1,115 @@
+@@ -0,0 +1,116 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -28287,6 +28370,7 @@ index 00000000000000..c84521b3aa7d34
 +const ( //checkheader:ignore
 +	// Key types
 +	_KeyTypeRSA              cString = "RSA\x00"
++	_KeyTypeDSA              cString = "DSA\x00"
 +	_KeyTypeEC               cString = "EC\x00"
 +	_KeyTypeED25519          cString = "ED25519\x00"
 +	_KeyTypeX25519           cString = "X25519\x00"
@@ -28756,7 +28840,7 @@ index 00000000000000..6ae4a6372f8d08
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/dsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/dsa.go
 new file mode 100644
-index 00000000000000..b2c643ab34a0c1
+index 00000000000000..292456d19eb32d
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/dsa.go
 @@ -0,0 +1,296 @@
@@ -29020,7 +29104,7 @@ index 00000000000000..b2c643ab34a0c1
 +		return nil, err
 +	}
 +	defer ossl.OSSL_PARAM_free(bldparams)
-+	pkey, err := newEvpFromParams(ossl.EVP_PKEY_DSA, selection, bldparams)
++	pkey, err := newEvpFromParams(_KeyTypeDSA, selection, bldparams)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -29196,7 +29280,7 @@ index 00000000000000..d871a04b37942b
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
 new file mode 100644
-index 00000000000000..60e56dfd573f47
+index 00000000000000..c7bb9437f22a47
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdh.go
 @@ -0,0 +1,331 @@
@@ -29428,7 +29512,7 @@ index 00000000000000..60e56dfd573f47
 +		return nil, err
 +	}
 +	defer ossl.OSSL_PARAM_free(params)
-+	pkey, err := newEvpFromParams(ossl.EVP_PKEY_EC, selection, params)
++	pkey, err := newEvpFromParams(_KeyTypeEC, selection, params)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -29533,7 +29617,7 @@ index 00000000000000..60e56dfd573f47
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 new file mode 100644
-index 00000000000000..ad6c0bcb821bc7
+index 00000000000000..1fe54d5813aa92
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ecdsa.go
 @@ -0,0 +1,212 @@
@@ -29747,7 +29831,7 @@ index 00000000000000..ad6c0bcb821bc7
 +		return nil, err
 +	}
 +	defer ossl.OSSL_PARAM_free(params)
-+	return newEvpFromParams(ossl.EVP_PKEY_EC, selection, params)
++	return newEvpFromParams(_KeyTypeEC, selection, params)
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ed25519.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/ed25519.go
 new file mode 100644
@@ -29966,10 +30050,10 @@ index 00000000000000..69565f949d4ac5
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go
 new file mode 100644
-index 00000000000000..86e10fc0059754
+index 00000000000000..73467de2d812f8
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/evp.go
-@@ -0,0 +1,634 @@
+@@ -0,0 +1,624 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -30219,16 +30303,6 @@ index 00000000000000..86e10fc0059754
 +			pkey, err = ossl.EVP_PKEY_Q_keygen_ED25519(nil, nil, _KeyTypeED25519.ptr())
 +		case ossl.EVP_PKEY_X25519:
 +			pkey, err = ossl.EVP_PKEY_Q_keygen_X25519(nil, nil, _KeyTypeX25519.ptr())
-+		case ossl.EVP_PKEY_MLKEM_768:
-+			pkey, err = ossl.EVP_PKEY_Q_keygen_MLKEM(nil, nil, _KeyTypeMLKEM768.ptr())
-+		case ossl.EVP_PKEY_MLKEM_1024:
-+			pkey, err = ossl.EVP_PKEY_Q_keygen_MLKEM(nil, nil, _KeyTypeMLKEM1024.ptr())
-+		case ossl.EVP_PKEY_ML_DSA_44:
-+			pkey, err = ossl.EVP_PKEY_Q_keygen_MLDSA(nil, nil, _KeyTypeMLDSA44.ptr())
-+		case ossl.EVP_PKEY_ML_DSA_65:
-+			pkey, err = ossl.EVP_PKEY_Q_keygen_MLDSA(nil, nil, _KeyTypeMLDSA65.ptr())
-+		case ossl.EVP_PKEY_ML_DSA_87:
-+			pkey, err = ossl.EVP_PKEY_Q_keygen_MLDSA(nil, nil, _KeyTypeMLDSA87.ptr())
 +		default:
 +			panic("unsupported key type '" + strconv.Itoa(int(id)) + "'")
 +		}
@@ -30564,8 +30638,8 @@ index 00000000000000..86e10fc0059754
 +	return key
 +}
 +
-+func newEvpFromParams(id int32, selection int32, params ossl.OSSL_PARAM_PTR) (ossl.EVP_PKEY_PTR, error) {
-+	ctx, err := ossl.EVP_PKEY_CTX_new_id(id, nil)
++func newEvpFromParams(name cString, selection int32, params ossl.OSSL_PARAM_PTR) (ossl.EVP_PKEY_PTR, error) {
++	ctx, err := ossl.EVP_PKEY_CTX_new_from_name(nil, name.ptr(), nil)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -31723,10 +31797,10 @@ index 00000000000000..16d59d713d77c5
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/mldsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/mldsa.go
 new file mode 100644
-index 00000000000000..97fc7406f75353
+index 00000000000000..d3e719f8716950
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/mldsa.go
-@@ -0,0 +1,499 @@
+@@ -0,0 +1,495 @@
 +// Copyright (c) Microsoft Corporation.
 +// Licensed under the MIT License.
 +
@@ -31775,11 +31849,11 @@ index 00000000000000..97fc7406f75353
 +// callers must probe each parameter set they intend to use.
 +func SupportsMLDSA(params MLDSAParameters) bool {
 +	switch params.keyType {
-+	case ossl.EVP_PKEY_ML_DSA_44:
++	case _KeyTypeMLDSA44:
 +		return supportsMLDSA44()
-+	case ossl.EVP_PKEY_ML_DSA_65:
++	case _KeyTypeMLDSA65:
 +		return supportsMLDSA65()
-+	case ossl.EVP_PKEY_ML_DSA_87:
++	case _KeyTypeMLDSA87:
 +		return supportsMLDSA87()
 +	default:
 +		return false
@@ -31811,8 +31885,7 @@ index 00000000000000..97fc7406f75353
 +// MLDSAParameters represents one of the fixed ML-DSA parameter sets.
 +type MLDSAParameters struct {
 +	name          string
-+	keyType       int32
-+	keyTypeName   cString
++	keyType       cString
 +	publicKeySize int
 +	signatureSize int
 +}
@@ -31820,22 +31893,19 @@ index 00000000000000..97fc7406f75353
 +var (
 +	mldsa44 = MLDSAParameters{
 +		name:          "ML-DSA-44",
-+		keyType:       ossl.EVP_PKEY_ML_DSA_44,
-+		keyTypeName:   _KeyTypeMLDSA44,
++		keyType:       _KeyTypeMLDSA44,
 +		publicKeySize: publicKeySizeMLDSA44,
 +		signatureSize: signatureSizeMLDSA44,
 +	}
 +	mldsa65 = MLDSAParameters{
 +		name:          "ML-DSA-65",
-+		keyType:       ossl.EVP_PKEY_ML_DSA_65,
-+		keyTypeName:   _KeyTypeMLDSA65,
++		keyType:       _KeyTypeMLDSA65,
 +		publicKeySize: publicKeySizeMLDSA65,
 +		signatureSize: signatureSizeMLDSA65,
 +	}
 +	mldsa87 = MLDSAParameters{
 +		name:          "ML-DSA-87",
-+		keyType:       ossl.EVP_PKEY_ML_DSA_87,
-+		keyTypeName:   _KeyTypeMLDSA87,
++		keyType:       _KeyTypeMLDSA87,
 +		publicKeySize: publicKeySizeMLDSA87,
 +		signatureSize: signatureSizeMLDSA87,
 +	}
@@ -32033,8 +32103,8 @@ index 00000000000000..97fc7406f75353
 +// Helper functions
 +
 +// generateMLDSASeed generates a new ML-DSA private key and extracts the seed.
-+func generateMLDSASeed(keyType int32, seed []byte) error {
-+	pkey, err := generateEVPPKey(keyType, 0, "")
++func generateMLDSASeed(name cString, seed []byte) error {
++	pkey, err := ossl.EVP_PKEY_Q_keygen_MLDSA(nil, nil, name.ptr())
 +	if err != nil {
 +		return err
 +	}
@@ -32045,7 +32115,7 @@ index 00000000000000..97fc7406f75353
 +}
 +
 +// newMLDSAPrivatePkey creates an ML-DSA EVP_PKEY from a 32-byte seed.
-+func newMLDSAPrivatePkey(id int32, seed []byte) (ossl.EVP_PKEY_PTR, error) {
++func newMLDSAPrivatePkey(name cString, seed []byte) (ossl.EVP_PKEY_PTR, error) {
 +	if len(seed) != privateKeySizeMLDSA {
 +		return nil, errors.New("mldsa: invalid seed size")
 +	}
@@ -32061,11 +32131,11 @@ index 00000000000000..97fc7406f75353
 +	}
 +	defer ossl.OSSL_PARAM_free(params)
 +
-+	return newEvpFromParams(id, ossl.EVP_PKEY_KEYPAIR, params)
++	return newEvpFromParams(name, ossl.EVP_PKEY_KEYPAIR, params)
 +}
 +
 +// newMLDSAPublicPkey creates an ML-DSA EVP_PKEY from encoded public key bytes.
-+func newMLDSAPublicPkey(id int32, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, error) {
++func newMLDSAPublicPkey(name cString, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, error) {
 +	bld := newParamBuilder()
 +	defer bld.finalize()
 +
@@ -32077,7 +32147,7 @@ index 00000000000000..97fc7406f75353
 +	}
 +	defer ossl.OSSL_PARAM_free(params)
 +
-+	return newEvpFromParams(id, ossl.EVP_PKEY_PUBLIC_KEY, params)
++	return newEvpFromParams(name, ossl.EVP_PKEY_PUBLIC_KEY, params)
 +}
 +
 +// mldsaExtractPublicKey derives and copies the encoded public key bytes from
@@ -32228,7 +32298,7 @@ index 00000000000000..97fc7406f75353
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/mlkem.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/mlkem.go
 new file mode 100644
-index 00000000000000..5c2ffbabe92e15
+index 00000000000000..8b5c69f6186413
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/mlkem.go
 @@ -0,0 +1,369 @@
@@ -32277,8 +32347,8 @@ index 00000000000000..5c2ffbabe92e15
 +
 +var supportsMLKEM768 = sync.OnceValue(func() bool {
 +	// EVP_KEYMGMT_fetch was added in OpenSSL 3.0; if it is not available we
-+	// are on 1.x and ML-KEM is not supported. On 3.0–3.4 the fetch returns
-+	// nil for the ML-KEM algorithm name, which the probe reports as false.
++	// are on 1.x and ML-KEM is not supported. Providers without ML-KEM return
++	// nil for the algorithm name, which the probe reports as false.
 +	if !ossl.EVP_KEYMGMT_fetch_Available() {
 +		return false
 +	}
@@ -32310,7 +32380,7 @@ index 00000000000000..5c2ffbabe92e15
 +// the default crypto/rand source. The decapsulation key must be kept secret.
 +func GenerateKeyMLKEM768() (DecapsulationKeyMLKEM768, error) {
 +	var dk DecapsulationKeyMLKEM768
-+	if err := generateMLKEMSeed(ossl.EVP_PKEY_MLKEM_768, dk[:]); err != nil {
++	if err := generateMLKEMSeed(_KeyTypeMLKEM768, dk[:]); err != nil {
 +		return DecapsulationKeyMLKEM768{}, err
 +	}
 +	return dk, nil
@@ -32340,13 +32410,13 @@ index 00000000000000..5c2ffbabe92e15
 +//
 +// The shared key must be kept secret.
 +func (dk DecapsulationKeyMLKEM768) Decapsulate(ciphertext []byte) (sharedKey []byte, err error) {
-+	return performDecapsulation(ossl.NID_ML_KEM_768, dk[:], ciphertext)
++	return performDecapsulation(_KeyTypeMLKEM768, dk[:], ciphertext)
 +}
 +
 +// EncapsulationKey returns the public encapsulation key necessary to produce
 +// ciphertexts.
 +func (dk DecapsulationKeyMLKEM768) EncapsulationKey() EncapsulationKeyMLKEM768 {
-+	ekBytes := extractEncapsulationKeyBytes(ossl.NID_ML_KEM_768, dk[:], encapsulationKeySizeMLKEM768)
++	ekBytes := extractEncapsulationKeyBytes(_KeyTypeMLKEM768, dk[:], encapsulationKeySizeMLKEM768)
 +	var ek EncapsulationKeyMLKEM768
 +	copy(ek[:], ekBytes)
 +	return ek
@@ -32378,11 +32448,11 @@ index 00000000000000..5c2ffbabe92e15
 +//
 +// The shared key must be kept secret.
 +func (ek EncapsulationKeyMLKEM768) Encapsulate() (sharedKey, ciphertext []byte) {
-+	return performEncapsulation(ossl.NID_ML_KEM_768, ciphertextSizeMLKEM768, ek[:])
++	return performEncapsulation(_KeyTypeMLKEM768, ciphertextSizeMLKEM768, ek[:])
 +}
 +
-+func performEncapsulation(id int32, ciphertextSize int, ek []byte) (sharedKey, ciphertext []byte) {
-+	pkey, err := createMLKEMPublicKey(id, ek)
++func performEncapsulation(name cString, ciphertextSize int, ek []byte) (sharedKey, ciphertext []byte) {
++	pkey, err := createMLKEMPublicKey(name, ek)
 +	if err != nil {
 +		panic(err)
 +	}
@@ -32414,12 +32484,12 @@ index 00000000000000..5c2ffbabe92e15
 +	return sharedKey[:sharedKeyLen], ciphertext[:ciphertextLen]
 +}
 +
-+func performDecapsulation(id int32, seed, ciphertext []byte) (sharedKey []byte, err error) {
++func performDecapsulation(name cString, seed, ciphertext []byte) (sharedKey []byte, err error) {
 +	if len(ciphertext) == 0 {
 +		return nil, errors.New("mlkem: invalid ciphertext size")
 +	}
 +
-+	pkey, err := createMLKEMPrivateKey(id, seed)
++	pkey, err := createMLKEMPrivateKey(name, seed)
 +	if err != nil {
 +		return nil, err
 +	}
@@ -32455,7 +32525,7 @@ index 00000000000000..5c2ffbabe92e15
 +// the default crypto/rand source. The decapsulation key must be kept secret.
 +func GenerateKeyMLKEM1024() (DecapsulationKeyMLKEM1024, error) {
 +	var dk DecapsulationKeyMLKEM1024
-+	if err := generateMLKEMSeed(ossl.EVP_PKEY_MLKEM_1024, dk[:]); err != nil {
++	if err := generateMLKEMSeed(_KeyTypeMLKEM1024, dk[:]); err != nil {
 +		return DecapsulationKeyMLKEM1024{}, err
 +	}
 +	return dk, nil
@@ -32485,13 +32555,13 @@ index 00000000000000..5c2ffbabe92e15
 +//
 +// The shared key must be kept secret.
 +func (dk DecapsulationKeyMLKEM1024) Decapsulate(ciphertext []byte) (sharedKey []byte, err error) {
-+	return performDecapsulation(ossl.NID_ML_KEM_1024, dk[:], ciphertext)
++	return performDecapsulation(_KeyTypeMLKEM1024, dk[:], ciphertext)
 +}
 +
 +// EncapsulationKey returns the public encapsulation key necessary to produce
 +// ciphertexts.
 +func (dk DecapsulationKeyMLKEM1024) EncapsulationKey() EncapsulationKeyMLKEM1024 {
-+	ekBytes := extractEncapsulationKeyBytes(ossl.NID_ML_KEM_1024, dk[:], encapsulationKeySizeMLKEM1024)
++	ekBytes := extractEncapsulationKeyBytes(_KeyTypeMLKEM1024, dk[:], encapsulationKeySizeMLKEM1024)
 +	var ek EncapsulationKeyMLKEM1024
 +	copy(ek[:], ekBytes)
 +	return ek
@@ -32523,14 +32593,14 @@ index 00000000000000..5c2ffbabe92e15
 +//
 +// The shared key must be kept secret.
 +func (ek EncapsulationKeyMLKEM1024) Encapsulate() (sharedKey, ciphertext []byte) {
-+	return performEncapsulation(ossl.NID_ML_KEM_1024, ciphertextSizeMLKEM1024, ek[:])
++	return performEncapsulation(_KeyTypeMLKEM1024, ciphertextSizeMLKEM1024, ek[:])
 +}
 +
 +// Helper functions
 +
 +// generateMLKEMSeed generates a new ML-KEM seed by creating a key and extracting its seed parameter.
-+func generateMLKEMSeed(keyType int32, seed []byte) error {
-+	pkey, err := generateEVPPKey(keyType, 0, "")
++func generateMLKEMSeed(name cString, seed []byte) error {
++	pkey, err := ossl.EVP_PKEY_Q_keygen_MLKEM(nil, nil, name.ptr())
 +	if err != nil {
 +		return err
 +	}
@@ -32541,7 +32611,7 @@ index 00000000000000..5c2ffbabe92e15
 +}
 +
 +// createMLKEMPrivateKey creates an ML-KEM private key from a seed
-+func createMLKEMPrivateKey(id int32, seed []byte) (ossl.EVP_PKEY_PTR, error) {
++func createMLKEMPrivateKey(name cString, seed []byte) (ossl.EVP_PKEY_PTR, error) {
 +	if len(seed) != seedSizeMLKEM {
 +		return nil, errors.New("mlkem: invalid seed size")
 +	}
@@ -32557,11 +32627,11 @@ index 00000000000000..5c2ffbabe92e15
 +	}
 +	defer ossl.OSSL_PARAM_free(params)
 +
-+	return newEvpFromParams(id, ossl.EVP_PKEY_KEYPAIR, params)
++	return newEvpFromParams(name, ossl.EVP_PKEY_KEYPAIR, params)
 +}
 +
 +// createMLKEMPublicKey creates an ML-KEM public key from encoded bytes.
-+func createMLKEMPublicKey(id int32, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, error) {
++func createMLKEMPublicKey(name cString, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, error) {
 +	bld := newParamBuilder()
 +	defer bld.finalize()
 +
@@ -32573,12 +32643,12 @@ index 00000000000000..5c2ffbabe92e15
 +	}
 +	defer ossl.OSSL_PARAM_free(params)
 +
-+	return newEvpFromParams(id, ossl.EVP_PKEY_PUBLIC_KEY, params)
++	return newEvpFromParams(name, ossl.EVP_PKEY_PUBLIC_KEY, params)
 +}
 +
 +// extractEncapsulationKeyBytes extracts the encapsulation key bytes from a decapsulation key.
-+func extractEncapsulationKeyBytes(id int32, seed []byte, expectedSize int) []byte {
-+	pkey, err := createMLKEMPrivateKey(id, seed)
++func extractEncapsulationKeyBytes(name cString, seed []byte, expectedSize int) []byte {
++	pkey, err := createMLKEMPrivateKey(name, seed)
 +	if err != nil {
 +		panic(err)
 +	}
@@ -33865,7 +33935,7 @@ index 00000000000000..37d12ec889a91e
 +}
 diff --git a/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 new file mode 100644
-index 00000000000000..a59ac6f76a1298
+index 00000000000000..c480993f983b99
 --- /dev/null
 +++ b/src/vendor/github.com/microsoft/go-crypto-openssl/openssl/rsa.go
 @@ -0,0 +1,706 @@
@@ -34223,7 +34293,7 @@ index 00000000000000..a59ac6f76a1298
 +	if isPriv {
 +		selection = ossl.EVP_PKEY_KEYPAIR
 +	}
-+	return newEvpFromParams(ossl.EVP_PKEY_RSA, int32(selection), params)
++	return newEvpFromParams(_KeyTypeRSA, int32(selection), params)
 +}
 +
 +// SupportsRSAPKCS1v15Encryption returns true if the RSA PKCS1 v1.5 padding is supported for encryption and decryption.
@@ -45257,7 +45327,7 @@ index 00000000000000..b7ffeea07c6b8d
 +	panic("cryptobackend: not available")
 +}
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index b34527fdb12010..378db1df78691f 100644
+index b34527fdb12010..4d6d96ac051d55 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,57 @@
@@ -45270,7 +45340,7 @@ index b34527fdb12010..378db1df78691f 100644
 +github.com/microsoft/go-crypto-darwin/internal/security
 +github.com/microsoft/go-crypto-darwin/internal/xsyscall
 +github.com/microsoft/go-crypto-darwin/xcrypto
-+# github.com/microsoft/go-crypto-openssl v0.5.1-0.20260728092821-b4aef158c3ae
++# github.com/microsoft/go-crypto-openssl v0.5.1-0.20260904065618-5fd04832939d
 +## explicit; go 1.25
 +github.com/microsoft/go-crypto-openssl/bbig
 +github.com/microsoft/go-crypto-openssl/internal/fakecgo


### PR DESCRIPTION
Backport of #2492 to `microsoft/release-branch.go1.27`.

Upgrade the OpenSSL backend to bring https://github.com/microsoft/go-crypto-openssl/pull/68.

The release branch dependency was updated directly and the patch series was regenerated with `git go-patch extract`.

Validation:
- `git go-patch extract` patch verification
- OpenSSL package build on macOS arm64 with cgo enabled and disabled
- OpenSSL package cross-build for Darwin amd64 and Linux amd64 with cgo disabled