### PR TITLE
[release-branch.go1.26] pipeline: exclude stage 0 toolchain from Component Governance

### DIFF
--- a/eng/pipeline/rolling-internal-pipeline.yml
+++ b/eng/pipeline/rolling-internal-pipeline.yml
@@ -100,6 +100,9 @@ extends:
         compiled:
           enabled: false
           justificationForDisabling: 'Scan runs in validation pipeline.'
+      componentgovernance:
+        # Stage 0 is a temporary bootstrap toolchain and is not shipped.
+        ignoreDirectories: '$(Build.SourcesDirectory)/eng/artifacts/_goStage0'
       suppression:
         suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
       tsa:

--- a/eng/utilities.ps1
+++ b/eng/utilities.ps1
@@ -26,9 +26,14 @@ function Download-Stage0() {
   # specific version of Go. The downloaded copy of Go is called the "stage 0" version.
   $stage0_go_version = 'go1.25.0-1'
 
+  # Install stage 0 Go inside the repository (under "eng/artifacts/") to avoid modifying the user's
+  # home directory, and to make cleanup easy (included in "git clean -xdf"). The "_" prefix prevents
+  # Go's moddeps_test from traversing into this directory. See https://github.com/microsoft/go/issues/12
+  $stage0_install_dir = Join-Path $PSScriptRoot "artifacts" "_goStage0"
+
   # Source the install script so that we can use the PATH it assigns.
   $installScriptPath = Join-Path $PSScriptRoot "_util" "go-install.ps1"
-  . $installScriptPath -Version $stage0_go_version
+  . $installScriptPath -Version $stage0_go_version -InstallDir $stage0_install_dir
 }
 
 # Copied from https://github.com/dotnet/install-scripts/blob/49d5da7f7d313aa65d24fe95cc29767faef553fd/src/dotnet-install.ps1#L180-L197


### PR DESCRIPTION
Backport of #2494.

## Summary

- install the temporary Stage 0 Go bootstrap toolchain under `eng/artifacts/_goStage0`, matching Go 1.27 behavior
- exclude that non-shipping directory from Component Governance scans
- avoid attributing bootstrap-toolchain findings such as CVE-2026-42508 to this repository

## Validation

- `pwsh eng/run.ps1 pipelineymlgen`
  - installed Stage 0 at `eng/artifacts/_goStage0/go1.25.0-1`
  - used that installation to regenerate the pipeline YAML
- `git diff --check`
- verified the installed Stage 0 binary is ignored by `eng/.gitignore`