### PR TITLE
pipeline: exclude stage 0 toolchain from Component Governance

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -101,6 +101,9 @@ extends:
         compiled:
           enabled: false
           justificationForDisabling: 'Scan runs in validation pipeline.'
+      componentgovernance:
+        # Stage 0 is a temporary bootstrap toolchain and is not shipped.
+        ignoreDirectories: '$(Build.SourcesDirectory)/eng/artifacts/_goStage0'
       suppression:
         suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
       tsa:

--- a/eng/pipeline/rolling-internal.gen.yml
+++ b/eng/pipeline/rolling-internal.gen.yml
@@ -105,6 +105,9 @@ extends:
         compiled:
           enabled: false
           justificationForDisabling: 'Scan runs in validation pipeline.'
+      componentgovernance:
+        # Stage 0 is a temporary bootstrap toolchain and is not shipped.
+        ignoreDirectories: '$(Build.SourcesDirectory)/eng/artifacts/_goStage0'
       suppression:
         suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
       tsa:


### PR DESCRIPTION
## Summary

- exclude the temporary Stage 0 Go bootstrap toolchain from Component Governance scans
- regenerate the rolling internal pipeline YAML
- prevent vulnerabilities in the downloaded, non-shipping toolchain, such as CVE-2026-42508, from being attributed to this repository

## Validation

- `pwsh eng/run.ps1 pipelineymlgen`
- `git diff --check -- eng/pipeline/rolling-internal.gen.yml eng/pipeline/rolling-internal-pipeline.yml`